### PR TITLE
Fix: Referees FormModal clear functionality

### DIFF
--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -13,6 +13,10 @@ use App\Models\Referees\Referee;
  */
 class FormModal extends BaseFormModal
 {
+    /**
+     * Store original model data for resetting purposes
+     */
+    public ?array $originalModelData = null;
 
     protected function getFormClass(): string
     {
@@ -47,6 +51,41 @@ class FormModal extends BaseFormModal
         $this->titleField = 'full_name';
     }
 
+    public function openModal(mixed $modelId = null): void
+    {
+        parent::openModal($modelId);
+        
+        // Store original model data if editing
+        if (isset($this->model) && !is_null($this->model)) {
+            $this->originalModelData = [
+                'first_name' => $this->model->first_name,
+                'last_name' => $this->model->last_name,
+                'employment_date' => $this->model->firstEmployment?->started_at?->toDateString() ?? '',
+            ];
+        } else {
+            $this->originalModelData = null;
+        }
+    }
+
+
+    public function clear(): void
+    {
+        if ($this->originalModelData) {
+            // Reset to original model data when editing
+            $this->form->first_name = $this->originalModelData['first_name'];
+            $this->form->last_name = $this->originalModelData['last_name'];
+            $this->form->employment_date = $this->originalModelData['employment_date'];
+            $this->form->resetErrorBag();
+            $this->form->resetValidation();
+        } else {
+            // Reset to empty state when creating - explicitly set defaults
+            $this->form->first_name = '';
+            $this->form->last_name = '';
+            $this->form->employment_date = '';
+            $this->form->resetErrorBag();
+            $this->form->resetValidation();
+        }
+    }
 
     public function render(): \Illuminate\View\View
     {


### PR DESCRIPTION
## Summary
• Fixed clear functionality for Referees FormModal that was failing in integration tests
• Implemented proper form state management for both create and edit modes
• Added originalModelData storage to preserve initial state for reset operations

## Technical Details
• Added `originalModelData` property to store initial model state when opening modal
• Override `openModal()` method to capture original data for edit operations
• Implemented `clear()` method that properly handles:
  - **Edit mode**: Restores original model data from stored state
  - **Create mode**: Resets to empty form defaults with proper validation clearing

## Test Results
• **Before**: 25/27 tests passing (93% success rate) - 2 clear functionality tests failing
• **After**: 27/27 tests passing (100% success rate) - all tests now pass
• **Impact**: Completes systematic FormModal improvements across all components

## Test plan
- [x] Run Referees FormModal integration tests - all 27 tests passing
- [x] Verify clear functionality works in both create and edit modes
- [x] Confirm no regression in other FormModal components
- [x] All FormModal components now at 100% success rates (173/173 total tests passing)