### PR TITLE
Fix: Update UserStatus enum reference to correct domain namespace

### DIFF
--- a/resources/views/components/users/index/table-pre.blade.php
+++ b/resources/views/components/users/index/table-pre.blade.php
@@ -1,6 +1,6 @@
 <div class="flex flex-wrap items-center lg:items-end justify-between gap-5 pb-7.5">
     <div class="flex flex-col justify-center gap-2">
-        <x-tables.meta-data enum="\App\Enums\UserStatus" />
+        <x-tables.meta-data enum="\App\Enums\Users\UserStatus" />
     </div>
     <div class="flex items-center gap-2.5">
         @can('create', \App\Models\User::class)


### PR DESCRIPTION
## Summary
- Fix users table-pre.blade.php to use correct domain-organized enum path
- Resolves failing UsersControllerTest due to missing enum reference
- Completes enum organization work from previous refactoring sessions

## Issue
The view was referencing `\App\Enums\UserStatus` but the actual enum is located at `\App\Enums\Users\UserStatus` following our domain organization standards.

## Changes
- Updated `resources/views/components/users/index/table-pre.blade.php`
- Changed enum reference from `\App\Enums\UserStatus` to `\App\Enums\Users\UserStatus`

## Test Results
✅ UsersControllerTest now passes
✅ All affected functionality working properly

This fix ensures consistency with the domain-organized enum structure established in previous refactoring work.