### PR TITLE
refactor: standardize Livewire form naming conventions (Phase 2)

### DIFF
--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -7,13 +7,13 @@ namespace App\Livewire\Events\Modals;
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Concerns\Data\PresentsVenuesList;
-use App\Livewire\Events\Forms\Form;
+use App\Livewire\Events\Forms\CreateEditForm;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use Illuminate\Support\Str;
 
 /**
- * @extends BaseFormModal<Form, Event>
+ * @extends BaseFormModal<CreateEditForm, Event>
  */
 class FormModal extends BaseFormModal
 {
@@ -23,7 +23,7 @@ class FormModal extends BaseFormModal
 
     protected function getFormClass(): string
     {
-        return Form::class;
+        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -6,11 +6,11 @@ namespace App\Livewire\Managers\Modals;
 
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Base\BaseFormModal;
-use App\Livewire\Managers\Forms\Form;
+use App\Livewire\Managers\Forms\CreateEditForm;
 use App\Models\Managers\Manager;
 
 /**
- * @extends BaseFormModal<Form, Manager>
+ * @extends BaseFormModal<CreateEditForm, Manager>
  */
 class FormModal extends BaseFormModal
 {
@@ -18,7 +18,7 @@ class FormModal extends BaseFormModal
 
     protected function getFormClass(): string
     {
-        return Form::class;
+        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -5,21 +5,20 @@ declare(strict_types=1);
 namespace App\Livewire\Referees\Modals;
 
 use App\Livewire\Base\BaseForm;
-use App\Livewire\Concerns\BaseModal;
-use App\Livewire\Referees\Forms\Form;
+use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Referees\Forms\CreateEditForm;
 use App\Models\Referees\Referee;
-use Illuminate\Support\Carbon;
 
 /**
- * @extends BaseModal<Form, Referee>
+ * @extends BaseFormModal<CreateEditForm, Referee>
  */
-class FormModal extends BaseModal
+class FormModal extends BaseFormModal
 {
     public BaseForm $form;
 
     protected function getFormClass(): string
     {
-        return Form::class;
+        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string
@@ -32,13 +31,12 @@ class FormModal extends BaseModal
         return 'livewire.referees.modals.form-modal';
     }
 
-    public function fillDummyFields(): void
+    protected function getDummyDataFields(): array
     {
-        /** @var Carbon|null $datetime */
-        $datetime = fake()->optional(0.8)->dateTimeBetween('now', '+3 month');
-
-        $this->modelForm->first_name = fake()->firstName();
-        $this->modelForm->last_name = fake()->lastName();
-        $this->modelForm->employment_date = $datetime?->format('Y-m-d H:i:s');
+        return [
+            'first_name' => fn() => fake()->firstName(),
+            'last_name' => fn() => fake()->lastName(),
+            'employment_date' => fn() => fake()->optional(0.8)->dateTimeBetween('now', '+3 month')?->format('Y-m-d H:i:s'),
+        ];
     }
 }

--- a/app/Livewire/Stables/Modals/FormModal.php
+++ b/app/Livewire/Stables/Modals/FormModal.php
@@ -9,12 +9,12 @@ use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Concerns\Data\PresentsManagersList;
 use App\Livewire\Concerns\Data\PresentsTagTeamsList;
 use App\Livewire\Concerns\Data\PresentsWrestlersList;
-use App\Livewire\Stables\Forms\Form;
+use App\Livewire\Stables\Forms\CreateEditForm;
 use App\Models\Stables\Stable;
 use Illuminate\Support\Str;
 
 /**
- * @extends BaseFormModal<Form, Stable>
+ * @extends BaseFormModal<CreateEditForm, Stable>
  */
 class FormModal extends BaseFormModal
 {
@@ -26,7 +26,7 @@ class FormModal extends BaseFormModal
 
     protected function getFormClass(): string
     {
-        return Form::class;
+        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -7,13 +7,13 @@ namespace App\Livewire\TagTeams\Modals;
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Concerns\Data\PresentsWrestlersList;
-use App\Livewire\TagTeams\Forms\Form;
+use App\Livewire\TagTeams\Forms\CreateEditForm;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Str;
 
 /**
- * @extends BaseFormModal<Form, TagTeam>
+ * @extends BaseFormModal<CreateEditForm, TagTeam>
  */
 class FormModal extends BaseFormModal
 {
@@ -23,7 +23,7 @@ class FormModal extends BaseFormModal
 
     protected function getFormClass(): string
     {
-        return Form::class;
+        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -6,12 +6,12 @@ namespace App\Livewire\Titles\Modals;
 
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Base\BaseFormModal;
-use App\Livewire\Titles\Forms\Form;
+use App\Livewire\Titles\Forms\CreateEditForm;
 use App\Models\Titles\Title;
 use Illuminate\Support\Str;
 
 /**
- * @extends BaseFormModal<Form, Title>
+ * @extends BaseFormModal<CreateEditForm, Title>
  */
 class FormModal extends BaseFormModal
 {
@@ -19,7 +19,7 @@ class FormModal extends BaseFormModal
 
     protected function getFormClass(): string
     {
-        return Form::class;
+        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Users/Modals/FormModal.php
+++ b/app/Livewire/Users/Modals/FormModal.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace App\Livewire\Users\Modals;
 
 use App\Livewire\Concerns\BaseModal;
-use App\Livewire\Users\Forms\Form;
+use App\Livewire\Users\Forms\CreateEditForm;
 use App\Models\Users\User;
 
 /**
- * @extends BaseModal<Form, User>
+ * @extends BaseModal<CreateEditForm, User>
  */
 class FormModal extends BaseModal
 {

--- a/app/Livewire/Venues/Modals/FormModal.php
+++ b/app/Livewire/Venues/Modals/FormModal.php
@@ -6,12 +6,12 @@ namespace App\Livewire\Venues\Modals;
 
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Base\BaseFormModal;
-use App\Livewire\Venues\Forms\Form;
+use App\Livewire\Venues\Forms\CreateEditForm;
 use App\Models\Events\Venue;
 use Illuminate\Support\Str;
 
 /**
- * @extends BaseFormModal<Form, Venue>
+ * @extends BaseFormModal<CreateEditForm, Venue>
  */
 class FormModal extends BaseFormModal
 {
@@ -19,7 +19,7 @@ class FormModal extends BaseFormModal
 
     protected function getFormClass(): string
     {
-        return Form::class;
+        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Wrestlers/Modals/FormModal.php
+++ b/app/Livewire/Wrestlers/Modals/FormModal.php
@@ -6,12 +6,12 @@ namespace App\Livewire\Wrestlers\Modals;
 
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Base\BaseFormModal;
-use App\Livewire\Wrestlers\Forms\Form;
+use App\Livewire\Wrestlers\Forms\CreateEditForm;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Str;
 
 /**
- * @extends BaseFormModal<Form, Wrestler>
+ * @extends BaseFormModal<CreateEditForm, Wrestler>
  */
 class FormModal extends BaseFormModal
 {
@@ -19,7 +19,7 @@ class FormModal extends BaseFormModal
 
     protected function getFormClass(): string
     {
-        return Form::class;
+        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/tests/Integration/Livewire/Events/Forms/FormTest.php
+++ b/tests/Integration/Livewire/Events/Forms/FormTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Events\Forms\Form;
+use App\Livewire\Events\Forms\CreateEditForm;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Users\User;
@@ -16,7 +16,7 @@ beforeEach(function () {
 
 describe('Form Validation Rules', function () {
     it('validates required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', '')
             ->set('date', '')
             ->set('venue_id', '')
@@ -32,7 +32,7 @@ describe('Form Validation Rules', function () {
     it('validates event name uniqueness', function () {
         Event::factory()->create(['name' => 'Existing Event']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Existing Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', Venue::factory()->create()->id)
@@ -42,7 +42,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', 'invalid-date')
             ->set('venue_id', Venue::factory()->create()->id)
@@ -52,7 +52,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates venue exists', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', 999)
@@ -65,7 +65,7 @@ describe('Form Validation Rules', function () {
         $yesterday = Carbon::yesterday()->toDateString();
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', $yesterday)
             ->set('venue_id', $venue->id)
@@ -78,7 +78,7 @@ describe('Form Validation Rules', function () {
         $tomorrow = Carbon::tomorrow()->toDateString();
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', $tomorrow)
             ->set('venue_id', $venue->id)
@@ -93,7 +93,7 @@ describe('Form Field Validation', function () {
         $longName = str_repeat('a', 256);
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $longName)
             ->set('date', '2024-12-31')
             ->set('venue_id', $venue->id)
@@ -106,7 +106,7 @@ describe('Form Field Validation', function () {
         $longDescription = str_repeat('a', 1001);
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', $venue->id)
@@ -120,7 +120,7 @@ describe('Form Field Validation', function () {
         $longPreview = str_repeat('a', 501);
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', $venue->id)
@@ -133,7 +133,7 @@ describe('Form Field Validation', function () {
     it('accepts valid optional fields', function () {
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', $venue->id)
@@ -149,7 +149,7 @@ describe('Form Store Operations', function () {
     it('can store valid event data', function () {
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'WrestleMania 40')
             ->set('date', '2024-04-06')
             ->set('venue_id', $venue->id)
@@ -172,7 +172,7 @@ describe('Form Store Operations', function () {
     it('stores event with minimal required data', function () {
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Basic Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', $venue->id)
@@ -190,7 +190,7 @@ describe('Form Store Operations', function () {
     it('converts date string to Carbon instance', function () {
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', '2024-04-06')
             ->set('venue_id', $venue->id)
@@ -214,7 +214,7 @@ describe('Form Update Operations', function () {
             'venue_id' => $venue1->id,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $event)
             ->set('name', 'Updated Event')
             ->set('date', '2024-02-01')
@@ -237,7 +237,7 @@ describe('Form Update Operations', function () {
         $event1 = Event::factory()->create(['name' => 'Event One']);
         $event2 = Event::factory()->create(['name' => 'Event Two']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $event2)
             ->set('name', 'Event One')
             ->set('date', '2024-12-31')
@@ -255,7 +255,7 @@ describe('Form Update Operations', function () {
             'venue_id' => $venue->id,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $event)
             ->set('name', 'Test Event')
             ->set('date', '2024-02-01')
@@ -275,7 +275,7 @@ describe('Form Business Logic', function () {
             'venue_id' => $venue->id,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $event)
             ->set('name', $event->name)
             ->set('date', '2024-12-31')
@@ -289,7 +289,7 @@ describe('Form Business Logic', function () {
     it('handles venue relationship correctly', function () {
         $venue = Venue::factory()->create(['name' => 'Test Arena']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', $venue->id)
@@ -304,7 +304,7 @@ describe('Form Business Logic', function () {
     it('validates venue is active', function () {
         $inactiveVenue = Venue::factory()->inactive()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', $inactiveVenue->id)
@@ -318,7 +318,7 @@ describe('Form State Management', function () {
     it('resets form after successful store', function () {
         $venue = Venue::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', '2024-12-31')
             ->set('venue_id', $venue->id)
@@ -331,7 +331,7 @@ describe('Form State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Event')
             ->set('date', 'invalid-date')
             ->call('store');
@@ -350,7 +350,7 @@ describe('Form State Management', function () {
             'description' => 'Test description',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $event);
 
         $form->assertSet('name', 'Test Event');

--- a/tests/Integration/Livewire/Events/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Events/Modals/FormModalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Events\Forms\Form;
+use App\Livewire\Events\Forms\CreateEditForm;
 use App\Livewire\Events\Modals\FormModal;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
@@ -21,7 +21,7 @@ describe('FormModal Configuration', function () {
         $method = $reflection->getMethod('getFormClass');
         $method->setAccessible(true);
 
-        expect($method->invoke($modal))->toBe(Form::class);
+        expect($method->invoke($modal))->toBe(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {

--- a/tests/Integration/Livewire/Managers/Forms/FormTest.php
+++ b/tests/Integration/Livewire/Managers/Forms/FormTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Managers\Forms\Form;
+use App\Livewire\Managers\Forms\CreateEditForm;
 use App\Models\Managers\Manager;
 use App\Models\Users\User;
 use Livewire\Livewire;
@@ -14,7 +14,7 @@ beforeEach(function () {
 
 describe('Form Validation Rules', function () {
     it('validates required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', '')
             ->set('last_name', '')
             ->call('store');
@@ -28,7 +28,7 @@ describe('Form Validation Rules', function () {
     it('validates field lengths', function () {
         $longName = str_repeat('a', 256);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', $longName)
             ->set('last_name', $longName)
             ->call('store');
@@ -42,7 +42,7 @@ describe('Form Validation Rules', function () {
     it('accepts valid field lengths', function () {
         $validName = str_repeat('a', 255);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', $validName)
             ->set('last_name', $validName)
             ->call('store');
@@ -51,7 +51,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates employment date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Doe')
             ->set('employment_date', 'invalid-date')
@@ -61,7 +61,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('accepts valid employment date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Doe')
             ->set('employment_date', '2023-01-15')
@@ -71,7 +71,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('allows null employment date', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Doe')
             ->set('employment_date', null)
@@ -83,7 +83,7 @@ describe('Form Validation Rules', function () {
 
 describe('Form Store Operations', function () {
     it('can store valid manager data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Manager')
             ->call('store');
@@ -98,7 +98,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores manager with complete name information', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'Professional')
             ->set('last_name', 'Wrestling')
             ->set('employment_date', '2023-06-15')
@@ -118,7 +118,7 @@ describe('Form Store Operations', function () {
     it('creates employment record when employment date provided', function () {
         $employmentDate = '2023-01-15';
         
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'Employed')
             ->set('last_name', 'Manager')
             ->set('employment_date', $employmentDate)
@@ -135,7 +135,7 @@ describe('Form Store Operations', function () {
     });
 
     it('does not create employment record when employment date omitted', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'Unemployed')
             ->set('last_name', 'Manager')
             ->call('store');
@@ -157,7 +157,7 @@ describe('Form Update Operations', function () {
             'last_name' => 'Name',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $manager)
             ->set('first_name', 'Updated')
             ->set('last_name', 'Manager')
@@ -179,7 +179,7 @@ describe('Form Update Operations', function () {
             'last_name' => 'Doe',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $manager)
             ->set('first_name', 'Jane')
             ->set('last_name', 'Doe')
@@ -195,7 +195,7 @@ describe('Form Update Operations', function () {
     it('can update employment date', function () {
         $manager = Manager::factory()->create();
         
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $manager)
             ->set('first_name', $manager->first_name)
             ->set('last_name', $manager->last_name)
@@ -212,7 +212,7 @@ describe('Form Update Operations', function () {
 
 describe('Form State Management', function () {
     it('resets form after successful store', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Manager')
             ->set('employment_date', '2023-01-15')
@@ -225,7 +225,7 @@ describe('Form State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', '')
             ->set('last_name', 'Manager')
             ->set('employment_date', '2023-01-15')
@@ -243,7 +243,7 @@ describe('Form State Management', function () {
             'last_name' => 'Test',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $manager);
 
         $form->assertSet('first_name', 'Load');
@@ -259,7 +259,7 @@ describe('Form State Management', function () {
             'started_at' => $employmentDate,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $manager);
 
         $form->assertSet('employment_date', $employmentDate);
@@ -277,7 +277,7 @@ describe('Form Manager Name Handling', function () {
         ];
 
         foreach ($nameTests as [$firstName, $lastName]) {
-            $form = Livewire::test(Form::class)
+            $form = Livewire::test(CreateEditForm::class)
                 ->set('first_name', $firstName)
                 ->set('last_name', $lastName)
                 ->call('store');
@@ -292,7 +292,7 @@ describe('Form Manager Name Handling', function () {
     });
 
     it('handles single character names', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'A')
             ->set('last_name', 'B')
             ->call('store');
@@ -309,7 +309,7 @@ describe('Form Manager Name Handling', function () {
         $longFirstName = str_repeat('A', 100);
         $longLastName = str_repeat('B', 100);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', $longFirstName)
             ->set('last_name', $longLastName)
             ->call('store');
@@ -327,7 +327,7 @@ describe('Form Employment Integration', function () {
     it('handles employment date creation correctly', function () {
         $employmentDate = '2023-06-15';
         
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'Employment')
             ->set('last_name', 'Test')
             ->set('employment_date', $employmentDate)
@@ -344,7 +344,7 @@ describe('Form Employment Integration', function () {
     });
 
     it('does not create employment without date', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'No Employment')
             ->set('last_name', 'Test')
             ->call('store');
@@ -366,7 +366,7 @@ describe('Form Employment Integration', function () {
             'started_at' => $employmentDate,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $manager);
 
         $form->assertSet('employment_date', $employmentDate);

--- a/tests/Integration/Livewire/Managers/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Managers/Modals/FormModalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Managers\Forms\Form;
+use App\Livewire\Managers\Forms\CreateEditForm;
 use App\Livewire\Managers\Modals\FormModal;
 use App\Models\Managers\Manager;
 use Illuminate\Foundation\Testing\RefreshDatabase;

--- a/tests/Integration/Livewire/Referees/Forms/FormTest.php
+++ b/tests/Integration/Livewire/Referees/Forms/FormTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Referees\Forms\Form;
+use App\Livewire\Referees\Forms\CreateEditForm;
 use App\Models\Referees\Referee;
 use App\Models\Users\User;
 use Livewire\Livewire;
@@ -14,7 +14,7 @@ beforeEach(function () {
 
 describe('Form Validation Rules', function () {
     it('validates required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', '')
             ->set('last_name', '')
             ->call('store');
@@ -28,7 +28,7 @@ describe('Form Validation Rules', function () {
     it('validates field lengths', function () {
         $longName = str_repeat('a', 256);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', $longName)
             ->set('last_name', $longName)
             ->call('store');
@@ -42,7 +42,7 @@ describe('Form Validation Rules', function () {
     it('accepts valid field lengths', function () {
         $validName = str_repeat('a', 255);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', $validName)
             ->set('last_name', $validName)
             ->call('store');
@@ -51,7 +51,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates employment date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Referee')
             ->set('employment_date', 'invalid-date')
@@ -61,7 +61,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('accepts valid employment date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Referee')
             ->set('employment_date', '2023-01-15')
@@ -71,7 +71,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('allows null employment date', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Referee')
             ->set('employment_date', null)
@@ -83,7 +83,7 @@ describe('Form Validation Rules', function () {
 
 describe('Form Store Operations', function () {
     it('can store valid referee data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Official')
             ->call('store');
@@ -98,7 +98,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores referee with complete name information', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'Senior')
             ->set('last_name', 'Referee')
             ->set('employment_date', '2023-06-15')
@@ -118,7 +118,7 @@ describe('Form Store Operations', function () {
     it('creates employment record when employment date provided', function () {
         $employmentDate = '2023-01-15';
         
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'Employed')
             ->set('last_name', 'Referee')
             ->set('employment_date', $employmentDate)
@@ -135,7 +135,7 @@ describe('Form Store Operations', function () {
     });
 
     it('does not create employment record when employment date omitted', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'Unemployed')
             ->set('last_name', 'Referee')
             ->call('store');
@@ -157,7 +157,7 @@ describe('Form Update Operations', function () {
             'last_name' => 'Official',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $referee)
             ->set('first_name', 'Updated')
             ->set('last_name', 'Referee')
@@ -179,7 +179,7 @@ describe('Form Update Operations', function () {
             'last_name' => 'Doe',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $referee)
             ->set('first_name', 'Jane')
             ->set('last_name', 'Doe')
@@ -195,7 +195,7 @@ describe('Form Update Operations', function () {
     it('can update employment date', function () {
         $referee = Referee::factory()->create();
         
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $referee)
             ->set('first_name', $referee->first_name)
             ->set('last_name', $referee->last_name)
@@ -212,7 +212,7 @@ describe('Form Update Operations', function () {
 
 describe('Form State Management', function () {
     it('resets form after successful store', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'John')
             ->set('last_name', 'Referee')
             ->set('employment_date', '2023-01-15')
@@ -225,7 +225,7 @@ describe('Form State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', '')
             ->set('last_name', 'Referee')
             ->set('employment_date', '2023-01-15')
@@ -243,7 +243,7 @@ describe('Form State Management', function () {
             'last_name' => 'Test',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $referee);
 
         $form->assertSet('first_name', 'Load');
@@ -259,7 +259,7 @@ describe('Form State Management', function () {
             'started_at' => $employmentDate,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $referee);
 
         $form->assertSet('employment_date', $employmentDate);
@@ -277,7 +277,7 @@ describe('Form Referee Official Handling', function () {
         ];
 
         foreach ($nameTests as [$firstName, $lastName]) {
-            $form = Livewire::test(Form::class)
+            $form = Livewire::test(CreateEditForm::class)
                 ->set('first_name', $firstName)
                 ->set('last_name', $lastName)
                 ->call('store');
@@ -300,7 +300,7 @@ describe('Form Referee Official Handling', function () {
         ];
 
         foreach ($nameTests as [$firstName, $lastName]) {
-            $form = Livewire::test(Form::class)
+            $form = Livewire::test(CreateEditForm::class)
                 ->set('first_name', $firstName)
                 ->set('last_name', $lastName)
                 ->call('store');
@@ -315,7 +315,7 @@ describe('Form Referee Official Handling', function () {
     });
 
     it('handles single character names', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'A')
             ->set('last_name', 'B')
             ->call('store');
@@ -332,7 +332,7 @@ describe('Form Referee Official Handling', function () {
         $longFirstName = str_repeat('Referee', 35); // 245 chars
         $longLastName = str_repeat('Official', 25); // 200 chars
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', $longFirstName)
             ->set('last_name', $longLastName)
             ->call('store');
@@ -350,7 +350,7 @@ describe('Form Employment Integration', function () {
     it('handles employment date creation correctly', function () {
         $employmentDate = '2023-06-15';
         
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'Employment')
             ->set('last_name', 'Test')
             ->set('employment_date', $employmentDate)
@@ -367,7 +367,7 @@ describe('Form Employment Integration', function () {
     });
 
     it('does not create employment without date', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('first_name', 'No Employment')
             ->set('last_name', 'Test')
             ->call('store');
@@ -389,7 +389,7 @@ describe('Form Employment Integration', function () {
             'started_at' => $employmentDate,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $referee);
 
         $form->assertSet('employment_date', $employmentDate);
@@ -406,7 +406,7 @@ describe('Form Employment Integration', function () {
             'started_at' => '2023-01-01',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $referee);
 
         $form->assertSet('first_name', 'Available');

--- a/tests/Integration/Livewire/Stables/Forms/FormTest.php
+++ b/tests/Integration/Livewire/Stables/Forms/FormTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Stables\Forms\Form;
+use App\Livewire\Stables\Forms\CreateEditForm;
 use App\Models\Managers\Manager;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
@@ -18,7 +18,7 @@ beforeEach(function () {
 
 describe('Form Validation Rules', function () {
     it('validates required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', '')
             ->set('started_at', '')
             ->call('store');
@@ -32,7 +32,7 @@ describe('Form Validation Rules', function () {
     it('validates stable name uniqueness', function () {
         Stable::factory()->create(['name' => 'Existing Stable']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Existing Stable')
             ->set('started_at', '2024-01-01')
             ->call('store');
@@ -41,7 +41,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates started_at date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', 'invalid-date')
             ->call('store');
@@ -50,7 +50,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates ended_at date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('ended_at', 'invalid-date')
@@ -60,7 +60,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates ended_at is after started_at', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-06-01')
             ->set('ended_at', '2024-01-01')
@@ -70,7 +70,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('allows ended_at to be null', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('ended_at', null)
@@ -80,7 +80,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('allows ended_at to be after started_at', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('ended_at', '2024-06-01')
@@ -94,7 +94,7 @@ describe('Form Field Validation', function () {
     it('validates name maximum length', function () {
         $longName = str_repeat('a', 256);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $longName)
             ->set('started_at', '2024-01-01')
             ->call('store');
@@ -105,7 +105,7 @@ describe('Form Field Validation', function () {
     it('accepts valid name length', function () {
         $validName = str_repeat('a', 255);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $validName)
             ->set('started_at', '2024-01-01')
             ->call('store');
@@ -114,7 +114,7 @@ describe('Form Field Validation', function () {
     });
 
     it('validates wrestlers array', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('wrestlers', 'invalid-array')
@@ -124,7 +124,7 @@ describe('Form Field Validation', function () {
     });
 
     it('validates tag_teams array', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('tag_teams', 'invalid-array')
@@ -134,7 +134,7 @@ describe('Form Field Validation', function () {
     });
 
     it('validates managers array', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('managers', 'invalid-array')
@@ -146,7 +146,7 @@ describe('Form Field Validation', function () {
 
 describe('Form Relationship Validation', function () {
     it('validates wrestlers exist', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('wrestlers', [999])
@@ -156,7 +156,7 @@ describe('Form Relationship Validation', function () {
     });
 
     it('validates tag teams exist', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('tag_teams', [999])
@@ -166,7 +166,7 @@ describe('Form Relationship Validation', function () {
     });
 
     it('validates managers exist', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('managers', [999])
@@ -178,7 +178,7 @@ describe('Form Relationship Validation', function () {
     it('accepts valid wrestler relationships', function () {
         $wrestler = Wrestler::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('wrestlers', [$wrestler->id])
@@ -190,7 +190,7 @@ describe('Form Relationship Validation', function () {
     it('accepts valid tag team relationships', function () {
         $tagTeam = TagTeam::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('tag_teams', [$tagTeam->id])
@@ -202,7 +202,7 @@ describe('Form Relationship Validation', function () {
     it('accepts valid manager relationships', function () {
         $manager = Manager::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('managers', [$manager->id])
@@ -214,7 +214,7 @@ describe('Form Relationship Validation', function () {
 
 describe('Form Store Operations', function () {
     it('can store valid stable data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'The New World Order')
             ->set('started_at', '2024-01-01')
             ->set('ended_at', '2024-12-31')
@@ -231,7 +231,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores stable with minimal required data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Basic Stable')
             ->set('started_at', '2024-01-01')
             ->call('store');
@@ -246,7 +246,7 @@ describe('Form Store Operations', function () {
     });
 
     it('converts date strings to Carbon instances', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('ended_at', '2024-12-31')
@@ -266,7 +266,7 @@ describe('Form Store Operations', function () {
         $tagTeam = TagTeam::factory()->create();
         $manager = Manager::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('wrestlers', [$wrestler->id])
@@ -290,7 +290,7 @@ describe('Form Update Operations', function () {
             'started_at' => '2024-01-01',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $stable)
             ->set('name', 'Updated Stable')
             ->set('started_at', '2024-01-02')
@@ -312,7 +312,7 @@ describe('Form Update Operations', function () {
         $stable1 = Stable::factory()->create(['name' => 'Stable One']);
         $stable2 = Stable::factory()->create(['name' => 'Stable Two']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $stable2)
             ->set('name', 'Stable One')
             ->set('started_at', '2024-01-01')
@@ -327,7 +327,7 @@ describe('Form Update Operations', function () {
             'started_at' => '2024-01-01',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $stable)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-02')
@@ -342,7 +342,7 @@ describe('Form Update Operations', function () {
         $wrestler = Wrestler::factory()->create();
         $tagTeam = TagTeam::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $stable)
             ->set('name', $stable->name)
             ->set('started_at', $stable->started_at->toDateString())
@@ -364,7 +364,7 @@ describe('Form Business Logic', function () {
             'started_at' => '2023-01-01',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $stable)
             ->set('name', $stable->name)
             ->set('started_at', '2024-01-01')
@@ -375,7 +375,7 @@ describe('Form Business Logic', function () {
     });
 
     it('handles activity period management correctly', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->call('store');
@@ -387,7 +387,7 @@ describe('Form Business Logic', function () {
     });
 
     it('handles ended stable correctly', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Ended Stable')
             ->set('started_at', '2024-01-01')
             ->set('ended_at', '2024-06-01')
@@ -402,7 +402,7 @@ describe('Form Business Logic', function () {
     it('validates member employment status', function () {
         $unemployedWrestler = Wrestler::factory()->unemployed()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('wrestlers', [$unemployedWrestler->id])
@@ -414,7 +414,7 @@ describe('Form Business Logic', function () {
 
 describe('Form State Management', function () {
     it('resets form after successful store', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->call('store');
@@ -426,7 +426,7 @@ describe('Form State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', 'invalid-date')
             ->call('store');
@@ -443,7 +443,7 @@ describe('Form State Management', function () {
             'ended_at' => '2024-12-31',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $stable);
 
         $form->assertSet('name', 'Test Stable');
@@ -455,7 +455,7 @@ describe('Form State Management', function () {
         $wrestler = Wrestler::factory()->create();
         $tagTeam = TagTeam::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Stable')
             ->set('started_at', '2024-01-01')
             ->set('wrestlers', [$wrestler->id])

--- a/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Stables\Forms\Form;
+use App\Livewire\Stables\Forms\CreateEditForm;
 use App\Livewire\Stables\Modals\FormModal;
 use App\Models\Managers\Manager;
 use App\Models\Stables\Stable;
@@ -23,7 +23,7 @@ describe('FormModal Configuration', function () {
         $method = $reflection->getMethod('getFormClass');
         $method->setAccessible(true);
 
-        expect($method->invoke($modal))->toBe(Form::class);
+        expect($method->invoke($modal))->toBe(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {

--- a/tests/Integration/Livewire/TagTeams/Forms/FormTest.php
+++ b/tests/Integration/Livewire/TagTeams/Forms/FormTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\TagTeams\Forms\Form;
+use App\Livewire\TagTeams\Forms\CreateEditForm;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Users\User;
@@ -20,7 +20,7 @@ beforeEach(function () {
 
 describe('Form Validation Rules', function () {
     it('validates required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', '')
             ->set('wrestlerA', null)
             ->set('wrestlerB', null)
@@ -36,7 +36,7 @@ describe('Form Validation Rules', function () {
     it('validates tag team name uniqueness', function () {
         TagTeam::factory()->create(['name' => 'Existing Team']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Existing Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -48,7 +48,7 @@ describe('Form Validation Rules', function () {
     it('validates signature move uniqueness', function () {
         TagTeam::factory()->create(['signature_move' => 'Existing Move']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'New Team')
             ->set('signature_move', 'Existing Move')
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -59,7 +59,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates wrestlers are different', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerA->id)
@@ -69,7 +69,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates wrestlers exist', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Team')
             ->set('wrestlerA', 99999)
             ->set('wrestlerB', 99998)
@@ -82,7 +82,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates managers exist', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -93,7 +93,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('allows null signature move', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Team')
             ->set('signature_move', null)
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -109,7 +109,7 @@ describe('Form Field Validation', function () {
         $longName = str_repeat('a', 256);
         $longMove = str_repeat('a', 256);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $longName)
             ->set('signature_move', $longMove)
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -126,7 +126,7 @@ describe('Form Field Validation', function () {
         $validName = str_repeat('a', 255);
         $validMove = str_repeat('a', 255);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $validName)
             ->set('signature_move', $validMove)
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -137,7 +137,7 @@ describe('Form Field Validation', function () {
     });
 
     it('validates employment date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -148,7 +148,7 @@ describe('Form Field Validation', function () {
     });
 
     it('accepts valid employment date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -161,7 +161,7 @@ describe('Form Field Validation', function () {
 
 describe('Form Store Operations', function () {
     it('can store valid tag team data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Tag Team')
             ->set('signature_move', 'Double Suplex')
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -178,7 +178,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores tag team with wrestler relationships', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Wrestling Duo')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -193,7 +193,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores tag team with manager relationships', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Managed Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -210,7 +210,7 @@ describe('Form Store Operations', function () {
     it('creates employment record when employment date provided', function () {
         $employmentDate = '2023-01-15';
         
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Employed Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -225,7 +225,7 @@ describe('Form Store Operations', function () {
     });
 
     it('does not create employment record when employment date omitted', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Unemployed Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -245,7 +245,7 @@ describe('Form Update Operations', function () {
             'signature_move' => 'Original Move',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $tagTeam)
             ->set('name', 'Updated Team')
             ->set('signature_move', 'Updated Move')
@@ -267,7 +267,7 @@ describe('Form Update Operations', function () {
         $tagTeam1 = TagTeam::factory()->create(['name' => 'Team One']);
         $tagTeam2 = TagTeam::factory()->create(['name' => 'Team Two']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $tagTeam2)
             ->set('name', 'Team One')
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -280,7 +280,7 @@ describe('Form Update Operations', function () {
     it('allows keeping same name when updating', function () {
         $tagTeam = TagTeam::factory()->create(['name' => 'Same Name Team']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $tagTeam)
             ->set('name', 'Same Name Team')
             ->set('signature_move', 'New Move')
@@ -297,7 +297,7 @@ describe('Form Update Operations', function () {
         $newWrestlerA = Wrestler::factory()->create();
         $newWrestlerB = Wrestler::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $tagTeam)
             ->set('name', $tagTeam->name)
             ->set('wrestlerA', $newWrestlerA->id)
@@ -315,7 +315,7 @@ describe('Form Update Operations', function () {
 
 describe('Form State Management', function () {
     it('resets form after successful store', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Team')
             ->set('signature_move', 'Test Move')
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -332,7 +332,7 @@ describe('Form State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', '')
             ->set('signature_move', 'Test Move')
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -352,7 +352,7 @@ describe('Form State Management', function () {
             'signature_move' => 'Load Move',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $tagTeam);
 
         $form->assertSet('name', 'Load Test Team');
@@ -363,7 +363,7 @@ describe('Form State Management', function () {
         $tagTeam = TagTeam::factory()->create();
         $tagTeam->wrestlers()->attach([$this->wrestlerA->id, $this->wrestlerB->id]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $tagTeam);
 
         $form->assertSet('wrestlerA', $this->wrestlerA->id);
@@ -374,7 +374,7 @@ describe('Form State Management', function () {
         $tagTeam = TagTeam::factory()->create();
         $tagTeam->managers()->attach([$this->manager->id]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $tagTeam);
 
         $form->assertSet('managers', [$this->manager->id]);
@@ -386,7 +386,7 @@ describe('Form Tag Team Relationships', function () {
         $manager1 = Manager::factory()->create();
         $manager2 = Manager::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Multi Manager Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -402,7 +402,7 @@ describe('Form Tag Team Relationships', function () {
     });
 
     it('handles empty managers array', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'No Manager Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)
@@ -420,7 +420,7 @@ describe('Form Tag Team Relationships', function () {
         $oldWrestler = Wrestler::factory()->create();
         $tagTeam->wrestlers()->attach($oldWrestler->id);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $tagTeam)
             ->set('name', $tagTeam->name)
             ->set('wrestlerA', $this->wrestlerA->id)
@@ -448,7 +448,7 @@ describe('Form Wrestling Team Validation', function () {
         ];
 
         foreach ($teamNames as $name) {
-            $form = Livewire::test(Form::class)
+            $form = Livewire::test(CreateEditForm::class)
                 ->set('name', $name)
                 ->set('wrestlerA', $this->wrestlerA->id)
                 ->set('wrestlerB', $this->wrestlerB->id)
@@ -468,7 +468,7 @@ describe('Form Wrestling Team Validation', function () {
         ];
 
         foreach ($signatureMoves as $move) {
-            $form = Livewire::test(Form::class)
+            $form = Livewire::test(CreateEditForm::class)
                 ->set('name', "Team for {$move}")
                 ->set('signature_move', $move)
                 ->set('wrestlerA', $this->wrestlerA->id)
@@ -480,7 +480,7 @@ describe('Form Wrestling Team Validation', function () {
     });
 
     it('handles tag team with no signature move', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Generic Team')
             ->set('wrestlerA', $this->wrestlerA->id)
             ->set('wrestlerB', $this->wrestlerB->id)

--- a/tests/Integration/Livewire/TagTeams/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/TagTeams/Modals/FormModalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\TagTeams\Forms\Form;
+use App\Livewire\TagTeams\Forms\CreateEditForm;
 use App\Livewire\TagTeams\Modals\FormModal;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;

--- a/tests/Integration/Livewire/Titles/Forms/FormTest.php
+++ b/tests/Integration/Livewire/Titles/Forms/FormTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\Titles\TitleType;
-use App\Livewire\Titles\Forms\Form;
+use App\Livewire\Titles\Forms\CreateEditForm;
 use App\Models\Titles\Title;
 use App\Models\Users\User;
 use Illuminate\Support\Carbon;
@@ -16,7 +16,7 @@ beforeEach(function () {
 
 describe('Form Validation Rules', function () {
     it('validates required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', '')
             ->set('type', '')
             ->call('store');
@@ -28,7 +28,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates title name ends with Title or Titles', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Championship Belt')
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -37,7 +37,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('accepts valid title names ending with Title', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Heavyweight Championship Title')
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -46,7 +46,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('accepts valid title names ending with Titles', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Tag Team Titles')
             ->set('type', TitleType::TagTeam->value)
             ->call('store');
@@ -57,7 +57,7 @@ describe('Form Validation Rules', function () {
     it('validates title name uniqueness', function () {
         Title::factory()->create(['name' => 'Existing Championship Title']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Existing Championship Title')
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -66,7 +66,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates title type enum values', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Championship Title')
             ->set('type', 'InvalidType')
             ->call('store');
@@ -75,14 +75,14 @@ describe('Form Validation Rules', function () {
     });
 
     it('accepts valid title type values', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Singles Championship Title')
             ->set('type', TitleType::Singles->value)
             ->call('store');
 
         $form->assertHasNoErrors(['type']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Tag Team Championship Titles')
             ->set('type', TitleType::TagTeam->value)
             ->call('store');
@@ -95,7 +95,7 @@ describe('Form Field Validation', function () {
     it('validates title name length', function () {
         $longName = str_repeat('a', 251) . 'Title';
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $longName)
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -106,7 +106,7 @@ describe('Form Field Validation', function () {
     it('accepts valid title name length', function () {
         $validName = str_repeat('a', 250) . 'Title';
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $validName)
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -115,7 +115,7 @@ describe('Form Field Validation', function () {
     });
 
     it('validates start date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Date Test Title')
             ->set('type', TitleType::Singles->value)
             ->set('start_date', 'invalid-date')
@@ -125,7 +125,7 @@ describe('Form Field Validation', function () {
     });
 
     it('accepts valid start date format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Date Valid Title')
             ->set('type', TitleType::Singles->value)
             ->set('start_date', '2023-01-15')
@@ -135,7 +135,7 @@ describe('Form Field Validation', function () {
     });
 
     it('allows null start date', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Null Date Title')
             ->set('type', TitleType::Singles->value)
             ->set('start_date', null)
@@ -147,7 +147,7 @@ describe('Form Field Validation', function () {
 
 describe('Form Store Operations', function () {
     it('can store valid title data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Championship Title')
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -162,7 +162,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores title with all fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Complete Championship Title')
             ->set('type', TitleType::TagTeam->value)
             ->set('start_date', '2023-06-15')
@@ -177,7 +177,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores title with proper enum casting', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Enum Test Title')
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -192,7 +192,7 @@ describe('Form Store Operations', function () {
     it('creates activity period when start date provided', function () {
         $startDate = '2023-01-15';
         
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Activity Test Title')
             ->set('type', TitleType::Singles->value)
             ->set('start_date', $startDate)
@@ -206,7 +206,7 @@ describe('Form Store Operations', function () {
     });
 
     it('does not create activity period when start date omitted', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'No Activity Test Title')
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -225,7 +225,7 @@ describe('Form Update Operations', function () {
             'type' => TitleType::Singles,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $title)
             ->set('name', 'Updated Championship Title')
             ->set('type', TitleType::TagTeam->value)
@@ -245,7 +245,7 @@ describe('Form Update Operations', function () {
         $title1 = Title::factory()->create(['name' => 'Title One']);
         $title2 = Title::factory()->create(['name' => 'Title Two']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $title2)
             ->set('name', 'Title One')
             ->set('type', $title2->type->value)
@@ -260,7 +260,7 @@ describe('Form Update Operations', function () {
             'type' => TitleType::Singles,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $title)
             ->set('name', 'Same Name Title')
             ->set('type', TitleType::TagTeam->value)
@@ -276,7 +276,7 @@ describe('Form Update Operations', function () {
             'type' => TitleType::Singles,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $title)
             ->set('name', 'Type Change Title')
             ->set('type', TitleType::TagTeam->value)
@@ -291,7 +291,7 @@ describe('Form Update Operations', function () {
 
 describe('Form State Management', function () {
     it('resets form after successful store', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Reset Test Title')
             ->set('type', TitleType::Singles->value)
             ->set('start_date', '2023-01-15')
@@ -304,7 +304,7 @@ describe('Form State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Invalid Name')
             ->set('type', TitleType::Singles->value)
             ->set('start_date', '2023-01-15')
@@ -322,7 +322,7 @@ describe('Form State Management', function () {
             'type' => TitleType::TagTeam,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $title);
 
         $form->assertSet('name', 'Load Test Title');
@@ -341,7 +341,7 @@ describe('Form State Management', function () {
             'started_at' => $startDate,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $title);
 
         $form->assertSet('start_date', '2023-01-15');
@@ -360,7 +360,7 @@ describe('Form Title Naming Conventions', function () {
         ];
 
         foreach ($validNames as $name) {
-            $form = Livewire::test(Form::class)
+            $form = Livewire::test(CreateEditForm::class)
                 ->set('name', $name)
                 ->set('type', TitleType::Singles->value)
                 ->call('store');
@@ -379,7 +379,7 @@ describe('Form Title Naming Conventions', function () {
         ];
 
         foreach ($invalidNames as $name) {
-            $form = Livewire::test(Form::class)
+            $form = Livewire::test(CreateEditForm::class)
                 ->set('name', $name)
                 ->set('type', TitleType::Singles->value)
                 ->call('store');
@@ -390,7 +390,7 @@ describe('Form Title Naming Conventions', function () {
 
     it('matches title type with naming conventions', function () {
         // Singles titles often use "Title"
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Singles Championship Title')
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -398,7 +398,7 @@ describe('Form Title Naming Conventions', function () {
         $form->assertHasNoErrors();
 
         // Tag team titles often use "Titles"
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Tag Team Championship Titles')
             ->set('type', TitleType::TagTeam->value)
             ->call('store');
@@ -409,7 +409,7 @@ describe('Form Title Naming Conventions', function () {
 
 describe('Form Activity Period Integration', function () {
     it('handles activity period creation on title store', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Activity Integration Title')
             ->set('type', TitleType::Singles->value)
             ->set('start_date', '2023-06-15')
@@ -423,7 +423,7 @@ describe('Form Activity Period Integration', function () {
     });
 
     it('does not create activity period without start date', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'No Activity Title')
             ->set('type', TitleType::Singles->value)
             ->call('store');
@@ -442,7 +442,7 @@ describe('Form Activity Period Integration', function () {
             'started_at' => $startDate,
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $title);
 
         $form->assertSet('start_date', '2023-03-01');

--- a/tests/Integration/Livewire/Titles/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Titles/Modals/FormModalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Titles\Forms\Form;
+use App\Livewire\Titles\Forms\CreateEditForm;
 use App\Livewire\Titles\Modals\FormModal;
 use App\Models\Titles\Title;
 use App\Models\Users\User;
@@ -20,7 +20,7 @@ describe('FormModal Configuration', function () {
         $method = $reflection->getMethod('getFormClass');
         $method->setAccessible(true);
 
-        expect($method->invoke($modal))->toBe(Form::class);
+        expect($method->invoke($modal))->toBe(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {

--- a/tests/Integration/Livewire/Users/Forms/UserFormTest.php
+++ b/tests/Integration/Livewire/Users/Forms/UserFormTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Users\Forms\Form;
+use App\Livewire\Users\Forms\CreateEditForm;
 use App\Models\Users\User;
 use Illuminate\Support\Facades\Hash;
 use Livewire\Livewire;
@@ -14,7 +14,7 @@ beforeEach(function () {
 
 describe('Form Validation Rules', function () {
     it('validates required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', '')
             ->set('email', '')
             ->set('password', '')
@@ -28,7 +28,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates email format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'invalid-email')
             ->set('password', 'password123')
@@ -40,7 +40,7 @@ describe('Form Validation Rules', function () {
     it('validates email uniqueness', function () {
         User::factory()->create(['email' => 'existing@example.com']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'existing@example.com')
             ->set('password', 'password123')
@@ -50,7 +50,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates password minimum length', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', '123')
@@ -60,7 +60,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates password confirmation', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -71,7 +71,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('accepts valid password with confirmation', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -86,7 +86,7 @@ describe('Form Field Validation', function () {
     it('validates name maximum length', function () {
         $longName = str_repeat('a', 256);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $longName)
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -98,7 +98,7 @@ describe('Form Field Validation', function () {
     it('validates email maximum length', function () {
         $longEmail = str_repeat('a', 248) . '@example.com';
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', $longEmail)
             ->set('password', 'password123')
@@ -111,7 +111,7 @@ describe('Form Field Validation', function () {
         $validName = str_repeat('a', 255);
         $validEmail = str_repeat('a', 243) . '@example.com';
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $validName)
             ->set('email', $validEmail)
             ->set('password', 'password123')
@@ -122,7 +122,7 @@ describe('Form Field Validation', function () {
     });
 
     it('validates role enum values', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -133,7 +133,7 @@ describe('Form Field Validation', function () {
     });
 
     it('accepts valid role values', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -146,7 +146,7 @@ describe('Form Field Validation', function () {
 
 describe('Form Store Operations', function () {
     it('can store valid user data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -165,7 +165,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores user with minimal required data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Basic User')
             ->set('email', 'basic@example.com')
             ->set('password', 'password123')
@@ -181,7 +181,7 @@ describe('Form Store Operations', function () {
     });
 
     it('hashes password when storing', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -196,7 +196,7 @@ describe('Form Store Operations', function () {
     });
 
     it('assigns default role when not specified', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -210,7 +210,7 @@ describe('Form Store Operations', function () {
     });
 
     it('sets user as unverified by default', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -232,7 +232,7 @@ describe('Form Update Operations', function () {
             'role' => 'User',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user)
             ->set('name', 'Updated Name')
             ->set('email', 'updated@example.com')
@@ -254,7 +254,7 @@ describe('Form Update Operations', function () {
         $user1 = User::factory()->create(['email' => 'user1@example.com']);
         $user2 = User::factory()->create(['email' => 'user2@example.com']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user2)
             ->set('name', $user2->name)
             ->set('email', 'user1@example.com')
@@ -269,7 +269,7 @@ describe('Form Update Operations', function () {
             'email' => 'test@example.com',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user)
             ->set('name', 'Updated Name')
             ->set('email', 'test@example.com')
@@ -282,7 +282,7 @@ describe('Form Update Operations', function () {
     it('does not require password when updating', function () {
         $user = User::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user)
             ->set('name', 'Updated Name')
             ->call('update');
@@ -295,7 +295,7 @@ describe('Form Update Operations', function () {
         $user = User::factory()->create();
         $originalPassword = $user->password;
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user)
             ->set('name', $user->name)
             ->set('email', $user->email)
@@ -313,7 +313,7 @@ describe('Form Update Operations', function () {
     it('validates password confirmation when updating password', function () {
         $user = User::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user)
             ->set('name', $user->name)
             ->set('email', $user->email)
@@ -328,7 +328,7 @@ describe('Form Update Operations', function () {
         $user = User::factory()->create();
         $originalPassword = $user->password;
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user)
             ->set('name', 'Updated Name')
             ->call('update');
@@ -342,7 +342,7 @@ describe('Form Update Operations', function () {
 
 describe('Form Role Management', function () {
     it('can assign administrator role', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Admin User')
             ->set('email', 'admin@example.com')
             ->set('password', 'password123')
@@ -358,7 +358,7 @@ describe('Form Role Management', function () {
     });
 
     it('can assign user role', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Regular User')
             ->set('email', 'user@example.com')
             ->set('password', 'password123')
@@ -376,7 +376,7 @@ describe('Form Role Management', function () {
     it('can change user role when updating', function () {
         $user = User::factory()->create(['role' => 'User']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user)
             ->set('name', $user->name)
             ->set('email', $user->email)
@@ -392,7 +392,7 @@ describe('Form Role Management', function () {
 
 describe('Form State Management', function () {
     it('resets form after successful store', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -407,7 +407,7 @@ describe('Form State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'invalid-email')
             ->set('password', 'password123')
@@ -426,7 +426,7 @@ describe('Form State Management', function () {
             'role' => 'Administrator',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $user);
 
         $form->assertSet('name', 'Test User');
@@ -439,7 +439,7 @@ describe('Form State Management', function () {
     it('clears password fields when loading existing model', function () {
         $user = User::factory()->create();
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('password', 'some-password')
             ->set('password_confirmation', 'some-password')
             ->call('setModel', $user);
@@ -451,7 +451,7 @@ describe('Form State Management', function () {
 
 describe('Form Security', function () {
     it('prevents password from being displayed in form state', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'password123')
@@ -466,7 +466,7 @@ describe('Form Security', function () {
     });
 
     it('validates password strength requirements', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'John Doe')
             ->set('email', 'john@example.com')
             ->set('password', 'weak')

--- a/tests/Integration/Livewire/Venues/Forms/FormTest.php
+++ b/tests/Integration/Livewire/Venues/Forms/FormTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Venues\Forms\Form;
+use App\Livewire\Venues\Forms\CreateEditForm;
 use App\Models\Events\Venue;
 use App\Models\Geo\State;
 use App\Models\Users\User;
@@ -17,7 +17,7 @@ beforeEach(function () {
 
 describe('Form Validation Rules', function () {
     it('validates required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', '')
             ->set('street_address', '')
             ->set('city', '')
@@ -37,7 +37,7 @@ describe('Form Validation Rules', function () {
     it('validates venue name uniqueness', function () {
         Venue::factory()->create(['name' => 'Existing Arena']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Existing Arena')
             ->set('street_address', '123 Main St')
             ->set('city', 'Los Angeles')
@@ -49,7 +49,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates state exists in database', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Arena')
             ->set('street_address', '123 Test St')
             ->set('city', 'Test City')
@@ -61,7 +61,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('validates zipcode format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Arena')
             ->set('street_address', '123 Test St')
             ->set('city', 'Test City')
@@ -73,7 +73,7 @@ describe('Form Validation Rules', function () {
     });
 
     it('accepts valid zipcode format', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Valid Arena')
             ->set('street_address', '123 Valid St')
             ->set('city', 'Valid City')
@@ -91,7 +91,7 @@ describe('Form Field Validation', function () {
         $longAddress = str_repeat('a', 256);
         $longCity = str_repeat('a', 256);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $longName)
             ->set('street_address', $longAddress)
             ->set('city', $longCity)
@@ -111,7 +111,7 @@ describe('Form Field Validation', function () {
         $validAddress = str_repeat('a', 255);
         $validCity = str_repeat('a', 255);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', $validName)
             ->set('street_address', $validAddress)
             ->set('city', $validCity)
@@ -123,7 +123,7 @@ describe('Form Field Validation', function () {
     });
 
     it('validates zipcode as numeric', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Arena')
             ->set('street_address', '123 Test St')
             ->set('city', 'Test City')
@@ -136,7 +136,7 @@ describe('Form Field Validation', function () {
 
     it('validates zipcode exact length', function () {
         // Test too short
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Arena')
             ->set('street_address', '123 Test St')
             ->set('city', 'Test City')
@@ -147,7 +147,7 @@ describe('Form Field Validation', function () {
         $form->assertHasErrors(['zipcode' => 'digits']);
 
         // Test too long
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Arena')
             ->set('street_address', '123 Test St')
             ->set('city', 'Test City')
@@ -161,7 +161,7 @@ describe('Form Field Validation', function () {
 
 describe('Form Store Operations', function () {
     it('can store valid venue data', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Wrestling Arena')
             ->set('street_address', '123 Wrestling Way')
             ->set('city', 'Los Angeles')
@@ -182,7 +182,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores venue with all required fields', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Complete Arena')
             ->set('street_address', '456 Complete St')
             ->set('city', 'Sacramento')
@@ -202,7 +202,7 @@ describe('Form Store Operations', function () {
     });
 
     it('stores venue with proper data types', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Type Test Arena')
             ->set('street_address', '789 Type Test St')
             ->set('city', 'San Francisco')
@@ -228,7 +228,7 @@ describe('Form Update Operations', function () {
             'zipcode' => '90210',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $venue)
             ->set('name', 'Updated Arena')
             ->set('street_address', '456 Updated Ave')
@@ -254,7 +254,7 @@ describe('Form Update Operations', function () {
         $venue1 = Venue::factory()->create(['name' => 'Venue One']);
         $venue2 = Venue::factory()->create(['name' => 'Venue Two']);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $venue2)
             ->set('name', 'Venue One')
             ->set('street_address', $venue2->street_address)
@@ -275,7 +275,7 @@ describe('Form Update Operations', function () {
             'zipcode' => '90210',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $venue)
             ->set('name', 'Same Name Arena')
             ->set('street_address', '456 Different St')
@@ -297,7 +297,7 @@ describe('Form Update Operations', function () {
             'zipcode' => '90210',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $venue)
             ->set('name', 'Partial Arena')
             ->set('street_address', '456 New Address')
@@ -316,7 +316,7 @@ describe('Form Update Operations', function () {
 
 describe('Form State Management', function () {
     it('resets form after successful store', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Arena')
             ->set('street_address', '123 Test St')
             ->set('city', 'Test City')
@@ -333,7 +333,7 @@ describe('Form State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Test Arena')
             ->set('street_address', '123 Test St')
             ->set('city', 'Test City')
@@ -358,7 +358,7 @@ describe('Form State Management', function () {
             'zipcode' => '95814',
         ]);
 
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->call('setModel', $venue);
 
         $form->assertSet('name', 'Load Test Arena');
@@ -371,7 +371,7 @@ describe('Form State Management', function () {
 
 describe('Form Address Validation', function () {
     it('validates complete address information', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Address Test Arena')
             ->set('street_address', '1234 Main Street')
             ->set('city', 'Los Angeles')
@@ -397,7 +397,7 @@ describe('Form Address Validation', function () {
         ];
 
         foreach ($addresses as $index => $address) {
-            $form = Livewire::test(Form::class)
+            $form = Livewire::test(CreateEditForm::class)
                 ->set('name', "Arena {$index}")
                 ->set('street_address', $address)
                 ->set('city', 'Test City')
@@ -416,7 +416,7 @@ describe('Form Address Validation', function () {
 
     it('validates state must exist in states table', function () {
         // Test with known invalid state
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'State Test Arena')
             ->set('street_address', '123 State St')
             ->set('city', 'State City')
@@ -428,7 +428,7 @@ describe('Form Address Validation', function () {
     });
 
     it('accepts valid state from states table', function () {
-        $form = Livewire::test(Form::class)
+        $form = Livewire::test(CreateEditForm::class)
             ->set('name', 'Valid State Arena')
             ->set('street_address', '123 Valid St')
             ->set('city', 'Valid City')

--- a/tests/Integration/Livewire/Wrestlers/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Modals/FormModalTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Livewire\Wrestlers\Forms\Form;
+use App\Livewire\Wrestlers\Forms\CreateEditForm;
 use App\Livewire\Wrestlers\Modals\FormModal;
 use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
@@ -20,7 +20,7 @@ describe('FormModal Configuration', function () {
         $method = $reflection->getMethod('getFormClass');
         $method->setAccessible(true);
 
-        expect($method->invoke($modal))->toBe(Form::class);
+        expect($method->invoke($modal))->toBe(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {
@@ -46,7 +46,7 @@ describe('FormModal Mounting', function () {
     it('can mount for creating new wrestler', function () {
         $component = Livewire::test(FormModal::class);
 
-        expect($component->instance()->form)->toBeInstanceOf(Form::class);
+        expect($component->instance()->form)->toBeInstanceOf(CreateEditForm::class);
         $component->assertSuccessful();
     });
 
@@ -55,7 +55,7 @@ describe('FormModal Mounting', function () {
 
         $component = Livewire::test(FormModal::class, ['modelId' => $wrestler->id]);
 
-        expect($component->instance()->form)->toBeInstanceOf(Form::class);
+        expect($component->instance()->form)->toBeInstanceOf(CreateEditForm::class);
         expect($component->instance()->form->name)->toBe($wrestler->name);
         $component->assertSuccessful();
     });


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the Livewire architecture standardization by renaming all generic Form classes to CreateEditForm for improved clarity and consistency.

## Changes Made

### Form Class Renaming
- **Renamed all Form.php files to CreateEditForm.php** across domains:
  - Referees/Forms/Form.php → CreateEditForm.php
  - Wrestlers/Forms/Form.php → CreateEditForm.php  
  - Events/Forms/Form.php → CreateEditForm.php
  - Venues/Forms/Form.php → CreateEditForm.php
  - Managers/Forms/Form.php → CreateEditForm.php
  - Stables/Forms/Form.php → CreateEditForm.php
  - TagTeams/Forms/Form.php → CreateEditForm.php
  - Titles/Forms/Form.php → CreateEditForm.php
  - Users/Forms/Form.php → CreateEditForm.php

### Modal Updates
- **Updated all FormModal classes** to reference new CreateEditForm classes
- **Fixed Referees FormModal** to properly extend BaseFormModal instead of BaseModal
- **Standardized dummy data pattern** using getDummyDataFields() method

### Test File Updates  
- **Updated all test files** to use CreateEditForm::class references
- **Maintained all existing test functionality** and coverage
- **Updated modal test files** to reference correct form classes

### Architectural Improvements
- **Improved naming clarity**: CreateEditForm clearly indicates dual purpose (create/edit)
- **Enhanced consistency**: All domains now follow same naming pattern
- **Better scalability**: Prepared for future separation of Create/Edit forms if needed
- **Type safety**: All @extends annotations updated with correct class names

## Benefits

✅ **Clearer Intent**: Form names now explicitly indicate they handle both creation and editing
✅ **Consistent Naming**: All domains follow the same naming convention  
✅ **Better Architecture**: Sets foundation for future form specialization
✅ **Maintained Compatibility**: All existing functionality preserved
✅ **Improved Developer Experience**: More descriptive class names aid understanding

## Test Plan

- [x] All form tests continue to pass with new class names
- [x] All modal tests reference correct form classes
- [x] Integration tests verify form functionality unchanged
- [x] No breaking changes to existing functionality

## Related

- Part of broader Livewire architecture standardization initiative
- Follows Phase 1 (Base Class Standardization) completed in PR #513
- Prepares for Phase 3 (Legacy Cleanup) and Phase 4 (Documentation)