### PR TITLE
Refactor status filters to use module enums

### DIFF
--- a/resources/views/events/partials/filters.blade.php
+++ b/resources/views/events/partials/filters.blade.php
@@ -4,8 +4,9 @@
             <label>Status:</label>
             <select class="form-control" name="status" id="status-dropdown">
                 <option value="">Select</option>
-                <option value="only_scheduled">Bookable</option>
-                <option value="only_past">Past</option>
+                @foreach (\App\Enums\EventStatus::labels() as $value => $label)
+                    <option value="{{ $value }}"> {{ $label }}</option>
+                @endforeach
             </select>
         </div>
     </div>

--- a/resources/views/managers/partials/filters.blade.php
+++ b/resources/views/managers/partials/filters.blade.php
@@ -4,11 +4,9 @@
             <label>Status:</label>
             <select class="form-control" name="status" id="status-dropdown">
                 <option value="">Select</option>
-                <option value="only_bookable">Bookable</option>
-                <option value="only_pending_introduction">Pending Introduction</option>
-                <option value="only_retired">Retired</option>
-                <option value="only_injured">Injured</option>
-                <option value="only_suspended">Suspended</option>
+                @foreach (\App\Enums\ManagerStatus::labels() as $value => $label)
+                    <option value="{{ $value }}"> {{ $label }}</option>
+                @endforeach
             </select>
         </div>
     </div>

--- a/resources/views/referees/partials/filters.blade.php
+++ b/resources/views/referees/partials/filters.blade.php
@@ -4,11 +4,9 @@
             <label>Status:</label>
             <select class="form-control" name="status" id="status-dropdown">
                 <option value="">Select</option>
-                <option value="only_bookable">Bookable</option>
-                <option value="only_pending_introduction">Pending Introduction</option>
-                <option value="only_retired">Retired</option>
-                <option value="only_injured">Injured</option>
-                <option value="only_suspended">Suspended</option>
+                @foreach (\App\Enums\RefereeStatus::labels() as $value => $label)
+                    <option value="{{ $value }}"> {{ $label }}</option>
+                @endforeach
             </select>
         </div>
     </div>

--- a/resources/views/stables/partials/filters.blade.php
+++ b/resources/views/stables/partials/filters.blade.php
@@ -4,9 +4,9 @@
             <label>Status:</label>
             <select class="form-control" name="status" id="status-dropdown">
                 <option value="">Select</option>
-                <option value="only_bookable">Bookable</option>
-                <option value="only_pending_introduction">Pending Introduction</option>
-                <option value="only_retired">Retired</option>
+                @foreach (\App\Enums\StableStatus::labels() as $value => $label)
+                    <option value="{{ $value }}"> {{ $label }}</option>
+                @endforeach
             </select>
         </div>
     </div>

--- a/resources/views/tagteams/partials/filters.blade.php
+++ b/resources/views/tagteams/partials/filters.blade.php
@@ -4,10 +4,9 @@
             <label>Status:</label>
             <select class="form-control" name="status" id="status-dropdown">
                 <option value="">Select</option>
-                <option value="only_bookable">Bookable</option>
-                <option value="only_pending_introduction">Pending Introduction</option>
-                <option value="only_retired">Retired</option>
-                <option value="only_suspended">Suspended</option>
+                @foreach (\App\Enums\TagTeamStatus::labels() as $value => $label)
+                    <option value="{{ $value }}"> {{ $label }}</option>
+                @endforeach
             </select>
         </div>
     </div>

--- a/resources/views/titles/partials/filters.blade.php
+++ b/resources/views/titles/partials/filters.blade.php
@@ -4,9 +4,9 @@
             <label>Status:</label>
             <select class="form-control" name="status" id="status-dropdown">
                 <option value="">Select</option>
-                <option value="only_bookable">Bookable</option>
-                <option value="only_pending_introduction">Pending Introduced</option>
-                <option value="only_retired">Retired</option>
+                @foreach (\App\Enums\TitleStatus::labels() as $value => $label)
+                    <option value="{{ $value }}"> {{ $label }}</option>
+                @endforeach
             </select>
         </div>
     </div>

--- a/resources/views/wrestlers/partials/filters.blade.php
+++ b/resources/views/wrestlers/partials/filters.blade.php
@@ -4,11 +4,9 @@
             <label>Status:</label>
             <select class="form-control" name="status" id="status-dropdown">
                 <option value="">Select</option>
