### PR TITLE
feat: fix TagTeam exceptions architecture and eliminate missing trait errors

### DIFF
--- a/app/Exceptions/Roster/TagTeams/CannotBeDeletedException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeDeletedException.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
-use App\Exceptions\Concerns\ProvidesRosterExceptionContext;
+use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
-use Exception;
 
 /**
  * Exception thrown when a tag team cannot be deleted due to business rule violations.
@@ -45,10 +44,8 @@ use Exception;
  * }
  * ```
  */
-class CannotBeDeletedException extends Exception
+class CannotBeDeletedException extends BaseBusinessException
 {
-    use ProvidesRosterExceptionContext;
-
     /**
      * Create exception for attempting to delete an employed tag team.
      *
@@ -154,15 +151,5 @@ class CannotBeDeletedException extends Exception
         $context = self::formatModelContext($tagTeam);
 
         return new self("{$context} cannot be deleted due to ongoing investigations: {$investigationDetails}. Complete all investigations before deletion.");
-    }
-
-    /**
-     * Get tag team context for logging and debugging.
-     *
-     * @return array<string, mixed> Tag team details for context
-     */
-    public function getTagTeamContext(): array
-    {
-        return $this->getRosterMemberContext();
     }
 }

--- a/app/Exceptions/Roster/TagTeams/CannotBeReinstatedException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeReinstatedException.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
-use App\Exceptions\Concerns\ProvidesRosterExceptionContext;
+use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
-use Exception;
 
 /**
  * Exception thrown when a tag team cannot be reinstated due to business rule violations.
@@ -41,10 +40,8 @@ use Exception;
  * }
  * ```
  */
-class CannotBeReinstatedException extends Exception
+class CannotBeReinstatedException extends BaseBusinessException
 {
-    use ProvidesRosterExceptionContext;
-
     /**
      * Create exception for attempting to reinstate a non-suspended tag team.
      *
@@ -125,15 +122,5 @@ class CannotBeReinstatedException extends Exception
         $context = self::formatModelContext($tagTeam);
 
         return new self("{$context} reinstatement conflicts with existing schedules: {$conflictDetails}. Coordinate timing with event planning and storyline development.");
-    }
-
-    /**
-     * Get tag team context for logging and debugging.
-     *
-     * @return array<string, mixed> Tag team details for context
-     */
-    public function getTagTeamContext(): array
-    {
-        return $this->getRosterMemberContext();
     }
 }

--- a/app/Exceptions/Roster/TagTeams/CannotBeReleasedException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeReleasedException.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
-use App\Exceptions\Concerns\ProvidesRosterExceptionContext;
+use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
-use Exception;
 
 /**
  * Exception thrown when a tag team cannot be released due to business rule violations.
@@ -41,10 +40,8 @@ use Exception;
  * }
  * ```
  */
-class CannotBeReleasedException extends Exception
+class CannotBeReleasedException extends BaseBusinessException
 {
-    use ProvidesRosterExceptionContext;
-
     /**
      * Create exception for attempting to release an unemployed tag team.
      *
@@ -140,15 +137,5 @@ class CannotBeReleasedException extends Exception
         $context = self::formatModelContext($tagTeam);
 
         return new self("{$context} cannot be released during probationary period: {$probationDetails}. Complete probationary requirements before release consideration.");
-    }
-
-    /**
-     * Get tag team context for logging and debugging.
-     *
-     * @return array<string, mixed> Tag team details for context
-     */
-    public function getTagTeamContext(): array
-    {
-        return $this->getRosterMemberContext();
     }
 }

--- a/app/Exceptions/Roster/TagTeams/CannotBeRestoredException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeRestoredException.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
-use App\Exceptions\Concerns\ProvidesRosterExceptionContext;
+use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
-use Exception;
 
 /**
  * Exception thrown when a tag team cannot be restored due to business rule violations.
@@ -41,10 +40,8 @@ use Exception;
  * }
  * ```
  */
-class CannotBeRestoredException extends Exception
+class CannotBeRestoredException extends BaseBusinessException
 {
-    use ProvidesRosterExceptionContext;
-
     /**
      * Create exception for attempting to restore a non-deleted tag team.
      *
@@ -151,15 +148,5 @@ class CannotBeRestoredException extends Exception
         $context = self::formatModelContext($tagTeam);
 
         return new self("{$context} cannot be restored due to legal or contractual conflicts: {$legalDetails}. Resolve all legal issues before restoration.");
-    }
-
-    /**
-     * Get tag team context for logging and debugging.
-     *
-     * @return array<string, mixed> Tag team details for context
-     */
-    public function getTagTeamContext(): array
-    {
-        return $this->getRosterMemberContext();
     }
 }

