### PR TITLE
Fix: Rename EventMatchPolicy to MatchPolicy

### DIFF
--- a/app/Policies/MatchPolicy.php
+++ b/app/Policies/MatchPolicy.php
@@ -5,17 +5,17 @@ declare(strict_types=1);
 namespace App\Policies;
 
 use App\Models\Users\User;
-use Tests\Unit\Policies\EventMatchPolicyTest;
+use Tests\Unit\Policies\MatchPolicyTest;
 
 /**
- * Simplified EventMatchPolicy using before hook pattern.
+ * Simplified MatchPolicy using before hook pattern.
  *
  * All repetitive administrator checks are handled by the before hook.
  * Business validation is handled in Actions using custom exceptions.
  *
- * @see EventMatchPolicyTest
+ * @see MatchPolicyTest
  */
-class EventMatchPolicy
+class MatchPolicy
 {
     /**
      * Administrator bypass for all actions.

--- a/tests/Unit/Policies/PolicyBeforeHookTest.php
+++ b/tests/Unit/Policies/PolicyBeforeHookTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Policies\EventMatchPolicy;
+use App\Policies\MatchPolicy;
 use App\Policies\EventPolicy;
 use App\Policies\ManagerPolicy;
 use App\Policies\RefereePolicy;
@@ -24,7 +24,7 @@ describe('Policy Before Hook Pattern', function () {
 
     beforeEach(function () {
         $this->policies = [
-            new EventMatchPolicy(),
+            new MatchPolicy(),
             new EventPolicy(),
             new ManagerPolicy(),
             new RefereePolicy(),


### PR DESCRIPTION
## Summary
Fixes missed policy rename from the namespace standardization. The test files were expecting `MatchPolicy` but the actual policy class was still named `EventMatchPolicy`.

## Issue
During the EventMatches → Matches namespace refactoring, the policy class rename was missed, causing a mismatch between:
- **Expected**: `MatchPolicy` (in tests)  
- **Actual**: `EventMatchPolicy` (in codebase)

## Changes
- **Rename**: `app/Policies/EventMatchPolicy.php` → `MatchPolicy.php`
- **Update**: Class name from `EventMatchPolicy` to `MatchPolicy`
- **Fix**: Test reference in `PolicyBeforeHookTest.php`
- **Update**: Documentation references to use new naming

## Completion
This completes the comprehensive EventMatches → Matches standardization:
- ✅ Application namespace (Controllers, Livewire, Views)
- ✅ Test files and directories  
- ✅ Policy classes (this fix)

## Consistency
All match-related components now use consistent "Matches" naming while preserving `EventMatch` model names due to PHP keyword restrictions.