### PR TITLE
Refactor: Livewire component standardization

### DIFF
--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -1,0 +1,336 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Base;
+
+use App\Livewire\Concerns\BaseModal;
+use App\Livewire\Concerns\GeneratesDummyData;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Base class for all form modals with essential functionality.
+ *
+ * This base class provides a standardized foundation for creating modal dialogs
+ * that contain forms for creating or editing Eloquent models. It combines the
+ * modal functionality from BaseModal with form-specific features like dummy
+ * data generation for development and testing purposes.
+ *
+ * The class follows a simple template method pattern where child classes provide
+ * configuration details (form class, model class, modal path) while this base
+ * class handles the common modal lifecycle and integration with the dummy data
+ * generation system.
+ *
+ * Key Features:
+ * - Seamless integration with BaseModal for consistent modal behavior
+ * - Automatic dummy data generation via GeneratesDummyData trait
+ * - Type-safe form and model class specification
+ * - Simplified configuration through abstract methods
+ * - Proper Livewire component lifecycle management
+ *
+ * Design Philosophy:
+ * - Composition over complexity: Uses traits for specialized functionality
+ * - Configuration over convention: Child classes specify their requirements
+ * - Fail fast: Let individual components handle their own validation
+ * - Single responsibility: Focus on modal-specific concerns
+ *
+ * @template TForm of LivewireBaseForm The form class this modal manages
+ * @template TModel of Model The Eloquent model type this modal creates/edits
+ *
+ * @extends BaseModal<TForm, TModel>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseModal For core modal functionality and lifecycle management
+ * @see GeneratesDummyData For dummy data generation capabilities
+ * @see LivewireBaseForm For form implementation requirements
+ *
+ * @example
+ * ```php
+ * // Creating a wrestler form modal
+ * class WrestlerFormModal extends BaseFormModal
+ * {
+ *     protected function getFormClass(): string
+ *     {
+ *         return WrestlerForm::class;
+ *     }
+ *
+ *     protected function getModelClass(): string
+ *     {
+ *         return Wrestler::class;
+ *     }
+ *
+ *     protected function getModalPath(): string
+ *     {
+ *         return 'modals.wrestler-form';
+ *     }
+ *
+ *     protected function getDummyDataFields(): array
+ *     {
+ *         return [
+ *             'name' => fn() => $this->generateWrestlingName(),
+ *             'hometown' => fn() => fake()->city(),
+ *             'weight' => fn() => fake()->numberBetween(150, 300),
+ *             'signature_move' => fn() => $this->generateSignatureMove(),
+ *         ];
+ *     }
+ * }
+ *
+ * // Usage in a Livewire component
+ * class ManageWrestlers extends Component
+ * {
+ *     public WrestlerFormModal $modal;
+ *
+ *     public function createWrestler(): void
+ *     {
+ *         $this->modal->openModal();
+ *     }
+ *
+ *     public function editWrestler(int $wrestlerId): void
+ *     {
+ *         $this->modal->openModal($wrestlerId);
+ *     }
+ * }
+ *
+ * // In Blade template
+ * <button wire:click="createWrestler">Add Wrestler</button>
+ * <button wire:click="modal.fillDummyFields">Fill Test Data</button>
+ * ```
+ */
+abstract class BaseFormModal extends BaseModal
+{
+    use GeneratesDummyData;
+
+    /**
+     * Get the form class that this modal will instantiate and manage.
+     *
+     * Returns the fully qualified class name of the Livewire form that will
+     * handle the creation or editing of models within this modal. The form
+     * must extend LivewireBaseForm to ensure compatibility with the modal's
+     * lifecycle and data binding patterns.
+     *
+     * This method is called during modal initialization to set up the proper
+     * form instance for handling user input and model persistence.
+     *
+     * @return class-string<TForm> Fully qualified form class name
+     *
+     * @example
+     * ```php
+     * protected function getFormClass(): string
+     * {
+     *     return WrestlerForm::class;
+     * }
+     *
+     * // For more complex scenarios:
+     * protected function getFormClass(): string
+     * {
+     *     // Could return different forms based on context
+     *     return $this->isAdvancedMode()
+     *         ? AdvancedWrestlerForm::class
+     *         : WrestlerForm::class;
+     * }
+     * ```
+     *
+     * @see LivewireBaseForm For form implementation requirements
+     * @see mount() For when this method is called during initialization
+     */
+    abstract protected function getFormClass(): string;
+
+    /**
+     * Get the Eloquent model class that this modal creates or edits.
+     *
+     * Returns the fully qualified class name of the Eloquent model that this
+     * modal's form will create (when opened without parameters) or edit (when
+     * opened with a model ID). This class is used for type safety and proper
+     * model resolution during the modal lifecycle.
+     *
+     * The model class must extend Illuminate\Database\Eloquent\Model and should
+     * be compatible with the form class returned by getFormClass().
+     *
+     * @return class-string<TModel> Fully qualified model class name
+     *
+     * @example
+     * ```php
+     * protected function getModelClass(): string
+     * {
+     *     return Wrestler::class;
+     * }
+     *
+     * // For polymorphic scenarios:
+     * protected function getModelClass(): string
+     * {
+     *     return match($this->entityType) {
+     *         'wrestler' => Wrestler::class,
+     *         'manager' => Manager::class,
+     *         default => throw new \InvalidArgumentException('Unknown entity type')
+     *     };
+     * }
+     * ```
+     *
+     * @see Model For base model requirements
+     * @see BaseModal For how model classes are used in modal lifecycle
+     */
+    abstract protected function getModelClass(): string;
+
+    /**
+     * Get the Blade view path for rendering this modal.
+     *
+     * Returns the view path (relative to resources/views) that contains the
+     * Blade template for this modal's UI. The view should include the modal
+     * structure, form fields, and any modal-specific styling or JavaScript.
+     *
+     * The path follows Laravel's dot notation convention for nested directories
+     * and should not include the .blade.php extension.
+     *
+     * @return string Blade view path using dot notation
+     *
+     * @example
+     * ```php
+     * protected function getModalPath(): string
+     * {
+     *     return 'modals.wrestler-form';
+     *     // Corresponds to: resources/views/modals/wrestler-form.blade.php
+     * }
+     *
+     * // For organized view structures:
+     * protected function getModalPath(): string
+     * {
+     *     return 'livewire.modals.forms.wrestler';
+     *     // Corresponds to: resources/views/livewire/modals/forms/wrestler.blade.php
+     * }
+     *
+     * // For dynamic view selection:
+     * protected function getModalPath(): string
+     * {
+     *     $baseView = 'modals.wrestler';
+     *     return $this->isCompactMode() ? $baseView . '-compact' : $baseView . '-full';
+     * }
+     * ```
+     *
+     * @see mount() For when this path is set during modal initialization
+     */
+    abstract protected function getModalPath(): string;
+
+    /**
+     * Indicates if the modal is currently open.
+     */
+    public bool $isModalOpen = false;
+
+    /**
+     * Open the modal.
+     */
+    public function openModal(mixed $modelId = null): void
+    {
+        // Ensure proper initialization if mount wasn't called
+        if (! isset($this->modalFormPath)) {
+            $this->mount($modelId);
+        } elseif ($modelId !== null) {
+            // Re-mount with the specific model ID
+            $this->mount($modelId);
+        }
+
+        $this->isModalOpen = true;
+    }
+
+    /**
+     * Close the modal.
+     */
+    public function closeModal(): void
+    {
+        $this->isModalOpen = false;
+    }
+
+    /**
+     * Submit the form through the modal.
+     *
+     * This method provides a bridge for testing that allows calling
+     * form submission directly on the modal component.
+     */
+    public function submitForm(): bool
+    {
+        // Ensure form has the correct model before submission
+        // This handles cases where Livewire form property hydration
+        // loses the model state between mount and submission
+        if (isset($this->model) && $this->form) {
+            $this->form->setModel($this->model);
+        }
+
+        $result = $this->form->store();
+
+        if ($result) {
+            $this->closeModal();
+            $this->dispatch('form-submitted');
+        }
+
+        return $result;
+    }
+
+    /**
+     * Initialize the modal with proper configuration and lifecycle setup.
+     *
+     * This method extends the parent BaseModal::mount() to add form-specific
+     * initialization including setting the modal view path and ensuring proper
+     * integration with the form and dummy data systems.
+     *
+     * The method is called automatically by Livewire when the component is
+     * instantiated, whether for creating new records (modelId = null) or
+     * editing existing ones (modelId provided).
+     *
+     * Initialization Flow:
+     * 1. Set modal view path from getModalPath()
+     * 2. Call parent mount() for core modal setup
+     * 3. Form and model binding handled by parent class
+     * 4. Dummy data capabilities available via trait
+     *
+     * @param  mixed  $modelId  The ID of the model to edit, or null for creation mode
+     *
+     * @example
+     * ```php
+     * // Called automatically by Livewire:
+     * // - When opening modal for new record: mount(null)
+     * // - When opening modal for editing: mount(123)
+     *
+     * // In parent component:
+     * public function openCreateModal(): void
+     * {
+     *     $this->modal->mount(); // Triggers mount(null)
+     * }
+     *
+     * public function openEditModal(int $id): void
+     * {
+     *     $this->modal->mount($id); // Triggers mount($id)
+     * }
+     * ```
+     *
+     * @see BaseModal::mount() For core modal initialization logic
+     * @see getModalPath() For view path configuration
+     */
+    public function mount(mixed $modelId = null): void
+    {
+        $this->modalFormPath = $this->getModalPath();
+
+        // Initialize the model type
+        $modelClass = $this->getModelClass();
+        $this->modelType = new $modelClass();
+
+        // Use the existing form property (Livewire manages this automatically)
+        // Don't create a new instance - use what Livewire provided
+
+        // Set the form as the modelForm for BaseModal compatibility
+        // IMPORTANT: Ensure both properties reference the same instance
+        $this->modelForm = $this->form;
+
+        // Set default title fields
+        $this->modelTitleField = 'name';
+        $this->titleField = 'name';
+
+        parent::mount($modelId);
+
+        // Ensure the form property also has the model if one was loaded
+        // This is critical because Livewire manages $this->form separately
+        if (isset($modelId) && isset($this->model)) {
+            $this->form->setModel($this->model);
+        }
+    }
+}

--- a/app/Livewire/Base/LivewireBaseForm.php
+++ b/app/Livewire/Base/LivewireBaseForm.php
@@ -4,50 +4,758 @@ declare(strict_types=1);
 
 namespace App\Livewire\Base;
 
+use EventMatches\EventMatchForm;
+use Events\EventForm;
+use Exception;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\ValidationException;
 use Livewire\Form;
+use Wrestlers\WrestlerForm;
 
 /**
- * @template TForm of LivewireBaseForm
- * @template TFormModel of Model|null
+ * Abstract base class for Livewire form components.
+ *
+ * This base form provides common functionality for all Livewire forms in the application,
+ * including model binding, form filling, and standardized validation patterns. It serves
+ * as a foundation for creating consistent form experiences across different entities.
+ *
+ * The class establishes a standardized pattern for form management that includes:
+ * - Consistent model binding and data population mechanisms
+ * - Standardized validation rule and attribute definition patterns
+ * - Common utility methods for form display and model interaction
+ * - Extensible hooks for custom data loading and transformation
+ * - Generic type support for maintaining type safety across implementations
+ *
+ * Key Design Principles:
+ * - Template Method Pattern: Defines the skeleton of form operations while allowing
+ *   subclasses to override specific steps (rules, validation attributes, data transformation)
+ * - Single Responsibility: Each method has a focused purpose in the form lifecycle
+ * - Extensibility: Provides hooks (loadExtraData) for custom implementations
+ * - Type Safety: Uses generics to maintain type safety while allowing flexibility
+ *
+ * The class uses generics to maintain type safety while allowing flexibility for
+ * different form implementations and their associated models. Child classes should
+ * extend this base to inherit common form behaviors while implementing their
+ * specific validation rules and data handling logic.
+ *
+ * @template TForm of LivewireBaseForm The concrete form class extending this base
+ * @template TFormModel of Model|null The Eloquent model type this form manages
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see WrestlerForm For a comprehensive implementation example
+ * @see EventForm For a simple implementation example
+ * @see EventMatchForm For a complex relationship example
+ *
+ * @example
+ * ```php
+ * // Creating a concrete form implementation
+ * class WrestlerForm extends LivewireBaseForm
+ * {
+ *     protected ?Model $formModel = null;
+ *
+ *     public string $name = '';
+ *     public string $hometown = '';
+ *     // ... other properties
+ *
+ *     protected function rules(): array
+ *     {
+ *         return [
+ *             'name' => 'required|string|max:255',
+ *             'hometown' => 'required|string|max:255',
+ *         ];
+ *     }
+ *
+ *     protected function getModelData(): array
+ *     {
+ *         return [
+ *             'name' => $this->name,
+ *             'hometown' => $this->hometown,
+ *         ];
+ *     }
+ * }
+ *
+ * // Using in a Livewire component
+ * class ManageWrestler extends Component
+ * {
+ *     public WrestlerForm $form;
+ *
+ *     public function mount(?Wrestler $wrestler = null): void
+ *     {
+ *         $this->form->setModel($wrestler);
+ *     }
+ *
+ *     public function save(): void
+ *     {
+ *         $this->form->store();
+ *         // Handle success response
+ *     }
+ * }
+ * ```
  */
 abstract class LivewireBaseForm extends Form
 {
     /**
-     * @var TFormModel
+     * The Eloquent model instance being managed by this form.
+     *
+     * This property holds the model that the form is either creating (null)
+     * or editing (populated model). The generic type TFormModel allows
+     * child classes to specify their exact model type while maintaining
+     * type safety throughout the application.
+     *
+     * State Management:
+     * - null: Form is in creation mode for new records
+     * - Model instance: Form is in edit mode for existing records
+     *
+     * The model serves as the source of truth for form data population
+     * and the target for data persistence operations.
+     *
+     * @var TFormModel The model instance or null for new records
      */
     protected ?Model $formModel;
 
+    /**
+     * The ID of the model being edited, or null for new records.
+     *
+     * This property persists across Livewire hydration cycles, ensuring
+     * that edit mode is maintained even when the formModel object reference
+     * is lost during Livewire's serialization/deserialization process.
+     *
+     * Made public so Livewire can properly hydrate this property.
+     *
+     * @var int|string|null The model's primary key value
+     */
+    public int|string|null $modelId = null;
+
+    /**
+     * A fallback field name for display purposes.
+     *
+     * Used by utility methods when a specific field name cannot be determined
+     * or when generating default display names for form elements. This provides
+     * a graceful fallback for error scenarios or incomplete data situations.
+     *
+     * @var string Default field name for fallback scenarios
+     */
     protected string $fieldName = 'Unknown';
 
     /**
-     * @param  TFormModel  $formModel
+     * Set the model for this form and populate form fields.
+     *
+     * This method implements the Template Method pattern by defining the standard
+     * flow for model binding while allowing subclasses to customize specific steps
+     * through the loadExtraData() hook method.
+     *
+     * The method performs several critical operations:
+     * 1. Binds the model instance to the form state
+     * 2. Populates form fields using Livewire's automatic fill mechanism
+     * 3. Triggers custom data loading for specialized form requirements
+     *
+     * When null is passed, the form is prepared for creating a new record with
+     * default values. When a model is passed, the form is prepared for editing
+     * that record with its current data values populated into form fields.
+     *
+     * @param  TFormModel  $formModel  The model to bind to this form, or null for new records
+     *
+     * @see fill() Livewire's automatic form field population
+     * @see loadExtraData() Hook for custom data loading implementations
+     *
+     * @example
+     * ```php
+     * // Setting up form for editing an existing wrestler
+     * $wrestler = Wrestler::find(1);
+     * $form->setModel($wrestler);
+     * // Form fields are now populated with wrestler data
+     * // Custom loadExtraData() is called for additional setup
+     *
+     * // Setting up form for creating a new wrestler
+     * $form->setModel(null);
+     * // Form is ready for new record creation with default values
+     * ```
      */
     public function setModel(?Model $formModel): void
     {
         $this->formModel = $formModel;
-        $this->fill($formModel);
+        $this->modelId = $formModel?->getKey();
+
+        // Fill form fields from model attributes if model exists
+        if ($formModel) {
+            $this->fill($formModel->getAttributes());
+        }
+
         $this->loadExtraData();
     }
 
+    /**
+     * Determine if the form is in creation mode.
+     *
+     * Utility method to check the current form state for conditional logic
+     * in form components. Useful for displaying different UI elements,
+     * applying different validation rules, or handling different workflows
+     * based on whether the form is creating or editing.
+     *
+     * @return bool True if creating a new record, false if editing existing
+     *
+     * @example
+     * ```php
+     * // In a form component
+     * public function getSubmitButtonText(): string
+     * {
+     *     return $this->isCreating() ? 'Create Wrestler' : 'Update Wrestler';
+     * }
+     *
+     * // In validation logic
+     * public function store(): bool
+     * {
+     *     $wasCreating = $this->isCreating();
+     *     $result = $this->storeModel();
+     *
+     *     if ($wasCreating && $result) {
+     *         // Handle post-creation logic
+     *         $this->handleNewRecordTasks();
+     *     }
+     *
+     *     return $result;
+     * }
+     * ```
+     */
+    public function isCreating(): bool
+    {
+        return $this->modelId === null;
+    }
+
+    /**
+     * Determine if the form is in editing mode.
+     *
+     * Utility method to check if the form is currently editing an existing
+     * model instance. Complementary to isCreating() for complete state
+     * checking capabilities in form logic.
+     *
+     * @return bool True if editing an existing record, false if creating new
+     *
+     * @example
+     * ```php
+     * // In form validation
+     * if ($this->isEditing()) {
+     *     // Apply edit-specific validation rules
+     *     $this->validateEditConstraints();
+     * }
+     *
+     * // In UI rendering - use HTML comment style for Blade examples
+     * <!-- In Blade template: -->
+     * <!-- @if($form->isEditing()) -->
+     * <!--     <p>Last updated: {{ $form->formModel->updated_at }}</p> -->
+     * <!-- @endif -->
+     * ```
+     */
+    public function isEditing(): bool
+    {
+        return $this->formModel !== null;
+    }
+
+    /**
+     * Generate a display name for editing based on a model field.
+     *
+     * This utility method safely extracts a field value from the bound model
+     * to create user-friendly display names, typically used in form headers,
+     * breadcrumbs, page titles, or any UI element that needs to display
+     * model-specific information.
+     *
+     * The method provides several layers of safety:
+     * 1. Checks if the model exists (handles creation mode gracefully)
+     * 2. Verifies the requested field exists on the model
+     * 3. Handles null field values with appropriate fallbacks
+     * 4. Converts values to strings for display purposes
+     *
+     * @param  string  $fieldName  The name of the model field to extract
+     * @return string The field value as a string, or 'Unknown' if unavailable
+     *
+     * @example
+     * ```php
+     * // In a form component for page titles
+     * public function getPageTitle(): string
+     * {
+     *     if ($this->isEditing()) {
+     *         return "Edit " . $this->generateModelEditName('name');
+     *         // Returns: "Edit Stone Cold Steve Austin"
+     *     }
+     *     return "Create New Wrestler";
+     * }
+     *
+     * // Usage in Blade templates for breadcrumbs
+     * // <nav aria-label="breadcrumb">
+     * //     <ol class="breadcrumb">
+     * //         <li><a href="/wrestlers">Wrestlers</a></li>
+     * //         <li>{{ $form->generateModelEditName('name') }}</li>
+     * //     </ol>
+     * // </nav>
+     *
+     * // For form headers with context
+     * // <h1>
+     * //     {{ $form->isEditing() ? 'Edit ' . $form->generateModelEditName('name') : 'New Wrestler' }}
+     * // </h1>
+     * ```
+     */
     public function generateModelEditName(string $fieldName): string
     {
+        // Handle creation mode - no model available
+        if (! $this->formModel) {
+            return 'Unknown';
+        }
+
+        // Check if the requested field exists on the model
         if (property_exists($this->formModel, $fieldName)) {
             return (string) ($this->formModel->{$fieldName} ?? 'Unknown');
         }
 
+        // Fallback for non-existent fields
         return 'Unknown';
     }
 
-    public function loadExtraData(): void {}
-
-    protected function rules(): array
+    /**
+     * Load additional data specific to the form implementation.
+     *
+     * This hook method implements part of the Template Method pattern by providing
+     * a customization point for subclasses to perform specialized data loading,
+     * transformation, or setup operations. It is called automatically after a
+     * model is set via setModel(), ensuring that all standard form population
+     * has completed before custom logic executes.
+     *
+     * The method is designed to be overridden by concrete form implementations
+     * that need to perform operations beyond simple field population, such as:
+     * - Converting stored data formats to form-friendly representations
+     * - Loading related model data that isn't automatically filled
+     * - Computing derived values for display purposes
+     * - Setting up default values for new records
+     * - Initializing complex form state based on model relationships
+     *
+     * Common Implementation Patterns:
+     *
+     * **Data Transformation**: Converting database storage formats to user-friendly
+     * form inputs (e.g., converting stored inches to feet/inches display format)
+     *
+     * **Relationship Loading**: Populating form fields with data from model
+     * relationships (e.g., loading employment start dates, match participants)
+     *
+     * **Computed Properties**: Calculating display values based on model data
+     * (e.g., age from birthdate, career statistics)
+     *
+     * **Conditional Setup**: Applying different initialization logic based on
+     * model state or user permissions
+     *
+     *
+     * @example
+     * ```php
+     * // In WrestlerForm - Data transformation example
+     * public function loadExtraData(): void
+     * {
+     *     if ($this->formModel) {
+     *         // Convert stored height (inches) to feet/inches for display
+     *         $height = $this->formModel->height;
+     *         $this->height_feet = (int) floor($height / 12);
+     *         $this->height_inches = $height % 12;
+     *
+     *         // Load employment start date from relationship
+     *         $this->start_date = $this->formModel->firstEmployment?->started_at;
+     *     } else {
+     *         // Set defaults for new records
+     *         $this->height_feet = 6;
+     *         $this->height_inches = 0;
+     *     }
+     * }
+     *
+     * // In EventMatchForm - Relationship loading example
+     * public function loadExtraData(): void
+     * {
+     *     if ($this->formModel) {
+     *         // Load many-to-many relationships as arrays
+     *         $this->wrestler_ids = $this->formModel->wrestlers->pluck('id')->toArray();
+     *         $this->referee_ids = $this->formModel->referees->pluck('id')->toArray();
+     *
+     *         // Load complex relationship data
+     *         $this->match_outcome_data = $this->formModel->outcome?->toFormData();
+     *     }
+     * }
+     *
+     * // In EventForm - Simple default setup example
+     * public function loadExtraData(): void
+     * {
+     *     if (!$this->formModel) {
+     *         // Set reasonable defaults for new events
+     *         $this->date = now()->addWeeks(2)->toDateString();
+     *         $this->start_time = '19:00';
+     *         $this->status = 'scheduled';
+     *     }
+     * }
+     * ```
+     *
+     * @see WrestlerForm::loadExtraData() For height conversion and employment loading
+     * @see EventMatchForm::loadExtraData() For relationship array population
+     * @see setModel() For the complete model binding workflow
+     */
+    protected function loadExtraData(): void
     {
-        return [];
+        // Default implementation does nothing
+        // Child classes should override this method to implement custom loading logic
     }
 
+    /**
+     * Store model data with validation and persistence handling.
+     *
+     * This method provides the standard workflow for persisting form data to
+     * the database. It handles both creation and update operations seamlessly,
+     * applying validation and transforming form data into model-compatible
+     * format before persistence.
+     *
+     * The method implements a standardized flow:
+     * 1. Validate all form data using defined rules
+     * 2. Transform form data using getModelData() method
+     * 3. Create or update the model based on current form state
+     * 4. Return success status for UI feedback
+     *
+     * Child classes can override this method to add custom logic such as:
+     * - Additional validation steps
+     * - Related model creation/updates
+     * - Event broadcasting
+     * - Cache invalidation
+     * - Audit logging
+     *
+     * @return bool True on successful storage, false on failure
+     *
+     * @throws ValidationException If validation fails
+     *
+     * @see getModelData() For data transformation implementation
+     * @see rules() For validation rule definition
+     * @see WrestlerForm::store() For example with employment relationship handling
+     *
+     * @example
+     * ```php
+     * // Basic usage in a Livewire component
+     * public function save(): void
+     * {
+     *     if ($this->form->store()) {
+     *         session()->flash('message', 'Record saved successfully!');
+     *         $this->redirect('/wrestlers');
+     *     }
+     * }
+     *
+     * // Override in child class for custom logic
+     * public function store(): bool
+     * {
+     *     $this->validate();
+     *
+     *     $wasCreating = $this->isCreating();
+     *     $result = $this->storeModel();
+     *
+     *     if ($result && $wasCreating) {
+     *         // Handle post-creation tasks
+     *         $this->createInitialEmployment();
+     *         $this->sendWelcomeNotification();
+     *     }
+     *
+     *     return $result;
+     * }
+     * ```
+     */
+    public function store(): bool
+    {
+        $this->validate();
+
+        return $this->storeModel();
+    }
+
+    /**
+     * Submit the form (alias for store method).
+     *
+     * Provides a convenient alias for the store method to match common
+     * form submission patterns and testing expectations.
+     *
+     * @return bool True on successful submission, false otherwise
+     */
+    public function submit(): bool
+    {
+        return $this->store();
+    }
+
+    /**
+     * Perform the actual model persistence operation.
+     *
+     * This method handles the low-level database operations for both creating
+     * new models and updating existing ones. It uses the getModelData() method
+     * to transform form data into model-compatible format and applies the
+     * appropriate persistence strategy based on the current form state.
+     *
+     * The method abstracts away the differences between creation and update
+     * operations, providing a consistent interface for child classes while
+     * handling the underlying Eloquent operations appropriately.
+     *
+     * For creation operations:
+     * - Creates a new model instance with the provided data
+     * - Saves the new instance to the database
+     * - Updates formModel property with the new instance
+     *
+     * For update operations:
+     * - Updates the existing model with new data
+     * - Saves changes to the database
+     * - Maintains the existing model reference
+     *
+     * @return bool True if the model was successfully saved, false otherwise
+     *
+     * @throws Exception If model creation or update fails
+     *
+     * @see getModelData() For data transformation requirements
+     * @see isCreating() For operation mode detection
+     *
+     * @example
+     * ```php
+     * // Called automatically by store() method
+     * public function store(): bool
+     * {
+     *     $this->validate();
+     *
+     *     // This will call storeModel() internally
+     *     $result = $this->storeModel();
+     *
+     *     if ($result) {
+     *         // Handle successful save
+     *         $this->handlePostSaveOperations();
+     *     }
+     *
+     *     return $result;
+     * }
+     * ```
+     */
+    protected function storeModel(): bool
+    {
+        $data = $this->getModelData();
+
+        if ($this->isCreating()) {
+            // Create new model instance
+            $modelClass = $this->getModelClass();
+            $this->formModel = $modelClass::create($data);
+            $this->modelId = $this->formModel->getKey();
+        } else {
+            // Update existing model
+            // Ensure we have the model instance - reload if necessary
+            if (! $this->formModel && $this->modelId) {
+                $modelClass = $this->getModelClass();
+                $this->formModel = $modelClass::findOrFail($this->modelId);
+            }
+
+            $this->formModel->update($data);
+        }
+
+        return true;
+    }
+
+    /**
+     * Transform form data into model-compatible format.
+     *
+     * This abstract method must be implemented by child classes to define how
+     * form fields are transformed into data suitable for model persistence.
+     * The method serves as a data transformation layer between the form's
+     * user-friendly representation and the model's storage requirements.
+     *
+     * The method should return an associative array where keys correspond to
+     * model attributes and values are the transformed form data. This allows
+     * for complex data transformations, calculations, and format conversions
+     * before database storage.
+     *
+     * Common transformation patterns include:
+     * - Converting display formats to storage formats
+     * - Combining multiple form fields into single model attributes
+     * - Applying business logic calculations
+     * - Filtering out fields that shouldn't be mass-assigned
+     * - Converting user input to appropriate data types
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     *
+     * @example
+     * ```php
+     * // In WrestlerForm - Complex transformation example
+     * protected function getModelData(): array
+     * {
+     *     // Convert feet/inches to total inches for storage
+     *     $height = new Height($this->height_feet, $this->height_inches);
+     *
+     *     return [
+     *         'name' => $this->name,
+     *         'hometown' => $this->hometown,
+     *         'height' => $height->toInches(), // Transform to storage format
+     *         'weight' => $this->weight,
+     *         'signature_move' => $this->signature_move,
+     *         // Note: employment data excluded - handled separately
+     *     ];
+     * }
+     *
+     * // In EventForm - Simple mapping example
+     * protected function getModelData(): array
+     * {
+     *     return [
+     *         'name' => $this->name,
+     *         'date' => $this->date,
+     *         'venue' => $this->venue,
+     *         'capacity' => $this->capacity,
+     *         'ticket_price' => $this->ticket_price * 100, // Convert to cents
+     *     ];
+     * }
+     *
+     * // In EventMatchForm - Relationship exclusion example
+     * protected function getModelData(): array
+     * {
+     *     return [
+     *         'event_id' => $this->event_id,
+     *         'match_type' => $this->match_type,
+     *         'scheduled_duration' => $this->scheduled_duration,
+     *         'notes' => $this->notes,
+     *         // wrestler_ids handled separately in relationships
+     *     ];
+     * }
+     * ```
+     *
+     * @see storeModel() For usage in persistence workflow
+     * @see WrestlerForm::getModelData() For complex transformation example
+     */
+    abstract protected function getModelData(): array;
+
+    /**
+     * Define validation rules for form fields.
+     *
+     * This abstract method must be implemented by child classes to specify
+     * the validation rules for their form fields. The method should return
+     * an array of Laravel validation rules that will be applied during the
+     * form submission process.
+     *
+     * The validation rules array follows Laravel's standard format where
+     * keys are field names and values are arrays of validation rules.
+     * Rules can include built-in Laravel validators, custom rule objects,
+     * conditional rules, and database uniqueness constraints.
+     *
+     * Child classes should implement comprehensive validation including:
+     * - Required field validation
+     * - Data type and format validation
+     * - Uniqueness constraints with proper model exclusion for updates
+     * - Custom business logic validation
+     * - Conditional validation based on form state
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     *
+     * @example
+     * ```php
+     * // In WrestlerForm - Comprehensive validation example
+     * protected function rules(): array
+     * {
+     *     return [
+     *         'name' => [
+     *             'required',
+     *             'string',
+     *             'max:255',
+     *             Rule::unique('wrestlers', 'name')->ignore($this->formModel)
+     *         ],
+     *         'hometown' => ['required', 'string', 'max:255'],
+     *         'height_feet' => ['required', 'integer', 'min:5', 'max:7'],
+     *         'height_inches' => ['required', 'integer', 'min:0', 'max:11'],
+     *         'weight' => ['required', 'integer', 'digits:3'],
+     *         'signature_move' => [
+     *             'nullable',
+     *             'string',
+     *             'max:255',
+     *             Rule::unique('wrestlers', 'signature_move')->ignore($this->formModel)
+     *         ],
+     *         'start_date' => [
+     *             'nullable',
+     *             'date',
+     *             new CanChangeEmploymentDate($this->formModel)
+     *         ],
+     *     ];
+     * }
+     *
+     * // In EventForm - Simpler validation example
+     * protected function rules(): array
+     * {
+     *     return [
+     *         'name' => ['required', 'string', 'max:255'],
+     *         'date' => ['required', 'date', 'after:today'],
+     *         'venue' => ['required', 'string', 'max:255'],
+     *         'capacity' => ['required', 'integer', 'min:50'],
+     *     ];
+     * }
+     * ```
+     *
+     * @see store() For validation usage in storage workflow
+     * @see validationAttributes() For custom field name definitions
+     */
+    abstract protected function rules(): array;
+
+    /**
+     * Define user-friendly attribute names for validation messages.
+     *
+     * This method allows child classes to provide custom field names that
+     * will be used in validation error messages instead of the actual form
+     * property names. This improves user experience by showing intuitive,
+     * readable field names in error messages.
+     *
+     * The method should return an array where keys are form property names
+     * and values are the user-friendly names that should appear in validation
+     * error messages. Only fields that need custom names need to be included;
+     * fields not specified will use their property names as-is.
+     *
+     * This is particularly useful for:
+     * - Converting technical field names to user-friendly terms
+     * - Providing proper capitalization and spacing
+     * - Using domain-specific terminology that users understand
+     * - Improving accessibility and user experience
+     *
+     * @return array<string, string> Field name mappings for validation messages
+     *
+     * @example
+     * ```php
+     * // In WrestlerForm - Technical to friendly mapping
+     * protected function validationAttributes(): array
+     * {
+     *     return [
+     *         'height_feet' => 'feet',
+     *         'height_inches' => 'inches',
+     *         'signature_move' => 'signature move',
+     *         'start_date' => 'start date',
+     *     ];
+     * }
+     * // Error message: "The feet field is required" instead of "The height_feet field is required"
+     *
+     * // In EventMatchForm - Domain terminology example
+     * protected function validationAttributes(): array
+     * {
+     *     return [
+     *         'wrestler_ids' => 'participating wrestlers',
+     *         'referee_id' => 'assigned referee',
+     *         'match_type' => 'match type',
+     *         'scheduled_duration' => 'scheduled duration',
+     *     ];
+     * }
+     * ```
+     *
+     * @see rules() For validation rule definitions
+     */
     protected function validationAttributes(): array
     {
         return [];
     }
+
+    /**
+     * Get the model class name for this form.
+     *
+     * This method should return the fully qualified class name of the model
+     * that this form manages. Used for creating new model instances.
+     *
+     * @return string The fully qualified model class name
+     *
+     * @example
+     * ```php
+     * protected function getModelClass(): string
+     * {
+     *     return Event::class;
+     * }
+     * ```
+     */
+    abstract protected function getModelClass(): string;
 }

