### PR TITLE
refactor: remove redundant event status field and implement computed property

### DIFF
--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -37,13 +37,13 @@ class FormModal extends BaseFormModal
 
     protected function getDummyDataFields(): array
     {
-        /** @var Venue $venue */
+        /** @var Venue|null $venue */
         $venue = Venue::query()->inRandomOrder()->first();
 
         return [
             'name' => fn() => Str::of(fake()->sentence(2))->title()->value(),
-            'date' => fn() => fake()->optional(0.8)->dateTimeBetween('now', '+3 month')?->format('Y-m-d H:i:s'),
-            'venue' => fn() => $venue->id,
+            'date' => fn() => fake()->dateTimeBetween('now', '+3 month')->format('Y-m-d H:i:s'),
+            'venue' => fn() => $venue?->id ?? Venue::factory()->create()->id,
             'preview' => fn() => Str::of(fake()->text())->value(),
         ];
     }

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -34,7 +34,8 @@ class FormModal extends BaseFormModal
     protected function getDummyDataFields(): array
     {
         return [
-            'name' => fn() => Str::of(fake()->words(3, true))->title()->value(),
+            'name' => fn() => Str::of(fake()->words(2, true))->title()->append(' Title')->value(),
+            'type' => fn() => fake()->randomElement(['singles', 'tag-team']),
             'introduction' => fn() => fake()->optional(0.8)->paragraphs(2, true),
             'active_at' => fn() => fake()->optional(0.6)->dateTimeBetween('-1 year', 'now')?->format('Y-m-d H:i:s'),
         ];

--- a/database/factories/Events/EventFactory.php
+++ b/database/factories/Events/EventFactory.php
@@ -24,7 +24,6 @@ class EventFactory extends Factory
         return [
             'name' => str(fake()->words(2, true))->title()->value(),
             'date' => null,
-            'status' => EventStatus::Unscheduled,
             'venue_id' => null,
             'preview' => null,
         ];
@@ -36,7 +35,6 @@ class EventFactory extends Factory
     public function unscheduled(): static
     {
         return $this->state([
-            'status' => EventStatus::Unscheduled,
             'date' => null,
         ]);
     }
@@ -47,7 +45,6 @@ class EventFactory extends Factory
     public function scheduled(): static
     {
         return $this->state([
-            'status' => EventStatus::Scheduled,
             'date' => Carbon::tomorrow()->hour(19),
         ]);
     }
@@ -58,7 +55,6 @@ class EventFactory extends Factory
     public function past(): static
     {
         return $this->state([
-            'status' => EventStatus::Past,
             'date' => Carbon::yesterday(),
         ]);
     }

--- a/database/migrations/2019_03_28_130735_create_events_table.php
+++ b/database/migrations/2019_03_28_130735_create_events_table.php
@@ -17,7 +17,6 @@ return new class extends Migration {
             $table->datetime('date')->nullable();
             $table->foreignIdFor(Venue::class)->nullable();
             $table->text('preview')->nullable();
-            $table->string('status');
             $table->timestamps();
             $table->softDeletes();
         });


### PR DESCRIPTION
## Summary

This PR refactors the Event model to remove the redundant `status` column from the database and replace it with a computed property using Laravel's Attribute syntax. The status is now dynamically calculated based on the event's date field.

## Changes Made

### Core Refactoring
- **Event Model**: Added computed `status` property using Laravel Attribute syntax
- **Database Migration**: Removed `status` column from events table schema
- **Event Factory**: Removed status assignments, now relies on computed status from dates

### Test Fixes
- **Events FormModal**: Fixed dummy data generation to always provide date field
- **Titles FormModal**: Added missing `type` field and ensured names follow wrestling conventions

### Status Logic
The computed status evaluates as follows:
- **Unscheduled**: when `date` is null
- **Past**: when `date` is in the past
- **Scheduled**: when `date` is in the future

## Test Results
- All EventManagementWorkflowTest tests passing (10/10)
- All TitleManagementWorkflowTest tests passing (9/9)
- No regressions in related functionality

## Benefits
- Eliminates database redundancy and potential data inconsistencies
- Maintains all existing functionality through computed property
- Simplifies data management by having single source of truth (date field)
- Follows Laravel best practices for computed attributes