### PR TITLE
Remove roster from all stable routes

### DIFF
--- a/app/Http/Controllers/Stables/ActivateController.php
+++ b/app/Http/Controllers/Stables/ActivateController.php
@@ -19,6 +19,6 @@ class ActivateController extends Controller
 
         $stable->activate();
 
-        return redirect()->route('roster.stables.index');
+        return redirect()->route('stables.index');
     }
 }

--- a/app/Http/Controllers/Stables/RestoreController.php
+++ b/app/Http/Controllers/Stables/RestoreController.php
@@ -21,6 +21,6 @@ class RestoreController extends Controller
 
         $stable->restore();
 
-        return redirect()->route('roster.stables.index');
+        return redirect()->route('stables.index');
     }
 }

--- a/app/Http/Controllers/Stables/RetireController.php
+++ b/app/Http/Controllers/Stables/RetireController.php
@@ -19,6 +19,6 @@ class RetireController extends Controller
 
         $stable->retire();
 
-        return redirect()->route('roster.stables.index');
+        return redirect()->route('stables.index');
     }
 }

--- a/app/Http/Controllers/Stables/StablesController.php
+++ b/app/Http/Controllers/Stables/StablesController.php
@@ -75,7 +75,7 @@ class StablesController extends Controller
             $stable->addTagTeams($request->input('tagteams'), $request->input('started_at'));
         }
 