--- a/app/Exceptions/Roster/TagTeams/CannotBeSuspendedException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeSuspendedException.php
@@ -4,9 +4,8 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
-use App\Exceptions\Concerns\ProvidesRosterExceptionContext;
+use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
-use Exception;
 
 /**
  * Exception thrown when a tag team cannot be suspended due to business rule violations.
@@ -41,10 +40,8 @@ use Exception;
  * }
  * ```
  */
-class CannotBeSuspendedException extends Exception
+class CannotBeSuspendedException extends BaseBusinessException
 {
-    use ProvidesRosterExceptionContext;
-
     /**
      * Create exception for attempting to suspend an unemployed tag team.
      *
@@ -125,15 +122,5 @@ class CannotBeSuspendedException extends Exception
         $context = self::formatModelContext($tagTeam);
 
         return new self("{$context} suspension conflicts with active storylines: {$storylineDetails}. Coordinate with creative team before disciplinary actions.");
-    }
-
-    /**
-     * Get tag team context for logging and debugging.
-     *
-     * @return array<string, mixed> Tag team details for context
-     */
-    public function getTagTeamContext(): array
-    {
-        return $this->getRosterMemberContext();
     }
 }


### PR DESCRIPTION
## Summary
• Fix fatal errors caused by missing `ProvidesRosterExceptionContext` trait in TagTeam exceptions
• Update 5 TagTeam exception classes to extend `BaseBusinessException` instead of `Exception`
• Align TagTeam exceptions with established codebase architectural patterns
• Remove unnecessary methods that referenced the missing trait

## Problem Solved

**Before**: 5 TagTeam exception classes were trying to use a non-existent trait `ProvidesRosterExceptionContext`, causing fatal errors when these exceptions were instantiated.

**After**: All TagTeam exceptions now properly extend `BaseBusinessException` like every other exception in the codebase, providing proven functionality and eliminating fatal errors.

## Files Changed

### Fixed TagTeam Exceptions:
- `app/Exceptions/Roster/TagTeams/CannotBeSuspendedException.php`
- `app/Exceptions/Roster/TagTeams/CannotBeRestoredException.php` 
- `app/Exceptions/Roster/TagTeams/CannotBeReleasedException.php`
- `app/Exceptions/Roster/TagTeams/CannotBeReinstatedException.php`
- `app/Exceptions/Roster/TagTeams/CannotBeDeletedException.php`

## Changes Made Per File

1. **Removed**: `use App\Exceptions\Concerns\ProvidesRosterExceptionContext;`
2. **Added**: `use App\Exceptions\BaseBusinessException;`
3. **Changed**: `extends Exception` → `extends BaseBusinessException`
4. **Removed**: `use ProvidesRosterExceptionContext;` trait usage
5. **Removed**: `getTagTeamContext()` methods that called missing trait methods

## Technical Benefits

- **✅ Eliminates fatal errors** from missing trait references
- **✅ Provides proven functionality** from `BaseBusinessException` (like `formatModelContext()`)
- **✅ Follows established patterns** used throughout the codebase (42+ other exception classes)
- **✅ Maintains business logic** - all static factory methods preserved
- **✅ Improves maintainability** through architectural consistency
- **✅ Consistent exception inheritance** across all business domains

## Root Cause

The `ProvidesRosterExceptionContext` trait was referenced in commit `f9c29e82` (July 30, 2025) as part of PR #548 "TagTeams Actions architectural refinements", but the trait file was never actually created. This created a mismatch where TagTeam exceptions used a different architecture pattern than the rest of the codebase.

## Verification

- **✅ No syntax errors** in any of the 5 fixed files
- **✅ No remaining references** to the missing trait
- **✅ Laravel application loads successfully** without fatal errors  
- **✅ Code formatting passes** Laravel Pint checks
- **✅ Consistent architecture** with all other exception classes

## Architecture Alignment

This change brings TagTeam exceptions in line with the established exception architecture used by:
- Roster exceptions (8 files)
- Stables exceptions (9 files) 
- Titles exceptions (5 files)
- Matches exceptions (3 files)
- Scheduling exceptions (2 files)
- Business Rules exceptions (4 files)
- Data exceptions (1 file)

All exceptions now consistently extend `BaseBusinessException` and follow the same proven patterns.