### PR TITLE
Change some duplicated exception tests to using data providers

### DIFF
--- a/tests/Feature/Http/Controllers/Managers/ClearInjuryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/ClearInjuryControllerTest.php
@@ -76,91 +76,29 @@ class ClearInjuryControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonclearableManagerTypes
      */
-    public function invoke_throws_exception_for_clearing_an_injury_from_an_unemployed_manager()
+    public function invoke_throws_exception_for_clearing_an_injury_from_a_non_clearable_manager($factoryState)
     {
         $this->expectException(CannotBeClearedFromInjuryException::class);
         $this->withoutExceptionHandling();
 
-        $manager = Manager::factory()->unemployed()->create();
+        $manager = Manager::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ClearInjuryController::class], $manager));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_available_manager()
+    public function nonclearableManagerTypes()
     {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->available()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_future_employed_manager()
-    {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_suspended_manager()
-    {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_retired_manager()
-    {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_released_manager()
-    {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $manager));
+        return [
+            'unemployed manager' => ['unemployed'],
+            'available manager' => ['available'],
+            'with future employed manager' => ['withFutureEmployment'],
+            'suspended manager' => ['suspended'],
+            'retired manager' => ['retired'],
+            'released manager' => ['released'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Managers/EmployControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/EmployControllerTest.php
@@ -120,61 +120,27 @@ class EmployControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonemployableManagerTypes
      */
-    public function invoke_throws_exception_for_employing_an_available_manager()
+    public function invoke_throws_exception_for_employing_a_non_employable_manager($factoryState)
     {
         $this->expectException(CannotBeEmployedException::class);
         $this->withoutExceptionHandling();
 
-        $manager = Manager::factory()->available()->create();
+        $manager = Manager::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([EmployController::class], $manager));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_employing_a_retired_manager()
+    public function nonemployableManagerTypes()
     {
-        $this->expectException(CannotBeEmployedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([EmployController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_employing_a_suspended_manager()
-    {
-        $this->expectException(CannotBeEmployedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([EmployController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_employing_an_injured_manager()
-    {
-        $this->expectException(CannotBeEmployedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([EmployController::class], $manager));
+        return [
+            'suspended manager' => ['suspended'],
+            'injured manager' => ['injured'],
+            'available manager' => ['available'],
+            'retired manager' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Managers/InjureControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/InjureControllerTest.php
@@ -75,91 +75,29 @@ class InjureControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider noninjurablemanagerTypes
      */
-    public function invoke_throws_exception_for_injuring_an_unemployed_manager()
+    public function invoke_throws_exception_for_injuring_a_non_injurable_manager($factoryState)
     {
         $this->expectException(CannotBeInjuredException::class);
         $this->withoutExceptionHandling();
 
-        $manager = Manager::factory()->unemployed()->create();
+        $manager = Manager::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(route('managers.injure', $manager));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_a_suspended_manager()
+    public function noninjurablemanagerTypes()
     {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(route('managers.injure', $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_a_released_manager()
-    {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(route('managers.injure', $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_a_future_employed_manager()
-    {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(route('managers.injure', $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_a_retired_manager()
-    {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(route('managers.injure', $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_an_injured_manager()
-    {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(route('managers.injure', $manager));
+        return [
+            'unemployed manager' => ['unemployed'],
+            'suspended manager' => ['suspended'],
+            'released manager' => ['released'],
+            'with future employed manager' => ['withFutureEmployment'],
+            'retired manager' => ['retired'],
+            'injured manager' => ['injured'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Managers/ReinstateControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/ReinstateControllerTest.php
@@ -77,91 +77,29 @@ class ReinstateControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonreinstatableManagerTypes
      */
-    public function invoke_throws_exception_for_reinstating_an_available_manager()
+    public function invoke_throws_exception_for_reinstating_a_non_reinstatable_manager($factoryState)
     {
         $this->expectException(CannotBeReinstatedException::class);
         $this->withoutExceptionHandling();
 
-        $manager = Manager::factory()->available()->create();
+        $manager = Manager::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ReinstateController::class], $manager));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_an_unemployed_manager()
+    public function nonreinstatableManagerTypes()
     {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_an_injured_manager()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_released_manager()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_future_employed_manager()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_retired_manager()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $manager));
+        return [
+            'available manager' => ['available'],
+            'unemployed manager' => ['unemployed'],
+            'injured manager' => ['injured'],
+            'released manager' => ['released'],
+            'with future employed manager' => ['withFutureEmployment'],
+            'retired manager' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Managers/ReleaseControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/ReleaseControllerTest.php
@@ -140,61 +140,27 @@ class ReleaseControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonreleasableManagerTypes
      */
-    public function invoke_throws_exception_for_releasing_an_unemployed_manager()
+    public function invoke_throws_exception_for_releasing_a_non_releasable_manager($factoryState)
     {
         $this->expectException(CannotBeReleasedException::class);
         $this->withoutExceptionHandling();
 
-        $manager = Manager::factory()->unemployed()->create();
+        $manager = Manager::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ReleaseController::class], $manager));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_releasing_a_future_employed_manager()
+    public function nonreleasableManagerTypes()
     {
-        $this->expectException(CannotBeReleasedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReleaseController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_releasing_a_released_manager()
-    {
-        $this->expectException(CannotBeReleasedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReleaseController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_releasing_a_retired_manager()
-    {
-        $this->expectException(CannotBeReleasedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReleaseController::class], $manager));
+        return [
+            'unemployed manager' => ['unemployed'],
+            'with future employed manager' => ['withFutureEmployment'],
+            'released manager' => ['released'],
+            'retired manager' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Managers/RetireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/RetireControllerTest.php
@@ -138,61 +138,27 @@ class RetireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonretirableManagerTypes
      */
-    public function invoke_throws_exception_for_retiring_a_retired_manager()
+    public function invoke_throws_exception_for_retiring_an_unemployed_manager($factoryState)
     {
         $this->expectException(CannotBeRetiredException::class);
         $this->withoutExceptionHandling();
 
-        $manager = Manager::factory()->retired()->create();
+        $manager = Manager::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([RetireController::class], $manager));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_a_future_employed_manager()
+    public function nonretirableManagerTypes()
     {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_a_released_manager()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_an_unemployed_manager()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $manager));
+        return [
+            'retired manager' => ['retired'],
+            'with future employed manager' => ['withFutureEmployment'],
+            'released manager' => ['released'],
+            'unemployed manager' => ['unemployed'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Managers/RetireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/RetireControllerTest.php
@@ -140,7 +140,7 @@ class RetireControllerTest extends TestCase
      * @test
      * @dataProvider nonretirableManagerTypes
      */
-    public function invoke_throws_exception_for_retiring_an_unemployed_manager($factoryState)
+    public function invoke_throws_exception_for_retiring_a_non_retirable_manager($factoryState)
     {
         $this->expectException(CannotBeRetiredException::class);
         $this->withoutExceptionHandling();

--- a/tests/Feature/Http/Controllers/Managers/SuspendControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/SuspendControllerTest.php
@@ -75,91 +75,29 @@ class SuspendControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonsuspendableManagerTypes
      */
-    public function invoke_throws_exception_for_suspending_an_unemployed_manager()
+    public function invoke_throws_exception_for_suspending_a_non_suspendable_manager($factoryState)
     {
         $this->expectException(CannotBeSuspendedException::class);
         $this->withoutExceptionHandling();
 
-        $manager = Manager::factory()->unemployed()->create();
+        $manager = Manager::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([SuspendController::class], $manager));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_a_future_employed_manager()
+    public function nonsuspendableManagerTypes()
     {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_an_injured_manager()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_a_released_manager()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_a_retired_manager()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $manager));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_a_suspended_manager()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $manager = Manager::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $manager));
+        return [
+            'unemployed manager' => ['unemployed'],
+            'with future employed manager' => ['withFutureEmployment'],
+            'injured manager' => ['injured'],
+            'released manager' => ['released'],
+            'retired manager' => ['retired'],
+            'suspended manager' => ['suspended'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Managers/UnretireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Managers/UnretireControllerTest.php
@@ -142,15 +142,28 @@ class UnretireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonunretirableManagerTypes
      */
-    public function invoke_throws_exception_for_unretiring_an_unemployed_manager()
+    public function invoke_throws_exception_for_unretiring_a_non_unretirable_manager($factoryState)
     {
         $this->expectException(CannotBeUnretiredException::class);
         $this->withoutExceptionHandling();
 
-        $manager = Manager::factory()->unemployed()->create();
+        $manager = Manager::factory()->{$factoryState}()->create();
 
         $this->actAs(Role::ADMINISTRATOR)
             ->patch(action([UnretireController::class], $manager));
+    }
+
+    public function nonunretirableManagerTypes()
+    {
+        return [
+            'available manager' => ['available'],
+            'with future employed manager' => ['withFutureEmployment'],
+            'injured manager' => ['injured'],
+            'released manager' => ['released'],
+            'suspended manager' => ['suspended'],
+            'unemployed manager' => ['unemployed'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Referees/ClearInjuryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Referees/ClearInjuryControllerTest.php
@@ -76,91 +76,29 @@ class ClearInjuryControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonclearableRefereeTypes
      */
-    public function invoke_throws_exception_for_clearing_an_injury_from_an_unemployed_referee()
+    public function invoke_throws_exception_for_clearing_an_injury_from_a_non_clearable_referee($factoryState)
     {
         $this->expectException(CannotBeClearedFromInjuryException::class);
         $this->withoutExceptionHandling();
 
-        $referee = Referee::factory()->unemployed()->create();
+        $referee = Referee::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ClearInjuryController::class], $referee));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_bookable_referee()
+    public function nonclearableRefereeTypes()
     {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->bookable()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_future_employed_referee()
-    {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_suspended_referee()
-    {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_retired_referee()
-    {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_clearing_an_injury_from_a_released_referee()
-    {
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $referee));
+        return [
+            'unemployed referee' => ['unemployed'],
+            'bookable referee' => ['bookable'],
+            'with future employed referee' => ['withFutureEmployment'],
+            'suspended referee' => ['suspended'],
+            'retired referee' => ['retired'],
+            'released referee' => ['released'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Referees/EmployControllerTest.php
+++ b/tests/Feature/Http/Controllers/Referees/EmployControllerTest.php
@@ -120,16 +120,27 @@ class EmployControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonemployableRefereeTypes
      */
-    public function invoke_throws_exception_for_employing_an_employed_referee()
+    public function invoke_throws_exception_for_employing_a_non_employable_referee($factoryState)
     {
         $this->expectException(CannotBeEmployedException::class);
         $this->withoutExceptionHandling();
 
-        $referee = Referee::factory()->employed()->create();
+        $referee = Referee::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([EmployController::class], $referee));
+    }
+
+    public function nonemployableRefereeTypes()
+    {
+        return [
+            'suspended referee' => ['suspended'],
+            'injured referee' => ['injured'],
+            'bookable referee' => ['bookable'],
+            'retired referee' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Referees/InjureControllerTest.php
+++ b/tests/Feature/Http/Controllers/Referees/InjureControllerTest.php
@@ -148,16 +148,29 @@ class InjureControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider noninjurableRefereeTypes
      */
-    public function invoke_throws_exception_for_injuring_an_injured_referee()
+    public function invoke_throws_exception_for_injuring_a_non_injurable_referee($factoryState)
     {
         $this->expectException(CannotBeInjuredException::class);
         $this->withoutExceptionHandling();
 
-        $referee = Referee::factory()->injured()->create();
+        $referee = Referee::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([InjureController::class], $referee));
+    }
+
+    public function noninjurableRefereeTypes()
+    {
+        return [
+            'unemployed referee' => ['unemployed'],
+            'suspended referee' => ['suspended'],
+            'released referee' => ['released'],
+            'with future employed referee' => ['withFutureEmployment'],
+            'retired referee' => ['retired'],
+            'injured referee' => ['injured'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Referees/ReinstateControllerTest.php
+++ b/tests/Feature/Http/Controllers/Referees/ReinstateControllerTest.php
@@ -75,91 +75,29 @@ class ReinstateControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonreinstatableRefereeTypes
      */
-    public function invoke_throws_exception_for_reinstating_a_bookable_referee()
+    public function invoke_throws_exception_for_reinstating_a_non_reinstatable_referee($factoryState)
     {
         $this->expectException(CannotBeReinstatedException::class);
         $this->withoutExceptionHandling();
 
-        $referee = Referee::factory()->bookable()->create();
+        $referee = Referee::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ReinstateController::class], $referee));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_an_unemployed_referee()
+    public function nonreinstatableRefereeTypes()
     {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_an_injured_referee()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_released_referee()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_future_employed_referee()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_retired_referee()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $referee));
+        return [
+            'bookable referee' => ['bookable'],
+            'unemployed referee' => ['unemployed'],
+            'injured referee' => ['injured'],
+            'released referee' => ['released'],
+            'with future employed referee' => ['withFutureEmployment'],
+            'retired referee' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Referees/ReleaseControllerTest.php
+++ b/tests/Feature/Http/Controllers/Referees/ReleaseControllerTest.php
@@ -158,16 +158,27 @@ class ReleaseControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonreleasableRefereeTypes
      */
-    public function invoke_throws_exception_for_releasing_a_retired_referee()
+    public function invoke_throws_exception_for_releasing_a_non_releasable_referee($factoryState)
     {
         $this->expectException(CannotBeReleasedException::class);
         $this->withoutExceptionHandling();
 
-        $referee = Referee::factory()->retired()->create();
+        $referee = Referee::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ReleaseController::class], $referee));
+    }
+
+    public function nonreleasableRefereeTypes()
+    {
+        return [
+            'unemployed referee' => ['unemployed'],
+            'with future employed referee' => ['withFutureEmployment'],
+            'released referee' => ['released'],
+            'retired referee' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Referees/RetireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Referees/RetireControllerTest.php
@@ -111,61 +111,27 @@ class RetireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonretirableRefereeTypes
      */
-    public function invoke_throws_exception_for_retiring_a_retired_referee()
+    public function invoke_throws_exception_for_retiring_a_non_retirable_referee($factoryState)
     {
         $this->expectException(CannotBeRetiredException::class);
         $this->withoutExceptionHandling();
 
-        $referee = Referee::factory()->retired()->create();
+        $referee = Referee::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([RetireController::class], $referee));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_a_future_employed_referee()
+    public function nonretirableRefereeTypes()
     {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_an_released_referee()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $referee));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_an_unemployed_referee()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $referee = Referee::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $referee));
+        return [
+            'retired referee' => ['retired'],
+            'with future employed referee' => ['withFutureEmployment'],
+            'released referee' => ['released'],
+            'unemployed referee' => ['unemployed'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Referees/SuspendControllerTest.php
+++ b/tests/Feature/Http/Controllers/Referees/SuspendControllerTest.php
@@ -150,16 +150,29 @@ class SuspendControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonsuspendableRefereeTypes
      */
-    public function invoke_throws_exception_for_suspending_a_suspended_referee()
+    public function invoke_throws_exception_for_suspending_a_non_suspendable_referee($factoryState)
     {
         $this->expectException(CannotBeSuspendedException::class);
         $this->withoutExceptionHandling();
 
-        $referee = Referee::factory()->suspended()->create();
+        $referee = Referee::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([SuspendController::class], $referee));
+    }
+
+    public function nonsuspendableRefereeTypes()
+    {
+        return [
+            'unemployed referee' => ['unemployed'],
+            'with future employed referee' => ['withFutureEmployment'],
+            'injured referee' => ['injured'],
+            'released referee' => ['released'],
+            'retired referee' => ['retired'],
+            'suspended referee' => ['suspended'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Referees/UnretireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Referees/UnretireControllerTest.php
@@ -150,16 +150,29 @@ class UnretireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonunretirableRefereeTypes
      */
-    public function invoke_throws_exception_for_unretiring_an_unemployed_referee()
+    public function invoke_throws_exception_for_unretiring_a_non_unretirable_referee($factoryState)
     {
         $this->expectException(CannotBeUnretiredException::class);
         $this->withoutExceptionHandling();
 
-        $referee = Referee::factory()->unemployed()->create();
+        $referee = Referee::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([UnretireController::class], $referee));
+    }
+
+    public function nonunretirableRefereeTypes()
+    {
+        return [
+            'bookable referee' => ['bookable'],
+            'with future employed referee' => ['withFutureEmployment'],
+            'injured referee' => ['injured'],
+            'released referee' => ['released'],
+            'suspended referee' => ['suspended'],
+            'unemployed referee' => ['unemployed'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Stables/ActivateControllerTest.php
+++ b/tests/Feature/Http/Controllers/Stables/ActivateControllerTest.php
@@ -149,31 +149,25 @@ class ActivateControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonactivatableStableTypes
      */
-    public function invoke_throws_exception_for_activating_an_retired_stable()
+    public function invoke_throws_exception_for_activating_a_non_activatable_stable($factoryState)
     {
         $this->expectException(CannotBeActivatedException::class);
         $this->withoutExceptionHandling();
 
-        $stable = Stable::factory()->retired()->create();
+        $stable = Stable::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ActivateController::class], $stable));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_activating_an_active_stable()
+    public function nonactivatableStableTypes()
     {
-        $this->expectException(CannotBeActivatedException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->active()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ActivateController::class], $stable));
+        return [
+            'retired stable' => ['retired'],
+            'active stable' => ['active'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Stables/DeactivateControllerTest.php
+++ b/tests/Feature/Http/Controllers/Stables/DeactivateControllerTest.php
@@ -85,61 +85,27 @@ class DeactivateControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nondeactivatableStableTypes
      */
-    public function invoke_throws_exception_for_deactivating_an_inactive_stable()
+    public function invoke_throws_exception_for_deactivating_a_non_deactivatable_stable($factoryState)
     {
         $this->expectException(CannotBeDeactivatedException::class);
         $this->withoutExceptionHandling();
 
-        $stable = Stable::factory()->inactive()->create();
+        $stable = Stable::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([DeactivateController::class], $stable));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_deactivating_an_retired_stable()
+    public function nondeactivatableStableTypes()
     {
-        $this->expectException(CannotBeDeactivatedException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([DeactivateController::class], $stable));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_deactivating_an_unactivated_stable()
-    {
-        $this->expectException(CannotBeDeactivatedException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->unactivated()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([DeactivateController::class], $stable));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_deactivating_a_future_activated_stable()
-    {
-        $this->expectException(CannotBeDeactivatedException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->withFutureActivation()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([DeactivateController::class], $stable));
+        return [
+            'inactive stable' => ['inactive'],
+            'retired stable' => ['retired'],
+            'unactivated stable' => ['unactivated'],
+            'with future activated stable' => ['withFutureActivation'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Stables/RestoreControllerTest.php
+++ b/tests/Feature/Http/Controllers/Stables/RestoreControllerTest.php
@@ -3,7 +3,6 @@
 namespace Tests\Feature\Http\Controllers\Stables;
 
 use App\Enums\Role;
-use App\Enums\StableStatus;
 use App\Http\Controllers\Stables\RestoreController;
 use App\Http\Controllers\Stables\StablesController;
 use App\Models\Stable;

--- a/tests/Feature/Http/Controllers/Stables/RetireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Stables/RetireControllerTest.php
@@ -114,46 +114,26 @@ class RetireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonretirableStableTypes
      */
-    public function invoke_throws_exception_for_retiring_a_retired_stable()
+    public function invoke_throws_exception_for_retiring_a_non_retirable_stable($factoryState)
     {
         $this->expectException(CannotBeRetiredException::class);
         $this->withoutExceptionHandling();
 
-        $stable = Stable::factory()->retired()->create();
+        $stable = Stable::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([RetireController::class], $stable));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_a_future_activated_stable()
+    public function nonretirableStableTypes()
     {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->withFutureActivation()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $stable));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_an_unactivated_stable()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->unactivated()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $stable));
+        return [
+            'retired stable' => ['retired'],
+            'with future activated stable' => ['withFutureActivation'],
+            'unactivated stable' => ['unactivated'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Stables/UnretireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Stables/UnretireControllerTest.php
@@ -80,61 +80,27 @@ class UnretireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonunretirableStableTypes
      */
-    public function unretiring_an_active_stable_throws_an_exception()
+    public function invoke_throws_exception_for_unretiring_a_non_unretirable_stable($factoryState)
     {
         $this->expectException(CannotBeUnretiredException::class);
         $this->withoutExceptionHandling();
 
-        $stable = Stable::factory()->active()->create();
+        $stable = Stable::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([UnretireController::class], $stable));
     }
 
-    /**
-     * @test
-     */
-    public function unretiring_a_future_activated_stable_throws_an_exception()
+    public function nonunretirableStableTypes()
     {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->withFutureActivation()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $stable));
-    }
-
-    /**
-     * @test
-     */
-    public function unretiring_an_inactive_stable_throws_an_exception()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->inactive()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $stable));
-    }
-
-    /**
-     * @test
-     */
-    public function unretiring_an_unactivated_stable_throws_an_exception()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $stable = Stable::factory()->unactivated()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $stable));
+        return [
+            'active stable' => ['active'],
+            'with future activated stable' => ['withFutureActivation'],
+            'inactive stable' => ['inactive'],
+            'unactivated stable' => ['unactivated'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/TagTeams/EmployControllerTest.php
+++ b/tests/Feature/Http/Controllers/TagTeams/EmployControllerTest.php
@@ -135,43 +135,25 @@ class EmployControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonemployableTagTeamTypes
      */
-    public function invoke_throws_exception_for_employing_a_bookable_tag_team()
+    public function invoke_throws_exception_for_employing_a_non_employable_tag_team($factoryState)
     {
         $this->expectException(CannotBeEmployedException::class);
         $this->withoutExceptionHandling();
 
-        $tagTeam = TagTeam::factory()->bookable()->create();
+        $tagTeam = TagTeam::factory()->{$factoryState}()->create();
 
         $this->actAs(Role::ADMINISTRATOR)
             ->patch(action([EmployController::class], $tagTeam));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_employing_a_retired_tag_team()
+    public function nonemployableTagTeamTypes()
     {
-        $this->expectException(CannotBeEmployedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->retired()->create();
-
-        $this->actAs(Role::ADMINISTRATOR)
-            ->patch(action([EmployController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_employing_a_suspended_tag_team()
-    {
-        $this->expectException(CannotBeEmployedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->suspended()->create();
-
-        $this->actAs(Role::ADMINISTRATOR)
-            ->patch(action([EmployController::class], $tagTeam));
+        return [
+            'bookable tag team' => ['bookable'],
+            'retired tag team' => ['retired'],
+            'suspended tag team' => ['suspended'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/TagTeams/ReinstateControllerTest.php
+++ b/tests/Feature/Http/Controllers/TagTeams/ReinstateControllerTest.php
@@ -81,76 +81,28 @@ class ReinstateControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonreinstatableTagTeamTypes
      */
-    public function invoke_throws_exception_for_reinstating_a_bookable_tag_team()
+    public function invoke_throws_exception_for_reinstating_a_non_reinstatable_tag_team($factoryState)
     {
         $this->expectException(CannotBeReinstatedException::class);
         $this->withoutExceptionHandling();
 
-        $tagTeam = TagTeam::factory()->bookable()->create();
+        $tagTeam = TagTeam::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ReinstateController::class], $tagTeam));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_future_employed_tag_team()
+    public function nonreinstatableTagTeamTypes()
     {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_an_unemployed_tag_team()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_released_tag_team()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_retired_tag_team()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $tagTeam));
+        return [
+            'bookable tag team' => ['bookable'],
+            'with future employed tag team' => ['withFutureEmployment'],
+            'unemployed tag team' => ['unemployed'],
+            'released tag team' => ['released'],
+            'retired tag team' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/TagTeams/ReleaseControllerTest.php
+++ b/tests/Feature/Http/Controllers/TagTeams/ReleaseControllerTest.php
@@ -148,16 +148,27 @@ class ReleaseControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonreleasableTagTeamTypes
      */
-    public function invoke_throws_an_exception_for_releasing_a_retired_tag_team()
+    public function invoke_throws_an_exception_for_releasing_a_non_releasable_tag_team($factoryState)
     {
         $this->expectException(CannotBeReleasedException::class);
         $this->withoutExceptionHandling();
 
-        $tagTeam = TagTeam::factory()->retired()->create();
+        $tagTeam = TagTeam::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ReleaseController::class], $tagTeam));
+    }
+
+    public function nonreleasableTagTeamTypes()
+    {
+        return [
+            'unemployed tag team' => ['unemployed'],
+            'with future employed tag team' => ['withFutureEmployment'],
+            'released tag team' => ['released'],
+            'retired tag team' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/TagTeams/RetireControllerTest.php
+++ b/tests/Feature/Http/Controllers/TagTeams/RetireControllerTest.php
@@ -123,61 +123,27 @@ class RetireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonretirableTagTeamTypes
      */
-    public function invoke_throws_exception_for_retiring_a_retired_tag_team()
+    public function invoke_throws_exception_for_retiring_a_non_retirable_tag_team($factoryState)
     {
         $this->expectException(CannotBeRetiredException::class);
         $this->withoutExceptionHandling();
 
-        $tagTeam = TagTeam::factory()->retired()->create();
+        $tagTeam = TagTeam::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([RetireController::class], $tagTeam));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_a_future_employed_tag_team()
+    public function nonretirableTagTeamTypes()
     {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_a_released_tag_team()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_retiring_an_unemployed_tag_team()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $tagTeam));
+        return [
+            'retired tag team' => ['retired'],
+            'with future employed tag team' => ['withFutureEmployment'],
+            'released tag team' => ['released'],
+            'unemployed tag team' => ['unemployed'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/TagTeams/SuspendControllerTest.php
+++ b/tests/Feature/Http/Controllers/TagTeams/SuspendControllerTest.php
@@ -75,76 +75,28 @@ class SuspendControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonsuspendableTagTeamTypes
      */
-    public function suspending_a_suspended_tag_team_throws_an_exception()
+    public function invoke_throws_exception_for_suspending_a_non_suspendable_tag_team($factoryState)
     {
         $this->expectException(CannotBeSuspendedException::class);
         $this->withoutExceptionHandling();
 
-        $tagTeam = TagTeam::factory()->suspended()->create();
+        $tagTeam = TagTeam::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([SuspendController::class], $tagTeam));
     }
 
-    /**
-     * @test
-     */
-    public function suspending_an_unemployed_tag_team_throws_an_exception()
+    public function nonsuspendableTagTeamTypes()
     {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function suspending_a_released_tag_team_throws_an_exception()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function suspending_a_future_employed_tag_team_throws_an_exception()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function suspending_a_retired_tag_team_throws_an_exception()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $tagTeam));
+        return [
+            'suspended tag team' => ['suspended'],
+            'unemployed tag team' => ['unemployed'],
+            'released tag team' => ['released'],
+            'with future employed tag team' => ['withFutureEmployment'],
+            'retired tag team' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/TagTeams/UnretireControllerTest.php
+++ b/tests/Feature/Http/Controllers/TagTeams/UnretireControllerTest.php
@@ -81,76 +81,28 @@ class UnretireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonunretirableTagTeamTypes
      */
-    public function invoke_throws_exception_for_unretiring_a_bookable_tag_team()
+    public function invoke_throws_exception_for_unretiring_a_non_unretirable_tag_team($factoryState)
     {
         $this->expectException(CannotBeUnretiredException::class);
         $this->withoutExceptionHandling();
 
-        $tagTeam = TagTeam::factory()->bookable()->create();
+        $tagTeam = TagTeam::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([UnretireController::class], $tagTeam));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_a_future_employed_tag_team()
+    public function nonunretirableTagTeamTypes()
     {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_a_released_tag_team()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_a_suspended_tag_team()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $tagTeam));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_an_unemployed_tag_team()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $tagTeam = TagTeam::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $tagTeam));
+        return [
+            'bookable tag team' => ['bookable'],
+            'with future employed tag team' => ['withFutureEmployment'],
+            'released tag team' => ['released'],
+            'suspended tag team' => ['suspended'],
+            'unemployed tag team' => ['unemployed'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Titles/ActivateControllerTest.php
+++ b/tests/Feature/Http/Controllers/Titles/ActivateControllerTest.php
@@ -111,31 +111,25 @@ class ActivateControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonactivatableTitleTypes
      */
-    public function invoke_throws_exception_for_activating_an_active_title()
+    public function invoke_throws_exception_for_activating_a_non_activatable_title($factoryState)
     {
         $this->expectException(CannotBeActivatedException::class);
         $this->withoutExceptionHandling();
 
-        $title = Title::factory()->active()->create();
+        $title = Title::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ActivateController::class], $title));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_activating_a_retired_title()
+    public function nonactivatableTitleTypes()
     {
-        $this->expectException(CannotBeActivatedException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ActivateController::class], $title));
+        return [
+            'active title' => ['active'],
+            'retired title' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Titles/DeactivateControllerTest.php
+++ b/tests/Feature/Http/Controllers/Titles/DeactivateControllerTest.php
@@ -72,61 +72,27 @@ class DeactivateControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nondeactivatableTitleTypes
      */
-    public function invoke_throws_exception_for_deactivating_an_unactivated_title()
+    public function invoke_throws_exception_for_deactivating_a_non_deactivatable_title($factoryState)
     {
         $this->expectException(CannotBeDeactivatedException::class);
         $this->withoutExceptionHandling();
 
-        $title = Title::factory()->unactivated()->create();
+        $title = Title::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([DeactivateController::class], $title));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_deactivating_a_future_activated_title()
+    public function nondeactivatableTitleTypes()
     {
-        $this->expectException(CannotBeDeactivatedException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->withFutureActivation()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([DeactivateController::class], $title));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_deactivating_an_inactive_title()
-    {
-        $this->expectException(CannotBeDeactivatedException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->inactive()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([DeactivateController::class], $title));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_deactivating_a_retired_title()
-    {
-        $this->expectException(CannotBeDeactivatedException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([DeactivateController::class], $title));
+        return [
+            'unactivated title' => ['unactivated'],
+            'with future activation title' => ['withFutureActivation'],
+            'inactive title' => ['inactive'],
+            'retired title' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Titles/RetireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Titles/RetireControllerTest.php
@@ -91,46 +91,26 @@ class RetireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonretirableTitleTypes
      */
-    public function retiring_a_retired_title_throws_an_exception()
+    public function invoke_throws_exception_for_retiring_a_non_retirable_title($factoryState)
     {
         $this->expectException(CannotBeRetiredException::class);
         $this->withoutExceptionHandling();
 
-        $title = Title::factory()->retired()->create();
+        $title = Title::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([RetireController::class], $title));
     }
 
-    /**
-     * @test
-     */
-    public function retiring_a_future_activated_title_throws_an_exception()
+    public function nonretirableTitleTypes()
     {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->withFutureActivation()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $title));
-    }
-
-    /**
-     * @test
-     */
-    public function retiring_an_unactivated_title_throws_an_exception()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->unactivated()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $title));
+        return [
+            'retired title' => ['retired'],
+            'with future activation title' => ['withFutureActivation'],
+            'unactivated title' => ['unactivated'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Titles/UnretireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Titles/UnretireControllerTest.php
@@ -73,58 +73,26 @@ class UnretireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonunretirableTitleTypes
      */
-    public function invoke_throws_exception_for_unretiring_an_active_title()
+    public function invoke_throws_exception_for_unretiring_a_non_unretirable_title($factoryState)
     {
         $this->expectException(CannotBeUnretiredException::class);
         $this->withoutExceptionHandling();
 
-        $title = Title::factory()->active()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $title));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_an_inactive_title()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->inactive()->create();
+        $title = Title::factory()->{$factoryState}()->create();
 
         $this->actAs(Role::ADMINISTRATOR)
             ->patch(action([UnretireController::class], $title));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_a_future_activated_title()
+    public function nonunretirableTitleTypes()
     {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->withFutureActivation()->create();
-
-        $this->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $title));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_an_unactivated_title()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $title = Title::factory()->unactivated()->create();
-
-        $this->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $title));
+        return [
+            'active title' => ['active'],
+            'inactive title' => ['inactive'],
+            'with future activation title' => ['withFutureActivation'],
+            'unactivated title' => ['unactivated'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Wrestlers/ClearInjuryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/ClearInjuryControllerTest.php
@@ -94,76 +94,29 @@ class ClearInjuryControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonclearableWrestlerTypes
      */
-    public function invoke_throws_an_exception_for_clearing_an_injury_from_an_unemployed_wrestler()
+    public function invoke_throws_an_exception_for_clearing_an_injury_from_a_non_clearable_wrestler($factoryState)
     {
         $this->withoutExceptionHandling();
         $this->expectException(CannotBeClearedFromInjuryException::class);
 
-        $wrestler = Wrestler::factory()->unemployed()->create();
+        $wrestler = Wrestler::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ClearInjuryController::class], $wrestler));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_clearing_an_injury_from_a_future_employed_wrestler()
+    public function nonclearableWrestlerTypes()
     {
-        $this->withoutExceptionHandling();
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-
-        $wrestler = Wrestler::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_clearing_an_injury_from_a_bookable_wrestler()
-    {
-        $this->withoutExceptionHandling();
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-
-        $wrestler = Wrestler::factory()->bookable()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_clearing_an_injury_from_a_retired_wrestler()
-    {
-        $this->withoutExceptionHandling();
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-
-        $wrestler = Wrestler::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_clearing_an_injury_from_a_suspended_wrestler()
-    {
-        $this->withoutExceptionHandling();
-        $this->expectException(CannotBeClearedFromInjuryException::class);
-
-        $wrestler = Wrestler::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ClearInjuryController::class], $wrestler));
+        return [
+            'unemployed wrestler' => ['unemployed'],
+            'released wrestler' => ['released'],
+            'with future employed wrestler' => ['withFutureEmployment'],
+            'bookable wrestler' => ['bookable'],
+            'retired wrestler' => ['retired'],
+            'suspended wrestler' => ['suspended'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Wrestlers/ClearInjuryControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/ClearInjuryControllerTest.php
@@ -48,14 +48,22 @@ class ClearInjuryControllerTest extends TestCase
      */
     public function clearing_an_injured_wrestler_on_an_unbookable_tag_team_makes_tag_team_bookable()
     {
-        $tagTeam = TagTeam::factory()->bookable()->create();
-        $wrestler = $tagTeam->currentWrestlers()->first();
+        $injuredWrestler = Wrestler::factory()->injured()->create();
+        $tagTeam = TagTeam::factory()
+            ->hasAttached($injuredWrestler, ['joined_at' => now()->toDateTimeString()])
+            ->hasAttached(Wrestler::factory()->bookable(), ['joined_at' => now()->toDateTimeString()])
+            ->bookable()
+            ->create();
 
         $this->actAs(Role::ADMINISTRATOR)
-            ->patch(route('wrestlers.clear-from-injury', $wrestler));
+            ->patch(route('wrestlers.clear-from-injury', $injuredWrestler));
 
-        tap($wrestler->fresh(), function ($wrestler) {
+        tap($injuredWrestler->fresh(), function ($wrestler) {
             $this->assertTrue($wrestler->isBookable());
+        });
+
+        tap($tagTeam->fresh(), function ($tagTeam) {
+            $this->assertTrue($tagTeam->isBookable());
         });
     }
 

--- a/tests/Feature/Http/Controllers/Wrestlers/EmployControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/EmployControllerTest.php
@@ -120,30 +120,26 @@ class EmployControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonemployableWrestlerTypes
      */
-    public function invoke_throws_exception_for_employing_an_employed_wrestler()
+    public function invoke_throws_exception_for_employing_a_non_employable_wrestler($factoryState)
     {
         $this->expectException(CannotBeEmployedException::class);
         $this->withoutExceptionHandling();
 
-        $wrestler = Wrestler::factory()->employed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([EmployController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_employing_a_retired_wrestler()
-    {
-        $this->expectException(CannotBeEmployedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->retired()->create();
+        $wrestler = Wrestler::factory()->{$factoryState}()->create();
 
         $this->actAs(Role::ADMINISTRATOR)
             ->patch(action([EmployController::class], $wrestler));
+    }
+
+    public function nonemployableWrestlerTypes()
+    {
+        return [
+            'suspended wrestler' => ['suspended'],
+            'injured wrestler' => ['injured'],
+            'bookable wrestler' => ['bookable'],
+            'retired wrestler' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Wrestlers/InjureControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/InjureControllerTest.php
@@ -98,91 +98,29 @@ class InjureControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider noninjurableWrestlerTypes
      */
-    public function invoke_throws_exception_for_injuring_an_unemployed_wrestler()
+    public function invoke_throws_exception_for_injuring_a_non_injurable_wrestler($factoryState)
     {
         $this->expectException(CannotBeInjuredException::class);
         $this->withoutExceptionHandling();
 
-        $wrestler = Wrestler::factory()->unemployed()->create();
+        $wrestler = Wrestler::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([InjureController::class], $wrestler));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_a_suspended_wrestler()
+    public function noninjurableWrestlerTypes()
     {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([InjureController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_a_released_wrestler()
-    {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([InjureController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_a_future_employed_wrestler()
-    {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([InjureController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_injuring_a_retired_wrestler_throws()
-    {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([InjureController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_injuring_an_injured_wrestler()
-    {
-        $this->expectException(CannotBeInjuredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([InjureController::class], $wrestler));
+        return [
+            'unemployed wrestler' => ['unemployed'],
+            'suspended wrestler' => ['suspended'],
+            'released wrestler' => ['released'],
+            'with future employed wrestler' => ['withFutureEmployment'],
+            'retired wrestler' => ['retired'],
+            'injured wrestler' => ['injured'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Wrestlers/ReinstateControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/ReinstateControllerTest.php
@@ -96,91 +96,29 @@ class ReinstateControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonreinstatableWrestlerTypes
      */
-    public function invoke_throws_exception_for_reinstating_a_bookable_wrestler()
+    public function invoke_throws_exception_for_reinstating_a_non_reinstatable_wrestler($factoryState)
     {
         $this->expectException(CannotBeReinstatedException::class);
         $this->withoutExceptionHandling();
 
-        $wrestler = Wrestler::factory()->bookable()->create();
+        $wrestler = Wrestler::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ReinstateController::class], $wrestler));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_an_unemployed_wrestler()
+    public function nonreinstatableWrestlerTypes()
     {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_an_injured_wrestler()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_released_wrestler()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_future_employed_wrestler()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_reinstating_a_retired_wrestler()
-    {
-        $this->expectException(CannotBeReinstatedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReinstateController::class], $wrestler));
+        return [
+            'bookable wrestler' => ['bookable'],
+            'unemployed wrestler' => ['unemployed'],
+            'injured wrestler' => ['injured'],
+            'released wrestler' => ['released'],
+            'with future employed wrestler' => ['withFutureEmployment'],
+            'retired wrestler' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Wrestlers/ReleaseControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/ReleaseControllerTest.php
@@ -132,61 +132,27 @@ class ReleaseControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonreleasableWrestlerTypes
      */
-    public function invoke_throws_an_exception_for_releasing_an_unemployed_wrestler()
+    public function invoke_throws_an_exception_for_releasing_a_non_releasable_wrestler($factoryState)
     {
         $this->expectException(CannotBeReleasedException::class);
         $this->withoutExceptionHandling();
 
-        $wrestler = Wrestler::factory()->unemployed()->create();
+        $wrestler = Wrestler::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([ReleaseController::class], $wrestler));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_releasing_a_future_employed_wrestler()
+    public function nonreleasableWrestlerTypes()
     {
-        $this->expectException(CannotBeReleasedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReleaseController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_releasing_a_released_wrestler()
-    {
-        $this->expectException(CannotBeReleasedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReleaseController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_releasing_a_retired_wrestler()
-    {
-        $this->expectException(CannotBeReleasedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([ReleaseController::class], $wrestler));
+        return [
+            'unemployed wrestler' => ['unemployed'],
+            'with future employed wrestler' => ['withFutureEmployment'],
+            'released wrestler' => ['released'],
+            'retired wrestler' => ['retired'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Wrestlers/RetireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/RetireControllerTest.php
@@ -130,61 +130,27 @@ class RetireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonretirableWrestlerTypes
      */
-    public function invoke_throws_an_exception_for_retiring_a_retired_wrestler()
+    public function invoke_throws_an_exception_for_retiring_a_non_retirable_wrestler($factoryState)
     {
         $this->expectException(CannotBeRetiredException::class);
         $this->withoutExceptionHandling();
 
-        $wrestler = Wrestler::factory()->retired()->create();
+        $wrestler = Wrestler::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([RetireController::class], $wrestler));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_retiring_a_future_employed_wrestler()
+    public function nonretirableWrestlerTypes()
     {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_retiring_a_released_wrestler()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_an_exception_for_retiring_an_unemployed_wrestler()
-    {
-        $this->expectException(CannotBeRetiredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([RetireController::class], $wrestler));
+        return [
+            'retired wrestler' => ['retired'],
+            'with future employed wrestler' => ['withFutureEmployment'],
+            'released wrestler' => ['released'],
+            'unemployed wrestler' => ['unemployed'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Wrestlers/SuspendControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/SuspendControllerTest.php
@@ -94,91 +94,29 @@ class SuspendControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonsuspendableWrestlerTypes
      */
-    public function invoke_throws_exception_for_suspending_an_unemployed_wrestler()
+    public function invoke_throws_exception_for_suspending_a_non_suspendable_wrestler($factoryState)
     {
         $this->expectException(CannotBeSuspendedException::class);
         $this->withoutExceptionHandling();
 
-        $wrestler = Wrestler::factory()->unemployed()->create();
+        $wrestler = Wrestler::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([SuspendController::class], $wrestler));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_a_future_employed_wrestler()
+    public function nonsuspendableWrestlerTypes()
     {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_an_injured_wrestler()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_a_released_wrestler()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_a_retired_wrestler()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->retired()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_suspending_a_suspended_wrestler()
-    {
-        $this->expectException(CannotBeSuspendedException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([SuspendController::class], $wrestler));
+        return [
+            'unemployed wrestler' => ['unemployed'],
+            'with future employed wrestler' => ['withFutureEmployment'],
+            'injured wrestler' => ['injured'],
+            'released wrestler' => ['released'],
+            'retired wrestler' => ['retired'],
+            'suspended wrestler' => ['suspended'],
+        ];
     }
 }

--- a/tests/Feature/Http/Controllers/Wrestlers/UnretireControllerTest.php
+++ b/tests/Feature/Http/Controllers/Wrestlers/UnretireControllerTest.php
@@ -75,91 +75,29 @@ class UnretireControllerTest extends TestCase
 
     /**
      * @test
+     * @dataProvider nonunretirableWrestlerTypes
      */
-    public function invoke_throws_exception_for_unretiring_a_bookable_wrestler()
+    public function invoke_throws_exception_for_unretiring_a_non_unretirable_wrestler($factoryState)
     {
         $this->expectException(CannotBeUnretiredException::class);
         $this->withoutExceptionHandling();
 
-        $wrestler = Wrestler::factory()->bookable()->create();
+        $wrestler = Wrestler::factory()->{$factoryState}()->create();
 
         $this
             ->actAs(Role::ADMINISTRATOR)
             ->patch(action([UnretireController::class], $wrestler));
     }
 
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_a_future_employed_wrestler()
+    public function nonunretirableWrestlerTypes()
     {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->withFutureEmployment()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_an_injured_wrestler()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->injured()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_a_released_wrestler()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->released()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_a_suspended_wrestler()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->suspended()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $wrestler));
-    }
-
-    /**
-     * @test
-     */
-    public function invoke_throws_exception_for_unretiring_an_unemployed_wrestler()
-    {
-        $this->expectException(CannotBeUnretiredException::class);
-        $this->withoutExceptionHandling();
-
-        $wrestler = Wrestler::factory()->unemployed()->create();
-
-        $this
-            ->actAs(Role::ADMINISTRATOR)
-            ->patch(action([UnretireController::class], $wrestler));
+        return [
+            'bookable wrestler' => ['bookable'],
+            'with future employed wrestler' => ['withFutureEmployment'],
+            'injured wrestler' => ['injured'],
+            'released wrestler' => ['released'],
+            'suspended wrestler' => ['suspended'],
+            'unemployed wrestler' => ['unemployed'],
+        ];
     }
 }


### PR DESCRIPTION
Some of the tests inside of our test suite have very similar tests and to remove those duplicated tests its best we create a data provider so that the files have less test methods written but still covers same cases.