-        return redirect()->route('roster.stables.index');
+        return redirect()->route('stables.index');
     }
 
     /**
@@ -126,7 +126,7 @@ class StablesController extends Controller
         $stable->wrestlerHistory()->sync($request->input('wrestlers'));
         $stable->tagTeamHistory()->sync($request->input('tagteams'));
 
-        return redirect()->route('roster.stables.index');
+        return redirect()->route('stables.index');
     }
 
     /**
@@ -141,6 +141,6 @@ class StablesController extends Controller
 
         $stable->delete();
 
-        return redirect()->route('roster.stables.index');
+        return redirect()->route('stables.index');
     }
 }

--- a/app/Http/Controllers/Stables/UnretireController.php
+++ b/app/Http/Controllers/Stables/UnretireController.php
@@ -19,6 +19,6 @@ class UnretireController extends Controller
 
         $stable->unretire();
 
-        return redirect()->route('roster.stables.index');
+        return redirect()->route('stables.index');
     }
 }

--- a/resources/views/stables/index.blade.php
+++ b/resources/views/stables/index.blade.php
@@ -14,7 +14,7 @@
         @include('stables.partials.filters')
     </div>
     <div class="kt-subheader__toolbar">
-        <a href="{{ route('roster.stables.create') }}"
+        <a href="{{ route('stables.create') }}"
             class="btn btn-label-brand btn-bold">
             Add Stable
         </a>

--- a/resources/views/stables/partials/action-cell.blade.php
+++ b/resources/views/stables/partials/action-cell.blade.php
@@ -6,7 +6,7 @@
         <ul class="kt-nav">
             @can('view', $model)
                 <li class="kt-nav__item">
-                    <a href="{{ route('roster.stables.show', $model) }}" class="kt-nav__link">
+                    <a href="{{ route('stables.show', $model) }}" class="kt-nav__link">
                         <i class="kt-nav__link-icon flaticon2-expand"></i>
                         <span class="kt-nav__link-text">View</span>
                     </a>
@@ -14,7 +14,7 @@
             @endcan
             @can('update', $model)
                 <li class="kt-nav__item">
-                    <a href="{{ route('roster.stables.edit', $model) }}" class="kt-nav__link">
+                    <a href="{{ route('stables.edit', $model) }}" class="kt-nav__link">
                         <i class="kt-nav__link-icon flaticon2-contract"></i>
                         <span class="kt-nav__link-text">Edit</span>
                     </a>
@@ -22,7 +22,7 @@
             @endcan
             @can('delete', $model)
                 <li class="kt-nav__item">
-                    <form action="{{ route('roster.stables.destroy', $model) }}" method="post" class="kt-nav__link">
+                    <form action="{{ route('stables.destroy', $model) }}" method="post" class="kt-nav__link">
                         @csrf
                         @method('DELETE')
                         <button class="btn w-100 text-left p-0">
@@ -34,7 +34,7 @@
             @endcan
             @can('retire', $model)
                 <li class="kt-nav__item">
-                    <form action="{{ route('roster.stables.retire', $model) }}" method="post" class="kt-nav__link">
+                    <form action="{{ route('stables.retire', $model) }}" method="post" class="kt-nav__link">
                         @csrf
                         @method('PUT')
                         <button class="btn w-100 text-left p-0">
@@ -46,7 +46,7 @@
             @endcan
             @can('unretire', $model)
                 <li class="kt-nav__item">
-                    <form action="{{ route('roster.stables.unretire', $model) }}" method="post" class="kt-nav__link">
+                    <form action="{{ route('stables.retire', $model) }}" method="post" class="kt-nav__link">
                         @csrf
                         @method('PUT')
                         <button class="btn w-100 text-left p-0">
@@ -58,7 +58,7 @@
             @endcan
             @can('activate', $model)
                 <li class="kt-nav__item">
-                    <form action="{{ route('roster.stables.activate', $model) }}" method="post" class="kt-nav__link">
+                    <form action="{{ route('stables.activate', $model) }}" method="post" class="kt-nav__link">
                         @csrf
                         @method('PUT')
                         <button class="btn w-100 text-left p-0">
@@ -70,7 +70,7 @@
             @endcan
             @can('disassemble', $model)
                 <li class="kt-nav__item">
-                    <form action="{{ route('roster.stables.activate', $model) }}" method="post" class="kt-nav__link">
+                    <form action="{{ route('stables.activate', $model) }}" method="post" class="kt-nav__link">
                         @csrf
                         @method('PUT')
                         <button class="btn w-100 text-left p-0">

--- a/routes/web/stables.php
+++ b/routes/web/stables.php
@@ -8,14 +8,7 @@ use App\Http\Controllers\Stables\UnretireController;
 use App\Http\Controllers\Stables\ActivateController;
 
 Route::resource('stables', StablesController::class);
-Route::get('/roster/stables', [StablesController::class, 'index'])->name('roster.stables.index');
-Route::get('/roster/stables/create', [StablesController::class, 'create'])->name('roster.stables.create');
-Route::post('/roster/stables', [StablesController::class, 'store'])->name('roster.stables.store');
-Route::get('/roster/stables/{stable}', [StablesController::class, 'show'])->name('roster.stables.show');
-Route::get('/roster/stables/{stable}/edit', [StablesController::class, 'edit'])->name('roster.stables.edit');
-Route::put('/roster/stables/{stable}', [StablesController::class, 'update'])->name('roster.stables.update');
-Route::delete('/roster/stables/{stable}/destroy', [StablesController::class, 'destroy'])->name('roster.stables.destroy');
-Route::put('/roster/stables/{stable}/restore', RestoreController::class)->name('roster.stables.restore');
-Route::put('/roster/stables/{stable}/retire', RetireController::class)->name('roster.stables.retire');
-Route::put('/roster/stables/{stable}/unretire', UnretireController::class)->name('roster.stables.unretire');
-Route::put('/roster/stables/{stable}/activate', ActivateController::class)->name('roster.stables.activate');
+Route::put('/roster/stables/{stable}/restore', RestoreController::class)->name('stables.restore');
+Route::put('/roster/stables/{stable}/retire', RetireController::class)->name('stables.retire');
+Route::put('/roster/stables/{stable}/unretire', UnretireController::class)->name('stables.unretire');
+Route::put('/roster/stables/{stable}/activate', ActivateController::class)->name('stables.activate');

--- a/tests/Feature/Admin/Stables/ActivateStableSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/ActivateStableSuccessConditionsTest.php
@@ -20,9 +20,9 @@ class ActivateStableSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->put(route('roster.stables.activate', $stable));
+        $response = $this->put(route('stables.activate', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         tap($stable->fresh(), function ($stable) {
             $this->assertTrue($stable->is_bookable);
         });

--- a/tests/Feature/Admin/Stables/CreateStableSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/CreateStableSuccessConditionsTest.php
@@ -41,7 +41,7 @@ class CreateStableSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $response = $this->get(route('roster.stables.create'));
+        $response = $this->get(route('stables.create'));
 
         $response->assertViewIs('stables.create');
     }
@@ -54,9 +54,9 @@ class CreateStableSuccessConditionsTest extends TestCase
 
         $this->actAs('administrator');
 
-        $response = $this->post(route('roster.stables.store'), $this->validParams());
+        $response = $this->post(route('stables.store'), $this->validParams());
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         tap(Stable::first(), function ($stable) use ($now) {
             $this->assertEquals('Example Stable Name', $stable->name);
             $this->assertEquals($now->toDateTimeString(), $stable->employment->started_at->toDateTimeString());

--- a/tests/Feature/Admin/Stables/DeleteStableSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/DeleteStableSuccessConditionsTest.php
@@ -20,9 +20,9 @@ class DeleteStableSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertSoftDeleted('stables', ['name' => $stable->name]);
     }
 
@@ -32,9 +32,9 @@ class DeleteStableSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertSoftDeleted('stables', ['name' => $stable->name]);
     }
 
@@ -44,9 +44,9 @@ class DeleteStableSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertSoftDeleted('stables', ['name' => $stable->name]);
     }
 }

--- a/tests/Feature/Admin/Stables/RestoreStableSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/RestoreStableSuccessConditionsTest.php
@@ -21,9 +21,9 @@ class RestoreStableSuccessConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $stable->delete();
 
-        $response = $this->put(route('roster.stables.restore', $stable));
+        $response = $this->put(route('stables.restore', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertNull($stable->fresh()->deleted_at);
     }
 }

--- a/tests/Feature/Admin/Stables/RetireStableSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/RetireStableSuccessConditionsTest.php
@@ -20,9 +20,9 @@ class RetireStableSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->put(route('roster.stables.retire', $stable));
+        $response = $this->put(route('stables.retire', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertEquals(now()->toDateTimeString(), $stable->fresh()->retirement->started_at);
     }
 }

--- a/tests/Feature/Admin/Stables/UnretireStableSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/UnretireStableSuccessConditionsTest.php
@@ -20,9 +20,9 @@ class UnretireStableSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->put(route('roster.stables.unretire', $stable));
+        $response = $this->put(route('stables.unretire', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertEquals(now()->toDateTimeString(), $stable->fresh()->retirements()->latest()->first()->ended_at);
     }
 }

--- a/tests/Feature/Admin/Stables/UpdateStableSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/UpdateStableSuccessConditionsTest.php
@@ -41,7 +41,7 @@ class UpdateStableSucessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->get(route('roster.stables.edit', $stable));
+        $response = $this->get(route('stables.edit', $stable));
 
         $response->assertViewIs('stables.edit');
         $this->assertTrue($response->data('stable')->is($stable));
@@ -53,9 +53,9 @@ class UpdateStableSucessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->put(route('roster.stables.update', $stable), $this->validParams());
+        $response = $this->put(route('stables.update', $stable), $this->validParams());
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         tap($stable->fresh(), function ($stable) {
             $this->assertEquals('Example Stable Name', $stable->name);
         });

--- a/tests/Feature/Admin/Stables/ViewStableBioPageSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/ViewStableBioPageSuccessConditionsTest.php
@@ -20,7 +20,7 @@ class ViewStableBioPageSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->get(route('roster.stables.show', $stable));
+        $response = $this->get(route('stables.show', $stable));
 
         $response->assertViewIs('stables.show');
         $this->assertTrue($response->data('stable')->is($stable));

--- a/tests/Feature/Admin/Stables/ViewStablesListSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Stables/ViewStablesListSuccessConditionsTest.php
@@ -50,7 +50,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $response = $this->get(route('roster.stables.index'));
+        $response = $this->get(route('stables.index'));
 
         $response->assertOk();
         $response->assertViewIs('stables.index');
@@ -61,7 +61,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('roster.stables.index'));
+        $responseAjax = $this->ajaxJson(route('stables.index'));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->stables->get('all')->count(),
@@ -74,7 +74,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('roster.stables.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('stables.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->stables->get('bookable')->count(),
@@ -87,7 +87,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('roster.stables.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('stables.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->stables->get('pending-introduction')->count(),
@@ -100,7 +100,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('roster.stables.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('stables.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->stables->get('retired')->count(),

--- a/tests/Feature/Generic/Stables/ActivateStableFailureConditionsTest.php
+++ b/tests/Feature/Generic/Stables/ActivateStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class ActivateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->put(route('roster.stables.activate', $stable));
+        $response = $this->put(route('stables.activate', $stable));
 
         $response->assertForbidden();
     }
@@ -31,7 +31,7 @@ class ActivateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->put(route('roster.stables.activate', $stable));
+        $response = $this->put(route('stables.activate', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/Generic/Stables/CreateStableFailureConditionsTest.php
+++ b/tests/Feature/Generic/Stables/CreateStableFailureConditionsTest.php
@@ -40,13 +40,13 @@ class CreateStableFailureConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $response = $this->from(route('roster.stables.create'))
-                        ->post(route('roster.stables.store'), $this->validParams([
+        $response = $this->from(route('stables.create'))
+                        ->post(route('stables.store'), $this->validParams([
                             'name' => ''
                         ]));
 
         $response->assertStatus(302);
-        $response->assertRedirect(route('roster.stables.create'));
+        $response->assertRedirect(route('stables.create'));
         $response->assertSessionHasErrors('name');
         $this->assertEquals(0, Stable::count());
     }
@@ -56,13 +56,13 @@ class CreateStableFailureConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $response = $this->from(route('roster.stables.create'))
-                        ->post(route('roster.stables.store'), $this->validParams([
+        $response = $this->from(route('stables.create'))
+                        ->post(route('stables.store'), $this->validParams([
                             'name' => ['not-a-string']
                         ]));
 
         $response->assertStatus(302);
-        $response->assertRedirect(route('roster.stables.create'));
+        $response->assertRedirect(route('stables.create'));
         $response->assertSessionHasErrors('name');
         $this->assertEquals(0, Stable::count());
     }
@@ -73,13 +73,13 @@ class CreateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         factory(Stable::class)->create(['name' => 'Example Stable Name']);
 
-        $response = $this->from(route('roster.stables.create'))
-                        ->post(route('roster.stables.store'), $this->validParams([
+        $response = $this->from(route('stables.create'))
+                        ->post(route('stables.store'), $this->validParams([
                             'name' => 'Example Stable Name'
                         ]));
 
         $response->assertStatus(302);
-        $response->assertRedirect(route('roster.stables.create'));
+        $response->assertRedirect(route('stables.create'));
         $response->assertSessionHasErrors('name');
         $this->assertEquals(1, Stable::count());
     }
@@ -89,13 +89,13 @@ class CreateStableFailureConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $response = $this->from(route('roster.stables.create'))
-                        ->post(route('roster.stables.store'), $this->validParams([
+        $response = $this->from(route('stables.create'))
+                        ->post(route('stables.store'), $this->validParams([
                             'started_at' => ['not-a-string']
                         ]));
 
         $response->assertStatus(302);
-        $response->assertRedirect(route('roster.stables.create'));
+        $response->assertRedirect(route('stables.create'));
         $response->assertSessionHasErrors('started_at');
         $this->assertEquals(0, Stable::count());
     }
@@ -105,13 +105,13 @@ class CreateStableFailureConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $response = $this->from(route('roster.stables.create'))
-                        ->post(route('roster.stables.store'), $this->validParams([
+        $response = $this->from(route('stables.create'))
+                        ->post(route('stables.store'), $this->validParams([
                             'started_at' => now()->toDateString()
                         ]));
 
         $response->assertStatus(302);
-        $response->assertRedirect(route('roster.stables.create'));
+        $response->assertRedirect(route('stables.create'));
         $response->assertSessionHasErrors('started_at');
         $this->assertEquals(0, Stable::count());
     }
@@ -122,14 +122,14 @@ class CreateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $wrestler = factory(Wrestler::class)->states('bookable')->create();
 
-        $response = $this->from(route('roster.stables.create'))
-                        ->post(route('roster.stables.store'), $this->validParams([
+        $response = $this->from(route('stables.create'))
+                        ->post(route('stables.store'), $this->validParams([
                             'wrestlers' => [$wrestler->getKey()],
                             'tagteams' => [],
                         ]));
 
         $response->assertStatus(302);
-        $response->assertRedirect(route('roster.stables.create'));
+        $response->assertRedirect(route('stables.create'));
         $response->assertSessionHasErrors('tagteams');
         $this->assertEquals(0, Stable::count());
     }
@@ -140,14 +140,14 @@ class CreateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $tagteam = factory(TagTeam::class)->states('bookable')->create();
 
-        $response = $this->from(route('roster.stables.create'))
-                        ->post(route('roster.stables.store'), $this->validParams([
+        $response = $this->from(route('stables.create'))
+                        ->post(route('stables.store'), $this->validParams([
                             'tagteams' => [$tagteam->getKey()],
                             'wrestlers' => [],
                         ]));
 
         $response->assertStatus(302);
-        $response->assertRedirect(route('roster.stables.create'));
+        $response->assertRedirect(route('stables.create'));
         $response->assertSessionHasErrors('wrestlers');
         $this->assertEquals(0, Stable::count());
     }

--- a/tests/Feature/Generic/Stables/CreateStableSuccessConditionsTest.php
+++ b/tests/Feature/Generic/Stables/CreateStableSuccessConditionsTest.php
@@ -45,7 +45,7 @@ class CreateStableSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $createdWrestlers = factory(Wrestler::class, 3)->states('bookable')->create();
 
-        $this->post(route('roster.stables.store'), $this->validParams([
+        $this->post(route('stables.store'), $this->validParams([
             'started_at' => $now->toDateTimeString(),
             'wrestlers' => $createdWrestlers->modelKeys()
         ]));
@@ -62,7 +62,7 @@ class CreateStableSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $createdTagTeams = factory(TagTeam::class, 3)->states('bookable')->create();
 
-        $this->post(route('roster.stables.store'), $this->validParams([
+        $this->post(route('stables.store'), $this->validParams([
             'tagteams' => $createdTagTeams->modelKeys()
         ]));
 
@@ -80,7 +80,7 @@ class CreateStableSuccessConditionsTest extends TestCase
 
         $this->actAs('administrator');
 
-        $this->post(route('roster.stables.store'), $this->validParams([
+        $this->post(route('stables.store'), $this->validParams([
             'started_at' => $now->toDateTimeString()
         ]));
 
@@ -110,7 +110,7 @@ class CreateStableSuccessConditionsTest extends TestCase
 
         $this->actAs('administrator');
 
-        $this->post(route('roster.stables.store'), $this->validParams([
+        $this->post(route('stables.store'), $this->validParams([
             'started_at' => ''
         ]));
 

--- a/tests/Feature/Generic/Stables/RestoreStableFailureConditionsTest.php
+++ b/tests/Feature/Generic/Stables/RestoreStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class RestoreStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->put(route('roster.stables.restore', $stable));
+        $response = $this->put(route('stables.restore', $stable));
 
         $response->assertNotFound();
     }
@@ -31,7 +31,7 @@ class RestoreStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->put(route('roster.stables.restore', $stable));
+        $response = $this->put(route('stables.restore', $stable));
 
         $response->assertNotFound();
     }
@@ -42,7 +42,7 @@ class RestoreStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->put(route('roster.stables.restore', $stable));
+        $response = $this->put(route('stables.restore', $stable));
 
         $response->assertNotFound();
     }

--- a/tests/Feature/Generic/Stables/RetireStableFailureConditionsTest.php
+++ b/tests/Feature/Generic/Stables/RetireStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class RetireStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->put(route('roster.stables.retire', $stable));
+        $response = $this->put(route('stables.retire', $stable));
 
         $response->assertForbidden();
     }
@@ -31,7 +31,7 @@ class RetireStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->put(route('roster.stables.retire', $stable));
+        $response = $this->put(route('stables.retire', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/Generic/Stables/UnretireStableFailureConditionsTest.php
+++ b/tests/Feature/Generic/Stables/UnretireStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class UnretireStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->put(route('roster.stables.unretire', $stable));
+        $response = $this->put(route('stables.unretire', $stable));
 
         $response->assertForbidden();
     }
@@ -31,7 +31,7 @@ class UnretireStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->put(route('roster.stables.unretire', $stable));
+        $response = $this->put(route('stables.unretire', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/Generic/Stables/UpdateStableFailureConditionsTest.php
+++ b/tests/Feature/Generic/Stables/UpdateStableFailureConditionsTest.php
@@ -41,12 +41,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'name' => ''
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('name');
     }
 
@@ -57,12 +57,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         factory(Stable::class)->create(['name' => 'Example Stable Name']);
         $stableB = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stableB))
-                        ->put(route('roster.stables.update', $stableB), $this->validParams([
+        $response = $this->from(route('stables.edit', $stableB))
+                        ->put(route('stables.update', $stableB), $this->validParams([
                             'name' => 'Example Stable Name'
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stableB));
+        $response->assertRedirect(route('stables.edit', $stableB));
         $response->assertSessionHasErrors('name');
     }
 
@@ -72,12 +72,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'started_at' => ''
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('started_at');
     }
 
@@ -87,12 +87,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'started_at' => today()->toDateString()
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('started_at');
     }
 
@@ -102,12 +102,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'started_at' => 'not-a-datetime'
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('started_at');
     }
 
@@ -118,13 +118,13 @@ class UpdateStableFailureConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $tagteam = factory(TagTeam::class)->states('bookable')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'tagteams' => [$tagteam->getKey()],
                             'wrestlers' => null,
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('wrestlers');
     }
 
@@ -134,12 +134,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'wrestlers' => 'not-an-array',
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('wrestlers');
     }
 
@@ -149,12 +149,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'wrestlers' => ['not-an-integer'],
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('wrestlers.*');
     }
 
@@ -164,12 +164,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'wrestlers' => [99],
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('wrestlers.*');
     }
 
@@ -180,12 +180,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $wrestler = factory(Wrestler::class)->states('pending-introduction')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'wrestlers' => [$wrestler->getKey()]
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('wrestlers.*');
     }
 
@@ -196,12 +196,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $wrestler = factory(Wrestler::class)->states('pending-introduction')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'wrestlers' => [$wrestler->getKey()]
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('wrestlers.*');
     }
 
@@ -212,12 +212,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $otherStable = factory(Stable::class)->states('bookable')->create();
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'wrestlers' => [$otherStable->currentWrestlers->first()->getKey()]
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('wrestlers.*');
     }
 
@@ -227,12 +227,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'tagteams' => 'not-an-array',
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('tagteams');
     }
 
@@ -243,13 +243,13 @@ class UpdateStableFailureConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $wrestlers = factory(Wrestler::class, 2)->states('bookable')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'tagteams' => null,
                             'wrestlers' => $wrestlers->modelKeys(),
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('tagteams');
     }
 
@@ -259,12 +259,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'tagteams' => ['not-an-integer'],
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('tagteams.*');
     }
 
@@ -274,12 +274,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'tagteams' => [99],
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('tagteams.*');
     }
 
@@ -290,12 +290,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $tagteam = factory(TagTeam::class)->states('pending-introduction')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'tagteams' => [$tagteam->getKey()]
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('tagteams.*');
     }
 
@@ -306,12 +306,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $tagteam = factory(TagTeam::class)->states('pending-introduction')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'tagteams' => [$tagteam->getKey()]
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('tagteams.*');
     }
 
@@ -322,12 +322,12 @@ class UpdateStableFailureConditionsTest extends TestCase
         $otherStable = factory(Stable::class)->states('bookable')->create();
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-                        ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+                        ->put(route('stables.update', $stable), $this->validParams([
                             'tagteams' => [$otherStable->currentTagTeams->first()->getKey()]
                         ]));
 
-        $response->assertRedirect(route('roster.stables.edit', $stable));
+        $response->assertRedirect(route('stables.edit', $stable));
         $response->assertSessionHasErrors('tagteams.*');
     }
 }

--- a/tests/Feature/Generic/Stables/UpdateStableSuccessConditionsTest.php
+++ b/tests/Feature/Generic/Stables/UpdateStableSuccessConditionsTest.php
@@ -47,8 +47,8 @@ class UpdateStableSuccessConditionsTest extends TestCase
         $wrestler = factory(Wrestler::class)->states('bookable')->create();
         $stable->wrestlerHistory()->attach($wrestler->getKey(), ['left_at' => now()]);
 
-        $this->from(route('roster.stables.edit', $stable))
-            ->put(route('roster.stables.update', [$stable]), [
+        $this->from(route('stables.edit', $stable))
+            ->put(route('stables.update', [$stable]), [
                 'wrestlers' => [$wrestler->getKey()]
             ]);
 
@@ -65,8 +65,8 @@ class UpdateStableSuccessConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $newStableWrestlers = factory(Wrestler::class, 2)->states('bookable')->create();
 
-        $response = $this->from(route('roster.stables.edit', $stable))
-            ->put(route('roster.stables.update', $stable), $this->validParams([
+        $response = $this->from(route('stables.edit', $stable))
+            ->put(route('stables.update', $stable), $this->validParams([
                 'wrestlers' => $newStableWrestlers->modelKeys(),
             ]));
 
@@ -87,8 +87,8 @@ class UpdateStableSuccessConditionsTest extends TestCase
 
         $newStableWrestlers = factory(Wrestler::class, 2)->states('bookable')->create();
 
-        $this->from(route('roster.stables.edit', $stable))
-            ->put(route('roster.stables.update', $stable), $this->validParams([
+        $this->from(route('stables.edit', $stable))
+            ->put(route('stables.update', $stable), $this->validParams([
                 'wrestlers' => $newStableWrestlers->modelKeys(),
             ]));
 
@@ -106,8 +106,8 @@ class UpdateStableSuccessConditionsTest extends TestCase
         $formerTagTeams = $stable->currentTagTeams;
         $tagteams = factory(TagTeam::class, 2)->states('bookable')->create();
 
-        $this->from(route('roster.stables.edit', $stable))
-            ->put(route('roster.stables.update', $stable), $this->validParams([
+        $this->from(route('stables.edit', $stable))
+            ->put(route('stables.update', $stable), $this->validParams([
                 'tagteams' => $tagteams->modelKeys(),
             ]));
 
@@ -124,8 +124,8 @@ class UpdateStableSuccessConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $tagteams = factory(TagTeam::class, 2)->states('bookable')->create();
 
-        $this->from(route('roster.stables.edit', $stable))
-            ->put(route('roster.stables.update', $stable), $this->validParams([
+        $this->from(route('stables.edit', $stable))
+            ->put(route('stables.update', $stable), $this->validParams([
                 'tagteams' => $tagteams->modelKeys(),
             ]));
 

--- a/tests/Feature/Generic/Stables/ViewStableBioPageSuccessConditionsTest.php
+++ b/tests/Feature/Generic/Stables/ViewStableBioPageSuccessConditionsTest.php
@@ -20,7 +20,7 @@ class ViewStableBioPageSuccessConditionsTest extends TestCase
         $this->actAs('administrator');
         $stable = factory(Stable::class)->create(['name' => 'Example Stable Name']);
 
-        $response = $this->get(route('roster.stables.show', $stable));
+        $response = $this->get(route('stables.show', $stable));
 
         $response->assertSee('Example Stable Name');
     }

--- a/tests/Feature/Guest/Stables/ActivateStableFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/ActivateStableFailureConditionsTest.php
@@ -19,7 +19,7 @@ class ActivateStableFailureConditionsTest extends TestCase
     {
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->put(route('roster.stables.activate', $stable));
+        $response = $this->put(route('stables.activate', $stable));
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/Guest/Stables/CreateStableFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/CreateStableFailureConditionsTest.php
@@ -37,7 +37,7 @@ class CreateStableFailureConditionsTest extends TestCase
     /** @test */
     public function a_guest_cannot_view_the_form_for_creating_a_stable()
     {
-        $response = $this->get(route('roster.stables.create'));
+        $response = $this->get(route('stables.create'));
 
         $response->assertRedirect(route('login'));
     }
