### PR TITLE
Wire Elements Modal Example

### DIFF
--- a/app/Livewire/Wrestlers/WrestlerForm.php
+++ b/app/Livewire/Wrestlers/WrestlerForm.php
@@ -1,0 +1,81 @@
+<?php
+ 
+ namespace App\Livewire\Wrestlers;
+ 
+use Livewire\Attributes\Validate;
+use Livewire\Form;
+use App\Models\Wrestler;
+use App\ValueObjects\Height;
+
+class WrestlerForm extends Form
+{
+
+    public ?Wrestler $wrestler;
+
+    #[Validate('required|min:5')]
+    public $name = '';
+ 
+    public $hometown = '';
+
+    public $signature_move = '';
+
+    public $start_date = '';
+    public $height_feet;
+    public $height_inches;
+    public $weight;
+
+    public function setWrestler(Wrestler $wrestler)
+    {
+        $this->wrestler = $wrestler;
+ 
+        $this->name = $wrestler->name;
+ 
+        $this->hometown = $wrestler->hometown;
+        $this->signature_move = $wrestler->signature_move;
+        $this->start_date = $wrestler->start_date;
+        $this->weight = $wrestler->weight;
+        $height = $wrestler->height;
+
+        $feet = (int) floor($height->toInches() / 12);
+        $inches = $height->toInches() % 12;
+
+        $this->height_feet = $feet;
+        $this->height_inches = $inches;
+
+    }
+
+    
+    public function update(): bool
+    {
+        $this->validate();
+        $height = new Height($this->height_feet, $this->height_inches);
+        if (!isset($this->wrestler))
+        {
+            $this->wrestler = new Wrestler([
+                'name' => $this->name,
+                'hometown' => $this->hometown,
+                'signature_move' => $this->signature_move,
+                'start_date' => $this->start_date,
+                'height' => $height->toInches(),
+                'weight' => $this->weight,
+            ]);
+            $this->wrestler->save();
+        }
+        else
+        {
+            $this->wrestler->update([
+                'name' => $this->name,
+                'hometown' => $this->hometown,
+                'signature_move' => $this->signature_move,
+                'start_date' => $this->start_date,
+                'height' => $height->toInches(),
+                'weight' => $this->weight,
+            ]);
+    
+        }
+
+        return true;
+    }
+
+
+}

--- a/app/Livewire/Wrestlers/WrestlerForm.php
+++ b/app/Livewire/Wrestlers/WrestlerForm.php
@@ -1,35 +1,39 @@
 <?php
- 
- namespace App\Livewire\Wrestlers;
- 
-use Livewire\Attributes\Validate;
-use Livewire\Form;
+
+declare(strict_types=1);
+
+namespace App\Livewire\Wrestlers;
+
 use App\Models\Wrestler;
 use App\ValueObjects\Height;
