### PR TITLE
Fix trait method collisions in TagTeam and Stable models

### DIFF
--- a/app/Models/Stables/Stable.php
+++ b/app/Models/Stables/Stable.php
@@ -12,7 +12,6 @@ use App\Models\Concerns\HasActivityPeriods;
 use App\Models\Concerns\HasMembers;
 use App\Models\Concerns\HasStatusHistory;
 use App\Models\Concerns\IsRetirable;
-use App\Models\Concerns\ValidatesRetirement;
 use App\Models\Concerns\ValidatesStableLifecycle;
 use App\Models\Contracts\Debutable;
 use App\Models\Contracts\HasActivityPeriods as HasActivityPeriodsContract;
@@ -128,7 +127,6 @@ class Stable extends Model implements Debutable, HasActivityPeriodsContract, Ret
     use IsRetirable;
 
     use SoftDeletes;
-    use ValidatesRetirement;
     use ValidatesStableLifecycle;
 
     /**

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -14,9 +14,6 @@ use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsRetirable;
 use App\Models\Concerns\IsSuspendable;
 use App\Models\Concerns\ProvidesTagTeamWrestlers;
-use App\Models\Concerns\ValidatesEmployment;
-use App\Models\Concerns\ValidatesRetirement;
-use App\Models\Concerns\ValidatesSuspension;
 use App\Models\Concerns\ValidatesTagTeamLifecycle;
 use App\Models\Contracts\BookableCompetitor;
 use App\Models\Contracts\CanBeAStableMember;
@@ -150,9 +147,6 @@ class TagTeam extends Model implements BookableCompetitor, CanBeAStableMember, C
     use ProvidesTagTeamWrestlers;
 
     use SoftDeletes;
-    use ValidatesEmployment;
-    use ValidatesRetirement;
-    use ValidatesSuspension;
     use ValidatesTagTeamLifecycle;
 
     /**


### PR DESCRIPTION
## Summary
- Resolves fatal trait method collision errors preventing database migrations
- Removes redundant validation traits that conflict with comprehensive lifecycle validation traits
- Maintains business logic validation through specialized lifecycle traits

## Changes
- **TagTeam.php**: Removed `ValidatesEmployment`, `ValidatesRetirement`, and `ValidatesSuspension` traits, keeping only `ValidatesTagTeamLifecycle`
- **Stable.php**: Removed `ValidatesRetirement` trait, keeping only `ValidatesStableLifecycle`

## Technical Details
The comprehensive lifecycle validation traits (`ValidatesTagTeamLifecycle`, `ValidatesStableLifecycle`) already provide ALL the validation methods from the basic traits but with entity-specific business logic. The basic traits were causing method name collisions without adding value.

## Test Plan
- [x] Database migrations now run successfully without trait collision errors
- [x] Code formatting passes (Laravel Pint)
- [ ] Run full test suite to ensure validation logic remains intact
- [ ] Verify TagTeam and Stable model functionality in application