### PR TITLE
feat: Phase 4 - Implement Advanced Action Composition Patterns (#544)

### DIFF
--- a/app/Actions/Stables/CreateAction.php
+++ b/app/Actions/Stables/CreateAction.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Actions\Stables;
 
-use App\Actions\Stables\EstablishAction;
 use App\Data\Stables\StableData;
 use App\Models\Stables\Stable;
 use App\Services\StableMembershipService;

--- a/app/Actions/Stables/DeleteAction.php
+++ b/app/Actions/Stables/DeleteAction.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Actions\Stables;
 
+use App\Data\Stables\StableMembershipData;
 use App\Models\Stables\Stable;
+use App\Services\StableMembershipService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -62,19 +64,16 @@ class DeleteAction
                 $stable->activityPeriods()->where('ended_at', null)->update(['ended_at' => $deletionDate]);
             }
 
-            // End current wrestler memberships (wrestlers continue as singles)
-            $stable->currentWrestlers->each(function ($wrestler) use ($stable, $deletionDate) {
-                $stable->wrestlers()->updateExistingPivot($wrestler->id, [
-                    'left_at' => $deletionDate,
-                ]);
-            });
+            // End all current memberships using service
+            if ($stable->currentWrestlers->isNotEmpty() || $stable->currentTagTeams->isNotEmpty()) {
+                $currentMembers = new StableMembershipData(
+                    wrestlers: $stable->currentWrestlers,
+                    tagTeams: $stable->currentTagTeams
+                );
 
-            // End current tag team memberships (tag teams continue independently)
-            $stable->currentTagTeams->each(function ($tagTeam) use ($stable, $deletionDate) {
-                $stable->tagTeams()->updateExistingPivot($tagTeam->id, [
-                    'left_at' => $deletionDate,
-                ]);
-            });
+                $membershipService = app(StableMembershipService::class);
+                $membershipService->removeMembers($stable, $currentMembers, $deletionDate);
+            }
 
             // Manager associations automatically end when wrestler/tag team memberships end
             // No direct manager removal needed since managers are associated through wrestlers/tag teams

--- a/app/Actions/Stables/RetireAction.php
+++ b/app/Actions/Stables/RetireAction.php
@@ -7,10 +7,12 @@ namespace App\Actions\Stables;
 use App\Actions\Managers\RetireAction as ManagersRetireAction;
 use App\Actions\TagTeams\RetireAction as TagTeamsRetireAction;
 use App\Actions\Wrestlers\RetireAction as WrestlersRetireAction;
+use App\Data\Stables\StableMembershipData;
 use App\Exceptions\Roster\CannotBeRetiredException;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
+use App\Services\StableMembershipService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -84,19 +86,17 @@ class RetireAction
             // Retire tag teams
             $tagTeamsToRetire->each(fn (TagTeam $tagTeam) => $this->tagTeamsRetireAction->handle($tagTeam, $retirementDate));
 
-            // End current memberships
+            // End current memberships using service
             // Note: Managers are not direct stable members, so we don't remove them
-            $stable->currentWrestlers->each(function (Wrestler $wrestler) use ($stable, $retirementDate) {
-                $stable->wrestlers()->updateExistingPivot($wrestler->id, [
-                    'left_at' => $retirementDate,
-                ]);
-            });
+            if ($stable->currentWrestlers->isNotEmpty() || $stable->currentTagTeams->isNotEmpty()) {
+                $currentMembers = new StableMembershipData(
+                    wrestlers: $stable->currentWrestlers,
+                    tagTeams: $stable->currentTagTeams
+                );
 
-            $stable->currentTagTeams->each(function (TagTeam $tagTeam) use ($stable, $retirementDate) {
-                $stable->tagTeams()->updateExistingPivot($tagTeam->id, [
-                    'left_at' => $retirementDate,
-                ]);
-            });
+                $membershipService = app(StableMembershipService::class);
+                $membershipService->removeMembers($stable, $currentMembers, $retirementDate);
+            }
 
             // Create retirement record for the stable
             $stable->retirements()->create([

--- a/app/Actions/Stables/ReuniteAction.php
+++ b/app/Actions/Stables/ReuniteAction.php
@@ -7,7 +7,6 @@ namespace App\Actions\Stables;
 use App\Exceptions\Roster\Stables\CannotBeEstablishedException;
 use App\Models\Stables\Stable;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class ReuniteAction
@@ -42,11 +41,6 @@ class ReuniteAction
 
         $reuniteDate ??= now();
 
-        DB::transaction(function () use ($stable, $reuniteDate): void {
-            $stable->activityPeriods()->create([
-                'started_at' => $reuniteDate,
-                'ended_at' => null,
-            ]);
-        });
+        EstablishAction::run($stable, $reuniteDate);
     }
 }

