### PR TITLE
Retrieve wrestler before employing

### DIFF
--- a/app/Repositories/WrestlerRepository.php
+++ b/app/Repositories/WrestlerRepository.php
@@ -162,4 +162,15 @@ class WrestlerRepository
             'left_at' => $removalDate,
         ]);
     }
+
+    /**
+     * Retrieve the model instance by the id field.
+     *
+     * @param  int $wrestlerId
+     * @return \App\Models\Wrestler
+     */
+    public function findById(int $wrestlerId)
+    {
+        return Wrestler::find($wrestlerId);
+    }
 }

--- a/app/Services/TagTeamService.php
+++ b/app/Services/TagTeamService.php
@@ -46,7 +46,8 @@ class TagTeamService
 
         if (isset($data['started_at'])) {
             $this->tagTeamRepository->employ($tagTeam, $data['started_at']);
-            foreach ($data['wrestlers'] as $wrestler) {
+            foreach ($data['wrestlers'] as $wrestlerId) {
+                $wrestler = $this->wrestlerRepository->findById($wrestlerId);
                 $this->wrestlerRepository->employ($wrestler, $data['started_at']);
             }
             $this->tagTeamRepository->addWrestlers($tagTeam, $data['wrestlers'], $data['started_at']);

--- a/tests/Unit/Services/TagTeamServiceTest.php
+++ b/tests/Unit/Services/TagTeamServiceTest.php
@@ -3,7 +3,9 @@
 namespace Tests\Unit\Services;
 
 use App\Models\TagTeam;
+use App\Models\Wrestler;
 use App\Repositories\TagTeamRepository;
+use App\Repositories\WrestlerRepository;
 use App\Services\TagTeamService;
 use Tests\TestCase;
 
@@ -22,10 +24,16 @@ class TagTeamServiceTest extends TestCase
         $data = ['started_at' => now()->toDateTimeString(), 'wrestlers' => ['1', '2']];
         $tagTeamMock = $this->mock(TagTeam::class);
         $repositoryMock = $this->mock(TagTeamRepository::class);
-        $service = new TagTeamService($repositoryMock);
+        $wrestlerRepositoryMock = $this->mock(WrestlerRepository::class);
+        $wrestlerMock = $this->mock(Wrestler::class);
+        $service = new TagTeamService($repositoryMock, $wrestlerRepositoryMock);
 
         $repositoryMock->expects()->create($data)->once()->andReturns($tagTeamMock);
         $repositoryMock->expects()->employ($tagTeamMock, $data['started_at'])->once();
+        $wrestlerRepositoryMock->expects()->findById($data['wrestlers'][0])->andReturns($wrestlerMock);
+        $wrestlerRepositoryMock->expects()->employ($wrestlerMock, $data['started_at'])->once();
+        $wrestlerRepositoryMock->expects()->findById($data['wrestlers'][1])->andReturns($wrestlerMock);
+        $wrestlerRepositoryMock->expects()->employ($wrestlerMock, $data['started_at'])->once();
         $repositoryMock->expects()->addWrestlers($tagTeamMock, $data['wrestlers'], $data['started_at'])->once();
 
         $service->create($data);
@@ -39,7 +47,8 @@ class TagTeamServiceTest extends TestCase
         $data = ['wrestlers' => ['1', '2']];
         $tagTeamMock = $this->mock(TagTeam::class);
         $repositoryMock = $this->mock(TagTeamRepository::class);
-        $service = new TagTeamService($repositoryMock);
+        $wrestlerRepositoryMock = $this->mock(WrestlerRepository::class);
+        $service = new TagTeamService($repositoryMock, $wrestlerRepositoryMock);
 
         $repositoryMock->expects()->create($data)->once()->andReturns($tagTeamMock);
         $repositoryMock->expects()->addWrestlers($tagTeamMock, $data['wrestlers'])->once();
@@ -55,7 +64,8 @@ class TagTeamServiceTest extends TestCase
         $data = [];
         $tagTeamMock = $this->mock(TagTeam::class);
         $repositoryMock = $this->mock(TagTeamRepository::class);
-        $service = new TagTeamService($repositoryMock);
+        $wrestlerRepositoryMock = $this->mock(WrestlerRepository::class);
+        $service = new TagTeamService($repositoryMock, $wrestlerRepositoryMock);
 
         $repositoryMock->expects()->create($data)->once()->andReturns($tagTeamMock);
         $repositoryMock->shouldNotHaveReceived('employ');
@@ -72,7 +82,8 @@ class TagTeamServiceTest extends TestCase
         $data = ['started_at' => now()->toDateTimeString(), 'wrestlers' => [1, 2]];
         $tagTeamMock = $this->mock(TagTeam::class);
         $repositoryMock = $this->mock(TagTeamRepository::class);
-        $service = new TagTeamService($repositoryMock);
+        $wrestlerRepositoryMock = $this->mock(WrestlerRepository::class);
+        $service = new TagTeamService($repositoryMock, $wrestlerRepositoryMock);
 
         $repositoryMock->expects()->update($tagTeamMock, $data)->once()->andReturns($tagTeamMock);
         $tagTeamMock->expects()->canHaveEmploymentStartDateChanged()->once()->andReturns(true);
@@ -92,7 +103,8 @@ class TagTeamServiceTest extends TestCase
         $data = ['started_at' => now()->toDateTimeString(), 'wrestlers' => [1, 2]];
         $tagTeamMock = $this->mock(TagTeam::class);
         $repositoryMock = $this->mock(TagTeamRepository::class);
-        $service = new TagTeamService($repositoryMock);
+        $wrestlerRepositoryMock = $this->mock(WrestlerRepository::class);
+        $service = new TagTeamService($repositoryMock, $wrestlerRepositoryMock);
 
         $repositoryMock->expects()->update($tagTeamMock, $data)->once()->andReturns($tagTeamMock);
         $tagTeamMock->expects()->canHaveEmploymentStartDateChanged()->once()->andReturns(true);
@@ -113,7 +125,8 @@ class TagTeamServiceTest extends TestCase
     {
         $tagTeamMock = $this->mock(TagTeam::class);
         $repositoryMock = $this->mock(TagTeamRepository::class);
-        $service = new TagTeamService($repositoryMock);
+        $wrestlerRepositoryMock = $this->mock(WrestlerRepository::class);
+        $service = new TagTeamService($repositoryMock, $wrestlerRepositoryMock);
 
         $repositoryMock->expects()->delete($tagTeamMock)->once();
 
@@ -127,7 +140,8 @@ class TagTeamServiceTest extends TestCase
     {
         $tagTeamMock = $this->mock(TagTeam::class);
         $repositoryMock = $this->mock(TagTeamRepository::class);
-        $service = new TagTeamService($repositoryMock);
+        $wrestlerRepositoryMock = $this->mock(WrestlerRepository::class);
+        $service = new TagTeamService($repositoryMock, $wrestlerRepositoryMock);
 
         $repositoryMock->expects()->restore($tagTeamMock)->once();
 


### PR DESCRIPTION
With this pull request, we are modifying the existing implementation of adding wrestlers to a tag team to make sure each wrestler is retrieved from the array of wrestler ids before adding them to the tag team.