### PR TITLE
refactor: standardize repository contract naming conventions

### DIFF
--- a/app/Repositories/Contracts/ManagesActivityInterface.php
+++ b/app/Repositories/Contracts/ManagesActivityInterface.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Carbon;
  * This interface defines the methods required for repositories
  * that handle activation and deactivation operations.
  */
-interface ManagesActivity
+interface ManagesActivityInterface
 {
     /**
      * End activity for the given model.

--- a/app/Repositories/Contracts/ManagesEmploymentInterface.php
+++ b/app/Repositories/Contracts/ManagesEmploymentInterface.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Carbon;
  * This interface defines the methods required for repositories
  * that handle employment, release, and reinstatement operations.
  */
-interface ManagesEmployment
+interface ManagesEmploymentInterface
 {
     /**
      * End employment for the given model.

--- a/app/Repositories/Contracts/ManagesInjuryInterface.php
+++ b/app/Repositories/Contracts/ManagesInjuryInterface.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Carbon;
  * This interface defines the methods required for repositories
  * that handle injury and recovery operations.
  */
-interface ManagesInjury
+interface ManagesInjuryInterface
 {
     /**
      * End injury for the given model.

--- a/app/Repositories/Contracts/ManagesRetirementInterface.php
+++ b/app/Repositories/Contracts/ManagesRetirementInterface.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Carbon;
  * This interface defines the methods required for repositories
  * that handle retirement and unretirement operations.
  */
-interface ManagesRetirement
+interface ManagesRetirementInterface
 {
     /**
      * End retirement for the given model.

--- a/app/Repositories/Contracts/ManagesStableMembersInterface.php
+++ b/app/Repositories/Contracts/ManagesStableMembersInterface.php
@@ -17,7 +17,7 @@ use Illuminate\Support\Carbon;
  * that handle adding/removing members from stables. Members can be
  * wrestlers, tag teams, or managers.
  */
-interface ManagesStableMembers
+interface ManagesStableMembersInterface
 {
     /**
      * Add a member to the stable.

--- a/app/Repositories/Contracts/ManagesSuspensionInterface.php
+++ b/app/Repositories/Contracts/ManagesSuspensionInterface.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Carbon;
  * This interface defines the methods required for repositories
  * that handle suspension and reinstatement operations.
  */
-interface ManagesSuspension
+interface ManagesSuspensionInterface
 {
     /**
      * End suspension for the given model.

--- a/app/Repositories/Contracts/ManagesTagTeamMembersInterface.php
+++ b/app/Repositories/Contracts/ManagesTagTeamMembersInterface.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Carbon;
  * This interface defines the methods required for repositories
  * that handle adding/removing wrestlers from tag teams.
  */
-interface ManagesTagTeamMembers
+interface ManagesTagTeamMembersInterface
 {
     /**
      * Add a wrestler to the tag team.

--- a/app/Repositories/Contracts/ManagesWrestlerRelationsInterface.php
+++ b/app/Repositories/Contracts/ManagesWrestlerRelationsInterface.php
@@ -14,7 +14,7 @@ use Illuminate\Support\Carbon;
  * This interface defines the methods required for repositories
  * that handle wrestler-manager relationships.
  */
-interface ManagesWrestlerRelations
+interface ManagesWrestlerRelationsInterface
 {
     /**
      * Add a manager to the wrestler.

--- a/app/Repositories/Contracts/StableCrudOperationsInterface.php
+++ b/app/Repositories/Contracts/StableCrudOperationsInterface.php
@@ -10,7 +10,7 @@ use App\Models\Stables\Stable;
 /**
  * Interface for stable CRUD operations.
  */
-interface StableCrudOperations
+interface StableCrudOperationsInterface
 {
     /**
      * Create a new stable.

--- a/app/Repositories/ManagerRepository.php
+++ b/app/Repositories/ManagerRepository.php
@@ -19,10 +19,10 @@ use App\Repositories\Concerns\ManagesMembers;
 use App\Repositories\Concerns\ManagesRetirement;
 use App\Repositories\Concerns\ManagesSuspension;
 use App\Repositories\Contracts\ManagerRepositoryInterface;
-use App\Repositories\Contracts\ManagesEmployment as ManagesEmploymentContract;
-use App\Repositories\Contracts\ManagesInjury as ManagesInjuryContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesSuspension as ManagesSuspensionContract;
+use App\Repositories\Contracts\ManagesEmploymentInterface;
+use App\Repositories\Contracts\ManagesInjuryInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesSuspensionInterface;
 use App\Repositories\Support\BaseRepository;
 use Illuminate\Support\Carbon;
 use Tests\Unit\Repositories\ManagerRepositoryTest;
@@ -35,7 +35,7 @@ use Tests\Unit\Repositories\ManagerRepositoryTest;
  *
  * @see ManagerRepositoryTest
  */
-class ManagerRepository extends BaseRepository implements ManagerRepositoryInterface, ManagesEmploymentContract, ManagesInjuryContract, ManagesRetirementContract, ManagesSuspensionContract
+class ManagerRepository extends BaseRepository implements ManagerRepositoryInterface, ManagesEmploymentInterface, ManagesInjuryInterface, ManagesRetirementInterface, ManagesSuspensionInterface
 {
     /** @use ManagesEmployment<ManagerEmployment, Manager> */
     use ManagesEmployment;

--- a/app/Repositories/RefereeRepository.php
+++ b/app/Repositories/RefereeRepository.php
@@ -14,10 +14,10 @@ use App\Repositories\Concerns\ManagesEmployment;
 use App\Repositories\Concerns\ManagesInjury;
 use App\Repositories\Concerns\ManagesRetirement;
 use App\Repositories\Concerns\ManagesSuspension;
-use App\Repositories\Contracts\ManagesEmployment as ManagesEmploymentContract;
-use App\Repositories\Contracts\ManagesInjury as ManagesInjuryContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesSuspension as ManagesSuspensionContract;
+use App\Repositories\Contracts\ManagesEmploymentInterface;
+use App\Repositories\Contracts\ManagesInjuryInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesSuspensionInterface;
 use App\Repositories\Contracts\RefereeRepositoryInterface;
 use App\Repositories\Support\BaseRepository;
 use Tests\Unit\Repositories\RefereeRepositoryTest;
@@ -30,7 +30,7 @@ use Tests\Unit\Repositories\RefereeRepositoryTest;
  *
  * @see RefereeRepositoryTest
  */
-class RefereeRepository extends BaseRepository implements ManagesEmploymentContract, ManagesInjuryContract, ManagesRetirementContract, ManagesSuspensionContract, RefereeRepositoryInterface
+class RefereeRepository extends BaseRepository implements ManagesEmploymentInterface, ManagesInjuryInterface, ManagesRetirementInterface, ManagesSuspensionInterface, RefereeRepositoryInterface
 {
     /** @use ManagesEmployment<RefereeEmployment, Referee> */
     use ManagesEmployment;

--- a/app/Repositories/StableRepository.php
+++ b/app/Repositories/StableRepository.php
@@ -17,16 +17,16 @@ use App\Models\Contracts\HasActivityPeriods;
 use App\Repositories\Concerns\ManagesActivity;
 use App\Repositories\Concerns\ManagesMembers;
 use App\Repositories\Concerns\ManagesRetirement;
-use App\Repositories\Contracts\ManagesActivity as ManagesActivityContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesStableMembers;
+use App\Repositories\Contracts\ManagesActivityInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesStableMembersInterface;
 use App\Repositories\Contracts\StableRepositoryInterface;
 use App\Repositories\Support\BaseRepository;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 use InvalidArgumentException;
 
-class StableRepository extends BaseRepository implements ManagesActivityContract, ManagesRetirementContract, ManagesStableMembers, StableRepositoryInterface
+class StableRepository extends BaseRepository implements ManagesActivityInterface, ManagesRetirementInterface, ManagesStableMembersInterface, StableRepositoryInterface
 {
     /** @use ManagesActivity<StableActivityPeriod, Stable> */
     use ManagesActivity;

--- a/app/Repositories/TagTeamRepository.php
+++ b/app/Repositories/TagTeamRepository.php
@@ -16,10 +16,10 @@ use App\Repositories\Concerns\ManagesEmployment;
 use App\Repositories\Concerns\ManagesMembers;
 use App\Repositories\Concerns\ManagesRetirement;
 use App\Repositories\Concerns\ManagesSuspension;
-use App\Repositories\Contracts\ManagesEmployment as ManagesEmploymentContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesSuspension as ManagesSuspensionContract;
-use App\Repositories\Contracts\ManagesTagTeamMembers;
+use App\Repositories\Contracts\ManagesEmploymentInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesSuspensionInterface;
+use App\Repositories\Contracts\ManagesTagTeamMembersInterface;
 use App\Repositories\Contracts\TagTeamRepositoryInterface;
 use App\Repositories\Support\BaseRepository;
 use Illuminate\Database\Eloquent\Collection;
@@ -34,7 +34,7 @@ use Tests\Unit\Repositories\TagTeamRepositoryTest;
  *
  * @see TagTeamRepositoryTest
  */
-class TagTeamRepository extends BaseRepository implements ManagesEmploymentContract, ManagesRetirementContract, ManagesSuspensionContract, ManagesTagTeamMembers, TagTeamRepositoryInterface
+class TagTeamRepository extends BaseRepository implements ManagesEmploymentInterface, ManagesRetirementInterface, ManagesSuspensionInterface, ManagesTagTeamMembersInterface, TagTeamRepositoryInterface
 {
     /** @use ManagesEmployment<TagTeamEmployment, TagTeam> */
     use ManagesEmployment;

--- a/app/Repositories/TitleRepository.php
+++ b/app/Repositories/TitleRepository.php
@@ -15,8 +15,8 @@ use App\Models\Titles\TitleRetirement;
 use App\Models\Wrestlers\Wrestler;
 use App\Repositories\Concerns\ManagesActivity;
 use App\Repositories\Concerns\ManagesRetirement;
-use App\Repositories\Contracts\ManagesActivity as ManagesActivityContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
+use App\Repositories\Contracts\ManagesActivityInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
 use App\Repositories\Contracts\TitleRepositoryInterface;
 use App\Repositories\Support\BaseRepository;
 use Illuminate\Support\Carbon;
@@ -31,7 +31,7 @@ use Tests\Unit\Repositories\TitleRepositoryTest;
  *
  * @see TitleRepositoryTest
  */
-class TitleRepository extends BaseRepository implements ManagesActivityContract, ManagesRetirementContract, TitleRepositoryInterface
+class TitleRepository extends BaseRepository implements ManagesActivityInterface, ManagesRetirementInterface, TitleRepositoryInterface
 {
     /** @use ManagesActivity<TitleActivityPeriod, Title> */
     use ManagesActivity;

--- a/app/Repositories/WrestlerRepository.php
+++ b/app/Repositories/WrestlerRepository.php
@@ -21,11 +21,11 @@ use App\Repositories\Concerns\ManagesInjury;
 use App\Repositories\Concerns\ManagesMembers;
 use App\Repositories\Concerns\ManagesRetirement;
 use App\Repositories\Concerns\ManagesSuspension;
-use App\Repositories\Contracts\ManagesEmployment as ManagesEmploymentContract;
-use App\Repositories\Contracts\ManagesInjury as ManagesInjuryContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesSuspension as ManagesSuspensionContract;
-use App\Repositories\Contracts\ManagesWrestlerRelations;
+use App\Repositories\Contracts\ManagesEmploymentInterface;
+use App\Repositories\Contracts\ManagesInjuryInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesSuspensionInterface;
+use App\Repositories\Contracts\ManagesWrestlerRelationsInterface;
 use App\Repositories\Contracts\WrestlerRepositoryInterface;
 use App\Repositories\Support\BaseRepository;
 use Illuminate\Database\Eloquent\Builder;
@@ -48,7 +48,7 @@ use Tests\Unit\Repositories\WrestlerRepositoryTest;
  *
  * @since 1.0.0
  */
-class WrestlerRepository extends BaseRepository implements ManagesEmploymentContract, ManagesInjuryContract, ManagesRetirementContract, ManagesSuspensionContract, ManagesWrestlerRelations, WrestlerRepositoryInterface
+class WrestlerRepository extends BaseRepository implements ManagesEmploymentInterface, ManagesInjuryInterface, ManagesRetirementInterface, ManagesSuspensionInterface, ManagesWrestlerRelationsInterface, WrestlerRepositoryInterface
 {
     /** @use ManagesDates<Wrestler, WrestlerEmployment> */
     use ManagesDates;

--- a/tests/Unit/Repositories/ManagerRepositoryTest.php
+++ b/tests/Unit/Repositories/ManagerRepositoryTest.php
@@ -11,10 +11,10 @@ use App\Repositories\Concerns\ManagesEmployment;
 use App\Repositories\Concerns\ManagesInjury;
 use App\Repositories\Concerns\ManagesRetirement;
 use App\Repositories\Concerns\ManagesSuspension;
-use App\Repositories\Contracts\ManagesEmployment as ManagesEmploymentContract;
-use App\Repositories\Contracts\ManagesInjury as ManagesInjuryContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesSuspension as ManagesSuspensionContract;
+use App\Repositories\Contracts\ManagesEmploymentInterface;
+use App\Repositories\Contracts\ManagesInjuryInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesSuspensionInterface;
 use App\Repositories\Contracts\ManagerRepositoryInterface;
 use App\Repositories\ManagerRepository;
 
@@ -48,10 +48,10 @@ describe('ManagerRepository Unit Tests', function () {
         });
 
         test('repository implements all required contracts', function () {
-            expect($this->repository)->toBeInstanceOf(ManagesEmploymentContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesInjuryContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesRetirementContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesSuspensionContract::class);
+            expect($this->repository)->toBeInstanceOf(ManagesEmploymentInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesInjuryInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesRetirementInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesSuspensionInterface::class);
         });
 
         test('repository uses all required traits', function () {

--- a/tests/Unit/Repositories/RefereeRepositoryTest.php
+++ b/tests/Unit/Repositories/RefereeRepositoryTest.php
@@ -12,10 +12,10 @@ use App\Repositories\Concerns\ManagesEmployment;
 use App\Repositories\Concerns\ManagesInjury;
 use App\Repositories\Concerns\ManagesRetirement;
 use App\Repositories\Concerns\ManagesSuspension;
-use App\Repositories\Contracts\ManagesEmployment as ManagesEmploymentContract;
-use App\Repositories\Contracts\ManagesInjury as ManagesInjuryContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesSuspension as ManagesSuspensionContract;
+use App\Repositories\Contracts\ManagesEmploymentInterface;
+use App\Repositories\Contracts\ManagesInjuryInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesSuspensionInterface;
 use App\Repositories\Contracts\RefereeRepositoryInterface;
 use App\Repositories\RefereeRepository;
 
@@ -45,10 +45,10 @@ describe('RefereeRepository Unit Tests', function () {
         });
 
         test('repository implements all required contracts', function () {
-            expect($this->repository)->toBeInstanceOf(ManagesEmploymentContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesInjuryContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesRetirementContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesSuspensionContract::class);
+            expect($this->repository)->toBeInstanceOf(ManagesEmploymentInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesInjuryInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesRetirementInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesSuspensionInterface::class);
         });
 
         test('repository uses all required traits', function () {

--- a/tests/Unit/Repositories/StableRepositoryTest.php
+++ b/tests/Unit/Repositories/StableRepositoryTest.php
@@ -12,9 +12,9 @@ use App\Models\Wrestlers\Wrestler;
 use App\Repositories\Concerns\ManagesActivity;
 use App\Repositories\Concerns\ManagesMembers;
 use App\Repositories\Concerns\ManagesRetirement;
-use App\Repositories\Contracts\ManagesActivity as ManagesActivityContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesStableMembers;
+use App\Repositories\Contracts\ManagesActivityInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesStableMembersInterface;
 use App\Repositories\Contracts\StableRepositoryInterface;
 use App\Repositories\StableRepository;
 use Illuminate\Database\Eloquent\Collection;
@@ -62,9 +62,9 @@ describe('StableRepository Unit Tests', function () {
         });
 
         test('repository implements all required contracts', function () {
-            expect($this->repository)->toBeInstanceOf(ManagesActivityContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesRetirementContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesStableMembers::class);
+            expect($this->repository)->toBeInstanceOf(ManagesActivityInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesRetirementInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesStableMembersInterface::class);
         });
 
         test('repository uses all required traits', function () {

--- a/tests/Unit/Repositories/TagTeamRepositoryTest.php
+++ b/tests/Unit/Repositories/TagTeamRepositoryTest.php
@@ -13,10 +13,10 @@ use App\Repositories\Concerns\ManagesEmployment;
 use App\Repositories\Concerns\ManagesMembers;
 use App\Repositories\Concerns\ManagesRetirement;
 use App\Repositories\Concerns\ManagesSuspension;
-use App\Repositories\Contracts\ManagesEmployment as ManagesEmploymentContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesSuspension as ManagesSuspensionContract;
-use App\Repositories\Contracts\ManagesTagTeamMembers;
+use App\Repositories\Contracts\ManagesEmploymentInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesSuspensionInterface;
+use App\Repositories\Contracts\ManagesTagTeamMembersInterface;
 use App\Repositories\Contracts\TagTeamRepositoryInterface;
 use App\Repositories\TagTeamRepository;
 use Illuminate\Support\Carbon;
@@ -48,10 +48,10 @@ describe('TagTeamRepository Unit Tests', function () {
         });
 
         test('repository implements all required contracts', function () {
-            expect($this->repository)->toBeInstanceOf(ManagesEmploymentContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesRetirementContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesSuspensionContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesTagTeamMembers::class);
+            expect($this->repository)->toBeInstanceOf(ManagesEmploymentInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesRetirementInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesSuspensionInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesTagTeamMembersInterface::class);
         });
 
         test('repository uses all required traits', function () {

--- a/tests/Unit/Repositories/TitleRepositoryTest.php
+++ b/tests/Unit/Repositories/TitleRepositoryTest.php
@@ -13,8 +13,8 @@ use App\Models\Titles\TitleRetirement;
 use App\Models\Wrestlers\Wrestler;
 use App\Repositories\Concerns\ManagesActivity;
 use App\Repositories\Concerns\ManagesRetirement;
-use App\Repositories\Contracts\ManagesActivity as ManagesActivityContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
+use App\Repositories\Contracts\ManagesActivityInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
 use App\Repositories\Contracts\TitleRepositoryInterface;
 use App\Repositories\TitleRepository;
 use Illuminate\Support\Carbon;
@@ -50,8 +50,8 @@ describe('TitleRepository Unit Tests', function () {
         });
 
         test('repository implements all required contracts', function () {
-            expect($this->repository)->toBeInstanceOf(ManagesActivityContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesRetirementContract::class);
+            expect($this->repository)->toBeInstanceOf(ManagesActivityInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesRetirementInterface::class);
         });
 
         test('repository uses all required traits', function () {

--- a/tests/Unit/Repositories/WrestlerRepositoryTest.php
+++ b/tests/Unit/Repositories/WrestlerRepositoryTest.php
@@ -13,10 +13,10 @@ use App\Repositories\Concerns\ManagesEmployment;
 use App\Repositories\Concerns\ManagesInjury;
 use App\Repositories\Concerns\ManagesRetirement;
 use App\Repositories\Concerns\ManagesSuspension;
-use App\Repositories\Contracts\ManagesEmployment as ManagesEmploymentContract;
-use App\Repositories\Contracts\ManagesInjury as ManagesInjuryContract;
-use App\Repositories\Contracts\ManagesRetirement as ManagesRetirementContract;
-use App\Repositories\Contracts\ManagesSuspension as ManagesSuspensionContract;
+use App\Repositories\Contracts\ManagesEmploymentInterface;
+use App\Repositories\Contracts\ManagesInjuryInterface;
+use App\Repositories\Contracts\ManagesRetirementInterface;
+use App\Repositories\Contracts\ManagesSuspensionInterface;
 use App\Repositories\Contracts\WrestlerRepositoryInterface;
 use App\Repositories\WrestlerRepository;
 use App\ValueObjects\Height;
@@ -48,10 +48,10 @@ describe('WrestlerRepository Unit Tests', function () {
         });
 
         test('repository implements all required contracts', function () {
-            expect($this->repository)->toBeInstanceOf(ManagesEmploymentContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesInjuryContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesRetirementContract::class);
-            expect($this->repository)->toBeInstanceOf(ManagesSuspensionContract::class);
+            expect($this->repository)->toBeInstanceOf(ManagesEmploymentInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesInjuryInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesRetirementInterface::class);
+            expect($this->repository)->toBeInstanceOf(ManagesSuspensionInterface::class);
         });
 
         test('repository uses all required traits', function () {


### PR DESCRIPTION
## Summary
- Standardized all repository contract naming to use consistent `Interface` suffix
- Renamed 9 contract interfaces to follow established naming patterns
- Updated all implementations and test files to use new interface names
- Removed need for contract aliases (e.g., `as ManagesActivityContract`)

## Changes Made
- **ManagesActivity** → **ManagesActivityInterface**
- **ManagesEmployment** → **ManagesEmploymentInterface**  
- **ManagesInjury** → **ManagesInjuryInterface**
- **ManagesRetirement** → **ManagesRetirementInterface**
- **ManagesStableMembers** → **ManagesStableMembersInterface**
- **ManagesSuspension** → **ManagesSuspensionInterface**
- **ManagesTagTeamMembers** → **ManagesTagTeamMembersInterface**
- **ManagesWrestlerRelations** → **ManagesWrestlerRelationsInterface**
- **StableCrudOperations** → **StableCrudOperationsInterface**

## Benefits
- ✅ Consistent naming across all repository contracts
- ✅ Follows established Interface suffix pattern
- ✅ Eliminates confusion between traits and interfaces
- ✅ Removes need for import aliases
- ✅ Improves code clarity and maintainability

## Testing
All repository tests updated to use new interface names and continue to pass.