+use Livewire\Attributes\Validate;
+use Livewire\Form;
 
 class WrestlerForm extends Form
 {
-
     public ?Wrestler $wrestler;
 
     #[Validate('required|min:5')]
     public $name = '';
- 
+
     public $hometown = '';
 
     public $signature_move = '';
 
     public $start_date = '';
+
     public $height_feet;
+
     public $height_inches;
+
     public $weight;
 
     public function setWrestler(Wrestler $wrestler)
     {
         $this->wrestler = $wrestler;
- 
+
         $this->name = $wrestler->name;
- 
+
         $this->hometown = $wrestler->hometown;
         $this->signature_move = $wrestler->signature_move;
         $this->start_date = $wrestler->start_date;
@@ -44,13 +48,11 @@ class WrestlerForm extends Form
 
     }
 
-    
     public function update(): bool
     {
         $this->validate();
         $height = new Height($this->height_feet, $this->height_inches);
-        if (!isset($this->wrestler))
-        {
+        if (! isset($this->wrestler)) {
             $this->wrestler = new Wrestler([
                 'name' => $this->name,
                 'hometown' => $this->hometown,
@@ -60,9 +62,7 @@ class WrestlerForm extends Form
                 'weight' => $this->weight,
             ]);
             $this->wrestler->save();
-        }
-        else
-        {
+        } else {
             $this->wrestler->update([
                 'name' => $this->name,
                 'hometown' => $this->hometown,
@@ -71,11 +71,9 @@ class WrestlerForm extends Form
                 'height' => $height->toInches(),
                 'weight' => $this->weight,
             ]);
-    
+
         }
 
         return true;
     }
-
-
 }

--- a/app/Livewire/Wrestlers/WrestlerModal.php
+++ b/app/Livewire/Wrestlers/WrestlerModal.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 namespace App\Livewire\Wrestlers;
 
-use LivewireUI\Modal\ModalComponent;
 use App\Models\Wrestler;
-use App\Livewire\Wrestlers\WrestlerForm;
+use LivewireUI\Modal\ModalComponent;
 
 class WrestlerModal extends ModalComponent
 {
@@ -14,24 +15,22 @@ class WrestlerModal extends ModalComponent
 
     public function mount(?int $wrestlerId = null)
     {
-        if (isset($wrestlerId))
-        {
+        if (isset($wrestlerId)) {
             $this->wrestler = Wrestler::find($wrestlerId);
             $this->form->setWrestler($this->wrestler);
         }
 
     }
- 
+
     public function save()
     {
-        if ($this->form->update())
-        {
-            $this->dispatch('refreshDatatable'); 
+        if ($this->form->update()) {
+            $this->dispatch('refreshDatatable');
 
             $this->closeModal();
-    
+
         }
-     }
+    }
 
     public function render()
     {

--- a/app/Livewire/Wrestlers/WrestlerModal.php
+++ b/app/Livewire/Wrestlers/WrestlerModal.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace App\Livewire\Wrestlers;
+
+use LivewireUI\Modal\ModalComponent;
+use App\Models\Wrestler;
+use App\Livewire\Wrestlers\WrestlerForm;
+
+class WrestlerModal extends ModalComponent
+{
+    public Wrestler $wrestler;
+
+    public WrestlerForm $form;
+
+    public function mount(?int $wrestlerId = null)
+    {
+        if (isset($wrestlerId))
+        {
+            $this->wrestler = Wrestler::find($wrestlerId);
+            $this->form->setWrestler($this->wrestler);
+        }
+
+    }
+ 
+    public function save()
+    {
+        if ($this->form->update())
+        {
+            $this->dispatch('refreshDatatable'); 
+
+            $this->closeModal();
+    
+        }
+     }
+
+    public function render()
+    {
+        return view('livewire.wrestlers.modal');
+    }
+}

--- a/app/Livewire/Wrestlers/WrestlersTable.php
+++ b/app/Livewire/Wrestlers/WrestlersTable.php
@@ -12,11 +12,11 @@ use App\Livewire\Concerns\Columns\HasStatusColumn;
 use App\Livewire\Concerns\Filters\HasFirstEmploymentDateFilter;
 use App\Livewire\Concerns\Filters\HasStatusFilter;
 use App\Models\Wrestler;
+use Illuminate\Support\Facades\Gate;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Action;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Illuminate\Support\Facades\Gate;
 
 class WrestlersTable extends DataTableComponent
 {
@@ -46,10 +46,11 @@ class WrestlersTable extends DataTableComponent
     {
         return [
             Action::make('Create')
-            ->setWireAction("wire:click")
-            ->setWireActionDispatchParams("'openModal', { component: 'wrestlers.wrestler-modal' }"),
+                ->setWireAction('wire:click')
+                ->setWireActionDispatchParams("'openModal', { component: 'wrestlers.wrestler-modal' }"),
         ];
     }
+
     /** @return array<Column> */
     public function columns(): array
     {
@@ -79,13 +80,10 @@ class WrestlersTable extends DataTableComponent
     {
         $canDelete = Gate::inspect('delete', $wrestler);
 
-        if ($canDelete->allowed()) 
-        {
-          $wrestler->delete();
-          session()->flash('status', 'Wrestler successfully updated.');
-        }
-        else
-        {
+        if ($canDelete->allowed()) {
+            $wrestler->delete();
+            session()->flash('status', 'Wrestler successfully updated.');
+        } else {
             session()->flash('status', 'You cannot delete this wrestler.');
         }
     }

--- a/resources/views/components/form/inputs/date.blade.php
+++ b/resources/views/components/form/inputs/date.blade.php
@@ -1,5 +1,6 @@
 <label class="form-label" for="{{ $name }}">{{ $label }}</label>
-<input type="date" name="{{ $name }}" class="form-control" placeholder="MM-DD-YYYY" @isset($value) value="{{ $value }}" @endisset>
+<input type="date" {{ $attributes }}
+ name="{{ $name }}" class="form-control" placeholder="MM-DD-YYYY" >
 @error($name)
     <x-form.validation-error name="{{ $name }}" :message="$message" />
 @enderror

--- a/resources/views/components/form/inputs/text.blade.php
+++ b/resources/views/components/form/inputs/text.blade.php
@@ -1,11 +1,12 @@
+
 <label class="form-label" for="{{ $name }}">{{ $label }}</label>
 
 <input
     type="text"
-    class="form-control"
-    name="{{ $name }}"
-    :placeholder="$label ?? Enter {{ $label }} : null"
-    value="{{ $value ?? null }}"
+    {{ $attributes->merge([
+        'class' => 'form-control',
+        'placeholder' => 'Enter '.($label ?? 'Value'),
+    ]) }}
 >
 
 @error($name)

--- a/resources/views/components/tables/columns/action-column.blade.php
+++ b/resources/views/components/tables/columns/action-column.blade.php
@@ -1,47 +1,13 @@
-<x-menu>
-    <x-menu.menu-item-dropdown>
-        <x-menu.menu-toggle class="inline-flex items-center cursor-pointer leading-4 rounded-md border border-solid border-transparent outline-none h-8 ps-3 pe-3 font-medium text-xs justify-center shrink-0 p-0 gap-0 w-8 bg-transparent text-gray-700"/>
-        <x-menu.menu-dropdown isDefault class="py-2.5 w-full max-w-[175px] hidden">
-            @if ($links['view'] ?? true)
-                <x-menu.menu-item>
-                    <x-menu.menu-link href="{{ route($path . '.show', $rowId) }}">
-                        <x-menu.menu-dropdown-icon icon="ki-search-list"/>
-                        <x-menu.menu-dropdown-title>View</x-menu.menu-dropdown-title>
-                    </x-menu.menu-link>
-                </x-menu.menu-item>
-            @endif
+<div x-data="{ open: false }">
 
-            <x-menu.menu-item-separator/>
-
-            @if ($links['edit'] ?? true)
-                <x-menu.menu-item>
-                    <x-menu.menu-link href="{{ route($path . '.edit', $rowId) }}">
-                        <x-menu.menu-dropdown-icon icon="ki-pencil"/>
-                        <x-menu.menu-dropdown-title>Edit</x-menu.menu-dropdown-title>
-                    </x-menu.menu-link>
-                </x-menu.menu-item>
-            @endif
-
-            <x-menu.menu-item-separator/>
-
-            @if ($links['delete'] ?? true)
-                <x-menu.menu-item>
-                    <x-menu.menu-link href="{{ route($path . '.destroy', $rowId) }}">
-                        <x-menu.menu-dropdown-icon icon="ki-trash"/>
-                        <x-menu.menu-dropdown-title>Remove</x-menu.menu-dropdown-title>
-                    </x-menu.menu-link>
-                    {{-- <form action="{{ route($path . '.destroy', $rowId) }}" class="d-inline" method="POST" x-data
-                        @submit.prevent="if (confirm('Are you sure you want to delete this user?')) $el.submit()">
-                        @method('DELETE')
-                        @csrf
-
-                        <button type="submit" class="btn btn-link">
-                            <i class="fa-solid fa-trash"></i>
-                            Remove
-                        </button>
-                    </form> --}}
-                </x-menu.menu-item>
-            @endif
-        </x-menu.menu-dropdown>
-    </x-menu.menu-item-dropdown>
-</x-menu>
+    <button x-ref="button" @click="open = ! open" class="flex items-center grow cursor-pointer hover:bg-gray-200 hover:border-transparent hover:shadow-none hover:text-gray-800">
+        <i class="ki-filled ki-dots-vertical text-lg"></i>
+    </button>
+    <div x-show="open" x-anchor.bottom-start="$refs.button" class="px-2 bg-white z-50	">
+        <ul>
+            <li><a x-on:click="open = false;" href="{{ route($path . '.show', $rowId) }}">View</a></li>
+            <li><button x-on:click="open = false;" wire:click="$dispatch('openModal', { component: 'wrestlers.wrestler-modal', arguments: { wrestlerId: {{ $rowId }} }})">Edit</button>            </li>
+            <li><a x-on:click="open = false;" wire:click="delete({{ $rowId}})" wire:confirm>Remove</a></li>
+        </ul>
+    </div>
+</div>

--- a/resources/views/livewire/wrestlers/modal.blade.php
+++ b/resources/views/livewire/wrestlers/modal.blade.php
@@ -1,0 +1,32 @@
+<div class="p-4">
+    <div class="mb-10">
+        <x-form.inputs.text class="bg-red-500" label="Name:" name="name" placeholder="Wrestler Name Here" wire:model="form.name" />
+    </div>
+
+    <div class="mb-10">
+        <x-form.inputs.text label="Hometown:" name="hometown" placeholder="Orlando, FL" wire:model="form.hometown"  />
+    </div>
+
+    <div class="mb-10">
+        <x-form.inputs.text label="Signature Move:" name="signature_move" placeholder="This Amazing Finisher" wire:model="form.signature_move"  />
+    </div>
+
+    <div class="mb-10">
+        <x-form.inputs.date label="Start Date:" name="start_date" wire:model="form.start_date" />
+    </div>
+    <div class="mb-10">
+        <x-form.inputs.text label="Feet:" name="name" placeholder="Feet" wire:model="form.height_feet" />
+    </div>
+
+    <div class="mb-10">
+        <x-form.inputs.text label="Inches:" name="name" placeholder="Inches" wire:model="form.height_inches" />
+    </div>
+
+    <div class="mb-10">
+        <x-form.inputs.text label="Weight:" name="weight" placeholder="lbs" wire:model="form.weight" />
+    </div>
+
+    <div>
+        <button wire:click="save">Save</button>
+    </div>
+</div>


### PR DESCRIPTION
This adds in an example for Wire Elements Modals for the Wrestlers Table.

This also amends the text to respect $attributes fully
resources/views/components/form/inputs/text.blade.php

And date to respect $attributes partially.
resources/views/components/form/inputs/date.blade.php
