### PR TITLE
feat: add architecture test for contract interface naming standards

### DIFF
--- a/tests/ArchitectureTest.php
+++ b/tests/ArchitectureTest.php
@@ -121,6 +121,11 @@ arch('interfaces namespace only contains interfaces')
     ->expect('App\\Interfaces')
     ->toBeInterfaces();
 
+arch('contracts directories only contain interfaces with Interface suffix')
+    ->expect('App\\*\\Contracts')
+    ->toBeInterfaces()
+    ->toHaveSuffix('Interface');
+
 // =============================================================================
 // SECURITY & DEBUGGING RULES
 // =============================================================================


### PR DESCRIPTION
## Summary
- Added comprehensive architecture test for contract interface naming standards
- Ensures all Contracts directories only contain interfaces  
- Enforces Interface suffix for all contract files
- Combined into single efficient architecture rule for better performance

## Benefits
- ✅ Prevents future violations of established contract naming conventions
- ✅ Ensures consistency across the entire codebase
- ✅ Catches naming issues early in development
- ✅ Enforces architectural standards automatically

## Implementation
Combined two checks into a single efficient architecture rule that validates:
1. All files in `App/**/Contracts` directories are interfaces
2. All contract files have the `Interface` suffix

This complements the recent contract naming standardization work and ensures the standards are maintained going forward.