### PR TITLE
Fix route references to remove roster

### DIFF
--- a/resources/views/layouts/partials/aside.blade.php
+++ b/resources/views/layouts/partials/aside.blade.php
@@ -92,7 +92,7 @@
                                 </a>
                             </li>
                             <li class="kt-menu__item {{ set_active('stables.index') }}" aria-haspopup="true">
-                                <a href="{{ route('roster.stables.index') }}" class="kt-menu__link">
+                                <a href="{{ route('stables.index') }}" class="kt-menu__link">
                                     <i class="kt-menu__link-bullet kt-menu__link-bullet--dot"><span></span></i>
                                     <span class="kt-menu__link-text">Stables</span>
                                 </a>

--- a/tests/Feature/SuperAdmin/Stables/ViewStableBioPageSuccessConditionsTest.php
+++ b/tests/Feature/SuperAdmin/Stables/ViewStableBioPageSuccessConditionsTest.php
@@ -20,7 +20,7 @@ class ViewStableBioPageSuccessConditionsTest extends TestCase
         $this->actAs('super-administrator');
         $stable = factory(Stable::class)->create();
 
-        $response = $this->get(route('roster.stables.show', $stable));
+        $response = $this->get(route('stables.show', $stable));
 
         $response->assertViewIs('stables.show');
         $this->assertTrue($response->data('stable')->is($stable));


### PR DESCRIPTION
With this pull request, we are fixing references to not include roster in the name.