### PR TITLE
Change references from today to now

### DIFF
--- a/tests/Feature/Admin/Wrestlers/RestoreWrestlerSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Wrestlers/RestoreWrestlerSuccessConditionsTest.php
@@ -18,7 +18,7 @@ class RestoreWrestlerSuccessConditionsTest extends TestCase
     public function an_administrator_can_restore_a_deleted_wrestler()
     {
         $this->actAs('administrator');
-        $wrestler = factory(Wrestler::class)->create(['deleted_at' => today()->subDays(3)->toDateTimeString()]);
+        $wrestler = factory(Wrestler::class)->create(['deleted_at' => now()->subDays(3)->toDateTimeString()]);
 
         $response = $this->put(route('wrestlers.restore', $wrestler));
 

--- a/tests/Feature/Guest/Wrestlers/RestoreWrestlerFailureConditionsTest.php
+++ b/tests/Feature/Guest/Wrestlers/RestoreWrestlerFailureConditionsTest.php
@@ -13,7 +13,7 @@ class RestoreWrestlerFailureConditionsTest extends TestCase
     /** @test */
     public function a_guest_cannot_restore_a_deleted_wrestler()
     {
-        $wrestler = factory(Wrestler::class)->create(['deleted_at' => today()->subDays(3)->toDateTimeString()]);
+        $wrestler = factory(Wrestler::class)->create(['deleted_at' => now()->subDays(3)->toDateTimeString()]);
 
         $response = $this->patch(route('wrestlers.restore', $wrestler));
 


### PR DESCRIPTION
With this pull request, we are changing the today helper to the now helper to include the time.