@@ -45,7 +45,7 @@ class CreateStableFailureConditionsTest extends TestCase
     /** @test */
     public function a_guest_cannot_create_a_stable()
     {
-        $response = $this->post(route('roster.stables.store'), $this->validParams());
+        $response = $this->post(route('stables.store'), $this->validParams());
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/Guest/Stables/DeleteStableFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/DeleteStableFailureConditionsTest.php
@@ -19,7 +19,7 @@ class DeleteStableFailureConditionsTest extends TestCase
     {
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
         $response->assertRedirect(route('login'));
     }
@@ -29,7 +29,7 @@ class DeleteStableFailureConditionsTest extends TestCase
     {
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
         $response->assertRedirect(route('login'));
     }
@@ -39,7 +39,7 @@ class DeleteStableFailureConditionsTest extends TestCase
     {
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/Guest/Stables/RestoreStableFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/RestoreStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class RestoreStableFailureConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $stable->delete();
 
-        $response = $this->put(route('roster.stables.restore', $stable));
+        $response = $this->put(route('stables.restore', $stable));
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/Guest/Stables/RetireStableFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/RetireStableFailureConditionsTest.php
@@ -19,7 +19,7 @@ class RetireStableFailureConditionsTest extends TestCase
     {
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->put(route('roster.stables.retire', $stable));
+        $response = $this->put(route('stables.retire', $stable));
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/Guest/Stables/UnretireStableFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/UnretireStableFailureConditionsTest.php
@@ -19,7 +19,7 @@ class UnretireStableFailureConditionsTest extends TestCase
     {
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->put(route('roster.stables.unretire', $stable));
+        $response = $this->put(route('stables.retire', $stable));
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/Guest/Stables/UpdateStableFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/UpdateStableFailureConditionsTest.php
@@ -40,7 +40,7 @@ class UpdateStableFailureConditionsTest extends TestCase
     {
         $stable = factory(Stable::class)->create();
 
-        $response = $this->get(route('roster.stables.edit', $stable));
+        $response = $this->get(route('stables.edit', $stable));
 
         $response->assertRedirect(route('login'));
     }
@@ -50,7 +50,7 @@ class UpdateStableFailureConditionsTest extends TestCase
     {
         $stable = factory(Stable::class)->create();
 
-        $response = $this->put(route('roster.stables.update', $stable), $this->validParams());
+        $response = $this->put(route('stables.update', $stable), $this->validParams());
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/Guest/Stables/ViewStableBioPageFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/ViewStableBioPageFailureConditionsTest.php
@@ -19,7 +19,7 @@ class ViewStableBioPageTest extends TestCase
     {
         $stable = factory(Stable::class)->create();
 
-        $response = $this->get(route('roster.stables.show', $stable));
+        $response = $this->get(route('stables.show', $stable));
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/Guest/Stables/ViewStablesListFailureConditionsTest.php
+++ b/tests/Feature/Guest/Stables/ViewStablesListFailureConditionsTest.php
@@ -16,7 +16,7 @@ class ViewStablesListFailureConditionsTest extends TestCase
     /** @test */
     public function a_guest_cannot_view_stables_page()
     {
-        $response = $this->get(route('roster.stables.index'));
+        $response = $this->get(route('stables.index'));
 
         $response->assertRedirect(route('login'));
     }

--- a/tests/Feature/SuperAdmin/Stables/ActivateStableSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/ActivateStableSuccessConditionsTest.php
@@ -20,9 +20,9 @@ class ActivateStableSuccessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->put(route('roster.stables.activate', $stable));
+        $response = $this->put(route('stables.activate', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         tap($stable->fresh(), function ($stable) {
             $this->assertTrue($stable->is_bookable);
         });

--- a/tests/Feature/SuperAdmin/Stables/CreateStableSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/CreateStableSuccessConditionsTest.php
@@ -41,7 +41,7 @@ class CreateStableSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $response = $this->get(route('roster.stables.create'));
+        $response = $this->get(route('stables.create'));
 
         $response->assertViewIs('stables.create');
     }
@@ -54,9 +54,9 @@ class CreateStableSuccessConditionsTest extends TestCase
 
         $this->actAs('super-administrator');
 
-        $response = $this->post(route('roster.stables.store'), $this->validParams());
+        $response = $this->post(route('stables.store'), $this->validParams());
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         tap(Stable::first(), function ($stable) use ($now) {
             $this->assertEquals('Example Stable Name', $stable->name);
             $this->assertEquals($now->toDateTimeString(), $stable->employment->started_at->toDateTimeString());

--- a/tests/Feature/SuperAdmin/Stables/DeleteStableSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/DeleteStableSuccessConditionsTest.php
@@ -20,9 +20,9 @@ class DeleteStableSuccessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertSoftDeleted('stables', ['name' => $stable->name]);
     }
 
@@ -32,9 +32,9 @@ class DeleteStableSuccessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertSoftDeleted('stables', ['name' => $stable->name]);
     }
 
@@ -44,9 +44,9 @@ class DeleteStableSuccessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertSoftDeleted('stables', ['name' => $stable->name]);
     }
 }

--- a/tests/Feature/SuperAdmin/Stables/RestoreStableSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/RestoreStableSuccessConditionsTest.php
@@ -21,9 +21,9 @@ class RestoreStableSuccessConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $stable->delete();
 
-        $response = $this->put(route('roster.stables.restore', $stable));
+        $response = $this->put(route('stables.restore', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertNull($stable->fresh()->deleted_at);
     }
 }

--- a/tests/Feature/SuperAdmin/Stables/RetireStableSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/RetireStableSuccessConditionsTest.php
@@ -20,9 +20,9 @@ class RetireStableSuccessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->put(route('roster.stables.retire', $stable));
+        $response = $this->put(route('stables.retire', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertEquals(now()->toDateTimeString(), $stable->fresh()->retirement->started_at);
     }
 }

--- a/tests/Feature/SuperAdmin/Stables/UnretireStableSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/UnretireStableSuccessConditionsTest.php
@@ -20,9 +20,9 @@ class UnretireStableSuccessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->put(route('roster.stables.unretire', $stable));
+        $response = $this->put(route('stables.unretire', $stable));
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         $this->assertEquals(now()->toDateTimeString(), $stable->fresh()->retirements()->latest()->first()->ended_at);
     }
 }

--- a/tests/Feature/SuperAdmin/Stables/UpdateStableSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/UpdateStableSuccessConditionsTest.php
@@ -41,7 +41,7 @@ class UpdateStableSucessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->get(route('roster.stables.edit', $stable));
+        $response = $this->get(route('stables.edit', $stable));
 
         $response->assertViewIs('stables.edit');
         $this->assertTrue($response->data('stable')->is($stable));
@@ -53,9 +53,9 @@ class UpdateStableSucessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->put(route('roster.stables.update', $stable), $this->validParams());
+        $response = $this->put(route('stables.update', $stable), $this->validParams());
 
-        $response->assertRedirect(route('roster.stables.index'));
+        $response->assertRedirect(route('stables.index'));
         tap($stable->fresh(), function ($stable) {
             $this->assertEquals('Example Stable Name', $stable->name);
         });

--- a/tests/Feature/SuperAdmin/Stables/ViewStablesListSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/ViewStablesListSuccessConditionsTest.php
@@ -50,7 +50,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $response = $this->get(route('roster.stables.index'));
+        $response = $this->get(route('stables.index'));
 
         $response->assertOk();
         $response->assertViewIs('stables.index');
@@ -61,7 +61,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('roster.stables.index'));
+        $responseAjax = $this->ajaxJson(route('stables.index'));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->stables->get('all')->count(),
@@ -74,7 +74,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('roster.stables.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('stables.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->stables->get('bookable')->count(),
@@ -87,7 +87,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('roster.stables.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('stables.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->stables->get('pending-introduction')->count(),
@@ -100,7 +100,7 @@ class ViewStablesSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('roster.stables.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('stables.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->stables->get('retired')->count(),

--- a/tests/Feature/User/Stables/ActivateStableFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/ActivateStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class ActivateStableFailureConditionsTest extends TestCase
         $this->actAs('basic-user');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->put(route('roster.stables.activate', $stable));
+        $response = $this->put(route('stables.activate', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/User/Stables/CreateStableFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/CreateStableFailureConditionsTest.php
@@ -39,7 +39,7 @@ class CreateStableTest extends TestCase
     {
         $this->actAs('basic-user');
 
-        $response = $this->get(route('roster.stables.create'));
+        $response = $this->get(route('stables.create'));
 
         $response->assertForbidden();
     }
@@ -49,7 +49,7 @@ class CreateStableTest extends TestCase
     {
         $this->actAs('basic-user');
 
-        $response = $this->post(route('roster.stables.store'), $this->validParams());
+        $response = $this->post(route('stables.store'), $this->validParams());
 
         $response->assertForbidden();
     }

--- a/tests/Feature/User/Stables/DeleteStableFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/DeleteStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class DeleteStableFailureConditionsTest extends TestCase
         $this->actAs('basic-user');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
         $response->assertForbidden();
     }
@@ -31,7 +31,7 @@ class DeleteStableFailureConditionsTest extends TestCase
         $this->actAs('basic-user');
         $stable = factory(Stable::class)->states('pending-introduction')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
         $response->assertForbidden();
     }
@@ -42,7 +42,7 @@ class DeleteStableFailureConditionsTest extends TestCase
         $this->actAs('basic-user');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->delete(route('roster.stables.destroy', $stable));
+        $response = $this->delete(route('stables.destroy', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/User/Stables/RestoreStableFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/RestoreStableFailureConditionsTest.php
@@ -21,7 +21,7 @@ class RestoreStableFailureConditionsTest extends TestCase
         $stable = factory(Stable::class)->create();
         $stable->delete();
 
-        $response = $this->put(route('roster.stables.restore', $stable));
+        $response = $this->put(route('stables.restore', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/User/Stables/RetireStableFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/RetireStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class RetireStableFailureConditionsTest extends TestCase
         $this->actAs('basic-user');
         $stable = factory(Stable::class)->states('bookable')->create();
 
-        $response = $this->put(route('roster.stables.retire', $stable));
+        $response = $this->put(route('stables.retire', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/User/Stables/UnretireStableFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/UnretireStableFailureConditionsTest.php
@@ -20,7 +20,7 @@ class UnretireStableFailureConditionsTest extends TestCase
         $this->actAs('basic-user');
         $stable = factory(Stable::class)->states('retired')->create();
 
-        $response = $this->put(route('roster.stables.unretire', $stable));
+        $response = $this->put(route('stables.retire', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/User/Stables/UpdateStableFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/UpdateStableFailureConditionsTest.php
@@ -41,7 +41,7 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('basic-user');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->get(route('roster.stables.edit', $stable));
+        $response = $this->get(route('stables.edit', $stable));
 
         $response->assertForbidden();
     }
@@ -52,7 +52,7 @@ class UpdateStableFailureConditionsTest extends TestCase
         $this->actAs('basic-user');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->put(route('roster.stables.update', $stable), $this->validParams());
+        $response = $this->put(route('stables.update', $stable), $this->validParams());
 
         $response->assertForbidden();
     }

--- a/tests/Feature/User/Stables/ViewStableBioPageFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/ViewStableBioPageFailureConditionsTest.php
@@ -22,7 +22,7 @@ class ViewStableBioPageFailureConditionsTest extends TestCase
         $otherUser = factory(User::class)->create();
         $stable = factory(Stable::class)->create(['user_id' => $otherUser->id]);
 
-        $response = $this->get(route('roster.stables.show', $stable));
+        $response = $this->get(route('stables.show', $stable));
 
         $response->assertForbidden();
     }

--- a/tests/Feature/User/Stables/ViewStableBioPageSuccessConditionsTest.php
+++ b/tests/Feature/User/Stables/ViewStableBioPageSuccessConditionsTest.php
@@ -20,7 +20,7 @@ class ViewStableBioPageSuccessConditionsTest extends TestCase
         $signedInUser = $this->actAs('basic-user');
         $stable = factory(Stable::class)->create(['user_id' => $signedInUser->id]);
 
-        $response = $this->get(route('roster.stables.show', $stable));
+        $response = $this->get(route('stables.show', $stable));
 
         $response->assertOk();
     }

--- a/tests/Feature/User/Stables/ViewStablesListFailureConditionsTest.php
+++ b/tests/Feature/User/Stables/ViewStablesListFailureConditionsTest.php
@@ -18,7 +18,7 @@ class ViewStablesListFailureConditionsTest extends TestCase
     {
         $this->actAs('basic-user');
 
-        $response = $this->get(route('roster.stables.index'));
+        $response = $this->get(route('stables.index'));
 
         $response->assertForbidden();
     }


### PR DESCRIPTION
With this pull request, we are modifying all stable related route references so that it does not include the prefix of roster.