-                <option value="only_bookable">Bookable</option>
-                <option value="only_pending_introduction">Pending Introduction</option>
-                <option value="only_retired">Retired</option>
-                <option value="only_injured">Injured</option>
-                <option value="only_suspended">Suspended</option>
+                @foreach (\App\Enums\WrestlerStatus::labels() as $value => $label)
+                    <option value="{{ $value }}"> {{ $label }}</option>
+                @endforeach
             </select>
         </div>
     </div>

--- a/tests/Feature/Admin/Events/ViewEventsListSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Events/ViewEventsListSuccessConditionsTest.php
@@ -74,7 +74,7 @@ class ViewScheduledEventListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('events.index', ['status' => 'only_scheduled']));
+        $responseAjax = $this->ajaxJson(route('events.index', ['status' => 'scheduled']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->events->get('scheduled')->count(),
@@ -87,7 +87,7 @@ class ViewScheduledEventListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('events.index', ['status' => 'only_past']));
+        $responseAjax = $this->ajaxJson(route('events.index', ['status' => 'past']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->events->get('past')->count(),

--- a/tests/Feature/Admin/Managers/ViewManagersListSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Managers/ViewManagersListSuccessConditionsTest.php
@@ -84,7 +84,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('bookable')->count(),
@@ -97,7 +97,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('pending-introduction')->count(),
@@ -110,7 +110,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('retired')->count(),
@@ -123,7 +123,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_suspended']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'suspended']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('suspended')->count(),
@@ -136,7 +136,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_injured']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'injured']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('injured')->count(),

--- a/tests/Feature/Admin/Referees/ViewRefereesListSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Referees/ViewRefereesListSuccessConditionsTest.php
@@ -84,7 +84,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('bookable')->count(),
@@ -97,7 +97,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('pending-introduction')->count(),
@@ -110,7 +110,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('retired')->count(),
@@ -123,7 +123,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_suspended']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'suspended']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('suspended')->count(),
@@ -136,7 +136,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_injured']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'injured']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('injured')->count(),

--- a/tests/Feature/Admin/TagTeams/ViewTagTeamsListSuccessConditionsTest.php
+++ b/tests/Feature/Admin/TagTeams/ViewTagTeamsListSuccessConditionsTest.php
@@ -77,7 +77,7 @@ class ViewTagTeamsListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->tagteams->get('bookable')->count(),
@@ -90,7 +90,7 @@ class ViewTagTeamsListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->tagteams->get('pending-introduction')->count(),
@@ -103,7 +103,7 @@ class ViewTagTeamsListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->tagteams->get('retired')->count(),
@@ -116,7 +116,7 @@ class ViewTagTeamsListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'only_suspended']));
+        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'suspended']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->tagteams->get('suspended')->count(),

