### PR TITLE
fix: prevent automatic styling commits on development branch

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -7,6 +7,7 @@ on:
       - '*/*'       # matches every branch containing a single '/'
       - '**'        # matches every branch
       - '!master'
+      - '!development'  # exclude protected development branch
     paths:
       - '**.php'
 


### PR DESCRIPTION
## Summary
- Exclude development branch from automatic Laravel Pint styling workflow
- Prevents direct commits to protected development branch
- Ensures all styling changes go through proper PR review process

## Changes
- Added `\!development` to pint.yml workflow branch exclusions
- Maintains automatic styling for all feature branches
- Preserves existing functionality while respecting branch protection

## Test plan
- [x] Verify workflow no longer runs on development branch pushes
- [x] Confirm feature branches still receive automatic styling
- [x] Test that styling changes require PR approval for development