### PR TITLE
refactor: move HasStatusScopes trait to app/Builders/Concerns

### DIFF
--- a/app/Builders/Concerns/HasStatusScopes.php
+++ b/app/Builders/Concerns/HasStatusScopes.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace App\Database\Query\Concerns;
+namespace App\Builders\Concerns;
 
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;

--- a/app/Models/Stables/Stable.php
+++ b/app/Models/Stables/Stable.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Stables;
 
 use App\Builders\Roster\StableBuilder;
-use App\Database\Query\Concerns\HasStatusScopes;
+use App\Builders\Concerns\HasStatusScopes;
 use App\Enums\Stables\StableStatus;
 use App\Models\Concerns\HasActivityPeriods;
 use App\Models\Concerns\HasMembers;

--- a/app/Models/Titles/Title.php
+++ b/app/Models/Titles/Title.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Titles;
 
 use App\Builders\Titles\TitleBuilder;
-use App\Database\Query\Concerns\HasStatusScopes;
+use App\Builders\Concerns\HasStatusScopes;
 use App\Enums\Titles\TitleStatus;
 use App\Enums\Titles\TitleType;
 use App\Models\Concerns\HasActivityPeriods;

--- a/tests/Unit/Models/Stables/StableTest.php
+++ b/tests/Unit/Models/Stables/StableTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use App\Builders\Roster\StableBuilder;
-use App\Database\Query\Concerns\HasStatusScopes;
+use App\Builders\Concerns\HasStatusScopes;
 use App\Enums\Stables\StableStatus;
 use App\Models\Concerns\HasActivityPeriods;
 use App\Models\Concerns\HasMembers;


### PR DESCRIPTION
## Summary

This PR moves the `HasStatusScopes` trait from `app/Database/Query/Concerns` to `app/Builders/Concerns` to align with established organizational patterns in the codebase.

## Changes Made

- **Moved trait**: `HasStatusScopes` from `app/Database/Query/Concerns` to `app/Builders/Concerns`
- **Updated namespace**: Changed from `App\Database\Query\Concerns` to `App\Builders\Concerns`
- **Updated imports**: Fixed imports in affected files:
  - `app/Models/Titles/Title.php`
  - `app/Models/Stables/Stable.php`
  - `tests/Unit/Models/Stables/StableTest.php`
- **Cleaned up**: Removed empty directory structure `app/Database/Query/Concerns`

## Rationale

The `app/Builders/Concerns` directory is the established location for query scope traits, containing similar traits like:
- `HasAvailabilityScopes.php`
- `HasRetirementScopes.php`

`HasStatusScopes` contains query scopes for activity period filtering, making it a natural fit for this location.

## Testing

- All existing tests pass
- No functional changes - purely organizational improvement
- Verified StableTest.php runs successfully with updated imports

## Benefits

- Improves code organization and discoverability
- Follows established architectural patterns
- Consolidates query scope traits in a single location
- Eliminates organizational inconsistency