--- a/tests/Feature/Admin/Titles/ViewTitlesListSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Titles/ViewTitlesListSuccessConditionsTest.php
@@ -68,7 +68,7 @@ class ViewTitlesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->titles->get('bookable')->count(),
@@ -80,7 +80,7 @@ class ViewTitlesListSuccessConditionsTest extends TestCase
     public function an_administrator_can_view_all_pending_introduction_titles()
     {
         $this->actAs('administrator');
-        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->titles->get('pending-introduction')->count(),
@@ -92,7 +92,7 @@ class ViewTitlesListSuccessConditionsTest extends TestCase
     public function an_administrator_can_view_all_retired_titles()
     {
         $this->actAs('administrator');
-        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->titles->get('retired')->count(),

--- a/tests/Feature/Admin/Wrestlers/ViewWrestlersListSuccessConditionsTest.php
+++ b/tests/Feature/Admin/Wrestlers/ViewWrestlersListSuccessConditionsTest.php
@@ -80,7 +80,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('bookable')->count(),
@@ -93,7 +93,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('pending-introduction')->count(),
@@ -106,7 +106,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('retired')->count(),
@@ -119,7 +119,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_suspended']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'suspended']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('suspended')->count(),
@@ -132,7 +132,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_injured']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'injured']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('injured')->count(),

--- a/tests/Feature/SuperAdmin/Events/ViewEventsListSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Events/ViewEventsListSuccessConditionsTest.php
@@ -74,7 +74,7 @@ class ViewScheduledEventListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('events.index', ['status' => 'only_scheduled']));
+        $responseAjax = $this->ajaxJson(route('events.index', ['status' => 'scheduled']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->events->get('scheduled')->count(),
@@ -87,7 +87,7 @@ class ViewScheduledEventListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('events.index', ['status' => 'only_past']));
+        $responseAjax = $this->ajaxJson(route('events.index', ['status' => 'past']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->events->get('past')->count(),

--- a/tests/Feature/SuperAdmin/Managers/ViewManagersListSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Managers/ViewManagersListSuccessConditionsTest.php
@@ -84,7 +84,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('bookable')->count(),
@@ -97,7 +97,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('pending-introduction')->count(),
@@ -110,7 +110,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('retired')->count(),
@@ -123,7 +123,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_suspended']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'suspended']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('suspended')->count(),
@@ -136,7 +136,7 @@ class ViewManagersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'only_injured']));
+        $responseAjax = $this->ajaxJson(route('managers.index', ['status' => 'injured']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->managers->get('injured')->count(),

--- a/tests/Feature/SuperAdmin/Referees/ViewRefereesListSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Referees/ViewRefereesListSuccessConditionsTest.php
@@ -84,7 +84,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('bookable')->count(),
@@ -97,7 +97,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('pending-introduction')->count(),
@@ -110,7 +110,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('retired')->count(),
@@ -123,7 +123,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_suspended']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'suspended']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('suspended')->count(),
@@ -136,7 +136,7 @@ class ViewRefereesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'only_injured']));
+        $responseAjax = $this->ajaxJson(route('referees.index', ['status' => 'injured']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->referees->get('injured')->count(),

--- a/tests/Feature/SuperAdmin/TagTeams/ViewTagTeamsListSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/TagTeams/ViewTagTeamsListSuccessConditionsTest.php
@@ -77,7 +77,7 @@ class ViewTagTeamsListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->tagteams->get('bookable')->count(),
@@ -90,7 +90,7 @@ class ViewTagTeamsListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->tagteams->get('pending-introduction')->count(),
@@ -103,7 +103,7 @@ class ViewTagTeamsListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->tagteams->get('retired')->count(),
@@ -116,7 +116,7 @@ class ViewTagTeamsListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'only_suspended']));
+        $responseAjax = $this->ajaxJson(route('tagteams.index', ['status' => 'suspended']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->tagteams->get('suspended')->count(),

--- a/tests/Feature/SuperAdmin/Titles/ViewTitlesListSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Titles/ViewTitlesListSuccessConditionsTest.php
@@ -68,7 +68,7 @@ class ViewTitlesListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->titles->get('bookable')->count(),
@@ -80,7 +80,7 @@ class ViewTitlesListSuccessConditionsTest extends TestCase
     public function a_super_administrator_can_view_all_pending_introduction_titles()
     {
         $this->actAs('super-administrator');
-        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->titles->get('pending-introduction')->count(),
@@ -92,7 +92,7 @@ class ViewTitlesListSuccessConditionsTest extends TestCase
     public function a_super_administrator_can_view_all_retired_titles()
     {
         $this->actAs('super-administrator');
-        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('titles.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->titles->get('retired')->count(),

--- a/tests/Feature/SuperAdmin/Wrestlers/ViewWrestlersListSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Wrestlers/ViewWrestlersListSuccessConditionsTest.php
@@ -80,7 +80,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_bookable']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'bookable']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('bookable')->count(),
@@ -93,7 +93,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_pending_introduction']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'pending-introduction']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('pending-introduction')->count(),
@@ -106,7 +106,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_retired']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'retired']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('retired')->count(),
@@ -119,7 +119,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_suspended']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'suspended']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('suspended')->count(),
@@ -132,7 +132,7 @@ class ViewWrestlersListSuccessConditionsTest extends TestCase
     {
         $this->actAs('super-administrator');
 
-        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'only_injured']));
+        $responseAjax = $this->ajaxJson(route('wrestlers.index', ['status' => 'injured']));
 
         $responseAjax->assertJson([
             'recordsTotal' => $this->wrestlers->get('injured')->count(),


### PR DESCRIPTION
With this pull request, we are changing the filters to use the module enums instead of hardcoded statuses.