--- a/app/Actions/Stables/SplitStableAction.php
+++ b/app/Actions/Stables/SplitStableAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Stables;
 
+use App\Data\Stables\StableData;
 use App\Data\Stables\StableMembershipData;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
@@ -52,16 +53,7 @@ class SplitStableAction
         }
 
         return DB::transaction(function () use ($originalStable, $newStableName, $membersForNewStable, $date): Stable {
-            // Create the new stable
-            $newStable = Stable::create([
-                'name' => $newStableName,
-            ]);
-
-            // Create activity period to make the stable active
-            $newStable->activityPeriods()->create([
-                'started_at' => $date,
-                'ended_at' => null,
-            ]);
+            // We'll create the stable with CreateAction after filtering members
 
             // Filter members to only include employed/available ones and create Eloquent Collections
             $availableWrestlers = null;
@@ -70,7 +62,7 @@ class SplitStableAction
             if (isset($membersForNewStable['wrestlers'])) {
                 $filteredWrestlers = collect($membersForNewStable['wrestlers'])
                     ->filter(fn ($wrestler) => $wrestler->isEmployed());
-                
+
                 if ($filteredWrestlers->isNotEmpty()) {
                     $availableWrestlers = new Collection($filteredWrestlers->all());
                 }
@@ -79,13 +71,26 @@ class SplitStableAction
             if (isset($membersForNewStable['tagTeams'])) {
                 $filteredTagTeams = collect($membersForNewStable['tagTeams'])
                     ->filter(fn ($tagTeam) => $tagTeam->isEmployed());
-                
+
                 if ($filteredTagTeams->isNotEmpty()) {
                     $availableTagTeams = new Collection($filteredTagTeams->all());
                 }
             }
 
-            // Use service to transfer available members
+            // Create StableData with members and start date for CreateAction
+            $stableData = new StableData(
+                name: $newStableName,
+                start_date: $date,
+                members: new StableMembershipData(
+                    wrestlers: $availableWrestlers,
+                    tagTeams: $availableTagTeams
+                )
+            );
+
+            // Use CreateAction to create and establish the new stable with members
+            $newStable = CreateAction::run($stableData);
+
+            // Remove transferred members from original stable
             if ($availableWrestlers !== null || $availableTagTeams !== null) {
                 $membershipData = new StableMembershipData(
                     wrestlers: $availableWrestlers,
@@ -93,7 +98,7 @@ class SplitStableAction
                 );
 
                 $membershipService = app(StableMembershipService::class);
-                $membershipService->transferMembers($originalStable, $newStable, $membershipData, $date);
+                $membershipService->removeMembers($originalStable, $membershipData, $date);
             }
 
             return $newStable;

--- a/app/Actions/Stables/UpdateAction.php
+++ b/app/Actions/Stables/UpdateAction.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Actions\Stables;
 
-use App\Actions\Stables\EstablishAction;
 use App\Data\Stables\StableData;
 use App\Models\Stables\Stable;
 use App\Services\StableMembershipService;

--- a/tests/Integration/Actions/Stables/LifecycleTest.php
+++ b/tests/Integration/Actions/Stables/LifecycleTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-use App\Actions\Stables\EstablishAction;
 use App\Actions\Stables\DisbandAction;
+use App\Actions\Stables\EstablishAction;
 use App\Actions\Stables\RetireAction;
 use App\Actions\Stables\ReuniteAction;
 use App\Actions\Stables\UnretireAction;
 use App\Enums\Stables\StableStatus;
 use App\Exceptions\Roster\CannotBeUnretiredException;
-use App\Exceptions\Status\CannotBeActivatedException;
 use App\Exceptions\Roster\Stables\CannotBeEstablishedException;
+use App\Exceptions\Status\CannotBeActivatedException;
 use App\Exceptions\Status\CannotBeDisbandedException;
 use App\Models\Stables\Stable;
 use Illuminate\Support\Carbon;


### PR DESCRIPTION
## Summary
• Establishes sophisticated action composition where Actions call other Actions
• Creates elegant chains like SplitStableAction → CreateAction → EstablishAction  
• Eliminates code duplication by reusing existing action logic
• Centralizes business logic in reusable, composable components

## Test plan
- [x] SplitStableAction tests pass (19/19) - verifies CreateAction composition chain
- [x] RetireAction tests pass (8/8) - verifies StableMembershipService integration
- [x] Code passes linting with 5 style issues auto-fixed
- [x] Advanced composition patterns work correctly in isolation and integration