--- a/app/Livewire/Base/Tables/BasePreviousManagersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousManagersTable.php
@@ -29,9 +29,9 @@ abstract class BasePreviousManagersTable extends DataTableComponent
         return [
             Column::make(__('managers.name'), 'manager.full_name')
                 ->searchable(),
-            DateColumn::make(__('managers.date_hired'), 'joined_at')
+            DateColumn::make(__('managers.date_hired'), 'hired_at')
                 ->outputFormat('Y-m-d'),
-            DateColumn::make(__('managers.date_fired'), 'left_at')
+            DateColumn::make(__('managers.date_fired'), 'fired_at')
                 ->outputFormat('Y-m-d'),
         ];
     }

--- a/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use App\Models\EventMatch;
-use App\Models\EventMatchCompetitor;
-use App\Models\Referee;
-use App\Models\Title;
-use Illuminate\Database\Eloquent\Model;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\EventMatchCompetitor;
+use App\Models\Referees\Referee;
+use App\Models\Titles\Title;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Columns\ArrayColumn;
@@ -40,8 +39,8 @@ abstract class BasePreviousMatchesTable extends DataTableComponent
     {
         return [
             LinkColumn::make(__('events.name'), 'event.name')
-                ->title(fn (Model $row) => $row->event->name)
-                ->location(fn (Model $row) => route('events.show', $row->event)),
+                ->title(fn (EventMatch $row) => $row->event->name)
+                ->location(fn (EventMatch $row) => route('events.show', $row->event)),
             DateColumn::make(__('events.date'), 'event.date')
                 ->inputFormat('Y-m-d H:i:s')
                 ->outputFormat('Y-m-d')
@@ -70,10 +69,10 @@ abstract class BasePreviousMatchesTable extends DataTableComponent
             Column::make(__('event-matches.result'))
                 ->label(function (EventMatch $row): string {
                     if ($row->result) {
-                        $winner = $row->result?->getWinner();
+                        $winner = $row->result->getWinner();
                         $type = str($winner->getMorphClass())->kebab()->plural();
 
-                        return '<a href="'.route($type.'.show', $winner->id).'">'.$winner->name.'</a> by '.$row->result?->decision->name;
+                        return '<a href="'.route($type.'.show', $winner->id).'">'.$winner->name.'</a> by '.$row->result->decision->name;
                     }
 
                     return 'N/A';

--- a/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
@@ -5,9 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use App\Models\TagTeam;
-use App\Models\TagTeamPartner;
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TagTeams\TagTeamWrestler;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
@@ -32,11 +30,11 @@ abstract class BasePreviousTagTeamsTable extends DataTableComponent
     {
         return [
             LinkColumn::make(__('tag-teams.name'))
-                ->title(fn (Model $row) => $row->tagTeam->name)
-                ->location(fn (Model $row) => route('tag-teams.show', $row)),
-            // LinkColumn::make(__('tag-teams.partner'))
-            //     ->title(fn (TagTeamPartner $row) => $row->partner->name)
-            //     ->location(fn (TagTeam $row) => route('wrestlers.show', $row)),
+                ->title(fn (TagTeamWrestler $row) => $row->tagTeam->name)
+                ->location(fn (TagTeamWrestler $row) => route('tag-teams.show', $row->tagTeam)),
+            LinkColumn::make(__('tag-teams.partner'))
+                ->title(fn (TagTeamWrestler $row) => $row->partner->name)
+                ->location(fn (TagTeamWrestler $row) => route('wrestlers.show', $row->partner)),
             DateColumn::make(__('stables.date_joined'), 'joined_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('stables.date_left'), 'left_at')

--- a/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use App\Models\TitleChampionship;
+use App\Models\Titles\TitleChampionship;
 use Illuminate\Database\Eloquent\Model;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\CountColumn;
 use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
 use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
@@ -17,16 +16,16 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
 {
     use ShowTableTrait;
 
-    protected string $databaseTableName = 'title_championships';
+    protected string $databaseTableName = 'titles_championships';
 
     protected string $resourceName = 'title championships';
 
     public function configure(): void
     {
         $this->addAdditionalSelects([
-            'title_championships.title_id',
-            'title_championships.won_at',
-            'title_championships.lost_at',
+            'titles_championships.title_id',
+            'titles_championships.won_at',
+            'titles_championships.lost_at',
         ]);
     }
 
@@ -42,24 +41,17 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
                 ->title(fn (TitleChampionship $row) => $row->title->name)
                 ->location(fn (TitleChampionship $row) => route('titles.show', $row->title)),
             LinkColumn::make(__('championships.previous_champion'))
-                ->title(fn (TitleChampionship $row) => $row->previousChampion->name ?? 'N/A')
+                ->title(fn (TitleChampionship $row) => 'N/A') // TODO: Implement previous champion lookup
                 ->location(function (Model $row) {
-                    $previousChampion = $row->previousChampion;
-
-                    if ($previousChampion) {
-                        $type = str($previousChampion->getMorphClass())->kebab()->plural();
-
-                        return route($type.'.show', $previousChampion);
-                    }
-
-                    return 'N/A';
+                    // TODO: Implement previous champion navigation
+                    return null;
                 }),
             DateColumn::make(__('championships.dates_held'), 'won_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('championships.dates_held'), 'lost_at')
                 ->outputFormat('Y-m-d'),
-            // CountColumn::make(__('championships.days_held'))
-            //     ->setDataSource('lengthInDays'),
+            Column::make(__('championships.days_held'))
+                ->label(fn (TitleChampionship $row) => $row->lengthInDays()),
         ];
     }
 }

--- a/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
@@ -27,7 +27,7 @@ abstract class BasePreviousWrestlersTable extends DataTableComponent
     public function columns(): array
     {
         return [
-            Column::make(__('wrestlers.name'), 'wrestler.name'),
+            Column::make(__('wrestlers.name'), 'member.name'),
             DateColumn::make(__('tag-teams.date_joined'), 'joined_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('tag-teams.date_left'), 'left_at')

--- a/app/Livewire/Components/Tables/Columns/FirstActivityPeriodColumn.php
+++ b/app/Livewire/Components/Tables/Columns/FirstActivityPeriodColumn.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Components\Tables\Columns;
+
+use App\Models\Stables\Stable;
+use App\Models\Titles\Title;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+
+class FirstActivityPeriodColumn extends Column
+{
+    public function __construct(string $title, ?string $from = null)
+    {
+        parent::__construct($title, $from);
+        $this->label(fn (Stable|Title $row, Column $column): string => $row->getFormattedFirstActivity());
+    }
+}

--- a/app/Livewire/Components/Tables/Columns/FirstEmploymentDateColumn.php
+++ b/app/Livewire/Components/Tables/Columns/FirstEmploymentDateColumn.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Components\Tables\Columns;
+
+use App\Models\Managers\Manager;
+use App\Models\Referees\Referee;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+
+class FirstEmploymentDateColumn extends Column
+{
+    public function __construct(string $title, ?string $from = null)
+    {
+        parent::__construct($title, $from);
+        $this->label(fn (Wrestler|TagTeam|Manager|Referee $row, Column $column): string => $row->getFormattedFirstEmployment());
+    }
+}

--- a/app/Livewire/Components/Tables/Filters/FirstActivityPeriodFilter.php
+++ b/app/Livewire/Components/Tables/Filters/FirstActivityPeriodFilter.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Components\Tables\Filters;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateRangeFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HandlesDates;
+use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasConfig;
+use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasOptions;
+use Rappasoft\LaravelLivewireTables\Views\Traits\Core\HasWireables;
+
+class FirstActivityPeriodFilter extends DateRangeFilter
+{
+    use HandlesDates,
+        HasConfig,
+        HasOptions,
+        HasWireables;
+
+    public string $filterRelationshipName = '';
+
+    public string $filterStartField = '';
+
+    public string $filterEndField = '';
+
+    public function __construct(string $name, ?string $key = null)
+    {
+        parent::__construct($name, $key);
+
+        $this->config([
+            'allowInput' => true,
+            'altFormat' => 'F j, Y',
+            'ariaDateFormat' => 'F j, Y',
+            'dateFormat' => 'Y-m-d',
+            'placeholder' => 'Enter Date Range',
+            'locale' => 'en',
+        ])
+            ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
+            ->filter(function (Builder $query, array $dateRange): void {
+                $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
+                    /**
+                     * @var array{'minDate': string, 'maxDate': string} $dateRange
+                     */
+                    $query
+                        ->where(function (Builder $query) use ($dateRange): void {
+                            $query->whereBetween(
+                                $this->filterStartField,
+                                [
+                                    Carbon::createFromFormat('Y-m-d', $dateRange['minDate'])?->startOfDay() ?? today()->startOfDay(),
+                                    Carbon::createFromFormat('Y-m-d', $dateRange['maxDate'])?->endOfDay() ?? today()->endOfDay(),
+                                ]);
+                        })
+                        ->orWhere(function (Builder $query) use ($dateRange): void {
+                            $query->whereBetween(
+                                $this->filterEndField,
+                                [
+                                    Carbon::createFromFormat('Y-m-d', $dateRange['minDate'])?->startOfDay() ?? today()->startOfDay(),
+                                    Carbon::createFromFormat('Y-m-d', $dateRange['maxDate'])?->endOfDay() ?? today()->endOfDay(),
+                                ]);
+                        });
+                });
+            });
+    }
+
+    public function setFields(string $relationshipName, string $startField, string $endField): self
+    {
+        $this->filterRelationshipName = $relationshipName;
+        $this->filterStartField = $startField;
+        $this->filterEndField = $endField;
+
+        return $this;
+    }
+}

--- a/app/Livewire/Components/Tables/Filters/FirstEmploymentFilter.php
+++ b/app/Livewire/Components/Tables/Filters/FirstEmploymentFilter.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Components\Tables\Filters;
+
+use Carbon\Carbon;
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\Views\Filters\DateRangeFilter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HandlesDates;
+use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasConfig;
+use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasOptions;
+use Rappasoft\LaravelLivewireTables\Views\Traits\Core\HasWireables;
+
+class FirstEmploymentFilter extends DateRangeFilter
+{
+    use HandlesDates,
+        HasConfig,
+        HasOptions,
+        HasWireables;
+
+    public string $filterRelationshipName = '';
+
+    public string $filterStartField = '';
+
+    public string $filterEndField = '';
+
+    public function __construct(string $name, ?string $key = null)
+    {
+        parent::__construct($name, $key);
+
+        $this->config([
+            'allowInput' => true,
+            'altFormat' => 'F j, Y',
+            'ariaDateFormat' => 'F j, Y',
+            'dateFormat' => 'Y-m-d',
+            'placeholder' => 'Enter Date Range',
+            'locale' => 'en',
+        ])
+            ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
+            ->filter(function (Builder $query, array $dateRange): void {
+                /**
+                 * @var array{'minDate': string, 'maxDate': string} $dateRange
+                 */
+                $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
+                    $query
+                        ->where(function (Builder $query) use ($dateRange): void {
+                            $query->whereBetween(
+                                $this->filterStartField,
+                                [
+                                    Carbon::createFromFormat('Y-m-d', $dateRange['minDate'])?->startOfDay() ?? today()->startOfDay(),
+                                    Carbon::createFromFormat('Y-m-d', $dateRange['maxDate'])?->endOfDay() ?? today()->endOfDay(),
+                                ]);
+                        })
+                        ->orWhere(function (Builder $query) use ($dateRange): void {
+                            $query->whereBetween(
+                                $this->filterEndField,
+                                [
+                                    Carbon::createFromFormat('Y-m-d', $dateRange['minDate'])?->startOfDay() ?? today()->startOfDay(),
+                                    Carbon::createFromFormat('Y-m-d', $dateRange['maxDate'])?->endOfDay() ?? today()->endOfDay(),
+                                ]);
+                        });
+                });
+            });
+    }
+
+    public function setFields(string $relationshipName, string $startField, string $endField): self
+    {
+        $this->filterRelationshipName = $relationshipName;
+        $this->filterStartField = $startField;
+        $this->filterEndField = $endField;
+
+        return $this;
+    }
+}

--- a/app/Livewire/Concerns/BaseModal.php
+++ b/app/Livewire/Concerns/BaseModal.php
@@ -22,7 +22,7 @@ abstract class BaseModal extends ModalComponent
     /**
      * @var TModelForm
      */
-    protected LivewireBaseForm $modelForm;
+    protected $modelForm;
 
     /**
      * @var TModelType
@@ -35,7 +35,7 @@ abstract class BaseModal extends ModalComponent
 
     protected string $titleField;
 
-    public function mount(?int $modelId = null): void
+    public function mount(mixed $modelId = null): void
     {
         if (isset($modelId)) {
             try {
@@ -79,6 +79,11 @@ abstract class BaseModal extends ModalComponent
      */
     public function render(): View
     {
+        // Ensure modalFormPath is set
+        if (! isset($this->modalFormPath)) {
+            $this->modalFormPath = 'blank';
+        }
+
         $view = 'livewire.'.$this->modalFormPath;
 
         if (! view()->exists($view)) {

--- a/app/Livewire/Concerns/Columns/HasActionColumn.php
+++ b/app/Livewire/Concerns/Columns/HasActionColumn.php
@@ -4,23 +4,27 @@ declare(strict_types=1);
 
 namespace App\Livewire\Concerns\Columns;
 
-use Illuminate\Database\Eloquent\Model;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 
+/**
+ * Provides action column functionality for Livewire table components.
+ *
+ * This trait adds the ability to include an action column in tables with
+ * view, edit, and delete links based on user permissions.
+ */
 trait HasActionColumn
 {
+    /**
+     * Get the default action column for the table.
+     */
     protected function getDefaultActionColumn(): Column
     {
         return Column::make(__('core.actions'))
-            ->setColumnLabelStatusDisabled()
-            ->label(
-                fn (Model $row, Column $column) => view('components.tables.columns.action-column')->with(
-                    [
-                        'rowId' => $row->id,
-                        'path' => $this->routeBasePath,
-                        'links' => $this->actionLinksToDisplay,
-                    ]
-                )
-            )->html();
+            ->label(fn ($row, Column $column) => view('components.tables.columns.action-column', [
+                'path' => $this->routeBasePath,
+                'rowId' => $row->id,
+            ]))
+            ->html()
+            ->excludeFromColumnSelect();
     }
 }

--- a/app/Livewire/Concerns/Data/PresentsManagersList.php
+++ b/app/Livewire/Concerns/Data/PresentsManagersList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns\Data;
+
+use App\Models\Managers\Manager;
+use Livewire\Attributes\Computed;
+
+trait PresentsManagersList
+{
+    /**
+     * @return array<int|string,string|null>
+     */
+    #[Computed(cache: true, key: 'managers-list', seconds: 180)]
+    public function getManagers(): array
+    {
+        return Manager::select('id', 'name')->pluck('name', 'id')->toArray();
+    }
+}

--- a/app/Livewire/Concerns/Data/PresentsMatchTypesList.php
+++ b/app/Livewire/Concerns/Data/PresentsMatchTypesList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns\Data;
+
+use App\Models\Matches\MatchType;
+use Livewire\Attributes\Computed;
+
+trait PresentsMatchTypesList
+{
+    /**
+     * @return array<int|string,string|null>
+     */
+    #[Computed(cache: true, key: 'match-types-list', seconds: 180)]
+    public function getMatchTypes(): array
+    {
+        return MatchType::select('id', 'name')->pluck('name', 'id')->toArray();
+    }
+}

--- a/app/Livewire/Concerns/Data/PresentsRefereesList.php
+++ b/app/Livewire/Concerns/Data/PresentsRefereesList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns\Data;
+
+use App\Models\Referees\Referee;
+use Livewire\Attributes\Computed;
+
+trait PresentsRefereesList
+{
+    /**
+     * @return array<int|string,string|null>
+     */
+    #[Computed(cache: true, key: 'referees-list', seconds: 180)]
+    public function getReferees(): array
+    {
+        return Referee::select('id', 'full_name')->pluck('full_name', 'id')->toArray();
+    }
+}

--- a/app/Livewire/Concerns/Data/PresentsTagTeamsList.php
+++ b/app/Livewire/Concerns/Data/PresentsTagTeamsList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns\Data;
+
+use App\Models\TagTeams\TagTeam;
+use Livewire\Attributes\Computed;
+
+trait PresentsTagTeamsList
+{
+    /**
+     * @return array<int|string,string|null>
+     */
+    #[Computed(cache: true, key: 'tag-teams-list', seconds: 180)]
+    public function getTagTeams(): array
+    {
+        return TagTeam::select('id', 'name')->pluck('name', 'id')->toArray();
+    }
+}

--- a/app/Livewire/Concerns/Data/PresentsTitlesList.php
+++ b/app/Livewire/Concerns/Data/PresentsTitlesList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns\Data;
+
+use App\Models\Titles\Title;
+use Livewire\Attributes\Computed;
+
+trait PresentsTitlesList
+{
+    /**
+     * @return array<int|string,string|null>
+     */
+    #[Computed(cache: true, key: 'titles-list', seconds: 180)]
+    public function getTitles(): array
+    {
+        return Title::select('id', 'name')->pluck('name', 'id')->toArray();
+    }
+}

--- a/app/Livewire/Concerns/Data/PresentsVenuesList.php
+++ b/app/Livewire/Concerns/Data/PresentsVenuesList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns\Data;
+
+use App\Models\Shared\Venue;
+use Livewire\Attributes\Computed;
+
+trait PresentsVenuesList
+{
+    /**
+     * @return array<int|string,string|null>
+     */
+    #[Computed(cache: true, key: 'venues-list', seconds: 180)]
+    public function getVenues(): array
+    {
+        return Venue::select('id', 'name')->pluck('name', 'id')->toArray();
+    }
+}

--- a/app/Livewire/Concerns/Data/PresentsWrestlersList.php
+++ b/app/Livewire/Concerns/Data/PresentsWrestlersList.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns\Data;
+
+use App\Models\Wrestlers\Wrestler;
+use Livewire\Attributes\Computed;
+
+trait PresentsWrestlersList
+{
+    /**
+     * @return array<int|string,string|null>
+     */
+    #[Computed(cache: true, key: 'wrestlers-list', seconds: 180)]
+    public function getWrestlers(): array
+    {
+        return Wrestler::select('id', 'name')->pluck('name', 'id')->toArray();
+    }
+}

--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -1,0 +1,393 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns;
+
+use Throwable;
+
+/**
+ * Trait for generating dummy data in Livewire forms and modals.
+ *
+ * This trait provides a standardized approach to populating form fields with
+ * realistic fake data for development and testing purposes. It automatically
+ * detects the form structure and populates fields accordingly.
+ *
+ * The trait works with both direct property assignment and form object patterns,
+ * making it flexible for different form architectures.
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ *
+ * @example
+ * ```php
+ * class EventMatchForm extends LivewireBaseForm
+ * {
+ *     use GeneratesDummyData;
+ *
+ *     public string $preview = '';
+ *     public int $matchTypeId = 0;
+ *
+ *     protected function getDummyDataFields(): array
+ *     {
+ *         return [
+ *             'preview' => fn() => fake()->paragraph() . ' Epic match!',
+ *             'matchTypeId' => fn() => fake()->numberBetween(1, 10),
+ *         ];
+ *     }
+ *
+ *     public function fillWithDummyData(): void
+ *     {
+ *         $this->fillDummyFields();
+ *     }
+ * }
+ * ```
+ */
+trait GeneratesDummyData
+{
+    /**
+     * Fill form fields with dummy data based on field definitions.
+     *
+     * This method automatically detects whether the form uses direct properties
+     * or a form object pattern and populates fields accordingly. It supports
+     * both callable generators and static values.
+     *
+     *
+     * @example
+     * ```php
+     * // Call this method to populate all defined dummy fields
+     * $this->fillDummyFields();
+     * ```
+     */
+    public function fillDummyFields(): void
+    {
+        $fields = $this->getDummyDataFields();
+
+        foreach ($fields as $field => $generator) {
+            $value = is_callable($generator) ? $generator() : $generator;
+
+            // Try to populate fields using available patterns
+            $this->populateField($field, $value);
+        }
+    }
+
+    /**
+     * Populate a single field with a value using available patterns.
+     *
+     * Attempts different field population strategies based on the class context.
+     *
+     * @param  string  $field  Field name to populate
+     * @param  mixed  $value  Value to set
+     */
+    private function populateField(string $field, mixed $value): void
+    {
+        // Strategy 1: Try modelForm property (for some form patterns)
+        if ($this->tryPopulateModelForm($field, $value)) {
+            return;
+        }
+
+        // Strategy 2: Try direct property assignment
+        if ($this->tryPopulateDirectProperty($field, $value)) {
+            return;
+        }
+
+        // Strategy 3: Try form property (for BaseFormModal pattern)
+        if ($this->tryPopulateFormProperty($field, $value)) {
+            return;
+        }
+
+        // If none work, silently skip (graceful degradation)
+    }
+
+    /**
+     * Try to populate via modelForm property.
+     *
+     * @param  string  $field  Field name
+     * @param  mixed  $value  Value to set
+     * @return bool True if successful
+     */
+    private function tryPopulateModelForm(string $field, mixed $value): bool
+    {
+        try {
+            if (isset($this->modelForm)) {
+                $this->modelForm->{$field} = $value;
+
+                return true;
+            }
+        } catch (Throwable) {
+            // Ignore and try next strategy
+        }
+
+        return false;
+    }
+
+    /**
+     * Try to populate via direct property.
+     *
+     * @param  string  $field  Field name
+     * @param  mixed  $value  Value to set
+     * @return bool True if successful
+     */
+    private function tryPopulateDirectProperty(string $field, mixed $value): bool
+    {
+        try {
+            if (property_exists($this, $field)) {
+                $this->{$field} = $value;
+
+                return true;
+            }
+        } catch (Throwable) {
+            // Ignore and try next strategy
+        }
+
+        return false;
+    }
+
+    /**
+     * Try to populate via form property (BaseFormModal pattern).
+     *
+     * @param  string  $field  Field name
+     * @param  mixed  $value  Value to set
+     * @return bool True if successful
+     */
+    private function tryPopulateFormProperty(string $field, mixed $value): bool
+    {
+        try {
+            if (isset($this->form)) {
+                $this->form->{$field} = $value;
+
+                return true;
+            }
+        } catch (Throwable) {
+            // Ignore - no more strategies
+        }
+
+        return false;
+    }
+
+    /**
+     * Get the dummy data field definitions for this form.
+     *
+     * This abstract method must be implemented by classes using this trait
+     * to define which fields should be populated and how they should be generated.
+     *
+     * @return array<string, callable|mixed> Array mapping field names to generators
+     *
+     * @example
+     * ```php
+     * protected function getDummyDataFields(): array
+     * {
+     *     return [
+     *         'name' => fn() => $this->generateWrestlingName(),
+     *         'signature_move' => fn() => $this->generateSignatureMove(),
+     *         'weight' => fn() => fake()->numberBetween(150, 300),
+     *         'active' => true, // Static value
+     *     ];
+     * }
+     * ```
+     */
+    abstract protected function getDummyDataFields(): array;
+
+    /**
+     * Generate a realistic wrestling-style name.
+     *
+     * Creates wrestling persona names using various patterns including
+     * real names, stage names with epithets, and single-word personas.
+     * Perfect for wrestler, manager, or character name generation.
+     *
+     * @return string A realistic wrestling name
+     *
+     * @example
+     * Possible outputs:
+     * - "John Smith"
+     * - "Thunder Johnson"
+     * - "The Destroyer"
+     * - "Mike 'Steel' Rodriguez"
+     */
+    protected function generateWrestlingName(): string
+    {
+        $patterns = [
+            fn () => fake()->firstName().' '.fake()->lastName(),
+            fn () => fake()->word().' '.fake()->lastName(),
+            fn () => 'The '.fake()->word(),
+            fn () => fake()->firstName().' "'.fake()->word().'" '.fake()->lastName(),
+        ];
+
+        $pattern = fake()->randomElement($patterns);
+
+        return ucwords($pattern());
+    }
+
+    /**
+     * Generate a realistic wrestling signature move name.
+     *
+     * Creates authentic-sounding wrestling move names by combining
+     * move types with optional modifiers, similar to real wrestling
+     * signature moves and finishers.
+     *
+     * @return string A realistic signature move name
+     *
+     * @example
+     * Possible outputs:
+     * - "Stone Cold Stunner"
+     * - "Tombstone Slam"
+     * - "Submission"
+     * - "People's Elbow"
+     */
+    protected function generateSignatureMove(): string
+    {
+        $moveTypes = [
+            'Stunner', 'Slam', 'Drop', 'Splash', 'Driver', 'Cutter', 'Bomb', 'Lock',
+            'Submission', 'Suplex', 'Clothesline', 'Elbow', 'Knee', 'Kick', 'Punch',
+        ];
+
+        $modifiers = [
+            'Stone Cold', 'Five Knuckle', 'Attitude', 'Rock Bottom', 'Sweet Chin',
+            'Razor\'s Edge', 'Tombstone', 'People\'s', 'Sharpshooter', 'Figure Four',
+        ];
+
+        $useModifier = fake()->boolean(60);
+
+        if ($useModifier) {
+            return fake()->randomElement($modifiers).' '.fake()->randomElement($moveTypes);
+        }
+
+        return fake()->randomElement($moveTypes);
+    }
+
+    /**
+     * Generate a realistic venue name with proper suffix.
+     *
+     * Creates venue names that sound like real wrestling arenas, combining
+     * either corporate sponsors with venue types or city names with
+     * appropriate venue suffixes.
+     *
+     * @return string A realistic venue name
+     *
+     * @example
+     * Possible outputs:
+     * - "Madison Square Garden"
+     * - "American Airlines Center"
+     * - "Chicago Stadium"
+     * - "Wells Fargo Arena"
+     */
+    protected function generateVenueName(): string
+    {
+        $suffixes = ['Arena', 'Center', 'Stadium', 'Coliseum', 'Garden', 'Dome', 'Auditorium'];
+        $prefixes = [
+            'American Airlines', 'Madison Square', 'Staples', 'Wells Fargo', 'TD Garden',
+            'United Center', 'Honda Center', 'Barclays', 'Target', 'Capital One',
+        ];
+
+        $usePrefix = fake()->boolean(70);
+
+        if ($usePrefix) {
+            return fake()->randomElement($prefixes).' '.fake()->randomElement($suffixes);
+        }
+
+        return fake()->city().' '.fake()->randomElement($suffixes);
+    }
+
+    /**
+     * Generate a realistic championship title name.
+     *
+     * Creates wrestling championship names that mirror real-world title
+     * structures, combining divisions/categories with appropriate title
+     * nomenclature used in professional wrestling.
+     *
+     * @return string A realistic championship title name
+     *
+     * @example
+     * Possible outputs:
+     * - "Intercontinental Championship Title"
+     * - "Women's Tag Team Titles"
+     * - "World Heavyweight Title"
+     * - "United States Championship"
+     */
+    protected function generateChampionshipTitle(): string
+    {
+        $titleTypes = [
+            'Championship Title', 'Title', 'Titles', 'Championship Titles',
+        ];
+
+        $categories = [
+            'Intercontinental', 'United States', 'European', 'Hardcore', 'Cruiserweight',
+            'Women\'s', 'Tag Team', 'World Heavyweight', 'Universal', 'Raw Women\'s',
+        ];
+
+        return fake()->randomElement($categories).' '.fake()->randomElement($titleTypes);
+    }
+
+    /**
+     * Generate realistic address components for US venues.
+     *
+     * Creates complete US address information suitable for venue locations,
+     * including proper state abbreviations and valid ZIP code formats.
+     *
+     * @return array<string, mixed> Address components with proper typing
+     *
+     * @example
+     * ```php
+     * $address = $this->generateUSAddress();
+     * // Returns:
+     * // [
+     * //     'street_address' => '123 Main Street',
+     * //     'city' => 'Chicago',
+     * //     'state' => 'IL',
+     * //     'zipcode' => 60601
+     * // ]
+     * ```
+     */
+    protected function generateUSAddress(): array
+    {
+        $stateAbbreviations = [
+            'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+            'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
+            'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
+            'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
+            'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
+        ];
+
+        return [
+            'street_address' => fake()->streetAddress(),
+            'city' => fake()->city(),
+            'state' => fake()->randomElement($stateAbbreviations),
+            'zipcode' => (int) fake()->numerify('#####'),
+        ];
+    }
+
+    /**
+     * Generate realistic future date for activations or employment.
+     *
+     * Creates future dates within a specified timeframe, useful for
+     * scheduling activations, contract start dates, or event dates.
+     * Uses probability to sometimes return null for optional dates.
+     *
+     * @param  float  $probability  Probability of generating a date (0.0 to 1.0)
+     * @param  string  $maxPeriod  Maximum future period (e.g., '+3 months', '+1 year')
+     * @return string|null Date string in Y-m-d format, or null
+     *
+     * @example
+     * ```php
+     * // 80% chance of a date within 3 months
+     * $startDate = $this->generateFutureDate(0.8, '+3 months');
+     *
+     * // Always generate a date within 1 year
+     * $contractDate = $this->generateFutureDate(1.0, '+1 year');
+     *
+     * // 30% chance of a date within 6 months
+     * $optionalDate = $this->generateFutureDate(0.3, '+6 months');
+     * ```
+     */
+    protected function generateFutureDate(float $probability = 0.8, string $maxPeriod = '+3 months'): ?string
+    {
+        if (! fake()->boolean($probability * 100)) {
+            return null;
+        }
+
+        $dateTime = fake()->dateTimeBetween('now', $maxPeriod);
+
+        return $dateTime->format('Y-m-d');
+    }
+}

--- a/app/Livewire/Concerns/ManagesActivityPeriods.php
+++ b/app/Livewire/Concerns/ManagesActivityPeriods.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns;
+
+use Illuminate\Database\QueryException;
+
+/**
+ * Trait for managing activity period operations in Livewire forms.
+ *
+ * This trait provides functionality for handling activity period creation and management
+ * within Livewire form components. It's designed to work with models that implement
+ * the HasActivityPeriods trait and provides automated activity period lifecycle
+ * management during form operations.
+ *
+ * The trait automatically handles activity period creation when new models are created
+ * with a specified start date, ensuring proper initialization of the activity period
+ * system without requiring manual intervention in each form class.
+ *
+ * Key Responsibilities:
+ * - Automatic activity period creation for new models
+ * - Integration with form model lifecycle events
+ * - Start date validation and processing
+ * - Activity period relationship management
+ *
+ * @requires HasActivityPeriods The target model must use HasActivityPeriods trait
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see HasActivityPeriods For model activity period functionality
+ *
+ * @example
+ * ```php
+ * class TitleForm extends LivewireBaseForm
+ * {
+ *     use ManagesActivityPeriods;
+ *
+ *     public string $start_date = '';
+ *
+ *     public function store(): bool
+ *     {
+ *         $this->validate();
+ *         $result = $this->storeModel();
+ *
+ *         // Automatically creates activity period if start_date is provided
+ *         $this->handleActivityPeriodCreation();
+ *
+ *         return $result;
+ *     }
+ * }
+ * ```
+ */
+trait ManagesActivityPeriods
+{
+    /**
+     * Handle activity period creation when creating a new model.
+     *
+     * Creates an initial activity period for the model if it's being created
+     * and has a start date specified. This method should be called after the
+     * main model has been saved to establish the initial activity period record.
+     *
+     * The method performs the following operations:
+     * 1. Checks if the form is in creation mode (not editing)
+     * 2. Validates that a start_date property exists and is not empty
+     * 3. Creates a new activity period record with the specified start date
+     *
+     * Integration Points:
+     * - Requires the formModel to use the HasActivityPeriods trait
+     * - Expects a $start_date property to be available on the form
+     * - Should be called after successful model creation
+     *
+     *
+     * @throws QueryException If activity period creation fails
+     *
+     * @example
+     * ```php
+     * public function store(): bool
+     * {
+     *     $this->validate();
+     *
+     *     // Create the main model
+     *     $result = $this->storeModel();
+     *
+     *     // Create activity period if applicable
+     *     $this->handleActivityPeriodCreation();
+     *
+     *     return $result;
+     * }
+     * ```
+     *
+     * @see HasActivityPeriods::activityPeriods() For the relationship method
+     */
+    protected function handleActivityPeriodCreation(): void
+    {
+        if (! empty($this->start_date)) {
+            $this->formModel->activityPeriods()->create([
+                'started_at' => $this->start_date,
+            ]);
+        }
+    }
+}

--- a/app/Livewire/Concerns/ManagesEmployment.php
+++ b/app/Livewire/Concerns/ManagesEmployment.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Concerns;
+
+trait ManagesEmployment
+{
+    protected function handleEmploymentCreation(): void
+    {
+        if (! empty($this->employment_date)) {
+            $this->formModel->employments()->create([
+                'started_at' => $this->employment_date,
+            ]);
+        }
+    }
+}

--- a/app/Livewire/Events/Forms/EventForm.php
+++ b/app/Livewire/Events/Forms/EventForm.php
@@ -1,0 +1,218 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Events\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Livewire\Concerns\Data\PresentsVenuesList;
+use App\Models\Events\Event;
+use App\Rules\Events\DateCanBeChanged;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
+
+/**
+ * Livewire form component for managing event creation and editing.
+ *
+ * This form handles the complete lifecycle of wrestling event management including
+ * event scheduling, venue assignment, and promotional content management.
+ * Provides specialized validation for event-specific requirements like date
+ * constraints and venue availability.
+ *
+ * Key Responsibilities:
+ * - Event information management (name, date, venue, preview)
+ * - Date validation with custom business rules for event scheduling
+ * - Venue relationship management and availability checking
+ * - Promotional content handling for event marketing
+ * - Event uniqueness validation across the system
+ * - Cached venue list presentation for efficient form rendering
+ *
+ * @extends LivewireBaseForm<EventForm, Event>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality
+ * @see PresentsVenuesList For venue selection functionality
+ * @see Event For the underlying event model
+ * @see DateCanBeChanged For custom date validation rules
+ *
+ * @property string $name Event name for promotional purposes
+ * @property Carbon|string|null $date Scheduled event date
+ * @property int $venue Venue ID for event location
+ * @property string $preview Promotional preview text for marketing
+ */
+class EventForm extends LivewireBaseForm
+{
+    use PresentsVenuesList;
+
+    /**
+     * The model instance being edited, or null for new event creation.
+     *
+     * @var Event|null Current event model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Event name for promotional and administrative purposes.
+     *
+     * Used for event marketing, match cards, ticket sales, and internal
+     * organization. Must be unique across all events in the system to
+     * avoid confusion in scheduling and promotion.
+     *
+     * @var string Event's promotional name
+     */
+    public string $name = '';
+
+    /**
+     * Scheduled date and time for the wrestling event.
+     *
+     * Critical for venue booking, promotional scheduling, and match planning.
+     * Validated against business rules to ensure proper event scheduling
+     * and avoid conflicts with existing events or venue availability.
+     *
+     * @var Carbon|string|null Event date and time
+     */
+    public Carbon|string|null $date = '';
+
+    /**
+     * Venue identifier for event location assignment.
+     *
+     * Links the event to a specific venue for logistical planning,
+     * capacity management, and promotional materials. Required when
+     * an event date is set to ensure proper venue booking.
+     *
+     * The PresentsVenuesList trait provides the getVenues() method
+     * for populating venue selection dropdowns in the UI.
+     *
+     * @var int Venue database ID
+     *
+     * @see getVenues() For venue selection list generation
+     */
+    public int $venue = 0;
+
+    /**
+     * Promotional preview content for marketing purposes.
+     *
+     * Used in promotional materials, websites, social media, and
+     * ticketing platforms to generate interest and provide event
+     * information to potential attendees.
+     *
+     * @var string|null Marketing preview text
+     */
+    public ?string $preview = '';
+
+    /**
+     * Load additional data when editing existing event records.
+     *
+     * Handles any specialized data loading for event edit operations.
+     * Currently no additional data loading is required for events
+     * beyond the standard form fill mechanism and venue list caching.
+     *
+     * The venue list is automatically cached via the PresentsVenuesList
+     * trait's computed property system for efficient rendering.
+     *
+     *
+     * @see PresentsVenuesList::getVenues() For venue list caching
+     */
+    public function loadExtraData(): void
+    {
+        // Map venue_id from model to venue form field
+        if ($this->formModel && isset($this->formModel->venue_id)) {
+            $this->venue = $this->formModel->venue_id;
+        }
+
+        // Venue list is cached automatically via PresentsVenuesList trait
+    }
+
+    /**
+     * Prepare event-specific data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure,
+     * ensuring proper field mapping and data type conversion for
+     * database persistence. Handles venue relationship mapping.
+     *
+     * Data Transformations:
+     * - Maps venue field to venue_id for proper foreign key relationship
+     * - Passes through date with proper Carbon/string handling
+     * - Maintains other fields with appropriate data types
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     *
+     * @see Event For model field requirements and relationships
+     */
+    protected function getModelData(): array
+    {
+        return [
+            'name' => $this->name,
+            'date' => $this->date,
+            'venue_id' => $this->venue,
+            'preview' => $this->preview,
+        ];
+    }
+
+    /**
+     * Get the model class for event form operations.
+     *
+     * Specifies the Event model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<Event> The Event model class
+     */
+    protected function getModelClass(): string
+    {
+        return Event::class;
+    }
+
+    /**
+     * Define validation rules for event form fields.
+     *
+     * Provides comprehensive validation for all event data including
+     * uniqueness constraints, date validation with custom business rules,
+     * venue relationship validation, and content requirements.
+     *
+     * The venue validation uses the exists rule to ensure the selected
+     * venue is available in the venues table, working in conjunction
+     * with the PresentsVenuesList trait's venue selection functionality.
+     *
+     * Validation Requirements:
+     * - Name: Required, unique across events, max 255 characters
+     * - Date: Optional, valid date format, custom business rule validation
+     * - Venue: Required when date is provided, must exist in venues table
+     * - Preview: Required promotional content, string format
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     *
+     * @see DateCanBeChanged For custom date validation logic
+     * @see Rule::unique() For database uniqueness constraints
+     * @see Rule::exists() For foreign key validation
+     * @see PresentsVenuesList::getVenues() For venue selection options
+     */
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('events', 'name')->ignore($this->formModel)],
+            'date' => ['nullable', 'date', new DateCanBeChanged($this->formModel)],
+            'venue' => ['required_with:date', 'integer', Rule::exists('venues', 'id')],
+            'preview' => ['nullable', 'string'],
+        ];
+    }
+
+    /**
+     * Get event-specific validation attributes.
+     *
+     * All standard attributes are provided by HasStandardValidationAttributes trait.
+     * This method handles event-specific field naming.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function getCustomValidationAttributes(): array
+    {
+        return [
+            'date' => 'event date',
+            'venue' => 'venue',
+            'preview' => 'event preview',
+        ];
+    }
+}

--- a/app/Livewire/Events/Modals/EventFormModal.php
+++ b/app/Livewire/Events/Modals/EventFormModal.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Events\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Events\Forms\EventForm;
+use App\Models\Events\Event;
+use App\Models\Shared\Venue;
+use Livewire\Attributes\Computed;
+
+/**
+ * Livewire modal component for wrestling event management.
+ *
+ * Manages the creation and editing of wrestling events including pay-per-views,
+ * television shows, house shows, and special events. Handles event scheduling,
+ * venue relationships, and promotional content generation.
+ *
+ * Key Features:
+ * - Modal-based event form interface
+ * - Wrestling event name generation
+ * - Event scheduling and venue assignment
+ * - Promotional content generation
+ * - Integration with event management workflows
+ *
+ * @extends BaseFormModal<EventForm, Event>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseFormModal For modal functionality and patterns
+ * @see Event For the underlying event model structure
+ */
+class EventFormModal extends BaseFormModal
+{
+    /**
+     * The event form instance for data management.
+     *
+     * Handles all event-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public EventForm $form;
+
+    /**
+     * Get list of venues for form dropdown.
+     */
+    #[Computed]
+    public function getVenues(): \Illuminate\Database\Eloquent\Collection
+    {
+        return Venue::orderBy('name')->get();
+    }
+
+    /**
+     * Get the form class that handles event data validation and processing.
+     *
+     * @return class-string<EventForm> The fully qualified class name of EventForm
+     */
+    protected function getFormClass(): string
+    {
+        return EventForm::class;
+    }
+
+    /**
+     * Get the model class that represents event entities.
+     *
+     * @return class-string<Event> The fully qualified class name of Event model
+     */
+    protected function getModelClass(): string
+    {
+        return Event::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the event form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'events.modals.form-modal';
+    }
+
+    /**
+     * Override mount to ensure proper form synchronization.
+     */
+    public function mount(mixed $modelId = null): void
+    {
+        parent::mount($modelId);
+
+        // Additional synchronization for EventForm
+        if ($modelId && $this->model) {
+            $this->form->setModel($this->model);
+        }
+    }
+
+    /**
+     * Generate dummy data fields for wrestling event testing and development.
+     *
+     * Returns field generators for event data including wrestling-appropriate
+     * names, scheduling, venue assignments, and promotional content.
+     *
+     * @return array<string, callable(): mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'name' => fn () => $this->generateEventName(),
+            'date' => fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d'),
+            /** @phpstan-ignore-next-line */
+            'venue' => fn () => Venue::inRandomOrder()->first()?->id ?? Venue::factory()->create()->id,
+            'preview' => fn () => $this->generateEventPreview(),
+        ];
+    }
+
+    /**
+     * Generate random event data for testing and development.
+     *
+     * Populates the form with realistic wrestling event data including names,
+     * scheduling, venue assignments, and promotional content. Generates data
+     * appropriate for various types of wrestling events.
+     */
+    public function generateRandomData(): void
+    {
+        // Generate venue assignment
+        /** @phpstan-ignore-next-line */
+        $venueId = Venue::inRandomOrder()->first()?->id ?? Venue::factory()->create()->id;
+
+        $this->form->fill([
+            'name' => $this->generateEventName(),
+            'date' => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d'),
+            'venue' => $venueId,
+            'preview' => $this->generateEventPreview(),
+        ]);
+    }
+
+    /**
+     * Generate a wrestling event name locally for this form.
+     */
+    private function generateEventName(): string
+    {
+        $famousEvents = [
+            'WrestleMania', 'SummerSlam', 'Royal Rumble', 'Survivor Series',
+            'Money in the Bank', 'Hell in a Cell', 'TLC', 'Extreme Rules',
+            'Fastlane', 'Elimination Chamber', 'Backlash', 'Payback',
+        ];
+
+        $weeklyShows = [
+            'Monday Night Raw', 'SmackDown Live', 'NXT', 'Friday Night SmackDown',
+            'Impact Wrestling', 'Dynamite', 'Rampage',
+        ];
+
+        $specialEvents = [
+            'Night of Champions', 'King of the Ring', 'Great American Bash',
+            'In Your House', 'No Way Out', 'Unforgiven', 'Vengeance',
+            'Judgment Day', 'Bad Blood', 'No Mercy', 'Armageddon',
+        ];
+
+        $adjectives = [
+            'Ultimate', 'Supreme', 'Mega', 'Super', 'Grand', 'Epic',
+            'Legendary', 'Championship', 'Elite', 'Prime', 'Maximum',
+        ];
+
+        $eventTypes = [
+            'Showdown', 'Clash', 'Battle', 'War', 'Rumble', 'Mayhem',
+            'Revolution', 'Evolution', 'Invasion', 'Uprising', 'Domination',
+        ];
+
+        $patterns = [
+            fn () => fake()->randomElement($famousEvents),
+            fn () => fake()->randomElement($weeklyShows),
+            fn () => fake()->randomElement($specialEvents),
+            fn () => fake()->randomElement($adjectives).' '.fake()->randomElement($eventTypes),
+        ];
+
+        return fake()->randomElement($patterns)();
+    }
+
+    /**
+     * Generate promotional preview content for wrestling events.
+     *
+     * Creates realistic promotional text that would be used to advertise
+     * wrestling events, including match previews, storyline elements,
+     * and promotional language typical of wrestling marketing.
+     *
+     * @return string Generated promotional preview text
+     *
+     * @example
+     * Returns text like: "Don't miss the most anticipated wrestling event of the year..."
+     */
+    protected function generateEventPreview(): string
+    {
+        $openings = [
+            "Don't miss the most anticipated wrestling event of the year",
+            'Get ready for an unforgettable night of sports entertainment',
+            'Witness history in the making at this epic wrestling spectacular',
+            'The biggest superstars collide in this must-see wrestling event',
+            'Experience the ultimate showdown between wrestling legends',
+            'Prepare for an action-packed evening of championship wrestling',
+        ];
+
+        $middles = [
+            'featuring championship matches, fierce rivalries, and unexpected surprises',
+            'with title matches, grudge matches, and career-defining moments',
+            'showcasing the best wrestlers from around the world',
+            'bringing you non-stop action and unforgettable moments',
+            'delivering high-impact matches and dramatic storylines',
+            'presenting the ultimate test of strength, skill, and determination',
+        ];
+
+        $endings = [
+            "Don't miss a single moment of the action!",
+            "This is one event you won't want to miss!",
+            'Be there live or watch on pay-per-view!',
+            'Tickets are selling fast - get yours today!',
+            'The excitement starts at 8 PM Eastern!',
+            'Order now and be part of wrestling history!',
+        ];
+
+        return fake()->randomElement($openings).', '.
+               fake()->randomElement($middles).'. '.
+               fake()->randomElement($endings);
+    }
+}

--- a/app/Livewire/Managers/Components/ManagerActionsComponent.php
+++ b/app/Livewire/Managers/Components/ManagerActionsComponent.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Managers\Components;
+
+use App\Actions\Managers\EmployAction;
+use App\Actions\Managers\HealAction;
+use App\Actions\Managers\InjureAction;
+use App\Actions\Managers\ReinstateAction;
+use App\Actions\Managers\ReleaseAction;
+use App\Actions\Managers\RestoreAction;
+use App\Actions\Managers\RetireAction;
+use App\Actions\Managers\SuspendAction;
+use App\Actions\Managers\UnretireAction;
+use App\Exceptions\Status\CannotBeClearedFromInjuryException;
+use App\Exceptions\Status\CannotBeEmployedException;
+use App\Exceptions\Status\CannotBeInjuredException;
+use App\Exceptions\Status\CannotBeReinstatedException;
+use App\Exceptions\Status\CannotBeReleasedException;
+use App\Exceptions\Status\CannotBeRetiredException;
+use App\Exceptions\Status\CannotBeSuspendedException;
+use App\Exceptions\Status\CannotBeUnretiredException;
+use App\Models\Managers\Manager;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+/**
+ * Manager Actions Component
+ *
+ * Handles all business actions that can be performed on a manager including
+ * employment management, health status changes, and career lifecycle operations.
+ * This component is designed to be reusable across different contexts (tables,
+ * detail pages, cards, etc.) while maintaining consistent authorization and
+ * error handling patterns.
+ */
+class ManagerActionsComponent extends Component
+{
+    public Manager $manager;
+
+    public function mount(Manager $manager): void
+    {
+        $this->manager = $manager;
+    }
+
+    /**
+     * Employ a manager.
+     */
+    public function employ(): void
+    {
+        Gate::authorize('employ', $this->manager);
+
+        try {
+            resolve(EmployAction::class)->handle($this->manager);
+            $this->dispatch('manager-updated');
+            session()->flash('status', 'Manager successfully employed.');
+        } catch (CannotBeEmployedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Release a manager.
+     */
+    public function release(): void
+    {
+        Gate::authorize('release', $this->manager);
+
+        try {
+            resolve(ReleaseAction::class)->handle($this->manager);
+            $this->dispatch('manager-updated');
+            session()->flash('status', 'Manager successfully released.');
+        } catch (CannotBeReleasedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Retire a manager.
+     */
+    public function retire(): void
+    {
+        Gate::authorize('retire', $this->manager);
+
+        try {
+            resolve(RetireAction::class)->handle($this->manager);
+            $this->dispatch('manager-updated');
+            session()->flash('status', 'Manager successfully retired.');
+        } catch (CannotBeRetiredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Unretire a manager.
+     */
+    public function unretire(): void
+    {
+        Gate::authorize('unretire', $this->manager);
+
+        try {
+            resolve(UnretireAction::class)->handle($this->manager);
+            $this->dispatch('manager-updated');
+            session()->flash('status', 'Manager successfully unretired.');
+        } catch (CannotBeUnretiredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Suspend a manager.
+     */
+    public function suspend(): void
+    {
+        Gate::authorize('suspend', $this->manager);
+
+        try {
+            resolve(SuspendAction::class)->handle($this->manager);
+            $this->dispatch('manager-updated');
+            session()->flash('status', 'Manager successfully suspended.');
+        } catch (CannotBeSuspendedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Reinstate a manager.
+     */
+    public function reinstate(): void
+    {
+        Gate::authorize('reinstate', $this->manager);
+
+        try {
+            resolve(ReinstateAction::class)->handle($this->manager);
+            $this->dispatch('manager-updated');
+            session()->flash('status', 'Manager successfully reinstated.');
+        } catch (CannotBeReinstatedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Injure a manager.
+     */
+    public function injure(): void
+    {
+        Gate::authorize('injure', $this->manager);
+
+        try {
+            resolve(InjureAction::class)->handle($this->manager);
+            $this->dispatch('manager-updated');
+            session()->flash('status', 'Manager injury recorded.');
+        } catch (CannotBeInjuredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Heal a manager from injury.
+     */
+    public function healFromInjury(): void
+    {
+        Gate::authorize('clearFromInjury', $this->manager);
+
+        try {
+            resolve(HealAction::class)->handle($this->manager);
+            $this->dispatch('manager-updated');
+            session()->flash('status', 'Manager cleared from injury.');
+        } catch (CannotBeClearedFromInjuryException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Restore a deleted manager.
+     */
+    public function restore(): void
+    {
+        Gate::authorize('restore', $this->manager);
+
+        resolve(RestoreAction::class)->handle($this->manager);
+        $this->dispatch('manager-updated');
+        session()->flash('status', 'Manager successfully restored.');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.managers.components.manager-actions-component');
+    }
+}

--- a/app/Livewire/Managers/Forms/ManagerForm.php
+++ b/app/Livewire/Managers/Forms/ManagerForm.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Managers\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Livewire\Concerns\ManagesEmployment;
+use App\Models\Managers\Manager;
+use App\Rules\Shared\CanChangeEmploymentDate;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * Livewire form component for managing manager creation and editing.
+ *
+ * This form handles wrestling manager personnel management including personal
+ * identification, name management, and employment tracking integration. Managers
+ * are key wrestling personalities who represent and guide wrestlers in storylines
+ * and business matters, requiring careful tracking of their employment status,
+ * personal information, and availability for wrestling programming.
+ *
+ * Key Responsibilities:
+ * - Manager personal identification (first and last name)
+ * - Employment relationship tracking for manager contracts
+ * - Personal information validation and data integrity
+ * - Integration with wrestler representation and storyline systems
+ * - Personnel record management for wrestling entertainment operations
+ *
+ * @extends LivewireBaseForm<ManagerForm, Manager>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ * @see ManagesEmployment For employment tracking capabilities
+ * @see CanChangeEmploymentDate For custom validation rules
+ *
+ * @property string $first_name Manager's first name for identification
+ * @property string $last_name Manager's last name for identification
+ * @property Carbon|string|null $employment_date Employment start date
+ */
+class ManagerForm extends LivewireBaseForm
+{
+    use ManagesEmployment;
+
+    /**
+     * The model instance being edited, or null for new manager creation.
+     *
+     * @var Manager|null Current manager model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Manager's first name for personal identification.
+     *
+     * Used for character development, storyline integration, promotional
+     * materials, employment documentation, and operational coordination.
+     * Combined with last name to create complete manager identification
+     * for wrestling programming and business operations.
+     *
+     * @var string Manager's first name
+     */
+    public string $first_name = '';
+
+    /**
+     * Manager's last name for personal identification.
+     *
+     * Used for character development, storyline integration, promotional
+     * materials, employment documentation, and operational coordination.
+     * Combined with first name to create complete manager identification
+     * for wrestling programming and business operations.
+     *
+     * @var string Manager's last name
+     */
+    public string $last_name = '';
+
+    /**
+     * Employment start date for manager contract tracking.
+     *
+     * Managed through ManagesEmployment trait for consistent employment
+     * tracking across all personnel types. Critical for storyline planning,
+     * payroll management, benefits administration, and availability
+     * scheduling for wrestling programming and events.
+     *
+     * @var Carbon|string|null Manager employment start date
+     */
+    public Carbon|string|null $employment_date = null;
+
+    /**
+     * Load additional data when editing existing manager records.
+     *
+     * Handles employment relationship data loading for edit operations,
+     * retrieving employment start date from the manager's employment
+     * relationship for display and modification in the form. Essential
+     * for maintaining accurate employment records.
+     *
+     * Employment Integration:
+     * - Loads start date from employment relationship
+     * - Handles null employment for managers not yet contracted
+     * - Converts Carbon dates to string format for form display
+     *
+     *
+     * @see ManagesEmployment::$employment_date For employment date handling
+     */
+    public function loadExtraData(): void
+    {
+        // Only process if we have a manager model
+        if (! $this->formModel instanceof Manager) {
+            return;
+        }
+
+        // Load employment start date from relationship
+        $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
+    }
+
+    /**
+     * Prepare manager data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure.
+     * Includes personal identification data while excluding employment
+     * information which is handled separately through the employment
+     * relationship system for proper data separation and integrity.
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     */
+    protected function getModelData(): array
+    {
+        return [
+            'first_name' => $this->first_name,
+            'last_name' => $this->last_name,
+        ];
+        // Note: employment data is managed separately through
+        // the employment relationship system
+    }
+
+    /**
+     * Get the model class for manager form operations.
+     *
+     * Specifies the Manager model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<Manager> The Manager model class
+     */
+    protected function getModelClass(): string
+    {
+        return Manager::class;
+    }
+
+    /**
+     * Define validation rules for manager form fields.
+     *
+     * Provides comprehensive validation for manager personal data including
+     * name requirements and employment date validation through custom rules.
+     * Ensures manager records have complete identification information for
+     * operational, storyline, and administrative purposes.
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     */
+    protected function rules(): array
+    {
+        return [
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
+            'employment_date' => ['nullable', 'date', new CanChangeEmploymentDate($this->formModel)],
+        ];
+    }
+
+    /**
+     * Get manager-specific validation attributes.
+     *
+     * Extends standard attributes with manager-specific field names for better
+     * user experience in validation messages.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function validationAttributes(): array
+    {
+        return [
+            'first_name' => 'first name',
+            'last_name' => 'last name',
+            'employment_date' => 'employment date',
+        ];
+    }
+}

--- a/app/Livewire/Managers/Modals/ManagerFormModal.php
+++ b/app/Livewire/Managers/Modals/ManagerFormModal.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Managers\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Managers\Forms\ManagerForm;
+use App\Models\Managers\Manager;
+use Livewire\Form;
+
+/**
+ * Livewire modal component for wrestling manager management.
+ *
+ * Handles the creation and editing of wrestling manager personnel including
+ * personal information, career start dates, and managerial credentials.
+ * Managers typically handle wrestler representation and storyline development.
+ *
+ * Key Features:
+ * - Modal-based manager form interface
+ * - Wrestling manager name generation
+ * - Career start date generation
+ * - Form validation with manager-specific rules
+ * - Integration with manager management workflows
+ *
+ * @extends BaseFormModal<ManagerForm, Manager>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseFormModal For modal functionality and patterns
+ * @see Manager For the underlying manager model structure
+ */
+class ManagerFormModal extends BaseFormModal
+{
+    /**
+     * The manager form instance for data management.
+     *
+     * Handles all manager-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public ManagerForm $form;
+
+    /**
+     * Get the form class that handles manager data validation and processing.
+     *
+     * @return class-string<ManagerForm> The fully qualified class name of ManagerForm
+     */
+    protected function getFormClass(): string
+    {
+        return ManagerForm::class;
+    }
+
+    /**
+     * Get the model class that represents manager entities.
+     *
+     * @return class-string<Manager> The fully qualified class name of Manager model
+     */
+    protected function getModelClass(): string
+    {
+        return Manager::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the manager form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'managers.modals.form-modal';
+    }
+
+    /**
+     * Generate dummy data fields for manager testing and development.
+     *
+     * Returns field generators for manager data including realistic names
+     * and career start dates appropriate for wrestling managerial personnel.
+     *
+     * @return array<string, callable(): mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'first_name' => fn () => $this->generateManagerFirstName(),
+            'last_name' => fn () => $this->generateManagerLastName(),
+            'employment_date' => fake()->optional(0.8, fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d H:i:s')),
+        ];
+    }
+
+    /**
+     * Generate random manager data for testing and development.
+     *
+     * Populates the form with realistic manager data including names and
+     * career start dates. Generates data appropriate for wrestling manager
+     * personnel records and testing workflows.
+     */
+    public function generateRandomData(): void
+    {
+        $this->form->fill([
+            'first_name' => $this->generateManagerFirstName(),
+            'last_name' => $this->generateManagerLastName(),
+            'employment_date' => fake()->optional(0.8, fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d H:i:s')),
+        ]);
+    }
+
+    /**
+     * Generate a realistic wrestling manager first name.
+     *
+     * Creates first names that are appropriate for wrestling manager
+     * personnel, including famous manager names and professional names
+     * suitable for managerial roles in wrestling.
+     *
+     * @return string A generated first name
+     *
+     * @example
+     * Returns names like: "Paul", "Bobby", "Jimmy", "Vickie"
+     */
+    protected function generateManagerFirstName(): string
+    {
+        // Famous wrestling manager names
+        $famousManagerNames = [
+            'Paul', 'Bobby', 'Jimmy', 'Vickie', 'Stephanie', 'Triple',
+            'Vince', 'Eric', 'Teddy', 'William', 'Dutch', 'Gorilla',
+            'Jesse', 'Jerry', 'Jim', 'Lana', 'Zelina', 'Lio',
+        ];
+
+        $professionalNames = [
+            'Alexander', 'Benjamin', 'Catherine', 'Dominic', 'Elizabeth',
+            'Frederick', 'Gabrielle', 'Harrison', 'Isabella', 'Jonathan',
+            'Katherine', 'Lawrence', 'Margaret', 'Nathaniel', 'Olivia',
+            'Patricia', 'Quinton', 'Rebecca', 'Sebastian', 'Victoria',
+        ];
+
+        $patterns = [
+            // 70% chance of famous manager names
+            fn () => fake()->randomElement($famousManagerNames),
+            // 30% chance of professional names
+            fn () => fake()->randomElement($professionalNames),
+        ];
+
+        return fake()->randomFloat(null, 0, 1) < 0.7
+            ? $patterns[0]()
+            : $patterns[1]();
+    }
+
+    /**
+     * Generate a realistic wrestling manager last name.
+     *
+     * Creates last names that are appropriate for wrestling manager
+     * personnel, including famous manager surnames and professional
+     * surnames suitable for executive and managerial positions.
+     *
+     * @return string A generated last name
+     *
+     * @example
+     * Returns names like: "Heyman", "Heenan", "Hart", "McMahon"
+     */
+    protected function generateManagerLastName(): string
+    {
+        // Famous wrestling manager surnames
+        $famousManagerSurnames = [
+            'Heyman', 'Heenan', 'Hart', 'McMahon', 'Guerrero', 'Cornette',
+            'Fuji', 'Blassie', 'Albano', 'Bearer', 'Long', 'Regal',
+            'Stephanie', 'Dolph', 'Lashley', 'Vega', 'Rush', 'Banks',
+        ];
+
+        $professionalSurnames = [
+            'Anderson', 'Barrett', 'Campbell', 'Davidson', 'Edwards',
+            'Fitzgerald', 'Goldman', 'Harrison', 'Jackson', 'Kingston',
+            'Lancaster', 'Morrison', 'Newcastle', 'Patterson', 'Richardson',
+            'Stevenson', 'Thompson', 'Wellington', 'Worthington', 'York',
+        ];
+
+        $patterns = [
+            // 60% chance of famous manager surnames
+            fn () => fake()->randomElement($famousManagerSurnames),
+            // 40% chance of professional surnames
+            fn () => fake()->randomElement($professionalSurnames),
+        ];
+
+        return fake()->randomFloat(null, 0, 1) < 0.6
+            ? $patterns[0]()
+            : $patterns[1]();
+    }
+}

--- a/app/Livewire/Managers/Tables/ManagersTable.php
+++ b/app/Livewire/Managers/Tables/ManagersTable.php
@@ -4,8 +4,8 @@ declare(strict_types=1);
 
 namespace App\Livewire\Managers\Tables;
 
-use App\Actions\Managers\ClearInjuryAction;
 use App\Actions\Managers\EmployAction;
+use App\Actions\Managers\HealAction;
 use App\Actions\Managers\InjureAction;
 use App\Actions\Managers\ReinstateAction;
 use App\Actions\Managers\ReleaseAction;
@@ -13,32 +13,30 @@ use App\Actions\Managers\RestoreAction;
 use App\Actions\Managers\RetireAction;
 use App\Actions\Managers\SuspendAction;
 use App\Actions\Managers\UnretireAction;
-use App\Builders\ManagerBuilder;
-use App\Enums\EmploymentStatus;
-use App\Exceptions\CannotBeClearedFromInjuryException;
-use App\Exceptions\CannotBeEmployedException;
-use App\Exceptions\CannotBeInjuredException;
-use App\Exceptions\CannotBeReinstatedException;
-use App\Exceptions\CannotBeReleasedException;
-use App\Exceptions\CannotBeRetiredException;
-use App\Exceptions\CannotBeSuspendedException;
-use App\Exceptions\CannotBeUnretiredException;
+use App\Builders\Roster\ManagerBuilder;
+use App\Enums\Shared\EmploymentStatus;
+use App\Exceptions\Status\CannotBeClearedFromInjuryException;
+use App\Exceptions\Status\CannotBeEmployedException;
+use App\Exceptions\Status\CannotBeInjuredException;
+use App\Exceptions\Status\CannotBeReinstatedException;
+use App\Exceptions\Status\CannotBeReleasedException;
+use App\Exceptions\Status\CannotBeRetiredException;
+use App\Exceptions\Status\CannotBeSuspendedException;
+use App\Exceptions\Status\CannotBeUnretiredException;
 use App\Livewire\Base\Tables\BaseTableWithActions;
-use App\Livewire\Concerns\Columns\HasStatusColumn;
-use App\Livewire\Concerns\Filters\HasStatusFilter;
-use App\Models\Manager;
-use App\View\Columns\FirstEmploymentDateColumn;
-use App\View\Filters\FirstEmploymentFilter;
+use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
+use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
+use App\Livewire\Managers\Components\ManagerActionsComponent;
+use App\Models\Managers\Manager;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Filter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class ManagersTable extends BaseTableWithActions
 {
-    use HasStatusColumn, HasStatusFilter;
-
     protected string $databaseTableName = 'managers';
 
     protected string $routeBasePath = 'managers';
@@ -55,7 +53,10 @@ class ManagersTable extends BaseTableWithActions
             ->oldest('last_name');
     }
 
-    public function configure(): void {}
+    public function configure(): void
+    {
+        Gate::authorize('viewList', Manager::class);
+    }
 
     /**
      * Undocumented function
@@ -67,7 +68,9 @@ class ManagersTable extends BaseTableWithActions
         return [
             Column::make(__('managers.name'), 'full_name')
                 ->searchable(),
-            $this->getDefaultStatusColumn(),
+            Column::make(__('core.status'), 'status')
+                ->label(fn ($row) => $row->status?->label() ?? 'Unknown')
+                ->excludeFromColumnSelect(),
             FirstEmploymentDateColumn::make(__('employments.started_at')),
         ];
     }
@@ -79,11 +82,28 @@ class ManagersTable extends BaseTableWithActions
      */
     public function filters(): array
     {
-        /** @var array<string, string> $statuses */
-        $statuses = collect(EmploymentStatus::cases())->pluck('name', 'value')->toArray();
-
         return [
-            $this->getDefaultStatusFilter($statuses),
+            SelectFilter::make(__('core.status')) // @phpstan-ignore-line method.notFound
+                ->setFilterPillTitle(__('core.status'))
+                ->options([
+                    '' => __('core.all'),
+                    'employed' => 'Employed',
+                    'future_employment' => 'Awaiting Employment',
+                    'released' => 'Released',
+                    'unemployed' => 'Unemployed',
+                    'retired' => 'Retired',
+                ])
+                ->filter(function ($builder, string $value) {
+                    /** @var ManagerBuilder<Manager> $builder */
+                    match ($value) {
+                        'employed' => $builder->employed(),
+                        'future_employment' => $builder->where('status', EmploymentStatus::FutureEmployment),
+                        'released' => $builder->released(),
+                        'unemployed' => $builder->unemployed(),
+                        'retired' => $builder->retired(),
+                        default => null,
+                    };
+                }),
             FirstEmploymentFilter::make('Employment Date')->setFields('employments', 'managers_employments.started_at', 'managers_employments.ended_at'),
         ];
     }
@@ -101,7 +121,7 @@ class ManagersTable extends BaseTableWithActions
         Gate::authorize('clearFromInjury', $manager);
 
         try {
-            resolve(ClearInjuryAction::class)->handle($manager);
+            resolve(HealAction::class)->handle($manager);
         } catch (CannotBeClearedFromInjuryException $e) {
             return redirect()->back()->with('error', $e->getMessage());
         }
@@ -237,5 +257,27 @@ class ManagersTable extends BaseTableWithActions
         }
 
         return back();
+    }
+
+    public function handleManagerAction(string $action, int $managerId): void
+    {
+        $manager = Manager::findOrFail($managerId);
+
+        // Delegate to the ManagerActionsComponent
+        $actionsComponent = new ManagerActionsComponent();
+        $actionsComponent->manager = $manager;
+
+        match ($action) {
+            'employ' => $actionsComponent->employ(),
+            'release' => $actionsComponent->release(),
+            'retire' => $actionsComponent->retire(),
+            'unretire' => $actionsComponent->unretire(),
+            'suspend' => $actionsComponent->suspend(),
+            'reinstate' => $actionsComponent->reinstate(),
+            'injure' => $actionsComponent->injure(),
+            'heal' => $actionsComponent->healFromInjury(),
+            'restore' => $actionsComponent->restore(),
+            default => null,
+        };
     }
 }

--- a/app/Livewire/Managers/Tables/PreviousStablesTable.php
+++ b/app/Livewire/Managers/Tables/PreviousStablesTable.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Managers\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
-use App\Models\StableManager;
+use App\Models\Stables\Stable;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -16,12 +16,14 @@ class PreviousStablesTable extends BasePreviousStablesTable
      */
     public ?int $managerId;
 
-    protected string $databaseTableName = 'stables_managers';
+    protected string $databaseTableName = 'stables';
 
     protected string $resourceName = 'stables';
 
     /**
-     * @return Builder<StableManager>
+     * Get stables that the manager was associated with through wrestlers/tag teams they managed.
+     *
+     * @return Builder<Stable>
      */
     public function builder(): Builder
     {
@@ -29,16 +31,30 @@ class PreviousStablesTable extends BasePreviousStablesTable
             throw new Exception("You didn't specify a manager");
         }
 
-        return StableManager::query()
-            ->where('manager_id', $this->managerId)
-            ->whereNotNull('left_at')
-            ->orderByDesc('joined_at');
+        // Get stables through wrestlers that this manager managed
+        $wrestlerStables = Stable::query()
+            ->join('stables_members as sm_w', 'stables.id', '=', 'sm_w.stable_id')
+            ->join('wrestler_managers as wm', 'sm_w.member_id', '=', 'wm.wrestler_id')
+            ->where('sm_w.member_type', 'wrestler')
+            ->where('wm.manager_id', $this->managerId)
+            ->whereNotNull('wm.ended_at')
+            ->select('stables.*', 'wm.started_at as joined_at', 'wm.ended_at as left_at');
+
+        // Get stables through tag teams that this manager managed
+        $tagTeamStables = Stable::query()
+            ->join('stables_members as sm_t', 'stables.id', '=', 'sm_t.stable_id')
+            ->join('tag_team_managers as ttm', 'sm_t.member_id', '=', 'ttm.tag_team_id')
+            ->where('sm_t.member_type', 'tagTeam')
+            ->where('ttm.manager_id', $this->managerId)
+            ->whereNotNull('ttm.ended_at')
+            ->select('stables.*', 'ttm.started_at as joined_at', 'ttm.ended_at as left_at');
+
+        // Union the results and return unique stables
+        return $wrestlerStables->union($tagTeamStables)->distinct();
     }
 
     public function configure(): void
     {
-        $this->addAdditionalSelects([
-            'stables_managers.stable_id as stable_id',
-        ]);
+        // No additional selects needed since we're selecting from stables directly
     }
 }

--- a/app/Livewire/Managers/Tables/PreviousTagTeamsTable.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeamsTable.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Managers\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use App\Models\TagTeamManager;
+use App\Models\TagTeams\TagTeamManager;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
@@ -36,7 +36,7 @@ class PreviousTagTeamsTable extends DataTableComponent
 
         return TagTeamManager::query()
             ->where('manager_id', $this->managerId)
-            ->whereNotNull('left_at')
+            ->whereNotNull('fired_at')
             ->orderByDesc('hired_at');
     }
 
@@ -58,7 +58,7 @@ class PreviousTagTeamsTable extends DataTableComponent
             Column::make(__('tag-teams.name'), 'tagTeam.name'),
             DateColumn::make(__('managers.date_hired'), 'hired_at')
                 ->outputFormat('Y-m-d'),
-            DateColumn::make(__('managers.date_fired'), 'left_at')
+            DateColumn::make(__('managers.date_fired'), 'fired_at')
                 ->outputFormat('Y-m-d'),
         ];
     }

--- a/app/Livewire/Managers/Tables/PreviousWrestlersTable.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlersTable.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Managers\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use App\Models\WrestlerManager;
+use App\Models\Wrestlers\WrestlerManager;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
@@ -33,7 +33,7 @@ class PreviousWrestlersTable extends DataTableComponent
 
         return WrestlerManager::query()
             ->where('manager_id', $this->managerId)
-            ->whereNotNull('left_at')
+            ->whereNotNull('fired_at')
             ->orderByDesc('hired_at');
     }
 
@@ -55,7 +55,7 @@ class PreviousWrestlersTable extends DataTableComponent
             Column::make(__('wrestlers.name'), 'wrestler.name'),
             DateColumn::make(__('wrestlers.date_hired'), 'hired_at')
                 ->outputFormat('Y-m-d'),
-            DateColumn::make(__('wrestlers.date_left'), 'left_at')
+            DateColumn::make(__('wrestlers.date_left'), 'fired_at')
                 ->outputFormat('Y-m-d'),
         ];
     }

--- a/app/Livewire/Matches/Forms/EventMatchForm.php
+++ b/app/Livewire/Matches/Forms/EventMatchForm.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Matches\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Livewire\Concerns\GeneratesDummyData;
+use App\Livewire\Concerns\HasStandardValidationAttributes;
+use App\Models\Matches\EventMatch;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Livewire form component for managing event match creation and editing.
+ *
+ * This form handles the complete lifecycle of wrestling match management within
+ * events, including competitor assignments, referee assignments, title stakes,
+ * and match type specifications. Provides specialized validation for complex
+ * wrestling match requirements and relationship management.
+ *
+ * Key Responsibilities:
+ * - Event match information management (preview, match type)
+ * - Competitor relationship management (wrestlers, tag teams)
+ * - Official assignments (referees)
+ * - Championship title stakes and implications
+ * - Match-specific validation and business rules
+ *
+ * @extends LivewireBaseForm<EventMatchForm, EventMatch>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ * @see EventMatch For the underlying event match model
+ *
+ * @property string $preview Match promotional preview content
+ * @property int $matchTypeId Match type identifier
+ * @property array<int> $competitors Array of competitor IDs (wrestlers/tag teams)
+ * @property array<int> $referees Array of referee IDs for match officials
+ * @property array<int> $titles Array of title IDs at stake in the match
+ */
+class EventMatchForm extends LivewireBaseForm
+{
+    use GeneratesDummyData;
+
+    /**
+     * The model instance being edited, or null for new event match creation.
+     *
+     * @var EventMatch|null Current event match model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Match promotional preview content for marketing purposes.
+     *
+     * Used in promotional materials, match cards, and event advertising
+     * to generate interest and provide match context to fans.
+     *
+     * @var string Marketing preview text for the match
+     */
+    public string $preview = '';
+
+    /**
+     * Match type identifier for match style specification.
+     *
+     * Determines the rules, structure, and requirements for the wrestling
+     * match (singles, tag team, ladder match, cage match, etc.).
+     *
+     * @var int Match type database ID
+     */
+    public int $matchTypeId = 0;
+
+    /**
+     * Array of competitor IDs participating in the match.
+     *
+     * Contains wrestler or tag team IDs depending on match type requirements.
+     * Used for match participant assignment and validation.
+     *
+     * @var array<int> Competitor database IDs
+     */
+    public array $competitors = [];
+
+    /**
+     * Array of referee IDs assigned to officiate the match.
+     *
+     * Most matches have one referee, but special matches may require
+     * additional officials for proper oversight.
+     *
+     * @var array<int> Referee database IDs
+     */
+    public array $referees = [];
+
+    /**
+     * Array of title IDs at stake in the match.
+     *
+     * Empty array for non-title matches, populated for championship
+     * matches with title implications.
+     *
+     * @var array<int> Title database IDs
+     */
+    public array $titles = [];
+
+    /**
+     * Load additional data when editing existing event match records.
+     *
+     * Handles complex relationship data loading for edit operations,
+     * retrieving competitor assignments, referee assignments, and title
+     * stakes from the event match's relationship system.
+     *
+     * Relationship Loading:
+     * - Loads match type from relationship
+     * - Loads competitor IDs from many-to-many relationships
+     * - Loads referee assignments
+     * - Loads title stakes for championship matches
+     */
+    public function loadExtraData(): void
+    {
+        // Only process if we have an event match model
+        if (! $this->formModel instanceof EventMatch) {
+            return;
+        }
+
+        // Load match type from relationship
+        $this->matchTypeId = $this->formModel->matchType?->getKey() ?? 0;
+
+        // Load competitor IDs from relationships
+        $this->referees = $this->formModel->referees->pluck('id')->toArray();
+        $this->titles = $this->formModel->titles->pluck('id')->toArray();
+        $this->competitors = $this->formModel->competitors->pluck('wrestler_id')->toArray(); // Assuming wrestler_id is the foreign key
+    }
+
+    /**
+     * Synchronize all event match relationships.
+     *
+     * Updates the relationships for referees, titles, and competitors
+     * to match the current form state. Handles both many-to-many
+     * and one-to-many relationships appropriately.
+     */
+    private function syncRelationships(): void
+    {
+        if (! $this->formModel instanceof EventMatch) {
+            return;
+        }
+
+        // Sync many-to-many relationships (assuming referees and titles are BelongsToMany)
+        $this->formModel->referees()->sync($this->referees);
+        $this->formModel->titles()->sync($this->titles);
+
+        // Handle competitors - assuming it's a HasMany relationship
+        $this->syncCompetitors();
+    }
+
+    /**
+     * Sync competitors for HasMany relationship.
+     *
+     * Removes existing competitors and creates new ones based on
+     * the current form state.
+     */
+    private function syncCompetitors(): void
+    {
+        if (! $this->formModel instanceof EventMatch) {
+            return;
+        }
+
+        // Delete existing competitors
+        $this->formModel->competitors()->delete();
+
+        // Create new competitor records
+        foreach ($this->competitors as $wrestlerId) {
+            $this->formModel->competitors()->create([
+                'wrestler_id' => $wrestlerId,
+                // Add any other required fields for the EventMatchCompetitor model
+            ]);
+        }
+    }
+
+    /**
+     * Prepare event match data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure.
+     * Excludes relationship data which is handled separately through
+     * the relationship synchronization system.
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     */
+    protected function getModelData(): array
+    {
+        return [
+            'preview' => $this->preview,
+            'match_type_id' => $this->matchTypeId,
+        ];
+        // Note: relationships (competitors, referees, titles) are handled
+        // separately through the relationship synchronization system
+    }
+
+    /**
+     * Get the model class for event match form operations.
+     *
+     * Specifies the EventMatch model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<EventMatch> The EventMatch model class
+     */
+    protected function getModelClass(): string
+    {
+        return EventMatch::class;
+    }
+
+    /**
+     * Define validation rules for event match form fields.
+     *
+     * Provides comprehensive validation for all event match data including
+     * match type requirements, competitor assignments, referee assignments,
+     * and promotional content validation.
+     *
+     * Validation Requirements:
+     * - Preview: Required promotional content
+     * - Match Type: Required, must exist in match_types table
+     * - Competitors: Required array, minimum participants based on match type
+     * - Referees: Required array, at least one referee
+     * - Titles: Optional array for championship matches
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     */
+    protected function rules(): array
+    {
+        return [
+            'matchTypeId' => ['required', 'integer', 'exists:match_types,id'],
+            'preview' => ['required', 'string'],
+            'competitors' => ['required', 'array', 'min:2'],
+            'competitors.*' => ['integer', 'exists:wrestlers,id'],
+            'referees' => ['required', 'array', 'min:1'],
+            'referees.*' => ['integer', 'exists:referees,id'],
+            'titles' => ['sometimes', 'array'],
+            'titles.*' => ['integer', 'exists:titles,id'],
+        ];
+    }
+
+    /**
+     * Get custom validation attributes specific to event match forms.
+     *
+     * Provides event match-specific field name mappings for validation
+     * error messages, extending the standard validation attributes from
+     * the HasStandardValidationAttributes trait.
+     *
+     * @return array<string, string> Field name mappings for validation messages
+     */
+    protected function getCustomValidationAttributes(): array
+    {
+        return [
+            'preview' => 'match preview',
+            'matchTypeId' => 'match type',
+            'competitors' => 'competitors',
+            'referees' => 'referees',
+            'titles' => 'championship titles',
+        ];
+    }
+
+    /**
+     * Get dummy data field definitions for event match forms.
+     *
+     * Provides realistic fake data generators for development and testing
+     * purposes, allowing quick population of match forms with wrestling-
+     * appropriate dummy data.
+     *
+     * @return array<string, callable|mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'preview' => fn () => fake()->paragraph(2).' This epic showdown promises to deliver non-stop action!',
+            'matchTypeId' => fn () => fake()->numberBetween(1, 10), // Assuming match types 1-10 exist
+            'competitors' => fn () => fake()->randomElements(range(1, 50), fake()->numberBetween(2, 6)), // 2-6 wrestlers
+            'referees' => fn () => [fake()->numberBetween(1, 20)], // Single referee
+            'titles' => fn () => fake()->boolean(0.3) ? fake()->randomElements(range(1, 15), fake()->numberBetween(1, 2)) : [], // 30% chance of title match
+        ];
+    }
+}

--- a/app/Livewire/Matches/Modals/EventMatchFormModal.php
+++ b/app/Livewire/Matches/Modals/EventMatchFormModal.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Matches\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Concerns\Data\PresentsMatchTypesList;
+use App\Livewire\Concerns\Data\PresentsRefereesList;
+use App\Livewire\Concerns\Data\PresentsTagTeamsList;
+use App\Livewire\Concerns\Data\PresentsTitlesList;
+use App\Livewire\Concerns\Data\PresentsWrestlersList;
+use App\Livewire\Matches\Forms\EventMatchForm;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchType;
+use App\Models\Referees\Referee;
+use App\Models\Titles\Title;
+use App\Models\Wrestlers\Wrestler;
+use Livewire\Form;
+
+/**
+ * Livewire modal component for wrestling match management within events.
+ *
+ * Manages the creation and editing of individual wrestling matches that occur
+ * during events. Handles complex relationships between wrestlers, referees,
+ * titles, match types, and promotional content. Supports dynamic view rendering
+ * based on match type requirements.
+ *
+ * Key Features:
+ * - Modal-based event match form interface
+ * - Match type and competitor assignment
+ * - Referee and title assignment
+ * - Dynamic view rendering based on match type
+ * - Wrestling match data generation for testing
+ *
+ * @extends BaseFormModal<EventMatchForm, EventMatch>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseFormModal For modal functionality and patterns
+ * @see EventMatch For the underlying match model structure
+ */
+class EventMatchFormModal extends BaseFormModal
+{
+    use PresentsMatchTypesList;
+    use PresentsRefereesList;
+    use PresentsTagTeamsList;
+    use PresentsTitlesList;
+    use PresentsWrestlersList;
+
+    /**
+     * The event match form instance for data management.
+     *
+     * Handles all event match-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public Form $form;
+
+    /**
+     * String name to render view for each match type.
+     *
+     * Determines which Blade template to use for rendering match-specific
+     * form fields based on the selected match type (singles, tag team, etc.).
+     *
+     * @var string View template identifier for dynamic rendering
+     */
+    public string $subViewToUse;
+
+    /**
+     * Get the form class that handles event match data validation and processing.
+     *
+     * @return class-string<EventMatchForm> The fully qualified class name of EventMatchForm
+     */
+    protected function getFormClass(): string
+    {
+        return EventMatchForm::class;
+    }
+
+    /**
+     * Get the model class that represents event match entities.
+     *
+     * @return class-string<EventMatch> The fully qualified class name of EventMatch model
+     */
+    protected function getModelClass(): string
+    {
+        return EventMatch::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the event match form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'event-matches.modals.form-modal';
+    }
+
+    /**
+     * Generate dummy data fields for event match testing and development.
+     *
+     * Returns field generators for event match data including match types,
+     * competitor assignments, referee assignments, title stakes, and promotional content.
+     *
+     * @return array<string, callable(): mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'matchTypeId' => fn () => $this->getRandomMatchTypeId(),
+            'referees' => fn () => $this->generateRefereeAssignments(),
+            'titles' => fn () => $this->generateTitleAssignments(),
+            'wrestlers' => fn () => $this->generateWrestlerAssignments(),
+            'preview' => fn () => $this->generateMatchPreview(),
+        ];
+    }
+
+    /**
+     * Generate random event match data for testing and development.
+     *
+     * Populates the form with realistic wrestling match data including
+     * match types, competitor assignments, referee assignments, title
+     * stakes, and promotional content.
+     */
+    public function generateRandomData(): void
+    {
+        $this->form->fill([
+            'matchTypeId' => $this->getRandomMatchTypeId(),
+            'referees' => $this->generateRefereeAssignments(),
+            'titles' => $this->generateTitleAssignments(),
+            'wrestlers' => $this->generateWrestlerAssignments(),
+            'preview' => $this->generateMatchPreview(),
+        ]);
+    }
+
+    /**
+     * Get a random match type ID for testing.
+     *
+     * Creates match type assignments for various wrestling match styles
+     * including singles, tag team, ladder matches, cage matches, etc.
+     *
+     * @return int A random match type ID
+     */
+    protected function getRandomMatchTypeId(): int
+    {
+        /** @phpstan-ignore-next-line */
+        return MatchType::inRandomOrder()->first()?->id ?? MatchType::factory()->create()->id;
+    }
+
+    /**
+     * Generate referee assignments for the match.
+     *
+     * Creates referee assignments appropriate for different match types.
+     * Most matches have one referee, but special matches may require
+     * additional officials.
+     *
+     * @return array<int> Array of referee IDs
+     */
+    protected function generateRefereeAssignments(): array
+    {
+        // Most matches have 1 referee, some special matches might have 2
+        $refereeCount = fake()->randomFloat(null, 0, 1) < 0.9 ? 1 : 2;
+
+        /** @phpstan-ignore-next-line */
+        return Referee::factory()->count($refereeCount)->create()->pluck('id')->toArray();
+    }
+
+    /**
+     * Generate title assignments for championship matches.
+     *
+     * Creates title stakes for matches, with some matches being for
+     * championships and others being non-title matches.
+     *
+     * @return array<int> Array of title IDs (empty for non-title matches)
+     */
+    protected function generateTitleAssignments(): array
+    {
+        // 30% chance of being a championship match
+        if (fake()->randomFloat(null, 0, 1) < 0.3) {
+            /** @phpstan-ignore-next-line */
+            return [Title::inRandomOrder()->first()?->id ?? Title::factory()->create()->id];
+        }
+
+        return []; // Non-title match
+    }
+
+    /**
+     * Generate wrestler assignments for the match.
+     *
+     * Creates wrestler assignments appropriate for different match types.
+     * Singles matches get 2 wrestlers, tag team matches get 4, etc.
+     *
+     * @return array<int> Array of wrestler IDs
+     */
+    protected function generateWrestlerAssignments(): array
+    {
+        // For now, generate 2-4 wrestlers (singles to tag team)
+        $wrestlerCount = fake()->numberBetween(2, 4);
+
+        /** @phpstan-ignore-next-line */
+        return Wrestler::factory()->count($wrestlerCount)->create()->pluck('id')->toArray();
+    }
+
+    /**
+     * Generate promotional preview content for wrestling matches.
+     *
+     * Creates realistic promotional text that would be used to advertise
+     * wrestling matches, including storyline elements, competitor highlights,
+     * and match stipulations.
+     *
+     * @return string Generated match preview text
+     */
+    protected function generateMatchPreview(): string
+    {
+        $matchIntros = [
+            'In what promises to be an explosive encounter',
+            'Two wrestling titans collide when',
+            'The stage is set for an epic showdown as',
+            'Tensions reach a boiling point in this highly anticipated match featuring',
+            'Get ready for non-stop action when',
+            'The rivalry intensifies as',
+        ];
+
+        $matchElements = [
+            'championship gold hangs in the balance',
+            'personal vendettas will be settled',
+            'only one competitor can emerge victorious',
+            'careers and reputations are on the line',
+            'months of buildup culminate in this decisive battle',
+            'the wrestling world will witness something special',
+        ];
+
+        $callsToAction = [
+            "Don't miss this incredible matchup!",
+            "You won't want to blink during this one!",
+            'This match could steal the entire show!',
+            'Witness wrestling at its absolute finest!',
+            'The action starts when the bell rings!',
+            'This is what wrestling is all about!',
+        ];
+
+        return fake()->randomElement($matchIntros).' '.
+               fake()->randomElement($matchElements).'. '.
+               fake()->randomElement($callsToAction);
+    }
+}

--- a/app/Livewire/Matches/Tables/EventMatchesTable.php
+++ b/app/Livewire/Matches/Tables/EventMatchesTable.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Matches\Tables;
+
+use App\Livewire\Concerns\ShowTableTrait;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\EventMatchCompetitor;
+use App\Models\Referees\Referee;
+use App\Models\Titles\Title;
+use Exception;
+use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Columns\ArrayColumn;
+
+class EventMatchesTable extends DataTableComponent
+{
+    use ShowTableTrait;
+
+    protected string $databaseTableName = 'events_matches';
+
+    protected string $resourceName = 'matches';
+
+    /**
+     * Event to use for component.
+     */
+    public ?int $eventId;
+
+    /**
+     * @return Builder<EventMatch>
+     */
+    public function builder(): Builder
+    {
+        if ($this->eventId === null) {
+            throw new Exception("You didn't specify a event");
+        }
+
+        return EventMatch::query()
+            ->with(['event', 'titles', 'competitors', 'result.winner', 'result.decision'])
+            ->where('event_id', $this->eventId);
+    }
+
+    public function configure(): void
+    {
+        $this->addAdditionalSelects([
+            'events_matches.event_id',
+        ]);
+    }
+
+    /**
+     * Undocumented function
+     *
+     * @return array<int, Column>
+     */
+    public function columns(): array
+    {
+        return [
+            Column::make(__('event-matches.match_type'), 'matchType.name'),
+            ArrayColumn::make(__('event-matches.competitors'))
+                ->data(fn (mixed $value, EventMatch $row) => ($row->competitors))
+                ->outputFormat(function (int $index, EventMatchCompetitor $value): string {
+                    $competitor = $value->getCompetitor();
+                    $type = str($competitor->getMorphClass())->kebab()->plural();
+
+                    return '<a href="'.route($type.'.show', $competitor->id).'">'.$competitor->name.'</a>';
+                })
+                ->separator(' vs '),
+            ArrayColumn::make(__('event-matches.referees'))
+                ->data(fn (mixed $value, EventMatch $row) => ($row->referees))
+                ->outputFormat(function (int $index, Referee $value): string {
+                    return '<a href="'.route('referees.show', $value->id).'">'.$value->full_name.'</a>';
+                })
+                ->separator(', ')
+                ->emptyValue('N/A'),
+            ArrayColumn::make(__('event-matches.titles'))
+                ->data(fn (mixed $value, EventMatch $row) => ($row->titles))
+                ->outputFormat(function (int $index, Title $value): string {
+                    return '<a href="'.route('titles.show', $value->id).'">'.$value->name.'</a>';
+                })
+                ->separator(', ')
+                ->emptyValue('N/A'),
+            Column::make(__('event-matches.result'))
+                ->label(
+                    function (EventMatch $row, Column $column): string {
+                        $winner = $row->result?->getWinner();
+
+                        if ($winner) {
+                            $type = str($winner->getMorphClass())->kebab()->plural();
+
+                            return '<a href="'.route($type.'.show', $winner->id).'">'.$winner->name.'</a> by '.$row->result?->decision->name;
+                        }
+
+                        return 'N/A';
+                    }
+                )->html(),
+        ];
+    }
+}

--- a/app/Livewire/Referees/Components/RefereeActionsComponent.php
+++ b/app/Livewire/Referees/Components/RefereeActionsComponent.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Referees\Components;
+
+use App\Actions\Referees\EmployAction;
+use App\Actions\Referees\HealAction;
+use App\Actions\Referees\InjureAction;
+use App\Actions\Referees\ReinstateAction;
+use App\Actions\Referees\ReleaseAction;
+use App\Actions\Referees\RestoreAction;
+use App\Actions\Referees\RetireAction;
+use App\Actions\Referees\SuspendAction;
+use App\Actions\Referees\UnretireAction;
+use App\Exceptions\Status\CannotBeClearedFromInjuryException;
+use App\Exceptions\Status\CannotBeEmployedException;
+use App\Exceptions\Status\CannotBeInjuredException;
+use App\Exceptions\Status\CannotBeReinstatedException;
+use App\Exceptions\Status\CannotBeReleasedException;
+use App\Exceptions\Status\CannotBeRetiredException;
+use App\Exceptions\Status\CannotBeSuspendedException;
+use App\Exceptions\Status\CannotBeUnretiredException;
+use App\Models\Referees\Referee;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+/**
+ * Referee Actions Component
+ *
+ * Handles all business actions that can be performed on a referee including
+ * employment management, health status changes, and career lifecycle operations.
+ * This component is designed to be reusable across different contexts (tables,
+ * detail pages, cards, etc.) while maintaining consistent authorization and
+ * error handling patterns.
+ */
+class RefereeActionsComponent extends Component
+{
+    public Referee $referee;
+
+    public function mount(Referee $referee): void
+    {
+        $this->referee = $referee;
+    }
+
+    /**
+     * Employ a referee.
+     */
+    public function employ(): void
+    {
+        Gate::authorize('employ', $this->referee);
+
+        try {
+            resolve(EmployAction::class)->handle($this->referee);
+            $this->dispatch('referee-updated');
+            session()->flash('status', 'Referee successfully employed.');
+        } catch (CannotBeEmployedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Release a referee.
+     */
+    public function release(): void
+    {
+        Gate::authorize('release', $this->referee);
+
+        try {
+            resolve(ReleaseAction::class)->handle($this->referee);
+            $this->dispatch('referee-updated');
+            session()->flash('status', 'Referee successfully released.');
+        } catch (CannotBeReleasedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Retire a referee.
+     */
+    public function retire(): void
+    {
+        Gate::authorize('retire', $this->referee);
+
+        try {
+            resolve(RetireAction::class)->handle($this->referee);
+            $this->dispatch('referee-updated');
+            session()->flash('status', 'Referee successfully retired.');
+        } catch (CannotBeRetiredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Unretire a referee.
+     */
+    public function unretire(): void
+    {
+        Gate::authorize('unretire', $this->referee);
+
+        try {
+            resolve(UnretireAction::class)->handle($this->referee);
+            $this->dispatch('referee-updated');
+            session()->flash('status', 'Referee successfully unretired.');
+        } catch (CannotBeUnretiredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Suspend a referee.
+     */
+    public function suspend(): void
+    {
+        Gate::authorize('suspend', $this->referee);
+
+        try {
+            resolve(SuspendAction::class)->handle($this->referee);
+            $this->dispatch('referee-updated');
+            session()->flash('status', 'Referee successfully suspended.');
+        } catch (CannotBeSuspendedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Reinstate a referee.
+     */
+    public function reinstate(): void
+    {
+        Gate::authorize('reinstate', $this->referee);
+
+        try {
+            resolve(ReinstateAction::class)->handle($this->referee);
+            $this->dispatch('referee-updated');
+            session()->flash('status', 'Referee successfully reinstated.');
+        } catch (CannotBeReinstatedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Injure a referee.
+     */
+    public function injure(): void
+    {
+        Gate::authorize('injure', $this->referee);
+
+        try {
+            resolve(InjureAction::class)->handle($this->referee);
+            $this->dispatch('referee-updated');
+            session()->flash('status', 'Referee injury recorded.');
+        } catch (CannotBeInjuredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Heal a referee from injury.
+     */
+    public function healFromInjury(): void
+    {
+        Gate::authorize('clearFromInjury', $this->referee);
+
+        try {
+            resolve(HealAction::class)->handle($this->referee);
+            $this->dispatch('referee-updated');
+            session()->flash('status', 'Referee cleared from injury.');
+        } catch (CannotBeClearedFromInjuryException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Restore a deleted referee.
+     */
+    public function restore(): void
+    {
+        Gate::authorize('restore', $this->referee);
+
+        resolve(RestoreAction::class)->handle($this->referee);
+        $this->dispatch('referee-updated');
+        session()->flash('status', 'Referee successfully restored.');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.referees.components.referee-actions-component');
+    }
+}

--- a/app/Livewire/Referees/Forms/RefereeForm.php
+++ b/app/Livewire/Referees/Forms/RefereeForm.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Referees\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Livewire\Concerns\ManagesEmployment;
+use App\Models\Referees\Referee;
+use App\Rules\Shared\CanChangeEmploymentDate;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * Livewire form component for managing referee creation and editing.
+ *
+ * This form handles referee personnel management including personal identification,
+ * name management, and employment tracking integration. Referees are essential
+ * match officials who oversee wrestling contests, requiring careful tracking of
+ * their employment status, availability, and personal information for match
+ * assignment and operational management.
+ *
+ * Key Responsibilities:
+ * - Referee personal identification (first and last name)
+ * - Employment relationship tracking for referee contracts
+ * - Personal information validation and data integrity
+ * - Integration with match assignment and scheduling systems
+ * - Official personnel record management for wrestling operations
+ *
+ * @extends LivewireBaseForm<RefereeForm, Referee>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ * @see ManagesEmployment For employment tracking capabilities
+ * @see CanChangeEmploymentDate For custom validation rules
+ *
+ * @property string $first_name Referee's first name for identification
+ * @property string $last_name Referee's last name for identification
+ * @property Carbon|string|null $employment_date Employment start date
+ */
+class RefereeForm extends LivewireBaseForm
+{
+    use ManagesEmployment;
+
+    /**
+     * The model instance being edited, or null for new referee creation.
+     *
+     * @var Referee|null Current referee model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Referee's first name for personal identification.
+     *
+     * Used for official match records, employment documentation, payroll
+     * systems, and match assignment coordination. Combined with last name
+     * to create complete referee identification for operational management
+     * and official wrestling event documentation.
+     *
+     * @var string Referee's first name
+     */
+    public string $first_name = '';
+
+    /**
+     * Referee's last name for personal identification.
+     *
+     * Used for official match records, employment documentation, payroll
+     * systems, and match assignment coordination. Combined with first name
+     * to create complete referee identification for operational management
+     * and official wrestling event documentation.
+     *
+     * @var string Referee's last name
+     */
+    public string $last_name = '';
+
+    /**
+     * Employment start date for referee contract tracking.
+     *
+     * Managed through ManagesEmployment trait for consistent employment
+     * tracking across all personnel types. Essential for payroll, benefits,
+     * scheduling availability, and operational planning for wrestling events
+     * requiring qualified officiating staff.
+     *
+     * @var Carbon|string|null Referee employment start date
+     */
+    public Carbon|string|null $employment_date = null;
+
+    /**
+     * Load additional data when editing existing referee records.
+     *
+     * Handles employment relationship data loading for edit operations,
+     * retrieving employment start date from the referee's employment
+     * relationship for display and modification in the form.
+     *
+     * Employment Integration:
+     * - Loads start date from employment relationship
+     * - Handles null employment for referees not yet contracted
+     * - Converts Carbon dates to string format for form display
+     *
+     *
+     * @see ManagesEmployment::$employment_date For employment date handling
+     */
+    public function loadExtraData(): void
+    {
+        // Only process if we have a referee model
+        if (! $this->formModel instanceof Referee) {
+            return;
+        }
+
+        // Load employment start date from relationship
+        $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
+    }
+
+    /**
+     * Prepare referee data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure.
+     * Includes personal identification data while excluding employment
+     * information which is handled separately through the employment
+     * relationship system for proper data separation.
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     */
+    protected function getModelData(): array
+    {
+        return [
+            'first_name' => $this->first_name,
+            'last_name' => $this->last_name,
+        ];
+        // Note: employment data is managed separately through
+        // the employment relationship system
+    }
+
+    /**
+     * Get the model class for referee form operations.
+     *
+     * Specifies the Referee model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<Referee> The Referee model class
+     */
+    protected function getModelClass(): string
+    {
+        return Referee::class;
+    }
+
+    /**
+     * Define validation rules for referee form fields.
+     *
+     * Provides comprehensive validation for referee personal data including
+     * name requirements and employment date validation through custom rules.
+     * Ensures referee records have complete identification information for
+     * operational and administrative purposes.
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     */
+    protected function rules(): array
+    {
+        return [
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
+            'employment_date' => 'nullable', 'date', new CanChangeEmploymentDate($this->formModel),
+        ];
+    }
+
+    /**
+     * Get referee-specific validation attributes.
+     *
+     * Extends standard attributes with referee-specific field names for better
+     * user experience in validation messages.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function validationAttributes(): array
+    {
+        return [
+            'first_name' => 'first name',
+            'last_name' => 'last name',
+            'employment_date' => 'employment date',
+        ];
+    }
+}

--- a/app/Livewire/Referees/Modals/RefereeFormModal.php
+++ b/app/Livewire/Referees/Modals/RefereeFormModal.php
@@ -1,0 +1,180 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Referees\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Referees\Forms\RefereeForm;
+use App\Models\Referees\Referee;
+use Livewire\Form;
+
+/**
+ * Livewire modal component for wrestling referee management.
+ *
+ * Handles the creation and editing of wrestling referee personnel including
+ * personal information, career start dates, and official credentials.
+ * Provides specialized data generation for referee testing and development.
+ *
+ * Key Features:
+ * - Modal-based referee form interface
+ * - Realistic referee name generation
+ * - Career start date generation
+ * - Form validation with referee-specific rules
+ * - Integration with referee management workflows
+ *
+ * @extends BaseFormModal<RefereeForm, Referee>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseFormModal For modal functionality and patterns
+ * @see Referee For the underlying referee model structure
+ */
+class RefereeFormModal extends BaseFormModal
+{
+    /**
+     * The referee form instance for data management.
+     *
+     * Handles all referee-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public Form $form;
+
+    /**
+     * Get the form class that handles referee data validation and processing.
+     *
+     * @return class-string<RefereeForm> The fully qualified class name of RefereeForm
+     */
+    protected function getFormClass(): string
+    {
+        return RefereeForm::class;
+    }
+
+    /**
+     * Get the model class that represents referee entities.
+     *
+     * @return class-string<Referee> The fully qualified class name of Referee model
+     */
+    protected function getModelClass(): string
+    {
+        return Referee::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the referee form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'referees.modals.form-modal';
+    }
+
+    /**
+     * Generate dummy data fields for referee testing and development.
+     *
+     * Returns field generators for referee data including realistic names
+     * and career start dates appropriate for wrestling officials.
+     *
+     * @return array<string, callable(): mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'first_name' => fn () => $this->generateRefereeFirstName(),
+            'last_name' => fn () => $this->generateRefereeLastName(),
+            'employment_date' => fn () => fake()->optional(0.8, fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d H:i:s')),
+        ];
+    }
+
+    /**
+     * Generate random referee data for testing and development.
+     *
+     * Populates the form with realistic referee data including names and
+     * career start dates. Generates data appropriate for wrestling referee
+     * personnel records and testing workflows.
+     */
+    public function generateRandomData(): void
+    {
+        $this->form->fill([
+            'first_name' => $this->generateRefereeFirstName(),
+            'last_name' => $this->generateRefereeLastName(),
+            'employment_date' => fake()->optional(0.8, fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d H:i:s')),
+        ]);
+    }
+
+    /**
+     * Generate a realistic referee first name.
+     *
+     * Creates first names that are appropriate for wrestling referee
+     * personnel, following common naming patterns for sports officials.
+     *
+     * @return string A generated first name
+     *
+     * @example
+     * Returns names like: "Earl", "Mike", "Charles", "John"
+     */
+    protected function generateRefereeFirstName(): string
+    {
+        // Mix of famous wrestling referee names and common professional names
+        $famousRefereeNames = [
+            'Earl', 'Mike', 'Charles', 'Tim', 'John', 'Dave', 'Red', 'Danny',
+            'Teddy', 'Nick', 'Scott', 'Chad', 'Darrick', 'Rod', 'Robinson',
+        ];
+
+        $commonNames = [
+            'James', 'Robert', 'Michael', 'William', 'David', 'Richard',
+            'Joseph', 'Thomas', 'Charles', 'Christopher', 'Daniel', 'Matthew',
+            'Anthony', 'Mark', 'Donald', 'Steven', 'Paul', 'Andrew', 'Joshua',
+        ];
+
+        $patterns = [
+            // 60% chance of famous referee names
+            fn () => fake()->randomElement($famousRefereeNames),
+            // 40% chance of common professional names
+            fn () => fake()->randomElement($commonNames),
+        ];
+
+        return fake()->randomFloat(null, 0, 1) < 0.6
+            ? $patterns[0]()
+            : $patterns[1]();
+    }
+
+    /**
+     * Generate a realistic referee last name.
+     *
+     * Creates last names that are appropriate for wrestling referee
+     * personnel, including famous referee surnames and common surnames.
+     *
+     * @return string A generated last name
+     *
+     * @example
+     * Returns names like: "Hebner", "Robinson", "Armstrong", "Chioda"
+     */
+    protected function generateRefereeLastName(): string
+    {
+        // Famous wrestling referee surnames
+        $famousRefereeSurnames = [
+            'Hebner', 'Robinson', 'Armstrong', 'Chioda', 'Edwards', 'Korderas',
+            'White', 'Long', 'Cone', 'Guerrera', 'Zamora', 'Ruiz', 'Doan',
+        ];
+
+        $commonSurnames = [
+            'Smith', 'Johnson', 'Williams', 'Brown', 'Jones', 'Garcia',
+            'Miller', 'Davis', 'Rodriguez', 'Martinez', 'Hernandez',
+            'Lopez', 'Gonzalez', 'Wilson', 'Anderson', 'Thomas', 'Taylor',
+        ];
+
+        $patterns = [
+            // 50% chance of famous referee surnames
+            fn () => fake()->randomElement($famousRefereeSurnames),
+            // 50% chance of common surnames
+            fn () => fake()->randomElement($commonSurnames),
+        ];
+
+        return fake()->randomFloat(null, 0, 1) < 0.5
+            ? $patterns[0]()
+            : $patterns[1]();
+    }
+}

--- a/app/Livewire/Referees/Tables/PreviousMatchesTable.php
+++ b/app/Livewire/Referees/Tables/PreviousMatchesTable.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Livewire\Referees\Tables;
 
-use App\Enums\EventStatus;
 use App\Livewire\Base\Tables\BasePreviousMatchesTable;
-use App\Models\EventMatch;
+use App\Models\Matches\EventMatch;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -36,7 +35,7 @@ class PreviousMatchesTable extends BasePreviousMatchesTable
                 $query->whereIn('referee_id', [$this->refereeId]);
             })
             ->withWhereHas('event', function (Builder $query): void {
-                $query->whereNotNull('date')->where('status', EventStatus::Past);
+                $query->whereNotNull('date')->where('date', '<', now()->toDateString());
             })
             ->orderByDesc('date');
     }

--- a/app/Livewire/Stables/Forms/StableForm.php
+++ b/app/Livewire/Stables/Forms/StableForm.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Stables\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Livewire\Concerns\ManagesActivityPeriods;
+use App\Models\Stables\Stable;
+use App\Rules\Shared\CanChangeDebutDate;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
+
+/**
+ * Livewire form component for managing stable creation and editing.
+ *
+ * This form handles stable (wrestling faction) management including group
+ * identification, naming conventions, and activation period tracking. Stables
+ * represent groups of wrestlers who work together in storylines and matches,
+ * requiring careful tracking of when groups are active, disbanded, or reformed
+ * throughout wrestling programming cycles.
+ *
+ * Key Responsibilities:
+ * - Stable identification and naming with minimum length requirements
+ * - Group uniqueness enforcement across all wrestling factions
+ * - Activation period tracking for stable history and storyline continuity
+ * - Minimum name length validation for meaningful group identification
+ * - Integration with stable activation relationship system
+ * - Wrestling storyline and faction management support
+ *
+ * @extends LivewireBaseForm<StableForm, Stable>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ * @see ManagesActivityPeriods For activation period tracking
+ * @see CanChangeDebutDate For custom activation validation
+ *
+ * @property string $name Stable's official name for storylines and promotion
+ * @property Carbon|string|null $start_date Stable activation start date
+ */
+class StableForm extends LivewireBaseForm
+{
+    use ManagesActivityPeriods;
+
+    /**
+     * The model instance being edited, or null for new stable creation.
+     *
+     * @var Stable|null Current stable model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Stable's official name for storylines and promotional materials.
+     *
+     * Used in wrestling storylines, promotional content, match announcements,
+     * and faction-based programming. Must be unique across all stables and
+     * have sufficient length (minimum 5 characters) for meaningful identification
+     * and fan recognition in complex storyline development.
+     *
+     * @var string Stable's primary name identifier
+     */
+    public string $name = '';
+
+    /**
+     * Stable activation start date for faction history tracking.
+     *
+     * Tracks when a wrestling stable becomes active and begins appearing
+     * in storylines and programming. Managed through ManagesActivityPeriods
+     * trait for consistent activation tracking across the stable system,
+     * allowing for stable reformations and storyline continuity.
+     *
+     * @var Carbon|string|null Stable activation start date
+     */
+    public Carbon|string|null $start_date = null;
+
+    /**
+     * Load additional data when editing existing stable records.
+     *
+     * Handles activation period data loading for edit operations,
+     * retrieving the first activation date from the stable's activation
+     * relationship system for display in the form. Essential for tracking
+     * stable history and storyline continuity.
+     *
+     * Activation Integration:
+     * - Loads start date from first activation relationship
+     * - Handles null activations for stables not yet activated
+     * - Converts Carbon dates to string format for form display
+     * - Supports stable reformation and reactivation scenarios
+     *
+     *
+     * @see ManagesActivityPeriods For activation period management
+     */
+    public function loadExtraData(): void
+    {
+        // Only process if we have a stable model
+        if (! $this->formModel instanceof Stable) {
+            return;
+        }
+
+        // Load activation start date from first activity period relationship
+        $this->start_date = $this->formModel->firstActivityPeriod?->started_at?->toDateString();
+    }
+
+    /**
+     * Handle additional tasks after stable creation.
+     *
+     * Creates activation record for new stables with start dates.
+     * Called automatically by the store pattern trait.
+     */
+    protected function handlePostCreationTasks(): void
+    {
+        // Create activation record for new stables with start dates
+        if ($this->start_date) {
+            $this->handleActivityPeriodCreation();
+        }
+    }
+
+    /**
+     * Prepare stable data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure.
+     * Only includes the stable name as activation dates are managed
+     * separately through the stable's activation relationship system
+     * to maintain proper separation of concerns in faction management.
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     */
+    protected function getModelData(): array
+    {
+        return [
+            'name' => $this->name,
+        ];
+        // Note: start_date is NOT included here because activation dates
+        // are managed separately through the stable's activation relationship system
+    }
+
+    /**
+     * Get the model class for stable form operations.
+     *
+     * Specifies the Stable model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<Stable> The Stable model class
+     */
+    protected function getModelClass(): string
+    {
+        return Stable::class;
+    }
+
+    /**
+     * Define validation rules for stable form fields.
+     *
+     * Provides comprehensive validation for wrestling stables including
+     * minimum name length requirements, uniqueness constraints, and
+     * activation date validation through custom rules. Ensures stables
+     * have meaningful names for storyline development and fan recognition.
+     *
+     * Validation Requirements:
+     * - Name: Required, unique, minimum 5 characters, max 255 characters
+     * - Minimum Length: Ensures meaningful stable names for storylines
+     * - Start Date: Optional, valid date, custom activation validation
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     *
+     * @see CanChangeDebutDate For custom date validation
+     * @see Rule::unique() For database uniqueness constraints
+     */
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('stables', 'name')->ignore($this->formModel)],
+            'start_date' => ['nullable', 'date', new CanChangeDebutDate($this->formModel)],
+        ];
+    }
+
+    /**
+     * Get stable-specific validation attributes.
+     *
+     * All standard attributes are provided by HasStandardValidationAttributes trait.
+     * This method handles stable-specific field naming.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function getCustomValidationAttributes(): array
+    {
+        return [
+            'start_date' => 'start date',
+        ];
+    }
+}

--- a/app/Livewire/Stables/Modals/StableFormModal.php
+++ b/app/Livewire/Stables/Modals/StableFormModal.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Stables\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Concerns\Data\PresentsManagersList;
+use App\Livewire\Concerns\Data\PresentsTagTeamsList;
+use App\Livewire\Concerns\Data\PresentsWrestlersList;
+use App\Livewire\Stables\Forms\StableForm;
+use App\Models\Stables\Stable;
+
+/**
+ * Livewire modal component for wrestling stable management.
+ *
+ * Manages the creation and editing of wrestling stables (groups of wrestlers,
+ * tag teams, and managers). Provides interfaces for building complex wrestling
+ * faction relationships and hierarchies within the organization.
+ *
+ * @extends BaseFormModal<StableForm, Stable>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see StableForm For stable validation and processing
+ * @see Stable For the underlying stable model structure
+ * @see PresentsManagersList For manager selection interface
+ * @see PresentsTagTeamsList For tag team selection interface
+ * @see PresentsWrestlersList For wrestler selection interface
+ * @see BaseFormModal For inherited modal functionality
+ */
+class StableFormModal extends BaseFormModal
+{
+    use PresentsManagersList;
+    use PresentsTagTeamsList;
+    use PresentsWrestlersList;
+
+    /**
+     * The stable form instance for data management.
+     *
+     * Handles all stable-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public StableForm $form;
+
+    /**
+     * Get the form class that handles stable data validation and processing.
+     *
+     * @return class-string<StableForm> The fully qualified class name of StableForm
+     */
+    protected function getFormClass(): string
+    {
+        return StableForm::class;
+    }
+
+    /**
+     * Get the model class that represents stable entities.
+     *
+     * @return class-string<Stable> The fully qualified class name of Stable model
+     */
+    protected function getModelClass(): string
+    {
+        return Stable::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the stable form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'stables.modals.form-modal';
+    }
+
+    /**
+     * Generate dummy data fields for stable testing and development.
+     *
+     * Creates realistic stable data including:
+     * - Faction names and branding
+     * - Formation dates for the group
+     *
+     * Uses local name generation for wrestling faction names
+     * that work well for wrestling faction names and group identities.
+     *
+     * @return array<string, callable(): mixed> Associative array where keys are field names
+     *                                          and values are closures that generate the dummy data
+     *
+     * @example
+     * // Example generated data:
+     * // [
+     * //     'name' => fn() => 'The Corporation',
+     * //     'start_date' => fn() => '2024-11-01 00:00:00'
+     * // ]
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'name' => fn (): string => $this->generateStableName(),
+            'start_date' => fake()->optional(0.8, fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d H:i:s')),
+        ];
+    }
+
+    /**
+     * Generate a wrestling stable name locally for this form.
+     */
+    private function generateStableName(): string
+    {
+        $prefixes = ['The', 'Team', 'Faction'];
+        $types = ['Corporation', 'Alliance', 'Brotherhood', 'Syndicate', 'Elite', 'Order', 'Nation'];
+
+        $prefix = fake()->randomElement($prefixes);
+        $type = fake()->randomElement($types);
+
+        return "{$prefix} {$type}";
+    }
+}

--- a/app/Livewire/Stables/Tables/PreviousManagersTable.php
+++ b/app/Livewire/Stables/Tables/PreviousManagersTable.php
@@ -5,18 +5,21 @@ declare(strict_types=1);
 namespace App\Livewire\Stables\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousManagersTable;
-use App\Models\StableManager;
+use App\Models\Managers\Manager;
+use App\Models\Stables\Stable;
+use App\Repositories\StableRepository;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class PreviousManagersTable extends BasePreviousManagersTable
 {
-    protected string $databaseTableName = 'stables_managers';
+    public string $databaseTableName = 'managers';
 
     public ?int $stableId;
 
     /**
-     * @return Builder<StableManager>
+     * @return Builder<Manager>
      */
     public function builder(): Builder
     {
@@ -24,17 +27,28 @@ class PreviousManagersTable extends BasePreviousManagersTable
             throw new Exception("You didn't specify a stable");
         }
 
-        return StableManager::query()
-            ->with(['manager'])
-            ->where('stable_id', $this->stableId)
-            ->whereNotNull('left_at')
-            ->orderByDesc('joined_at');
+        // Note: Stables do not directly have managers.
+        // Managers are associated with individual wrestlers and tag teams.
+        // This table would show managers who previously managed members of this stable.
+        // For now, return empty query since this is not a valid business relationship.
+        return Manager::query()->whereRaw('1 = 0'); // Empty result set
     }
 
     public function configure(): void
     {
-        $this->addAdditionalSelects([
-            'stables_managers.manager_id',
-        ]);
+        // No additional selects needed for direct manager query
+    }
+
+    /**
+     * @return array<int, Column>
+     */
+    public function columns(): array
+    {
+        return [
+            Column::make(__('managers.name'), 'full_name')
+                ->searchable(),
+            Column::make(__('managers.status'), 'status')
+                ->searchable(),
+        ];
     }
 }

--- a/app/Livewire/Stables/Tables/PreviousWrestlersTable.php
+++ b/app/Livewire/Stables/Tables/PreviousWrestlersTable.php
@@ -4,19 +4,27 @@ declare(strict_types=1);
 
 namespace App\Livewire\Stables\Tables;
 
-use App\Livewire\Base\Tables\BasePreviousWrestlersTable;
-use App\Models\StableWrestler;
+use App\Livewire\Concerns\ShowTableTrait;
+use App\Models\Stables\StableMember;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
+use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
-class PreviousWrestlersTable extends BasePreviousWrestlersTable
+class PreviousWrestlersTable extends DataTableComponent
 {
-    protected string $databaseTableName = 'stables_wrestlers';
+    use ShowTableTrait;
+
+    protected string $resourceName = 'wrestlers';
+
+    protected string $databaseTableName = 'stables_members';
 
     public ?int $stableId;
 
     /**
-     * @return Builder<StableWrestler>
+     * @return Builder<StableMember>
      */
     public function builder(): Builder
     {
@@ -24,17 +32,33 @@ class PreviousWrestlersTable extends BasePreviousWrestlersTable
             throw new Exception("You didn't specify a stable");
         }
 
-        return StableWrestler::query()
-            ->with(['wrestler'])
-            ->where('stable_id', $this->stableId)
-            ->whereNotNull('left_at')
-            ->orderByDesc('joined_at');
+        return StableMember::query()
+            ->with('member')
+            ->where('stables_members.stable_id', $this->stableId)
+            ->where('stables_members.member_type', 'wrestler')
+            ->whereNotNull('stables_members.left_at')
+            ->orderByDesc('stables_members.joined_at');
+    }
+
+    /**
+     * @return array<int, Column>
+     */
+    public function columns(): array
+    {
+        return [
+            LinkColumn::make(__('wrestlers.name'))
+                ->title(fn (StableMember $row) => $row->member?->name ?? 'Unknown')
+                ->location(fn (StableMember $row) => $row->member ? route('wrestlers.show', $row->member) : '#'),
+            DateColumn::make(__('stables.date_joined'), 'joined_at')
+                ->outputFormat('Y-m-d'),
+            DateColumn::make(__('stables.date_left'), 'left_at')
+                ->outputFormat('Y-m-d'),
+        ];
     }
 
     public function configure(): void
     {
-        $this->addAdditionalSelects([
-            'stables_wrestlers.wrestler_id as wrestler_id',
-        ]);
+        // Removed additional selects that were causing SQL conflicts
+        // The polymorphic relationship handles member selection automatically
     }
 }

--- a/app/Livewire/TagTeams/Forms/TagTeamForm.php
+++ b/app/Livewire/TagTeams/Forms/TagTeamForm.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\TagTeams\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Livewire\Concerns\ManagesEmployment;
+use App\Models\TagTeams\TagTeam;
+use App\Rules\Shared\CanChangeEmploymentDate;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
+
+/**
+ * Livewire form component for managing tag team creation and editing.
+ *
+ * This form handles the complete lifecycle of tag team partnership management
+ * including team identification, wrestler relationships, signature moves, and
+ * employment tracking integration. Provides specialized validation for
+ * wrestling tag team requirements and relationship management.
+ *
+ * Key Responsibilities:
+ * - Tag team profile management (name, signature moves)
+ * - Wrestler relationship tracking and validation
+ * - Manager relationship tracking and assignment
+ * - Employment relationship tracking and validation
+ * - Tag team partnership data (formation dates, career information)
+ * - Custom validation rules for wrestling tag team requirements
+ *
+ * @extends LivewireBaseForm<TagTeamForm, TagTeam>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ * @see ManagesEmployment For employment tracking capabilities
+ * @see CanChangeEmploymentDate For custom validation rules
+ *
+ * @property string $name Tag team's official name
+ * @property string|null $signature_move Tag team's finishing move or signature
+ * @property int|null $wrestlerA First wrestler ID in the tag team
+ * @property int|null $wrestlerB Second wrestler ID in the tag team
+ * @property array<int, int> $managers Array of manager IDs assigned to the tag team
+ * @property Carbon|string|null $employment_date Employment start date
+ */
+class TagTeamForm extends LivewireBaseForm
+{
+    use ManagesEmployment;
+
+    /**
+     * The model instance being edited, or null for new tag team creation.
+     *
+     * @var TagTeam|null Current tag team model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Tag team's official name for identification and promotion.
+     *
+     * Used for match announcements, promotional materials, and team
+     * identification. Must be unique across all tag teams in the system.
+     *
+     * @var string Tag team's primary name identifier
+     */
+    public string $name = '';
+
+    /**
+     * Tag team's signature finishing move or special technique.
+     *
+     * Optional field for tag team persona development. Represents the
+     * coordinated finishing move that the team uses to win matches.
+     * Must be unique if provided to avoid confusion in match commentary.
+     *
+     * @var string|null Tag team signature wrestling move name
+     */
+    public ?string $signature_move = '';
+
+    /**
+     * First wrestler ID in the tag team partnership.
+     *
+     * References the first wrestler in the tag team. Both wrestlers
+     * must be different and valid wrestler IDs in the system.
+     *
+     * @var int|null First wrestler's ID
+     */
+    public ?int $wrestlerA = null;
+
+    /**
+     * Second wrestler ID in the tag team partnership.
+     *
+     * References the second wrestler in the tag team. Must be different
+     * from wrestlerA and a valid wrestler ID in the system.
+     *
+     * @var int|null Second wrestler's ID
+     */
+    public ?int $wrestlerB = null;
+
+    /**
+     * Array of manager IDs assigned to the tag team.
+     *
+     * Represents the managers currently associated with the tag team.
+     * Supports multiple managers for comprehensive tag team management.
+     * Each ID must reference a valid manager in the system.
+     *
+     * @var array<int, int> Array of manager IDs
+     */
+    public array $managers = [];
+
+    /**
+     * Employment start date for contract and career tracking.
+     *
+     * Managed through ManagesEmployment trait for consistent employment
+     * tracking across all personnel types. Supports Carbon objects or
+     * string dates for flexible input handling.
+     *
+     * @var Carbon|string|null Employment start date
+     */
+    public Carbon|string|null $employment_date = '';
+
+    /**
+     * Load additional data when editing existing tag team records.
+     *
+     * Handles complex data loading including employment relationships
+     * and wrestler relationships. Called automatically during form
+     * initialization for edit operations.
+     *
+     * Employment Integration:
+     * - Loads start date from employment relationship
+     * - Handles null employment for new tag teams
+     *
+     * Wrestler Relationships:
+     * - Loads current wrestler assignments
+     * - Handles relationship changes and updates
+     *
+     *
+     * @see ManagesEmployment::$start_date For employment date handling
+     */
+    public function loadExtraData(): void
+    {
+        // Only process if we have a tag team model
+        if (! $this->formModel instanceof TagTeam) {
+            return;
+        }
+
+        // Load employment start date from relationship (with type safety)
+        if ($this->formModel->hasEmployments()) {
+            $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
+        }
+
+        // Load current wrestler assignments
+        $currentWrestlers = $this->formModel->currentWrestlers;
+        if ($currentWrestlers->isNotEmpty()) {
+            $this->wrestlerA = $currentWrestlers->first()->getKey();
+            $this->wrestlerB = $currentWrestlers->skip(1)->first()->getKey();
+        }
+
+        // Load current manager assignments
+        $this->managers = $this->formModel->currentManagers->pluck('id')->toArray();
+    }
+
+    /**
+     * Handle additional tasks after tag team creation.
+     *
+     * Manages wrestler relationship synchronization and employment setup
+     * for new tag teams. Called automatically by the store pattern trait.
+     */
+    protected function handlePostCreationTasks(): void
+    {
+        // Create employment record for new tag teams with start dates
+        if ($this->employment_date) {
+            $this->handleEmploymentCreation();
+        }
+
+        // Handle wrestler relationships
+        if ($this->formModel instanceof TagTeam) {
+            $this->updateWrestlerRelationships();
+            $this->updateManagerRelationships();
+        }
+    }
+
+    /**
+     * Update wrestler relationships for the tag team.
+     *
+     * Manages the many-to-many relationship between the tag team and
+     * its wrestler members. Ensures proper relationship synchronization.
+     */
+    private function updateWrestlerRelationships(): void
+    {
+        if (! $this->formModel instanceof TagTeam) {
+            return;
+        }
+
+        $wrestlerIds = array_filter([$this->wrestlerA, $this->wrestlerB]);
+        $this->formModel->wrestlers()->sync($wrestlerIds);
+    }
+
+    /**
+     * Update manager relationships for the tag team.
+     *
+     * Manages the many-to-many relationship between the tag team and
+     * its assigned managers. Ensures proper relationship synchronization.
+     */
+    private function updateManagerRelationships(): void
+    {
+        if (! $this->formModel instanceof TagTeam) {
+            return;
+        }
+
+        $this->formModel->managers()->sync($this->managers);
+    }
+
+    /**
+     * Prepare tag team-specific data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure.
+     * Excludes employment and wrestler relationship data which are
+     * handled separately through their respective systems.
+     *
+     * Data Transformations:
+     * - Passes through tag team fields with appropriate typing
+     * - Excludes wrestler IDs (handled via relationships)
+     * - Excludes employment data (handled separately)
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     */
+    protected function getModelData(): array
+    {
+        return [
+            'name' => $this->name,
+            'signature_move' => $this->signature_move,
+        ];
+        // Note: wrestler relationships and employment data handled separately
+    }
+
+    /**
+     * Get the model class for tag team form operations.
+     *
+     * Specifies the TagTeam model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<TagTeam> The TagTeam model class
+     */
+    protected function getModelClass(): string
+    {
+        return TagTeam::class;
+    }
+
+    /**
+     * Define validation rules for tag team form fields.
+     *
+     * Provides comprehensive validation for all tag team data including
+     * uniqueness constraints, wrestler relationship validation, and
+     * employment date validation through custom rules.
+     *
+     * Validation Requirements:
+     * - Name: Required, unique, max 255 characters
+     * - Signature Move: Optional, unique if provided, max 255 characters
+     * - Wrestlers: Required, different wrestlers, valid IDs
+     * - Employment Date: Optional, valid date, custom employment validation
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     *
+     * @see CanChangeEmploymentDate For custom date validation
+     * @see Rule::unique() For database uniqueness constraints
+     */
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('tag_teams', 'name')->ignore($this->formModel)],
+            'signature_move' => ['nullable', 'string', 'max:255', Rule::unique('tag_teams', 'signature_move')->ignore($this->formModel)],
+            'wrestlerA' => ['required', 'integer', 'exists:wrestlers,id'],
+            'wrestlerB' => ['required', 'integer', 'exists:wrestlers,id', 'different:wrestlerA'],
+            'managers' => ['array'],
+            'managers.*' => ['integer', 'exists:managers,id'],
+            'employment_date' => ['nullable', 'date', new CanChangeEmploymentDate($this->formModel)],
+        ];
+    }
+
+    /**
+     * Get tag team-specific validation attributes.
+     *
+     * All standard attributes (signature_move, employment_date) are provided by
+     * HasStandardValidationAttributes trait. This method handles tag team-specific
+     * wrestler and manager field naming.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function validationAttributes(): array
+    {
+        return [
+            'signature_move' => 'signature move',
+            'wrestlerA' => 'first wrestler',
+            'wrestlerB' => 'second wrestler',
+            'managers' => 'managers',
+            'managers.*' => 'manager',
+            'employment_date' => 'employment date',
+        ];
+    }
+}

--- a/app/Livewire/TagTeams/Modals/TagTeamFormModal.php
+++ b/app/Livewire/TagTeams/Modals/TagTeamFormModal.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\TagTeams\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Concerns\Data\PresentsWrestlersList;
+use App\Livewire\TagTeams\Forms\TagTeamForm;
+use App\Models\Managers\Manager;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+use Livewire\Form;
+
+/**
+ * Livewire modal component for wrestling tag team management.
+ *
+ * Manages the creation and editing of tag team partnerships, including
+ * team naming, wrestler relationships, signature moves, and career timelines.
+ * Provides specialized data generation for tag team testing and development.
+ *
+ * Key Features:
+ * - Modal-based tag team form interface
+ * - Wrestling tag team name generation
+ * - Automatic wrestler relationship creation
+ * - Signature move generation for teams
+ * - Integration with tag team management workflows
+ *
+ * @extends BaseFormModal<TagTeamForm, TagTeam>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseFormModal For modal functionality and patterns
+ * @see TagTeam For the underlying tag team model structure
+ */
+class TagTeamFormModal extends BaseFormModal
+{
+    use PresentsWrestlersList;
+
+    /**
+     * The tag team form instance for data management.
+     *
+     * Handles all tag team-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public TagTeamForm $form;
+
+    /**
+     * Get the form class that handles tag team data validation and processing.
+     *
+     * @return class-string<TagTeamForm> The fully qualified class name of TagTeamForm
+     */
+    protected function getFormClass(): string
+    {
+        return TagTeamForm::class;
+    }
+
+    /**
+     * Get the model class that represents tag team entities.
+     *
+     * @return class-string<TagTeam> The fully qualified class name of TagTeam model
+     */
+    protected function getModelClass(): string
+    {
+        return TagTeam::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the tag team form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'tag-teams.modals.form-modal';
+    }
+
+    /**
+     * Generate dummy data fields for tag team testing and development.
+     *
+     * Returns field generators for tag team data including wrestling-appropriate
+     * names, wrestler relationships, signature moves, and formation dates.
+     *
+     * @return array<string, callable(): mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'name' => fn () => fake()->words(3, true),
+            'employment_date' => fake()->optional(0.8, fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d H:i:s')),
+            'signature_move' => fake()->optional(0.7, fn () => fake()->words(3, true)),
+            /** @phpstan-ignore-next-line */
+            'wrestlerA' => fn () => Wrestler::inRandomOrder()->first()?->id ?? Wrestler::factory()->create()->id,
+            /** @phpstan-ignore-next-line */
+            'wrestlerB' => fn () => Wrestler::inRandomOrder()->first()?->id ?? Wrestler::factory()->create()->id,
+            /** @phpstan-ignore-next-line */
+            'managers' => fn () => Manager::inRandomOrder()->first()?->id ?? Manager::factory()->create()->id,
+        ];
+    }
+}

--- a/app/Livewire/TagTeams/Tables/PreviousManagersTable.php
+++ b/app/Livewire/TagTeams/Tables/PreviousManagersTable.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\TagTeams\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousManagersTable;
-use App\Models\TagTeamManager;
+use App\Models\TagTeams\TagTeamManager;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -29,7 +29,7 @@ class PreviousManagersTable extends BasePreviousManagersTable
 
         return TagTeamManager::query()
             ->where('tag_team_id', $this->tagTeamId)
-            ->whereNotNull('left_at')
+            ->whereNotNull('fired_at')
             ->orderByDesc('hired_at');
     }
 

--- a/app/Livewire/TagTeams/Tables/PreviousMatchesTable.php
+++ b/app/Livewire/TagTeams/Tables/PreviousMatchesTable.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace App\Livewire\TagTeams\Tables;
 
-use App\Enums\EventStatus;
 use App\Livewire\Base\Tables\BasePreviousMatchesTable;
-use App\Models\EventMatch;
-use App\Models\TagTeam;
+use App\Models\Matches\EventMatch;
+use App\Models\TagTeams\TagTeam;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -39,7 +38,7 @@ class PreviousMatchesTable extends BasePreviousMatchesTable
                 $query->whereMorphedTo('competitor', $tagTeam);
             })
             ->withWhereHas('event', function (Builder $query): void {
-                $query->whereNotNull('date')->where('status', EventStatus::Past);
+                $query->whereNotNull('date')->where('date', '<', now()->toDateString());
             })
             ->orderByDesc('date');
     }

--- a/app/Livewire/TagTeams/Tables/PreviousStablesTable.php
+++ b/app/Livewire/TagTeams/Tables/PreviousStablesTable.php
@@ -5,18 +5,18 @@ declare(strict_types=1);
 namespace App\Livewire\TagTeams\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
-use App\Models\StableTagTeam;
+use App\Models\Stables\StableMember;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
 class PreviousStablesTable extends BasePreviousStablesTable
 {
-    protected string $databaseTableName = 'stables_tag_teams';
+    protected string $databaseTableName = 'stables_members';
 
     public ?int $tagTeamId;
 
     /**
-     * @return Builder<StableTagTeam>
+     * @return Builder<StableMember>
      */
     public function builder(): Builder
     {
@@ -24,8 +24,9 @@ class PreviousStablesTable extends BasePreviousStablesTable
             throw new Exception("You didn't specify a tag team");
         }
 
-        return StableTagTeam::query()
-            ->where('tag_team_id', $this->tagTeamId)
+        return StableMember::query()
+            ->where('member_id', $this->tagTeamId)
+            ->where('member_type', 'tagTeam')
             ->whereNotNull('left_at')
             ->orderByDesc('joined_at');
     }
@@ -33,7 +34,7 @@ class PreviousStablesTable extends BasePreviousStablesTable
     public function configure(): void
     {
         $this->addAdditionalSelects([
-            'stables_tag_teams.stable_id as stable_id',
+            'stables_members.stable_id as stable_id',
         ]);
     }
 }

--- a/app/Livewire/TagTeams/Tables/PreviousTitleChampionshipsTable.php
+++ b/app/Livewire/TagTeams/Tables/PreviousTitleChampionshipsTable.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Livewire\TagTeams\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousTitleChampionshipsTable;
-use App\Models\TagTeam;
-use App\Models\TitleChampionship;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\TitleChampionship;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -28,11 +28,12 @@ class PreviousTitleChampionshipsTable extends BasePreviousTitleChampionshipsTabl
 
         return TitleChampionship::query()
             ->whereHasMorph(
-                'previousChampion',
+                'champion',
                 [TagTeam::class],
                 function (Builder $query): void {
                     $query->whereIn('id', [$this->tagTeamId]);
                 }
-            );
+            )
+            ->whereNotNull('lost_at');
     }
 }

--- a/app/Livewire/TagTeams/Tables/PreviousWrestlersTable.php
+++ b/app/Livewire/TagTeams/Tables/PreviousWrestlersTable.php
@@ -4,19 +4,27 @@ declare(strict_types=1);
 
 namespace App\Livewire\TagTeams\Tables;
 
-use App\Livewire\Base\Tables\BasePreviousWrestlersTable;
-use App\Models\TagTeamPartner;
+use App\Livewire\Concerns\ShowTableTrait;
+use App\Models\TagTeams\TagTeamWrestler;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Rappasoft\LaravelLivewireTables\DataTableComponent;
+use Rappasoft\LaravelLivewireTables\Views\Column;
+use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
+use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
-class PreviousWrestlersTable extends BasePreviousWrestlersTable
+class PreviousWrestlersTable extends DataTableComponent
 {
-    protected string $databaseTableName = 'tag_team_wrestler';
+    use ShowTableTrait;
+
+    protected string $resourceName = 'wrestlers';
+
+    protected string $databaseTableName = 'tag_teams_wrestlers';
 
     public ?int $tagTeamId;
 
     /**
-     * @return Builder<TagTeamPartner>
+     * @return Builder<TagTeamWrestler>
      */
     public function builder(): Builder
     {
@@ -24,16 +32,32 @@ class PreviousWrestlersTable extends BasePreviousWrestlersTable
             throw new Exception("You didn't specify a tag team");
         }
 
-        return TagTeamPartner::query()
-            ->where('tag_team_id', $this->tagTeamId)
-            ->whereNotNull('left_at')
-            ->orderByDesc('joined_at');
+        return TagTeamWrestler::query()
+            ->with('wrestler')
+            ->where('tag_teams_wrestlers.tag_team_id', $this->tagTeamId)
+            ->whereNotNull('tag_teams_wrestlers.left_at')
+            ->orderByDesc('tag_teams_wrestlers.joined_at');
+    }
+
+    /**
+     * @return array<int, Column>
+     */
+    public function columns(): array
+    {
+        return [
+            LinkColumn::make(__('wrestlers.name'))
+                ->title(fn (TagTeamWrestler $row) => $row->wrestler?->name ?? 'Unknown')
+                ->location(fn (TagTeamWrestler $row) => $row->wrestler ? route('wrestlers.show', $row->wrestler) : '#'),
+            DateColumn::make(__('tag-teams.date_joined'), 'joined_at')
+                ->outputFormat('Y-m-d'),
+            DateColumn::make(__('tag-teams.date_left'), 'left_at')
+                ->outputFormat('Y-m-d'),
+        ];
     }
 
     public function configure(): void
     {
-        $this->addAdditionalSelects([
-            'tag_team_wrestler.wrestler_id as wrestler_id',
-        ]);
+        // Removed additional selects that were causing SQL conflicts
+        // The relationship handles member selection automatically
     }
 }

--- a/app/Livewire/Titles/Components/TitleActionsComponent.php
+++ b/app/Livewire/Titles/Components/TitleActionsComponent.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Titles\Components;
+
+use App\Actions\Titles\DebutAction;
+use App\Actions\Titles\PullAction;
+use App\Actions\Titles\ReinstateAction;
+use App\Actions\Titles\RestoreAction;
+use App\Actions\Titles\RetireAction;
+use App\Actions\Titles\UnretireAction;
+use App\Exceptions\Status\CannotBeDebutedException;
+use App\Exceptions\Status\CannotBePulledException;
+use App\Exceptions\Status\CannotBeReinstatedException;
+use App\Exceptions\Status\CannotBeRetiredException;
+use App\Exceptions\Status\CannotBeUnretiredException;
+use App\Models\Titles\Title;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+/**
+ * Title Actions Component
+ *
+ * Handles all business actions that can be performed on a title including
+ * employment management, health status changes, and career lifecycle operations.
+ * This component is designed to be reusable across different contexts (tables,
+ * detail pages, cards, etc.) while maintaining consistent authorization and
+ * error handling patterns.
+ */
+class TitleActionsComponent extends Component
+{
+    public Title $title;
+
+    public function mount(Title $title): void
+    {
+        $this->title = $title;
+    }
+
+    /**
+     * Employ a title.
+     */
+    public function debut(): void
+    {
+        Gate::authorize('debut', $this->title);
+
+        try {
+            resolve(DebutAction::class)->handle($this->title);
+            $this->dispatch('title-updated');
+            session()->flash('status', 'Title successfully debuted.');
+        } catch (CannotBeDebutedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Retire a title.
+     */
+    public function retire(): void
+    {
+        Gate::authorize('retire', $this->title);
+
+        try {
+            resolve(RetireAction::class)->handle($this->title);
+            $this->dispatch('title-updated');
+            session()->flash('status', 'Title successfully retired.');
+        } catch (CannotBeRetiredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Unretire a title.
+     */
+    public function unretire(): void
+    {
+        Gate::authorize('unretire', $this->title);
+
+        try {
+            resolve(UnretireAction::class)->handle($this->title);
+            $this->dispatch('title-updated');
+            session()->flash('status', 'Title successfully unretired.');
+        } catch (CannotBeUnretiredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Pull a title.
+     */
+    public function deactivate(): void
+    {
+        Gate::authorize('pull', $this->title);
+
+        try {
+            resolve(PullAction::class)->handle($this->title);
+            $this->dispatch('title-updated');
+            session()->flash('status', 'Title successfully pulled.');
+        } catch (CannotBePulledException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Reinstate a title.
+     */
+    public function reinstate(): void
+    {
+        Gate::authorize('reinstate', $this->title);
+
+        try {
+            resolve(ReinstateAction::class)->handle($this->title);
+            $this->dispatch('title-updated');
+            session()->flash('status', 'Title successfully reinstated.');
+        } catch (CannotBeReinstatedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Restore a deleted title.
+     */
+    public function restore(): void
+    {
+        Gate::authorize('restore', $this->title);
+
+        resolve(RestoreAction::class)->handle($this->title);
+        $this->dispatch('title-updated');
+        session()->flash('status', 'Title successfully restored.');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.titles.components.title-actions-component');
+    }
+}

--- a/app/Livewire/Titles/Forms/TitleForm.php
+++ b/app/Livewire/Titles/Forms/TitleForm.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Titles\Forms;
+
+use App\Enums\Titles\TitleType;
+use App\Livewire\Base\LivewireBaseForm;
+use App\Livewire\Concerns\ManagesActivityPeriods;
+use App\Models\Titles\Title;
+use App\Rules\Shared\CanChangeDebutDate;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
+
+/**
+ * Livewire form component for managing championship title creation and editing.
+ *
+ * This form handles championship title management including title identification,
+ * naming conventions, and activation period tracking. Championship titles represent
+ * wrestling belts and honors that wrestlers compete for, requiring careful tracking
+ * of when titles are active, retired, or temporarily inactive.
+ *
+ * Key Responsibilities:
+ * - Championship title creation and naming with wrestling conventions
+ * - Title uniqueness enforcement across all championships
+ * - Activation period tracking for title history and lineage
+ * - Wrestling-specific validation (titles must end with "Title" or "Titles")
+ * - Integration with title activation relationship system
+ *
+ * @extends LivewireBaseForm<TitleForm, Title>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ * @see ManagesActivityPeriods For activation period tracking
+ * @see CanChangeDebutDate For custom activation validation
+ *
+ * @property string $name Championship title name (must end with Title/Titles)
+ * @property TitleType|string $type Title type (singles or tag-team)
+ * @property Carbon|string|null $start_date Title activation start date
+ */
+class TitleForm extends LivewireBaseForm
+{
+    use ManagesActivityPeriods;
+
+    /**
+     * The model instance being edited, or null for new title creation.
+     *
+     * @var Title|null Current title model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Championship title's official name following wrestling conventions.
+     *
+     * Must end with "Title" or "Titles" to follow standard wrestling
+     * nomenclature (e.g., "Heavyweight Championship Title", "Tag Team Titles").
+     * Used in match announcements, promotional materials, and championship
+     * records. Must be unique across all titles in the system.
+     *
+     * @var string Championship title name with required suffix
+     */
+    public string $name = '';
+
+    /**
+     * Championship title type classification.
+     *
+     * Defines whether the title is for individual competitors (singles)
+     * or tag team competitors (tag-team). This affects championship
+     * rules, match types, and who can compete for the title.
+     *
+     * @var TitleType|string Title type (singles or tag-team)
+     */
+    public TitleType|string $type = '';
+
+    /**
+     * Title activation start date for championship history tracking.
+     *
+     * Tracks when a championship title becomes active and available for
+     * competition. Managed through ManagesActivityPeriods trait for
+     * consistent activation tracking across the title system.
+     *
+     * @var Carbon|string|null Title activation start date
+     */
+    public Carbon|string|null $start_date = '';
+
+    /**
+     * Load additional data when editing existing title records.
+     *
+     * Handles activation period data loading for edit operations,
+     * retrieving the first activation date from the title's activation
+     * relationship system for display in the form.
+     *
+     * Activation Integration:
+     * - Loads start date from first activation relationship
+     * - Handles null activations for titles not yet activated
+     * - Converts Carbon dates to string format for form display
+     *
+     *
+     * @see ManagesActivityPeriods For activation period management
+     */
+    public function loadExtraData(): void
+    {
+        // Only process if we have a title model
+        if (! $this->formModel instanceof Title) {
+            return;
+        }
+
+        // Load activation start date from first activity period relationship
+        $this->start_date = $this->formModel->firstActivityPeriod?->started_at?->toDateString();
+    }
+
+    /**
+     * Handle additional tasks after title creation.
+     *
+     * Creates activation record for new titles with start dates.
+     * Called automatically by the store pattern trait.
+     */
+    protected function handlePostCreationTasks(): void
+    {
+        // Create activation record for new titles with start dates
+        if ($this->start_date) {
+            $this->handleActivityPeriodCreation();
+        }
+    }
+
+    /**
+     * Prepare title data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure.
+     * Only includes the title name as activation dates are managed
+     * separately through the title's activation relationship system
+     * to maintain proper separation of concerns.
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     */
+    protected function getModelData(): array
+    {
+        return [
+            'name' => $this->name,
+            'type' => $this->type,
+        ];
+        // Note: start_date is NOT included here because activation dates
+        // are managed separately through the title's activation relationship system
+    }
+
+    /**
+     * Get the model class for title form operations.
+     *
+     * Specifies the Title model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<Title> The Title model class
+     */
+    protected function getModelClass(): string
+    {
+        return Title::class;
+    }
+
+    /**
+     * Define validation rules for championship title fields.
+     *
+     * Provides comprehensive validation for championship titles including
+     * wrestling industry naming conventions, uniqueness constraints, and
+     * activation date validation through custom rules.
+     *
+     * Validation Requirements:
+     * - Name: Required, unique, max 255 characters, must end with Title/Titles
+     * - Wrestling Convention: Enforces standard championship naming patterns
+     * - Start Date: Optional, valid date, custom activation validation
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     *
+     * @see CanChangeDebutDate For custom date validation
+     * @see Rule::unique() For database uniqueness constraints
+     */
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', 'ends_with:Title,Titles', Rule::unique('titles', 'name')->ignore($this->formModel)],
+            'type' => ['required', Rule::enum(TitleType::class)],
+            'start_date' => ['nullable', 'date', new CanChangeDebutDate($this->formModel)],
+        ];
+    }
+
+    /**
+     * Get title-specific validation attributes.
+     *
+     * All standard attributes are provided by HasStandardValidationAttributes trait.
+     * This method handles title-specific field naming.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function getCustomValidationAttributes(): array
+    {
+        return [
+            'type' => 'title type',
+            'start_date' => 'start date',
+        ];
+    }
+}

--- a/app/Livewire/Titles/Modals/TitleFormModal.php
+++ b/app/Livewire/Titles/Modals/TitleFormModal.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Titles\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Titles\Forms\TitleForm;
+use App\Models\Titles\Title;
+use Livewire\Form;
+
+/**
+ * Livewire modal component for championship title form management.
+ *
+ * Manages the creation and editing of championship titles within the wrestling
+ * management system. Provides specialized data generation for championship
+ * titles following wrestling industry naming conventions and activation patterns.
+ *
+ * Key Features:
+ * - Modal-based title form interface
+ * - Wrestling-specific title name generation
+ * - Automatic activation date generation
+ * - Form validation with championship naming rules
+ * - Integration with title management workflows
+ *
+ * @extends BaseFormModal<TitleForm, Title>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseFormModal For modal functionality and patterns
+ * @see Title For the underlying title model structure
+ */
+class TitleFormModal extends BaseFormModal
+{
+    /**
+     * The title form instance for data management.
+     *
+     * Handles all title-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public TitleForm $form;
+
+    /**
+     * Get the form class that handles title data validation and processing.
+     *
+     * @return class-string<TitleForm> The fully qualified class name of TitleForm
+     */
+    protected function getFormClass(): string
+    {
+        return TitleForm::class;
+    }
+
+    /**
+     * Get the model class that represents title entities.
+     *
+     * @return class-string<Title> The fully qualified class name of Title model
+     */
+    protected function getModelClass(): string
+    {
+        return Title::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the title form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'titles.modals.form-modal';
+    }
+
+    /**
+     * Generate dummy data fields for title form testing and development.
+     *
+     * Returns field generators for championship title data including wrestling-
+     * appropriate names and activation dates following industry conventions.
+     *
+     * @return array<string, callable(): mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'name' => fn () => $this->generateChampionshipTitle(),
+            'type' => fn () => fake()->randomElement(['singles', 'tag-team']),
+            'start_date' => fake()->optional(0.8, fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d H:i:s')),
+        ];
+    }
+
+    /**
+     * Generate random title data for testing and development.
+     *
+     * Populates the form with realistic championship title data including
+     * wrestling-appropriate names and activation dates. Ensures all generated
+     * data follows championship naming conventions and validation rules.
+     */
+    public function generateRandomData(): void
+    {
+        $this->form->fill([
+            'name' => $this->generateChampionshipTitle(),
+            'type' => fake()->randomElement(['singles', 'tag-team']),
+            'start_date' => fake()->optional(0.8, fn () => fake()->dateTimeBetween('now', '+3 months')->format('Y-m-d H:i:s')),
+        ]);
+    }
+}

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionshipsTable.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Livewire\Titles\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use App\Models\TitleChampionship;
+use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Gate;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 
@@ -24,7 +26,10 @@ class PreviousTitleChampionshipsTable extends DataTableComponent
      */
     public ?int $titleId;
 
-    public function configure(): void {}
+    public function configure(): void
+    {
+        Gate::authorize('viewList', Title::class);
+    }
 
     /**
      * @return Builder<TitleChampionship>

--- a/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
+++ b/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Titles\Tables;
 
-use App\Models\Title;
+use App\Models\Titles\Title;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 

--- a/app/Livewire/Titles/Tables/TitlesTable.php
+++ b/app/Livewire/Titles/Tables/TitlesTable.php
@@ -4,119 +4,227 @@ declare(strict_types=1);
 
 namespace App\Livewire\Titles\Tables;
 
-use App\Actions\Titles\ActivateAction;
-use App\Actions\Titles\DeactivateAction;
+use App\Actions\Titles\DebutAction;
+use App\Actions\Titles\PullAction;
 use App\Actions\Titles\RestoreAction;
 use App\Actions\Titles\RetireAction;
 use App\Actions\Titles\UnretireAction;
-use App\Builders\TitleBuilder;
-use App\Enums\ActivationStatus;
-use App\Exceptions\CannotBeActivatedException;
-use App\Exceptions\CannotBeDeactivatedException;
-use App\Exceptions\CannotBeRetiredException;
-use App\Exceptions\CannotBeUnretiredException;
+use App\Builders\Titles\TitleBuilder;
 use App\Livewire\Base\Tables\BaseTableWithActions;
-use App\Livewire\Concerns\Columns\HasStatusColumn;
-use App\Livewire\Concerns\Filters\HasStatusFilter;
-use App\Models\Title;
-use App\View\Columns\FirstActivationDateColumn;
-use App\View\Filters\FirstActivationFilter;
-use Exception;
+use App\Livewire\Components\Tables\Columns\FirstActivityPeriodColumn;
+use App\Livewire\Components\Tables\Filters\FirstActivityPeriodFilter;
+use App\Livewire\Titles\Components\TitleActionsComponent;
+use App\Models\Titles\Title;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 use Rappasoft\LaravelLivewireTables\Views\Filter;
+use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
+/**
+ * Livewire table component for managing championship titles.
+ *
+ * This table displays all championship titles in the system with their current
+ * status, activation dates, and provides actions for title lifecycle management.
+ * It supports filtering by activation status and date ranges, along with search
+ * functionality for title names.
+ *
+ * The table integrates with various title management actions including activation,
+ * deactivation, retirement, restoration, and deletion through a comprehensive
+ * action system with proper authorization and error handling.
+ *
+ * @example
+ * ```php
+ * // In a Blade template
+ * <livewire:titles.tables.titles-table />
+ *
+ * // The table displays titles like:
+ * // - WWE Championship Title (Active, First Activated: 2020-01-15)
+ * // - Intercontinental Title (Retired, First Activated: 2019-06-01)
+ * // - Tag Team Titles (Inactive, First Activated: 2021-03-10)
+ * ```
+ */
 class TitlesTable extends BaseTableWithActions
 {
-    use HasStatusColumn, HasStatusFilter;
-
+    /**
+     * The database table name for the main query.
+     *
+     * @var string The name of the titles table
+     */
     protected string $databaseTableName = 'titles';
 
+    /**
+     * The base route path for title-related actions.
+     *
+     * @var string The route prefix for title management
+     */
     protected string $routeBasePath = 'titles';
 
+    /**
+     * The resource name for authorization and routing.
+     *
+     * @var string The resource identifier for titles
+     */
     protected string $resourceName = 'titles';
 
     /**
-     * @return TitleBuilder<Title>
+     * Build the query for retrieving titles with their relationships.
+     *
+     * Creates a query that fetches all titles with their current activity period
+     * information, ordered alphabetically by name. The current activity period
+     * relationship provides access to activation status and dates.
+     *
+     * @return TitleBuilder<Title> Query builder for titles with eager loaded relationships
+     *
+     * @example
+     * ```php
+     * // The query retrieves titles with their activity status:
+     * // SELECT titles.*, activity_periods.* FROM titles
+     * // LEFT JOIN activity_periods ON titles.id = activity_periods.title_id
+     * // WHERE activity_periods.ended_at IS NULL
+     * // ORDER BY titles.name ASC
+     * ```
      */
     public function builder(): TitleBuilder
     {
         return Title::query()
-            ->with(['currentActivation'])
+            ->with(['currentActivityPeriod'])
             ->oldest('name');
     }
 
-    public function configure(): void {}
+    /**
+     * Configure additional table settings and behavior.
+     *
+     * Includes authorization check to ensure only authorized users can access
+     * the titles table, plus any additional table-specific configuration.
+     */
+    public function configure(): void
+    {
+        Gate::authorize('viewList', Title::class);
+    }
 
     /**
-     * Undocumented function
+     * Define the table columns for title display.
      *
-     * @return array<int, Column>
+     * Configures the columns shown in the titles table including the title name,
+     * current status, and first activation date. The status column shows whether
+     * a title is currently active, inactive, or retired.
+     *
+     * @return array<int, Column> Array of column definitions for the table
+     *
+     * @example
+     * ```php
+     * // Table displays columns:
+     * // | Name                    | Status   | First Activation |
+     * // | WWE Championship Title  | Active   | 2020-01-15      |
+     * // | Intercontinental Title  | Retired  | 2019-06-01      |
+     * // | Tag Team Titles         | Inactive | 2021-03-10      |
+     * ```
      */
     public function columns(): array
     {
         return [
             Column::make(__('titles.name'), 'name')
                 ->searchable(),
-            $this->getDefaultStatusColumn(),
+            Column::make(__('core.status'), 'status')
+                ->label(fn ($row) => $row->status?->label() ?? 'Unknown')
+                ->excludeFromColumnSelect(),
             // Column::make(__('titles.current_champion'), 'champion_name'),
-            FirstActivationDateColumn::make(__('activations.started_at')),
+            FirstActivityPeriodColumn::make(__('activations.started_at')),
         ];
     }
 
     /**
-     * Undocumented function
+     * Define the available filters for the titles table.
      *
-     * @return array<int, Filter>
+     * Provides filtering options including activity status filter (Undebuted,
+     * Active, Inactive, Pending Debut) and first activation date range filter for finding
+     * titles activated within specific time periods.
+     *
+     * @return array<int, Filter> Array of filter definitions for the table
+     *
+     * @example
+     * ```php
+     * // Available filters:
+     * // - Status: [All, Undebuted, Active, Inactive, Pending Debut]
+     * // - Activation Date: [Date range picker for first activation]
+     * ```
      */
     public function filters(): array
     {
-        /** @var array<string, string> $statuses */
-        $statuses = collect(ActivationStatus::cases())->pluck('name', 'value')->toArray();
-
         return [
-            $this->getDefaultStatusFilter($statuses),
-            FirstActivationFilter::make('Activation Date')->setFields('activations', 'titles_activations.started_at', 'titles_activations.ended_at'),
+            SelectFilter::make('Status', 'status')
+                ->options([
+                    '' => 'All',
+                    'undebuted' => 'Undebuted',
+                    'active' => 'Active',
+                    'inactive' => 'Inactive',
+                    'with_pending_debut' => 'Pending Debut',
+                ])
+                ->filter(function (Builder $builder, string $value): void {
+                    /** @var TitleBuilder $builder */
+                    match ($value) {
+                        'undebuted' => $builder->undebuted(),
+                        'active' => $builder->active(),
+                        'inactive' => $builder->inactive(),
+                        'with_pending_debut' => $builder->withPendingDebut(),
+                        default => null,
+                    };
+                }),
+            FirstActivityPeriodFilter::make('Activation Date')->setFields('activations', 'titles_activations.started_at', 'titles_activations.ended_at'),
         ];
     }
 
+    /**
+     * Delete a title from the system.
+     *
+     * Performs soft deletion of the specified title using the base table's
+     * delete functionality. The title will be moved to trash and can be
+     * restored later if needed.
+     *
+     * @param  Title  $title  The title to delete
+     */
     public function delete(Title $title): void
     {
         $this->deleteModel($title);
     }
 
+    /**
+     * Activate a title for competition.
+     *
+     * @param  Title  $title  The title to activate
+     * @return RedirectResponse Redirect response with success or error message
+     */
     public function activate(Title $title): RedirectResponse
     {
-        Gate::authorize('activate', $title);
-
-        try {
-            resolve(ActivateAction::class)->handle($title);
-        } catch (CannotBeActivatedException $e) {
-            return redirect()->back()->with('error', $e->getMessage());
-        }
-
-        return back();
+        return $this->executeAction(
+            DebutAction::class,
+            $title,
+            'debut'
+        );
     }
 
     /**
-     * Deactivates a title.
+     * Pull a title from active competition.
+     *
+     * @param  Title  $title  The title to pull
+     * @return RedirectResponse Redirect response with success or error message
      */
     public function deactivate(Title $title): RedirectResponse
     {
-        Gate::authorize('deactivate', $title);
-
-        try {
-            resolve(DeactivateAction::class)->handle($title);
-        } catch (CannotBeDeactivatedException $e) {
-            return redirect()->back()->with('error', $e->getMessage());
-        }
-
-        return back();
+        return $this->executeAction(
+            PullAction::class,
+            $title,
+            'pull'
+        );
     }
 
     /**
-     * Restores a title.
+     * Restore a previously deleted title.
+     *
+     * @param  int  $titleId  The ID of the deleted title to restore
+     * @return RedirectResponse Redirect response with success or error message
      */
     public function restore(int $titleId): RedirectResponse
     {
@@ -124,44 +232,57 @@ class TitlesTable extends BaseTableWithActions
 
         Gate::authorize('restore', $title);
 
-        try {
-            resolve(RestoreAction::class)->handle($title);
-        } catch (Exception $e) {
-            return redirect()->back()->with('error', $e->getMessage());
-        }
+        resolve(RestoreAction::class)->handle($title);
 
         return back();
     }
 
     /**
-     * Retires a title.
+     * Retire a title permanently.
+     *
+     * @param  Title  $title  The title to retire
+     * @return RedirectResponse Redirect response with success or error message
      */
     public function retire(Title $title): RedirectResponse
     {
-        Gate::authorize('retire', $title);
-
-        try {
-            resolve(RetireAction::class)->handle($title);
-        } catch (CannotBeRetiredException $e) {
-            return redirect()->back()->with('error', $e->getMessage());
-        }
-
-        return back();
+        return $this->executeAction(
+            RetireAction::class,
+            $title,
+            'retire'
+        );
     }
 
     /**
-     * Unretire a title.
+     * Unretire a previously retired title.
+     *
+     * @param  Title  $title  The title to unretire
+     * @return RedirectResponse Redirect response with success or error message
      */
     public function unretire(Title $title): RedirectResponse
     {
-        Gate::authorize('unretire', $title);
+        return $this->executeAction(
+            UnretireAction::class,
+            $title,
+            'unretire'
+        );
+    }
 
-        try {
-            resolve(UnretireAction::class)->handle($title);
-        } catch (CannotBeUnretiredException $e) {
-            return redirect()->back()->with('error', $e->getMessage());
-        }
+    public function handleTitleAction(string $action, int $titleId): void
+    {
+        $title = Title::findOrFail($titleId);
 
-        return back();
+        // Delegate to the TitleActionsComponent
+        $actionsComponent = new TitleActionsComponent();
+        $actionsComponent->title = $title;
+
+        match ($action) {
+            'debut' => $actionsComponent->debut(),
+            'pull' => $actionsComponent->deactivate(),
+            'reinstate' => $actionsComponent->reinstate(),
+            'retire' => $actionsComponent->retire(),
+            'unretire' => $actionsComponent->unretire(),
+            'restore' => $actionsComponent->restore(),
+            default => null,
+        };
     }
 }

--- a/app/Livewire/Users/Forms/UserForm.php
+++ b/app/Livewire/Users/Forms/UserForm.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Users\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Models\Users\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\Rule;
+
+/**
+ * Livewire form component for managing user creation and editing.
+ *
+ * This form handles complete user account management including authentication
+ * credentials, profile information, and role assignments. Provides secure
+ * password handling, email validation, and user identification management
+ * for the wrestling management system's access control.
+ *
+ * Key Responsibilities:
+ * - User account creation and profile management
+ * - Secure password handling with hashing and confirmation
+ * - Email uniqueness validation for authentication
+ * - User identification and contact information
+ * - Role-based access control preparation
+ *
+ * @extends LivewireBaseForm<UserForm, User>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ *
+ * @property string $name Full name for user identification and display
+ * @property string $email Email address for authentication and communication
+ * @property string $password Secure password for account access
+ * @property string $password_confirmation Password confirmation for security
+ */
+class UserForm extends LivewireBaseForm
+{
+    /**
+     * The model instance being edited, or null for new user creation.
+     *
+     * @var User|null Current user model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * User's full name for identification and display purposes.
+     *
+     * Used throughout the system for user identification, display in
+     * interfaces, and communication purposes. Should be the user's
+     * real name for administrative and operational clarity.
+     *
+     * @var string User's full name for identification
+     */
+    public string $name = '';
+
+    /**
+     * User's email address for authentication and communication.
+     *
+     * Primary identifier for user authentication and system communications.
+     * Must be unique across all users and follow valid email format.
+     * Used for login, password resets, and operational notifications.
+     *
+     * @var string Email address for authentication
+     */
+    public string $email = '';
+
+    /**
+     * User's password for secure account access.
+     *
+     * Plain text password input that will be hashed before storage.
+     * Must meet security requirements for length and complexity.
+     * Only used during creation and password change operations.
+     *
+     * @var string Plain text password for hashing
+     */
+    public string $password = '';
+
+    /**
+     * Password confirmation for security validation.
+     *
+     * Must match the password field exactly to prevent typos and
+     * ensure user knows their chosen password. Required for both
+     * account creation and password change operations.
+     *
+     * @var string Password confirmation for validation
+     */
+    public string $password_confirmation = '';
+
+    /**
+     * Load additional data when editing existing user records.
+     *
+     * Handles user-specific data loading for edit operations while
+     * maintaining security by never loading password information.
+     * Can be extended to load role assignments and other relationships.
+     *
+     * Security Note:
+     * - Password fields are never populated during edit operations
+     * - Sensitive data loading follows security best practices
+     */
+    public function loadExtraData(): void
+    {
+        // Password fields are intentionally not loaded for security
+        // Additional user data can be loaded here as needed:
+        // $this->roles = $this->formModel?->roles->pluck('name')->toArray() ?? [];
+    }
+
+    /**
+     * Prepare user data for model storage with secure password handling.
+     *
+     * Transforms form fields into model-compatible data structure with
+     * secure password hashing. Handles both creation and update scenarios
+     * appropriately for password management.
+     *
+     * Security Features:
+     * - Passwords are hashed using Laravel's secure Hash facade
+     * - Password is only included when provided (allows updates without password change)
+     * - Uses bcrypt hashing for maximum security
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     *
+     * @see Hash::make() For secure password hashing
+     */
+    protected function getModelData(): array
+    {
+        $data = [
+            'name' => $this->name,
+            'email' => $this->email,
+        ];
+
+        // Only include password if provided (allows profile updates without password change)
+        if (! empty($this->password)) {
+            $data['password'] = Hash::make($this->password);
+        }
+
+        return $data;
+    }
+
+    /**
+     * Get the model class for user form operations.
+     *
+     * Specifies the User model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<User> The User model class
+     */
+    protected function getModelClass(): string
+    {
+        return User::class;
+    }
+
+    /**
+     * Define validation rules for user form fields.
+     *
+     * Provides comprehensive validation for all user account data including
+     * uniqueness constraints, security requirements, and format validation
+     * to ensure secure and reliable user management.
+     *
+     * Validation Requirements:
+     * - Name: Required, max 255 characters for database compatibility
+     * - Email: Required, valid format, unique across users
+     * - Password: Required for creation, minimum 8 characters, confirmed
+     * - Password updates: Optional for existing users, same requirements when provided
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     *
+     * @see Rule::unique() For email uniqueness validation
+     */
+    protected function rules(): array
+    {
+        $rules = [
+            'name' => $this->getRequiredStringRules(),
+            'email' => [
+                'required',
+                'email',
+                'max:255',
+                Rule::unique('users', 'email')->ignore($this->formModel),
+            ],
+        ];
+
+        // Password rules - required for creation, optional for updates
+        if ($this->isCreating() || ! empty($this->password)) {
+            $rules['password'] = ['required', 'string', 'min:8', 'confirmed'];
+            $rules['password_confirmation'] = ['required'];
+        }
+
+        return $rules;
+    }
+
+    /**
+     * Get user-specific validation attributes.
+     *
+     * All standard attributes are provided by HasStandardValidationAttributes trait.
+     * This method handles user-specific field naming.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function getCustomValidationAttributes(): array
+    {
+        return [
+            'password_confirmation' => 'password confirmation',
+        ];
+    }
+}

--- a/app/Livewire/Users/Modals/UserFormModal.php
+++ b/app/Livewire/Users/Modals/UserFormModal.php
@@ -1,0 +1,148 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Users\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Users\Forms\UserForm;
+use App\Models\Users\User;
+use Livewire\Form;
+
+/**
+ * Livewire modal component for user account form management.
+ *
+ * Handles the creation and editing of user accounts within the wrestling
+ * management system. Provides secure user management with password handling,
+ * email validation, and account security features through a modal interface.
+ *
+ * Key Features:
+ * - Modal-based user form interface
+ * - Automatic data generation for testing and development
+ * - Secure password handling and validation
+ * - Email uniqueness validation
+ * - User account management workflows
+ *
+ * @extends BaseFormModal<UserForm, User>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseFormModal For modal functionality and patterns
+ * @see User For the underlying user model structure
+ */
+class UserFormModal extends BaseFormModal
+{
+    /**
+     * The user form instance for data management.
+     *
+     * Handles all user-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public Form $form;
+
+    /**
+     * Get the form class that handles user data validation and processing.
+     *
+     * @return class-string<UserForm> The fully qualified class name of UserForm
+     */
+    protected function getFormClass(): string
+    {
+        return UserForm::class;
+    }
+
+    /**
+     * Get the model class that represents user entities.
+     *
+     * @return class-string<User> The fully qualified class name of User model
+     */
+    protected function getModelClass(): string
+    {
+        return User::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the user form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'users.modals.form-modal';
+    }
+
+    /**
+     * Generate dummy data fields for user form testing and development.
+     *
+     * Returns field generators for user account data including names, emails,
+     * and secure passwords with proper confirmation handling.
+     *
+     * @return array<string, callable(): mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        // Generate password once for consistency between password and confirmation
+        $password = 'password123';
+
+        return [
+            'name' => fn () => $this->generateUserName(),
+            'email' => fn () => $this->generateUniqueEmail(),
+            'password' => fn () => $password,
+            'password_confirmation' => fn () => $password,
+        ];
+    }
+
+    /**
+     * Generate random user data for testing and development.
+     *
+     * Populates the form with realistic user data including names, emails,
+     * and secure passwords. Ensures email uniqueness and proper password
+     * confirmation for testing authentication workflows.
+     */
+    public function generateRandomData(): void
+    {
+        // Generate consistent password for both fields
+        $password = 'password123';
+
+        $this->form->fill([
+            'name' => $this->generateUserName(),
+            'email' => $this->generateUniqueEmail(),
+            'password' => $password,
+            'password_confirmation' => $password,
+        ]);
+    }
+
+    /**
+     * Generate a realistic user name for testing.
+     *
+     * Creates full names using faker patterns appropriate for
+     * user accounts in a wrestling management system.
+     *
+     * @return string A generated full name
+     *
+     * @example
+     * Returns names like: "John Smith", "Sarah Johnson", "Michael Brown"
+     */
+    protected function generateUserName(): string
+    {
+        return fake()->firstName().' '.fake()->lastName();
+    }
+
+    /**
+     * Generate a unique email address for testing.
+     *
+     * Creates email addresses that are unique and follow realistic
+     * patterns while avoiding conflicts with existing user accounts.
+     * Uses safe email generation to prevent real email issues.
+     *
+     * @return string A unique email address
+     *
+     * @example
+     * Returns emails like: "john.smith@example.com", "sarah.j@test.org"
+     */
+    protected function generateUniqueEmail(): string
+    {
+        // Use faker's unique email generation with safe domains
+        return fake()->unique()->safeEmail();
+    }
+}

--- a/app/Livewire/Users/Tables/UsersTable.php
+++ b/app/Livewire/Users/Tables/UsersTable.php
@@ -4,25 +4,22 @@ declare(strict_types=1);
 
 namespace App\Livewire\Users\Tables;
 
-use App\Builders\UserBuilder;
-use App\Enums\Role;
+use App\Builders\Users\UserBuilder;
+use App\Enums\Users\Role;
 use App\Livewire\Base\Tables\BaseTableWithActions;
-use App\Livewire\Concerns\Columns\HasStatusColumn;
-use App\Livewire\Concerns\Filters\HasStatusFilter;
-use App\Models\User;
+use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Model;
 use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class UsersTable extends BaseTableWithActions
 {
-    use HasStatusColumn, HasStatusFilter;
-
     protected string $databaseTableName = 'users';
 
     protected string $routeBasePath = 'users';
 
     protected string $resourceName = 'users';
 
+    /** @return UserBuilder<User> */
     public function builder(): UserBuilder
     {
         return User::query()
@@ -45,11 +42,13 @@ class UsersTable extends BaseTableWithActions
                 ->searchable(),
             Column::make(__('users.role'), 'role')
                 ->format(fn (Role $value) => $value->name),
-            $this->getDefaultStatusColumn(),
+            Column::make(__('core.status'), 'status')
+                ->label(fn ($row) => $row->status?->label() ?? 'Unknown')
+                ->excludeFromColumnSelect(),
             Column::make(__('users.email'), 'email')
                 ->searchable(),
             Column::make(__('users.phone'), 'phone_number')
-                ->label(fn (User $row, Column $column): string => $row->getFormattedPhoneNumber()),
+                ->label(fn (User $row, Column $column): string => $row->formattedPhoneNumber),
         ];
     }
 }

--- a/app/Livewire/Venues/Forms/VenueForm.php
+++ b/app/Livewire/Venues/Forms/VenueForm.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Venues\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Models\Shared\Venue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\Rule;
+
+/**
+ * Livewire form component for managing venue creation and editing.
+ *
+ * This form handles venue location data management for wrestling events and shows.
+ * Provides validation for complete venue information including address verification
+ * and state existence validation. Venues represent physical locations where
+ * wrestling events take place, requiring accurate location data for event planning,
+ * fan travel, and operational logistics.
+ *
+ * Key Responsibilities:
+ * - Venue identification and naming with uniqueness enforcement
+ * - Complete address management with comprehensive validation
+ * - State verification against valid state records in database
+ * - ZIP code format validation for postal accuracy
+ * - Location data integrity for event management systems
+ *
+ * @extends LivewireBaseForm<VenueForm, Venue>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ *
+ * @property string $name Venue's official name for events and promotion
+ * @property string $street_address Complete street address for location
+ * @property string $city City where venue is located
+ * @property string $state State name (validated against State model)
+ * @property int|string $zipcode 5-digit ZIP code for postal addressing
+ */
+class VenueForm extends LivewireBaseForm
+{
+    /**
+     * The model instance being edited, or null for new venue creation.
+     *
+     * @var Venue|null Current venue model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Venue's official name for events and promotional materials.
+     *
+     * Used in event announcements, ticket sales, promotional content,
+     * and venue booking systems. Must be unique across all venues
+     * to prevent confusion in event scheduling and fan communications.
+     *
+     * @var string Venue's primary name identifier
+     */
+    public string $name = '';
+
+    /**
+     * Complete street address including number and street name.
+     *
+     * Full physical address for venue location, essential for GPS navigation,
+     * shipping logistics, emergency services, and official documentation.
+     * Combined with city, state, and ZIP code for complete addressing.
+     *
+     * @var string Street address for venue location
+     */
+    public string $street_address = '';
+
+    /**
+     * City where the venue is located.
+     *
+     * Municipal location for the venue, used in event announcements,
+     * marketing materials, and fan travel planning. Critical for regional
+     * event scheduling and local promotional partnerships.
+     *
+     * @var string City name for venue location
+     */
+    public string $city = '';
+
+    /**
+     * State where the venue is located.
+     *
+     * Validated against existing State model records to ensure data accuracy
+     * and prevent entry errors. Used for regional event planning, tax compliance,
+     * regulatory requirements, and state-specific operational procedures.
+     *
+     * @var string State name (must exist in states table)
+     */
+    public string $state = '';
+
+    /**
+     * 5-digit ZIP code for postal addressing.
+     *
+     * Standard US postal code format essential for mail delivery, location
+     * identification, and regional analysis. Validated as exactly 5 digits
+     * to ensure proper format for shipping and correspondence systems.
+     *
+     * @var int|string ZIP code in 5-digit format
+     */
+    public int|string $zipcode = '';
+
+    /**
+     * Load additional data when editing existing venue records.
+     *
+     * Handles data loading for venue-specific fields when editing
+     * existing venues. Called automatically during form initialization
+     * for edit operations. No special data transformation needed for venues.
+     */
+    public function loadExtraData(): void
+    {
+        // No additional data loading required for venues
+        // All venue data is loaded via standard form fill mechanism
+    }
+
+    /**
+     * Prepare venue data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure ready
+     * for database persistence. All venue fields are passed through directly
+     * as they represent simple scalar values without complex transformations.
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     */
+    protected function getModelData(): array
+    {
+        return [
+            'name' => $this->name,
+            'street_address' => $this->street_address,
+            'city' => $this->city,
+            'state' => $this->state,
+            'zipcode' => $this->zipcode,
+        ];
+    }
+
+    /**
+     * Get the model class for venue form operations.
+     *
+     * Specifies the Venue model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<Venue> The Venue model class
+     */
+    protected function getModelClass(): string
+    {
+        return Venue::class;
+    }
+
+    /**
+     * Define validation rules for venue form fields.
+     *
+     * Provides comprehensive validation for all venue location data including
+     * uniqueness constraints, address completeness, state existence verification,
+     * and ZIP code format validation to ensure operational reliability.
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     */
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('venues', 'name')->ignore($this->formModel)],
+            'street_address' => ['required', 'string', 'max:255'],
+            'city' => ['required', 'string', 'max:255'],
+            'state' => ['required', 'string', Rule::exists('states', 'name')],
+            'zipcode' => ['required', 'digits:5'],
+        ];
+    }
+
+    /**
+     * Get venue-specific validation attributes.
+     *
+     * Extends standard attributes with venue-specific field names for better
+     * user experience in validation messages.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function validationAttributes(): array
+    {
+        return [
+            'street_address' => 'street address',
+            'zipcode' => 'zip code',
+        ];
+    }
+}

--- a/app/Livewire/Venues/Modals/VenueFormModal.php
+++ b/app/Livewire/Venues/Modals/VenueFormModal.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Venues\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Venues\Forms\VenueForm;
+use App\Models\Shared\Venue;
+use Livewire\Form;
+
+/**
+ * Livewire modal component for venue form management.
+ *
+ * Manages the creation and editing of wrestling venue entities. Handles
+ * venue-specific data including location information, address details,
+ * and geographical data for wrestling events and shows.
+ *
+ * Key Features:
+ * - Modal-based venue form interface
+ * - Automatic data generation for testing and development
+ * - Form validation with user feedback
+ * - Creation and editing mode support
+ * - Integration with venue-specific business logic
+ *
+ * @extends BaseFormModal<VenueForm, Venue>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see BaseFormModal For modal functionality and patterns
+ * @see Venue For the underlying venue model structure
+ */
+class VenueFormModal extends BaseFormModal
+{
+    /**
+     * The venue form instance for data management.
+     *
+     * Handles all venue-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public VenueForm $form;
+
+    /**
+     * Get the form class that handles venue data validation and processing.
+     *
+     * @return class-string<VenueForm> The fully qualified class name of VenueForm
+     */
+    protected function getFormClass(): string
+    {
+        return VenueForm::class;
+    }
+
+    /**
+     * Get the model class that represents venue entities.
+     *
+     * @return class-string<Venue> The fully qualified class name of Venue model
+     */
+    protected function getModelClass(): string
+    {
+        return Venue::class;
+    }
+
+    /**
+     * Get the Blade view path for rendering the venue form modal.
+     *
+     * @return string The view path relative to resources/views
+     */
+    protected function getModalPath(): string
+    {
+        return 'venues.modals.form-modal';
+    }
+
+    /**
+     * Generate dummy data fields for venue form testing and development.
+     *
+     * Creates realistic test data for venue locations including:
+     * - Venue names (arenas, stadiums, theaters)
+     * - Complete US address information
+     * - Street address, city, state, and ZIP code
+     *
+     * Uses optimized approach to generate address data once and reuse
+     * across multiple fields for consistency and efficiency.
+     *
+     * @return array<string, callable(): mixed> Array mapping field names to generators
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'name' => fn () => $this->generateVenueName(),
+            'street_address' => fn () => $this->generateUSAddress()['street_address'],
+            'city' => fn () => $this->generateUSAddress()['city'],
+            'state' => fn () => $this->generateUSAddress()['state'],
+            'zipcode' => fn () => $this->generateUSAddress()['zipcode'],
+        ];
+    }
+
+    /**
+     * Generate random venue data for testing and development.
+     *
+     * Populates the form with realistic venue data including names and
+     * complete address information. Uses consistent address generation
+     * to ensure all address fields are from the same location.
+     */
+    public function generateRandomData(): void
+    {
+        // Generate address data once for consistency
+        $addressData = $this->generateUSAddress();
+
+        $this->form->fill([
+            'name' => $this->generateVenueName(),
+            'street_address' => $addressData['street_address'],
+            'city' => $addressData['city'],
+            'state' => $addressData['state'],
+            'zipcode' => $addressData['zipcode'],
+        ]);
+    }
+}

--- a/app/Livewire/Venues/Tables/PreviousEventsTable.php
+++ b/app/Livewire/Venues/Tables/PreviousEventsTable.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Livewire\Venues\Tables;
 
-use App\Builders\EventBuilder;
+use App\Builders\Events\EventBuilder;
 use App\Livewire\Concerns\ShowTableTrait;
-use App\Models\Event;
+use App\Models\Events\Event;
 use Exception;
 use Rappasoft\LaravelLivewireTables\DataTableComponent;
 use Rappasoft\LaravelLivewireTables\Views\Column;

--- a/app/Livewire/Venues/Tables/VenuesTable.php
+++ b/app/Livewire/Venues/Tables/VenuesTable.php
@@ -6,7 +6,7 @@ namespace App\Livewire\Venues\Tables;
 
 use App\Actions\Venues\RestoreAction;
 use App\Livewire\Base\Tables\BaseTableWithActions;
-use App\Models\Venue;
+use App\Models\Shared\Venue;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
@@ -29,7 +29,10 @@ class VenuesTable extends BaseTableWithActions
             ->orderBy('name');
     }
 
-    public function configure(): void {}
+    public function configure(): void
+    {
+        Gate::authorize('viewList', Venue::class);
+    }
 
     /**
      * Undocumented function

--- a/app/Livewire/Wrestlers/Components/WrestlerActionsComponent.php
+++ b/app/Livewire/Wrestlers/Components/WrestlerActionsComponent.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Wrestlers\Components;
+
+use App\Actions\Wrestlers\EmployAction;
+use App\Actions\Wrestlers\HealAction;
+use App\Actions\Wrestlers\InjureAction;
+use App\Actions\Wrestlers\ReinstateAction;
+use App\Actions\Wrestlers\ReleaseAction;
+use App\Actions\Wrestlers\RestoreAction;
+use App\Actions\Wrestlers\RetireAction;
+use App\Actions\Wrestlers\SuspendAction;
+use App\Actions\Wrestlers\UnretireAction;
+use App\Exceptions\Status\CannotBeClearedFromInjuryException;
+use App\Exceptions\Status\CannotBeEmployedException;
+use App\Exceptions\Status\CannotBeInjuredException;
+use App\Exceptions\Status\CannotBeReinstatedException;
+use App\Exceptions\Status\CannotBeReleasedException;
+use App\Exceptions\Status\CannotBeRetiredException;
+use App\Exceptions\Status\CannotBeSuspendedException;
+use App\Exceptions\Status\CannotBeUnretiredException;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Gate;
+use Livewire\Component;
+
+/**
+ * Wrestler Actions Component
+ *
+ * Handles all business actions that can be performed on a wrestler including
+ * employment management, health status changes, and career lifecycle operations.
+ * This component is designed to be reusable across different contexts (tables,
+ * detail pages, cards, etc.) while maintaining consistent authorization and
+ * error handling patterns.
+ */
+class WrestlerActionsComponent extends Component
+{
+    public Wrestler $wrestler;
+
+    public function mount(Wrestler $wrestler): void
+    {
+        $this->wrestler = $wrestler;
+    }
+
+    /**
+     * Employ a wrestler.
+     */
+    public function employ(): void
+    {
+        Gate::authorize('employ', $this->wrestler);
+
+        try {
+            resolve(EmployAction::class)->handle($this->wrestler);
+            $this->dispatch('wrestler-updated');
+            session()->flash('status', 'Wrestler successfully employed.');
+        } catch (CannotBeEmployedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Release a wrestler.
+     */
+    public function release(): void
+    {
+        Gate::authorize('release', $this->wrestler);
+
+        try {
+            resolve(ReleaseAction::class)->handle($this->wrestler);
+            $this->dispatch('wrestler-updated');
+            session()->flash('status', 'Wrestler successfully released.');
+        } catch (CannotBeReleasedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Retire a wrestler.
+     */
+    public function retire(): void
+    {
+        Gate::authorize('retire', $this->wrestler);
+
+        try {
+            resolve(RetireAction::class)->handle($this->wrestler);
+            $this->dispatch('wrestler-updated');
+            session()->flash('status', 'Wrestler successfully retired.');
+        } catch (CannotBeRetiredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Unretire a wrestler.
+     */
+    public function unretire(): void
+    {
+        Gate::authorize('unretire', $this->wrestler);
+
+        try {
+            resolve(UnretireAction::class)->handle($this->wrestler);
+            $this->dispatch('wrestler-updated');
+            session()->flash('status', 'Wrestler successfully unretired.');
+        } catch (CannotBeUnretiredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Suspend a wrestler.
+     */
+    public function suspend(): void
+    {
+        Gate::authorize('suspend', $this->wrestler);
+
+        try {
+            resolve(SuspendAction::class)->handle($this->wrestler);
+            $this->dispatch('wrestler-updated');
+            session()->flash('status', 'Wrestler successfully suspended.');
+        } catch (CannotBeSuspendedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Reinstate a wrestler.
+     */
+    public function reinstate(): void
+    {
+        Gate::authorize('reinstate', $this->wrestler);
+
+        try {
+            resolve(ReinstateAction::class)->handle($this->wrestler);
+            $this->dispatch('wrestler-updated');
+            session()->flash('status', 'Wrestler successfully reinstated.');
+        } catch (CannotBeReinstatedException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Injure a wrestler.
+     */
+    public function injure(): void
+    {
+        Gate::authorize('injure', $this->wrestler);
+
+        try {
+            resolve(InjureAction::class)->handle($this->wrestler);
+            $this->dispatch('wrestler-updated');
+            session()->flash('status', 'Wrestler injury recorded.');
+        } catch (CannotBeInjuredException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Heal a wrestler from injury.
+     */
+    public function healFromInjury(): void
+    {
+        Gate::authorize('clearFromInjury', $this->wrestler);
+
+        try {
+            resolve(HealAction::class)->handle($this->wrestler);
+            $this->dispatch('wrestler-updated');
+            session()->flash('status', 'Wrestler cleared from injury.');
+        } catch (CannotBeClearedFromInjuryException $e) {
+            session()->flash('error', $e->getMessage());
+        }
+    }
+
+    /**
+     * Restore a deleted wrestler.
+     */
+    public function restore(): void
+    {
+        Gate::authorize('restore', $this->wrestler);
+
+        resolve(RestoreAction::class)->handle($this->wrestler);
+        $this->dispatch('wrestler-updated');
+        session()->flash('status', 'Wrestler successfully restored.');
+    }
+
+    public function render(): View
+    {
+        return view('livewire.wrestlers.components.wrestler-actions-component');
+    }
+}

--- a/app/Livewire/Wrestlers/Forms/WrestlerForm.php
+++ b/app/Livewire/Wrestlers/Forms/WrestlerForm.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Wrestlers\Forms;
+
+use App\Livewire\Base\LivewireBaseForm;
+use App\Livewire\Concerns\ManagesEmployment;
+use App\Models\Wrestlers\Wrestler;
+use App\Rules\Shared\CanChangeEmploymentDate;
+use App\ValueObjects\Height;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+use Illuminate\Validation\Rule;
+
+/**
+ * Livewire form component for managing wrestler creation and editing.
+ *
+ * This form handles the complete lifecycle of wrestler data management including
+ * personal information, physical characteristics, wrestling persona details,
+ * and employment tracking integration. Provides specialized validation for
+ * wrestling-specific fields like height measurements and signature moves.
+ *
+ * Key Responsibilities:
+ * - Wrestler profile management (name, hometown, physical stats)
+ * - Height value object integration with feet/inches conversion
+ * - Employment relationship tracking and validation
+ * - Wrestling persona data (signature moves, career information)
+ * - Custom validation rules for wrestling industry requirements
+ *
+ * @extends LivewireBaseForm<WrestlerForm, Wrestler>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ * @see LivewireBaseForm For base form functionality and patterns
+ * @see ManagesEmployment For employment tracking capabilities
+ * @see Height For height value object operations
+ * @see CanChangeEmploymentDate For custom validation rules
+ *
+ * @property string $name Wrestler's ring name or real name
+ * @property string $hometown Wrestler's billed hometown for storylines
+ * @property int $height_feet Height measurement in feet (5-7 typical range)
+ * @property int $height_inches Additional inches for height (0-11 range)
+ * @property int $weight Wrestler's weight in pounds
+ * @property string|null $signature_move Wrestler's finishing move or signature
+ * @property Carbon|string|null $employment_date Employment start date
+ */
+class WrestlerForm extends LivewireBaseForm
+{
+    use ManagesEmployment;
+
+    /**
+     * The model instance being edited, or null for new wrestler creation.
+     *
+     * @var Wrestler|null Current wrestler model or null for creation
+     */
+    protected ?Model $formModel = null;
+
+    /**
+     * Wrestler's ring name or legal name for identification.
+     *
+     * Used for roster management, match cards, and promotional materials.
+     * Must be unique across all active wrestlers in the system.
+     *
+     * @var string Wrestler's primary name identifier
+     */
+    public string $name = '';
+
+    /**
+     * Wrestler's billed hometown for storyline and promotional purposes.
+     *
+     * Used in match introductions, promotional materials, and character
+     * development. Can be real hometown or kayfabe location for storylines.
+     *
+     * @var string Hometown for promotional billing
+     */
+    public string $hometown = '';
+
+    /**
+     * Height measurement in feet (5-7 typical range for wrestlers).
+     *
+     * Combined with height_inches to create complete Height value object.
+     * Validated to ensure realistic wrestler measurements.
+     *
+     * @var int Feet component of wrestler height
+     */
+    public int $height_feet = 0;
+
+    /**
+     * Additional inches for height measurement (0-11 valid range).
+     *
+     * Works with height_feet to provide precise height measurements.
+     * Converted to total inches for Height value object storage.
+     *
+     * @var int Inches component of wrestler height
+     */
+    public int $height_inches = 0;
+
+    /**
+     * Wrestler's weight in pounds for promotional billing.
+     *
+     * Used for match announcements, weight class determination,
+     * and promotional materials. Validated as 3-digit number.
+     *
+     * @var int Weight in pounds
+     */
+    public int $weight = 0;
+
+    /**
+     * Wrestler's signature finishing move or special technique.
+     *
+     * Optional field for wrestling persona development. Must be unique
+     * if provided to avoid confusion in match commentary and promotion.
+     *
+     * @var string|null Signature wrestling move name
+     */
+    public ?string $signature_move = '';
+
+    /**
+     * Employment start date for contract and career tracking.
+     *
+     * Managed through ManagesEmployment trait for consistent employment
+     * tracking across all personnel types. Supports Carbon objects or
+     * string dates for flexible input handling.
+     *
+     * @var Carbon|string|null Employment start date
+     */
+    public Carbon|string|null $employment_date = '';
+
+    /**
+     * Load additional data when editing existing wrestler records.
+     *
+     * Handles complex data loading including employment relationships
+     * and Height value object conversion to separate feet/inches fields.
+     * Called automatically during form initialization for edit operations.
+     *
+     * Employment Integration:
+     * - Loads start date from employment relationship
+     * - Handles null employment for new wrestlers
+     *
+     * Height Conversion:
+     * - Converts stored inches to feet/inches display format
+     * - Uses Height value object for accurate calculations
+     *
+     *
+     * @see ManagesEmployment::$employment_date For employment date handling
+     * @see Height::toInches() For height conversion calculations
+     */
+    public function loadExtraData(): void
+    {
+        // Early return if no model
+        if (! $this->formModel) {
+            return;
+        }
+
+        // Load employment start date from relationship
+        $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
+
+        // Convert Height value object to separate feet/inches fields
+        $height = $this->formModel->height;
+        $this->height_feet = (int) floor($height->toInches() / 12);
+        $this->height_inches = $height->toInches() % 12;
+    }
+
+    /**
+     * Prepare wrestler-specific data for model storage.
+     *
+     * Transforms form fields into model-compatible data structure,
+     * including Height value object creation from feet/inches inputs.
+     * Excludes employment data which is handled separately.
+     *
+     * Data Transformations:
+     * - Combines height_feet and height_inches into Height value object
+     * - Converts Height to total inches for database storage
+     * - Passes through other fields with appropriate typing
+     *
+     * @return array<string, mixed> Model data ready for persistence
+     *
+     * @see Height::__construct() For height object creation
+     * @see Height::toInches() For database storage format
+     */
+    protected function getModelData(): array
+    {
+        $height = new Height($this->height_feet, $this->height_inches);
+
+        return [
+            'name' => $this->name,
+            'hometown' => $this->hometown,
+            'height' => $height->toInches(),
+            'weight' => $this->weight,
+            'signature_move' => $this->signature_move,
+        ];
+    }
+
+    /**
+     * Get the model class for wrestler form operations.
+     *
+     * Specifies the Wrestler model class for type-safe model operations
+     * including creation, updates, and relationship management.
+     *
+     * @return class-string<Wrestler> The Wrestler model class
+     */
+    protected function getModelClass(): string
+    {
+        return Wrestler::class;
+    }
+
+    /**
+     * Define validation rules for wrestler form fields.
+     *
+     * Provides comprehensive validation for all wrestler data including
+     * uniqueness constraints, realistic physical measurements, and
+     * employment date validation through custom rules.
+     *
+     * @return array<string, array<int, mixed>> Laravel validation rules array
+     */
+    protected function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255', Rule::unique('wrestlers', 'name')->ignore($this->formModel)],
+            'hometown' => ['required', 'string', 'max:255'],
+            'height_feet' => ['required', 'integer', 'max:7'],
+            'height_inches' => ['required', 'integer', 'max:11'],
+            'weight' => ['required', 'integer', 'digits:3'],
+            'signature_move' => ['nullable', 'string', 'max:255', Rule::unique('wrestlers', 'signature_move')->ignore($this->formModel)],
+            'employment_date' => ['nullable', 'date', new CanChangeEmploymentDate($this->formModel)],
+        ];
+    }
+
+    /**
+     * Get wrestler-specific validation attributes.
+     *
+     * Extends standard attributes with wrestler-specific field names for better
+     * user experience in validation messages.
+     *
+     * @return array<string, string> Custom validation attributes for this form
+     */
+    protected function validationAttributes(): array
+    {
+        return [
+            'height_feet' => 'first name',
+            'height_inches' => 'last name',
+            'signature_move' => 'signature move',
+            'employment_date' => 'employment date',
+        ];
+    }
+}

--- a/app/Livewire/Wrestlers/Modals/WrestlerFormModal.php
+++ b/app/Livewire/Wrestlers/Modals/WrestlerFormModal.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Wrestlers\Modals;
+
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Wrestlers\Forms\WrestlerForm;
+use App\Models\Wrestlers\Wrestler;
+
+/**
+ * Modal for creating and editing wrestlers.
+ *
+ * This modal provides a user-friendly interface for wrestler management,
+ * including creation of new wrestler profiles and editing of existing ones.
+ * It integrates dummy data generation for development and testing purposes.
+ *
+ * @extends BaseFormModal<WrestlerForm, Wrestler>
+ *
+ * @author Your Name
+ *
+ * @since 1.0.0
+ */
+class WrestlerFormModal extends BaseFormModal
+{
+    /**
+     * The wrestler form instance for data management.
+     *
+     * Handles all wrestler-specific validation, data transformation,
+     * and persistence operations within the modal interface.
+     */
+    public WrestlerForm $form;
+
+    /**
+     * Get the form class for wrestler management.
+     *
+     * @return class-string<WrestlerForm>
+     */
+    protected function getFormClass(): string
+    {
+        return WrestlerForm::class;
+    }
+
+    /**
+     * Get the model class for wrestlers.
+     *
+     * @return class-string<Wrestler>
+     */
+    protected function getModelClass(): string
+    {
+        return Wrestler::class;
+    }
+
+    /**
+     * Get the Blade view path for the wrestler modal.
+     */
+    protected function getModalPath(): string
+    {
+        return 'wrestlers.modals.form-modal';
+    }
+
+    /**
+     * Get dummy data fields for wrestler forms.
+     *
+     * Provides realistic fake data for development and testing purposes,
+     * using wrestling-specific generators and matching the exact fields
+     * from WrestlerForm. All field names match the form properties.
+     *
+     * @return array<string, callable(): mixed>
+     */
+    protected function getDummyDataFields(): array
+    {
+        return [
+            'name' => fn () => $this->generateWrestlingName(),
+            'hometown' => fn () => fake()->city().', '.fake()->randomElement([
+                'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
+                'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
+                'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
+                'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
+                'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
+            ]),
+            'height_feet' => fn () => fake()->numberBetween(5, 7),
+            'height_inches' => fn () => fake()->numberBetween(0, 11),
+            'weight' => fn () => fake()->numberBetween(150, 350),
+            'signature_move' => fn () => $this->generateSignatureMove(),
+            'employment_date' => fn () => fake()->dateTimeBetween('-2 years', '-1 month')->format('Y-m-d H:i:s'),
+        ];
+    }
+}

--- a/app/Livewire/Wrestlers/Tables/PreviousManagersTable.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousManagersTable.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Wrestlers\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousManagersTable;
-use App\Models\WrestlerManager;
+use App\Models\Wrestlers\WrestlerManager;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -16,7 +16,7 @@ class PreviousManagersTable extends BasePreviousManagersTable
      */
     public ?int $wrestlerId;
 
-    protected string $databaseTableName = 'wrestlers_managers';
+    public string $databaseTableName = 'wrestlers_managers';
 
     /**
      * @return Builder<WrestlerManager>
@@ -29,7 +29,7 @@ class PreviousManagersTable extends BasePreviousManagersTable
 
         return WrestlerManager::query()
             ->where('wrestler_id', $this->wrestlerId)
-            ->whereNotNull('left_at')
+            ->whereNotNull('fired_at')
             ->orderByDesc('hired_at');
     }
 

--- a/app/Livewire/Wrestlers/Tables/PreviousMatchesTable.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousMatchesTable.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace App\Livewire\Wrestlers\Tables;
 
-use App\Enums\EventStatus;
 use App\Livewire\Base\Tables\BasePreviousMatchesTable;
-use App\Models\EventMatch;
-use App\Models\Wrestler;
+use App\Models\Matches\EventMatch;
+use App\Models\Wrestlers\Wrestler;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -18,13 +17,15 @@ class PreviousMatchesTable extends BasePreviousMatchesTable
      */
     public ?int $wrestlerId;
 
+    public string $databaseTableName = 'events_matches_competitors';
+
     /**
      * @return Builder<EventMatch>
      */
     public function builder(): Builder
     {
         if (! isset($this->wrestlerId)) {
-            throw new Exception("You didn't sp ecify a wrestler");
+            throw new Exception("You didn't specify a wrestler");
         }
 
         $wrestler = Wrestler::find($this->wrestlerId);
@@ -35,7 +36,7 @@ class PreviousMatchesTable extends BasePreviousMatchesTable
                 $query->whereMorphedTo('competitor', $wrestler);
             })
             ->withWhereHas('event', function (Builder $query): void {
-                $query->whereNotNull('date')->where('status', EventStatus::Past);
+                $query->whereNotNull('date')->where('date', '<', now()->toDateString());
             })
             ->orderByDesc('date');
     }

--- a/app/Livewire/Wrestlers/Tables/PreviousStablesTable.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousStablesTable.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Wrestlers\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
-use App\Models\StableWrestler;
+use App\Models\Stables\StableMember;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -16,10 +16,10 @@ class PreviousStablesTable extends BasePreviousStablesTable
      */
     public ?int $wrestlerId;
 
-    protected string $databaseTableName = 'stables_wrestlers';
+    public string $databaseTableName = 'stables_members';
 
     /**
-     * @return Builder<StableWrestler>
+     * @return Builder<StableMember>
      */
     public function builder(): Builder
     {
@@ -27,8 +27,9 @@ class PreviousStablesTable extends BasePreviousStablesTable
             throw new Exception("You didn't specify a wrestler");
         }
 
-        return StableWrestler::query()
-            ->where('wrestler_id', $this->wrestlerId)
+        return StableMember::query()
+            ->where('member_id', $this->wrestlerId)
+            ->where('member_type', 'wrestler')
             ->whereNotNull('left_at')
             ->orderByDesc('joined_at');
     }
@@ -36,7 +37,7 @@ class PreviousStablesTable extends BasePreviousStablesTable
     public function configure(): void
     {
         $this->addAdditionalSelects([
-            'stables_wrestlers.stable_id as stable_id',
+            'stables_members.stable_id as stable_id',
         ]);
     }
 }

--- a/app/Livewire/Wrestlers/Tables/PreviousTagTeamsTable.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTagTeamsTable.php
@@ -5,21 +5,72 @@ declare(strict_types=1);
 namespace App\Livewire\Wrestlers\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousTagTeamsTable;
-use App\Models\TagTeamPartner;
+use App\Models\TagTeams\TagTeamWrestler;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
+/**
+ * Livewire table component for displaying a wrestler's previous tag team memberships.
+ *
+ * This component shows the historical tag teams that a wrestler was previously
+ * a member of (where they have left). It extends the base previous tag teams
+ * table to provide wrestler-specific filtering and data retrieval.
+ *
+ * The table displays tag teams ordered by when the wrestler joined them,
+ * showing only completed memberships (where left_at is not null).
+ *
+ * @example
+ * ```php
+ * // In a Blade template
+ * <livewire:wrestlers.tables.previous-tag-teams-table :wrestler-id="$wrestler->id" />
+ *
+ * // In a Livewire component
+ * public function render()
+ * {
+ *     return view('livewire.wrestler.show', [
+ *         'wrestler' => $this->wrestler,
+ *     ]);
+ * }
+ * ```
+ */
 class PreviousTagTeamsTable extends BasePreviousTagTeamsTable
 {
     /**
-     * Wrestler to use for component.
+     * The ID of the wrestler whose previous tag teams should be displayed.
+     *
+     * This property must be set when the component is mounted to filter
+     * the tag teams to only those the specified wrestler was a member of.
+     *
+     * @var int|null The wrestler's ID, or null if not set
      */
     public ?int $wrestlerId;
 
-    protected string $databaseTableName = 'tag_teams';
+    /**
+     * The database table name for the main query.
+     *
+     * @var string The name of the tag_teams_wrestlers pivot table
+     */
+    public string $databaseTableName = 'tag_teams_wrestlers';
 
     /**
-     * @return Builder<TagTeamPartner>
+     * Build the query for retrieving the wrestler's previous tag teams.
+     *
+     * Creates a query using the TagTeamWrestler pivot model to find all
+     * tag team memberships where the wrestler has left (left_at is not null).
+     * Results are ordered by join date in descending order to show the
+     * most recent previous memberships first.
+     *
+     * @return Builder<TagTeamWrestler> Query builder for tag team wrestler pivot records
+     *
+     * @throws Exception If wrestlerId is not set
+     *
+     * @example
+     * ```php
+     * // The query finds pivot records like:
+     * // - TagTeamWrestler(wrestler_id: 1, tag_team_id: 5, joined_at: '1997-01-01', left_at: '1999-03-01')
+     * // - TagTeamWrestler(wrestler_id: 1, tag_team_id: 8, joined_at: '1999-04-01', left_at: '2000-01-01')
+     * // But excludes current memberships where left_at is null
+     * ```
      */
     public function builder(): Builder
     {
@@ -27,12 +78,27 @@ class PreviousTagTeamsTable extends BasePreviousTagTeamsTable
             throw new Exception("You didn't specify a wrestler");
         }
 
-        return TagTeamPartner::query()
+        return TagTeamWrestler::query()
             ->where('wrestler_id', $this->wrestlerId)
             ->whereNotNull('left_at')
             ->orderByDesc('joined_at');
     }
 
+    /**
+     * Configure additional query selections and table settings.
+     *
+     * Adds the tag team ID from the pivot table to the select statement
+     * to ensure proper data retrieval for the table display. This allows
+     * the table to access both the pivot data and related tag team information.
+     *
+     *
+     * @example
+     * ```php
+     * // Ensures the query selects:
+     * // SELECT *, tag_team_id FROM tag_teams_wrestlers WHERE...
+     * // This allows access to both pivot and tag team data in the table
+     * ```
+     */
     public function configure(): void
     {
         $this->addAdditionalSelects([

--- a/app/Livewire/Wrestlers/Tables/PreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTitleChampionshipsTable.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Livewire\Wrestlers\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousTitleChampionshipsTable;
-use App\Models\TitleChampionship;
-use App\Models\Wrestler;
+use App\Models\Titles\TitleChampionship;
+use App\Models\Wrestlers\Wrestler;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -17,7 +17,7 @@ class PreviousTitleChampionshipsTable extends BasePreviousTitleChampionshipsTabl
      */
     public ?int $wrestlerId;
 
-    protected string $databaseTableName = 'tittle_championships';
+    public string $databaseTableName = 'titles_championships';
 
     protected string $resourceName = 'title championships';
 
@@ -41,11 +41,12 @@ class PreviousTitleChampionshipsTable extends BasePreviousTitleChampionshipsTabl
 
         return TitleChampionship::query()
             ->whereHasMorph(
-                'previousChampion',
+                'champion',
                 [Wrestler::class],
                 function (Builder $query): void {
                     $query->whereIn('id', [$this->wrestlerId]);
                 }
-            );
+            )
+            ->whereNotNull('lost_at');
     }
 }


### PR DESCRIPTION
Standardize base Livewire component 
  architecture with LivewireBaseForm. Implement reusable concerns and traits for modal and table functionality. Create consistent component 
  library with shared patterns. Update all domain-specific components to follow new standards.