### PR TITLE
docs: Add multi-tenant architecture specs and consolidate documentation

### DIFF
--- a/.agent-os/product/mission-lite.md
+++ b/.agent-os/product/mission-lite.md
@@ -1,0 +1,15 @@
+# Ringside Mission (Lite)
+
+**Ringside** empowers wrestling promoters to manage their operations professionally—handling roster management, event planning, match generation, and championship tracking—so they can focus on creative storytelling while the system ensures business rule compliance and data integrity.
+
+## Core Value
+Unified wrestling promotion management with computed status intelligence, eliminating data inconsistencies and manual tracking overhead.
+
+## Target Users
+Independent promoters, regional promotion owners, operations managers, and wrestling academies seeking professional-grade promotion management.
+
+## Differentiators
+- Industry-specific business logic for wrestling operations
+- Computed status system (never stored, always accurate)
+- Complete temporal tracking for historical accuracy
+- 100% test coverage for enterprise reliability

--- a/.agent-os/product/prd-lite.md
+++ b/.agent-os/product/prd-lite.md
@@ -1,0 +1,52 @@
+# Ringside PRD (Lite)
+
+> Condensed product context for AI development assistance
+
+## What Is Ringside?
+
+A **wrestling promotion management system** for professional wrestling promoters to manage rosters, events, matches, and championships.
+
+## Core Entities
+
+| Entity | Purpose | Key Rules |
+|--------|---------|-----------|
+| **Wrestler** | Individual performer | Employable, bookable, can join teams/stables |
+| **Tag Team** | 2-wrestler team | Bookable when both members are bookable |
+| **Manager** | Manages wrestlers/teams | NOT bookable, both parties must be employed |
+| **Referee** | Officiates matches | Bookable when employed + healthy |
+| **Stable** | Wrestling faction | Min 3 members for active status |
+| **Event** | Wrestling show | Contains matches at a venue |
+| **Match** | Competition | 13+ types, requires bookable competitors |
+| **Title** | Championship belt | Singles or Tag Team type |
+
+## Business Rules
+
+**Status Computation** (never stored, always computed):
+```
+Priority: Retired > Employed > FutureEmployment > Released > Unemployed
+```
+
+**Bookability** = Employed + Not Injured + Not Suspended + Not Future-Dated
+
+**Employment Relationships**: Manager-Wrestler/TagTeam requires both employed
+
+## Match Types
+Singles, Tag Team, Triple Threat, Fatal 4 Way, 6/8/10-Man Tag, Handicap (2v1, 3v2), Battle Royal, Royal Rumble, Tornado Tag, Gauntlet
+
+## Tech Stack
+- PHP 8.4 / Laravel 12 / Livewire 3 / Tailwind 4.1
+- MySQL / Eloquent ORM
+- Pest testing (100% coverage required)
+
+## Current Status
+- **Phase 0**: Complete (core platform)
+- **Phase 1**: In planning (dashboard, mobile, analytics)
+
+## Key Patterns
+- Computed status (no stored status fields)
+- Polymorphic relationships (wrestlers OR tag teams as champions/competitors)
+- Temporal data (all employment/membership has date ranges)
+- Soft deletes on all entities
+
+---
+*Full PRD: `.agent-os/product/prd.md` | Technical: `CLAUDE.md`*

--- a/.agent-os/product/prd.md
+++ b/.agent-os/product/prd.md
@@ -1,0 +1,409 @@
+# Ringside - Product Requirements Document
+
+> Version: 1.0
+> Last Updated: 2026-01-15
+> Status: Phase 0 Complete, Phase 1 In Planning
+
+---
+
+## 1. Executive Summary
+
+**Ringside** is a comprehensive wrestling promotion management system that empowers professional wrestling promoters to efficiently manage every aspect of their wrestling company operations. The platform provides unified roster management, intelligent match generation, championship tracking, and sophisticated business rule enforcement—enabling promoters to focus on creative storytelling while Ringside handles operational complexity.
+
+### Key Value Propositions
+- **Unified Operations**: Single platform for roster, events, matches, and championships
+- **Business Intelligence**: Computed status system eliminating data inconsistencies
+- **Temporal Accuracy**: Complete historical tracking with point-in-time calculations
+- **Industry-Specific Logic**: Deep understanding of wrestling business rules and patterns
+
+### Target Market
+Independent wrestling promotions, regional wrestling companies, wrestling academies, and operations managers seeking professional-grade promotion management tools.
+
+---
+
+## 2. Problem Statement
+
+### Industry Challenges
+
+Wrestling promoters face complex operational challenges that generic business tools cannot address:
+
+**Roster Management Complexity**
+- Tracking employment status across multiple personnel types (wrestlers, managers, referees)
+- Managing injuries, suspensions, and retirements with proper business logic
+- Maintaining accurate career histories and employment relationships
+
+**Event Planning Friction**
+- Coordinating matches with complex eligibility rules
+- Ensuring competitor availability (employment + health + suspension status)
+- Managing 15+ different match types with specific requirements
+
+**Championship Administration**
+- Tracking title lineages and reign durations
+- Managing championship succession and storyline continuity
+- Maintaining championship prestige through accurate historical records
+
+**Business Rule Enforcement**
+- Wrestling industry has unique employment patterns and status hierarchies
+- Manager-talent relationships have specific constraints
+- Match eligibility depends on multiple computed factors
+
+### Current Solutions Gap
+
+Existing tools (spreadsheets, generic databases, manual tracking) fail wrestling promotions because they:
+- Cannot compute status from employment/lifecycle data
+- Don't understand wrestling-specific relationship rules
+- Lack temporal tracking for historical accuracy
+- Require manual enforcement of business logic
+
+---
+
+## 3. Target Users
+
+### Primary Personas
+
+| Persona | Profile | Key Needs |
+|---------|---------|-----------|
+| **Independent Promoter** | Solo operator, 1-3 shows/month | Streamlined roster tracking, simple event scheduling |
+| **Regional Promotion Owner** | 10-50 talent, monthly events | Full employment management, championship system |
+| **Operations Manager** | Day-to-day for larger companies | Regulatory compliance, reporting, talent utilization |
+| **Wrestling Trainer** | Academy managing developmental talent | Student progress tracking, practice show booking |
+
+### Secondary Personas
+
+| Persona | Access Level | Use Case |
+|---------|--------------|----------|
+| **Wrestling Talent** | View-only | Personal career tracking, match history |
+| **Fans/Media** | Public views | Championship histories, roster information |
+
+### User Success Metrics
+- 70% reduction in administrative overhead
+- Elimination of roster status inconsistencies
+- Ability to manage larger, more complex operations
+- Improved championship and storyline tracking
+
+---
+
+## 4. Product Overview
+
+### Core Domain Concepts
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│                        RINGSIDE DOMAIN                          │
+├─────────────────────────────────────────────────────────────────┤
+│                                                                 │
+│  ROSTER                    EVENTS                 TITLES        │
+│  ┌─────────┐              ┌─────────┐            ┌─────────┐   │
+│  │Wrestlers│──┐           │  Event  │            │  Title  │   │
+│  └─────────┘  │           └────┬────┘            └────┬────┘   │
+│  ┌─────────┐  │                │                      │        │
+│  │Tag Teams│──┼───────────►┌───┴───┐◄────────────────┘        │
+│  └─────────┘  │            │ Match │                           │
+│  ┌─────────┐  │            └───┬───┘                           │
+│  │Managers │──┤                │                               │
+│  └─────────┘  │           ┌────┴────┐                          │
+│  ┌─────────┐  │           │ Result  │                          │
+│  │Referees │──┘           └─────────┘                          │
+│  └─────────┘                                                   │
+│  ┌─────────┐              ┌─────────┐                          │
+│  │ Stables │              │ Venues  │                          │
+│  └─────────┘              └─────────┘                          │
+│                                                                 │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+### System Architecture
+
+- **Backend**: PHP 8.4, Laravel 12, Eloquent ORM
+- **Frontend**: Livewire 3, Alpine.js, Tailwind CSS 4.1
+- **Database**: MySQL with sophisticated relationship schema
+- **Testing**: Pest 4.0 with 100% coverage requirement
+- **Quality**: PHPStan, Laravel Pint, Rector
+
+---
+
+## 5. Feature Specifications
+
+### 5.1 Roster Management
+
+#### Wrestlers
+- **Attributes**: Name, height, weight, hometown, signature move
+- **Employment**: Hire/fire dates with temporal history
+- **Status**: Computed from employment data (Employed, Unemployed, Retired, Future Employment, Released)
+- **Lifecycle**: Injuries, suspensions, retirements with date tracking
+- **Relationships**: Can join tag teams, stables; can be managed
+
+#### Tag Teams
+- **Formation**: Exactly 2 wrestlers per team
+- **Employment**: Independent tracking from individual wrestlers
+- **Membership**: Join/leave dates with complete history
+- **Bookability**: All current members must be individually bookable
+
+#### Managers
+- **Role**: Professional managers who guide wrestler/tag team careers
+- **Relationships**: Can manage both wrestlers and tag teams simultaneously
+- **Employment Rule**: Both manager AND managed entity must be employed
+- **Note**: Managers are NOT bookable (don't participate in matches)
+
+#### Referees
+- **Role**: Officials who officiate matches
+- **Employment**: Standard employment tracking with injuries/suspensions
+- **Bookability**: Bookable when employed, healthy, and not suspended
+- **Assignment**: Can be assigned to multiple matches per event
+
+#### Stables
+- **Definition**: Wrestling factions/groups
+- **Membership**: Wrestlers and/or tag teams
+- **Minimum**: 3 members required for active status
+- **Lifecycle**: Formation, activity periods, disbandment
+
+### 5.2 Event & Match Management
+
+#### Events
+- **Attributes**: Name, date, venue, preview content
+- **Status**: Computed from date (Scheduled, Past, Unscheduled)
+- **Structure**: Contains multiple matches organized by match number
+
+#### Match Types (13+)
+| Type | Competitors | Notes |
+|------|-------------|-------|
+| Singles | 2 | One-on-one |
+| Tag Team | 2 teams | Standard tag match |
+| Triple Threat | 3 | First to score wins |
+| Triangle | 3 | Three-way dance |
+| Fatal 4 Way | 4 | Four competitors |
+| 6/8/10-Man Tag | 2 teams | Large team matches |
+| Handicap | 2v1 or 3v2 | Uneven sides |
+| Battle Royal | Many | Last one standing |
+| Royal Rumble | 30 | Timed entries |
+| Tornado Tag | 2 teams | All in ring simultaneously |
+| Gauntlet | 2+ | Sequential matches |
+
+#### Match Results
+- **Decisions**: Pinfall, Submission, Count Out, Disqualification, Draw, No Decision
+- **Tracking**: Winner(s), loser(s), decision type, championship implications
+
+### 5.3 Championship System
+
+#### Titles
+- **Types**: Singles (individual wrestlers) or Tag Team
+- **Lifecycle**: Undebuted → Pending Debut → Active → Inactive → Retired
+- **Champion Types**: Polymorphic (wrestlers or tag teams can hold titles)
+
+#### Championships (Reigns)
+- **Tracking**: Won date, lost date, associated match
+- **Duration**: Automatically calculated reign length
+- **Lineage**: Complete championship history maintained
+
+### 5.4 Business Rules Engine
+
+#### Status Computation
+All status fields are **computed, never stored**, eliminating data inconsistency:
+
+```
+Priority Hierarchy:
+1. Retired (highest priority)
+2. Employed
+3. Future Employment
+4. Released
+5. Unemployed (default)
+```
+
+#### Bookability Rules
+An entity is **bookable** when ALL conditions are met:
+- Currently employed
+- Not injured
+- Not suspended
+- Not awaiting future employment start date
+
+#### Relationship Constraints
+- Manager employment: Both parties must be employed
+- Stable membership: Entity must be employed to join
+- Match participation: Must be bookable + match type eligible
+
+### 5.5 Venue Management
+
+- **Attributes**: Name, address, city, state, zipcode
+- **Event History**: Track all events held at venue
+- **Usage**: Associate events with venues for location tracking
+
+---
+
+## 6. User Workflows
+
+### Daily Promoter Workflow
+1. **Dashboard Review**: Check upcoming events, roster alerts
+2. **Roster Updates**: Process injuries, returns, employment changes
+3. **Match Planning**: Build match cards for upcoming events
+4. **Championship Management**: Update title situations as needed
+
+### Event Creation Flow
+1. Create event with name, date, venue
+2. Add matches with type selection
+3. Assign competitors (system validates bookability)
+4. Assign referees (system validates availability)
+5. Set championship stakes if applicable
+6. Publish event
+
+### Match Booking Flow
+1. Select match type (UI adapts to type)
+2. Choose competitors from bookable roster
+3. System validates eligibility rules
+4. Assign referee(s)
+5. Optionally attach title defense
+6. Save match to event
+
+### Championship Management Flow
+1. Create title with type (Singles/Tag Team)
+2. Crown initial champion (via match or assignment)
+3. Track defenses through match results
+4. System maintains lineage automatically
+5. Manage title status (activate, retire)
+
+---
+
+## 7. Technical Architecture
+
+### Technology Stack
+| Layer | Technology | Purpose |
+|-------|------------|---------|
+| Backend | PHP 8.4 | Server-side logic |
+| Framework | Laravel 12 | Application structure |
+| Frontend | Livewire 3 | Dynamic components |
+| JS | Alpine.js | Client-side interactivity |
+| CSS | Tailwind 4.1 | Styling |
+| Database | MySQL | Data persistence |
+| ORM | Eloquent | Database abstraction |
+| Testing | Pest 4.0 | Test framework |
+
+### Key Architectural Patterns
+
+**Computed Status (Never Stored)**
+```php
+// Status derived from actual data
+public function status(): EmploymentStatus
+{
+    if ($this->isRetired()) return EmploymentStatus::Retired;
+    if ($this->isCurrentlyEmployed()) return EmploymentStatus::Employed;
+    // ... priority chain
+}
+```
+
+**Polymorphic Relationships**
+- Match competitors can be wrestlers OR tag teams
+- Champions can be wrestlers OR tag teams
+- Managed entities can be wrestlers OR tag teams
+
+**Temporal Data Management**
+- All employment/membership uses date ranges
+- Point-in-time queries supported
+- Complete historical reconstruction possible
+
+### Data Model Overview
+- **Core Entities**: Wrestler, TagTeam, Manager, Referee, Stable, Event, EventMatch, Title
+- **Pivot Tables**: Employments, memberships, match competitors, championships
+- **Soft Deletes**: All entities support soft deletion for data integrity
+
+---
+
+## 8. Roadmap
+
+### Phase 0: Core Platform ✅ COMPLETE
+- Wrestler, Tag Team, Manager, Referee management
+- Event and Match system with 15+ match types
+- Championship system with lineage tracking
+- Stable/faction management
+- Complete business rule enforcement
+- 100% test coverage
+
+### Phase 1: User Experience (Current Priority)
+- [ ] Executive dashboard with metrics
+- [ ] Mobile responsiveness
+- [ ] UI/UX polish
+- [ ] Reporting and analytics
+
+### Phase 2: API & Integration
+- [ ] RESTful API
+- [ ] Webhooks
+- [ ] Social media integration
+- [ ] Calendar export
+
+### Phase 3: Advanced Features
+- [ ] Storyline management
+- [ ] Financial/payroll tracking
+- [ ] Contract management
+
+### Phase 4: Multi-Promotion
+- [ ] Multiple promotion support
+- [ ] Cross-promotion events
+- [ ] Talent sharing/loans
+
+### Phase 5: Community
+- [ ] Fan portal
+- [ ] Voting system
+- [ ] Media management
+
+---
+
+## 9. Success Metrics
+
+### Quality Standards
+| Metric | Target | Current |
+|--------|--------|---------|
+| Test Coverage | 100% | ✅ 100% |
+| Production Bugs | Zero critical | ✅ Zero |
+| Page Load Time | < 200ms | ✅ Met |
+| Business Rule Coverage | 100% | ✅ 100% |
+
+### Phase 1 Targets
+- User satisfaction: > 4.5/5
+- Mobile usage: > 60% of traffic
+- Dashboard engagement: > 80% of users
+- Performance: 30% improvement
+
+### Long-term Goals
+- Support 100+ wrestling promotions
+- 50+ third-party API integrations
+- 10,000+ active community users
+- Industry standard for wrestling promotion management
+
+---
+
+## 10. Glossary
+
+### Domain Terminology
+
+| Term | Definition |
+|------|------------|
+| **Bookable** | An entity eligible to participate in matches (employed + healthy + not suspended) |
+| **Stable** | A wrestling faction/group containing wrestlers and/or tag teams |
+| **Reign** | A period during which a wrestler/team holds a championship |
+| **Lineage** | The historical record of all championship holders |
+| **Card** | The list of matches scheduled for an event |
+| **Heel/Face** | Character alignment (villain/hero) - future feature |
+| **Push** | Promotional focus on a wrestler - future feature |
+
+### Status Definitions
+
+| Status | Meaning |
+|--------|---------|
+| **Employed** | Currently under contract with active employment |
+| **Unemployed** | No active or pending employment |
+| **Future Employment** | Hired but start date is in the future |
+| **Released** | Employment terminated (fired) |
+| **Retired** | Voluntarily ended career |
+| **Suspended** | Temporarily barred from competition |
+| **Injured** | Cannot compete due to injury |
+
+### Relationship Types
+
+| Relationship | Entities | Description |
+|--------------|----------|-------------|
+| **Employment** | Manager ↔ Wrestler/TagTeam | Professional management relationship |
+| **Membership** | Stable ↔ Wrestler/TagTeam | Faction membership with join/leave dates |
+| **Partnership** | Wrestler ↔ TagTeam | Tag team membership with history |
+| **Championship** | Title ↔ Wrestler/TagTeam | Title holder relationship with reign tracking |
+
+---
+
+*This document serves as the authoritative reference for Ringside product requirements. For technical implementation details, see `CLAUDE.md` and `docs/architecture/`.*

--- a/.agent-os/specs/2025-08-28-design-system/spec-lite.md
+++ b/.agent-os/specs/2025-08-28-design-system/spec-lite.md
@@ -1,0 +1,10 @@
+# Design System - Quick Reference
+
+> Comprehensive Blade component library based on Metronic Tailwind template
+
+Create a comprehensive design system with anonymous Blade components based on the Metronic Tailwind template, following FluxUI architectural patterns and design principles. This design system provides reusable, well-tested UI components that maintain Metronic's professional design while integrating seamlessly with Ringside's wrestling management system and existing Livewire + Tailwind 4.1 setup.
+
+## Key Points
+- Build comprehensive Blade component library based on Metronic Tailwind template design system
+- Follow FluxUI architectural patterns for component organization and API design consistency
+- Integrate seamlessly with existing Livewire + Tailwind 4.1 setup and wrestling domain requirements

--- a/.agent-os/specs/2025-08-28-design-system/spec.md
+++ b/.agent-os/specs/2025-08-28-design-system/spec.md
@@ -1,12 +1,12 @@
 # Spec Requirements Document
 
-> Spec: Metronic Component Library
+> Spec: Design System
 > Created: 2025-08-28
 > Status: Planning
 
 ## Overview
 
-Create a comprehensive anonymous Blade component library based on the Metronic Tailwind template, following FluxUI architectural patterns and design principles. This component library will provide reusable, domain-agnostic UI components that maintain Metronic's professional design while integrating seamlessly with any Laravel application and the existing Livewire + Tailwind 4.1 setup.
+Create a comprehensive design system with anonymous Blade components based on the Metronic Tailwind template, following FluxUI architectural patterns and design principles. This design system provides reusable, domain-agnostic UI components that maintain Metronic's professional design while integrating seamlessly with any Laravel application and the existing Livewire + Tailwind 4.1 setup.
 
 ## User Stories
 
@@ -52,5 +52,8 @@ As a development team, I want to maintain styling and behavior changes in a sing
 
 ## Spec Documentation
 
-- Tasks: @.agent-os/specs/2025-08-28-metronic-component-library/tasks.md
-- Technical Specification: @.agent-os/specs/2025-08-28-metronic-component-library/sub-specs/technical-spec.md
+- Tasks: @.agent-os/specs/2025-08-28-design-system/tasks.md
+- Technical Specification: @.agent-os/specs/2025-08-28-design-system/sub-specs/technical-spec.md
+- Design Tokens: @.agent-os/specs/2025-08-28-design-system/sub-specs/design-tokens.md
+- Component Inventory: @.agent-os/specs/2025-08-28-design-system/sub-specs/component-inventory.md
+- Page Patterns: @.agent-os/specs/2025-08-28-design-system/sub-specs/page-patterns.md

--- a/.agent-os/specs/2025-08-28-design-system/sub-specs/component-inventory.md
+++ b/.agent-os/specs/2025-08-28-design-system/sub-specs/component-inventory.md
@@ -1,6 +1,7 @@
 # Component Inventory
 
-This is the comprehensive component inventory for the spec detailed in @.agent-os/specs/2025-08-28-metronic-component-library/spec.md
+> Design System
+> Reference: @.agent-os/specs/2025-08-28-design-system/spec.md
 
 > Created: 2025-08-28
 > Version: 1.0.0

--- a/.agent-os/specs/2025-08-28-design-system/sub-specs/design-tokens.md
+++ b/.agent-os/specs/2025-08-28-design-system/sub-specs/design-tokens.md
@@ -1,0 +1,243 @@
+# Design Tokens
+
+> Design System
+> Reference: @.agent-os/specs/2025-08-28-design-system/spec.md
+
+---
+
+## Overview
+
+Design tokens are the foundational visual design decisions that ensure consistency across the entire application. These tokens are implemented as Tailwind CSS custom properties and utility classes.
+
+---
+
+## Color Palette
+
+### Brand Colors
+
+| Token | Tailwind Class | Usage |
+|-------|---------------|-------|
+| Primary | `bg-primary`, `text-primary` | Primary actions, links, focus states |
+| Secondary | `bg-secondary`, `text-secondary` | Secondary actions, subtle emphasis |
+| Accent | `bg-accent`, `text-accent` | Highlights, notifications |
+
+### Semantic Colors
+
+| Token | Tailwind Class | Usage |
+|-------|---------------|-------|
+| Success | `bg-success`, `text-success` | Positive states, confirmations |
+| Warning | `bg-warning`, `text-warning` | Caution states, alerts |
+| Danger | `bg-danger`, `text-danger` | Error states, destructive actions |
+| Info | `bg-info`, `text-info` | Informational states |
+
+### Neutral Colors
+
+| Token | Usage |
+|-------|-------|
+| `gray-50` - `gray-950` | Backgrounds, borders, text |
+| `white` | Card backgrounds, light mode base |
+| `black` | Text, dark mode elements |
+
+### Dark Mode
+
+All color tokens support dark mode via Tailwind's `dark:` variant:
+```blade
+<div class="bg-white dark:bg-gray-800 text-gray-900 dark:text-gray-100">
+```
+
+---
+
+## Typography
+
+### Font Family
+
+| Token | Class | Usage |
+|-------|-------|-------|
+| Sans | `font-sans` | Body text, UI elements |
+| Mono | `font-mono` | Code, technical data |
+
+### Font Sizes
+
+| Token | Class | Size | Usage |
+|-------|-------|------|-------|
+| xs | `text-xs` | 12px | Labels, captions |
+| sm | `text-sm` | 14px | Secondary text, table cells |
+| base | `text-base` | 16px | Body text |
+| lg | `text-lg` | 18px | Lead text, subheadings |
+| xl | `text-xl` | 20px | Section headings |
+| 2xl | `text-2xl` | 24px | Page headings |
+| 3xl | `text-3xl` | 30px | Hero headings |
+
+### Font Weights
+
+| Token | Class | Usage |
+|-------|-------|-------|
+| Normal | `font-normal` | Body text |
+| Medium | `font-medium` | Emphasis, labels |
+| Semibold | `font-semibold` | Subheadings, buttons |
+| Bold | `font-bold` | Headings, strong emphasis |
+
+---
+
+## Spacing
+
+### Spacing Scale
+
+Based on Tailwind's default 4px base unit:
+
+| Token | Class | Value | Usage |
+|-------|-------|-------|-------|
+| 0 | `p-0`, `m-0` | 0px | Reset |
+| 1 | `p-1`, `m-1` | 4px | Tight spacing |
+| 2 | `p-2`, `m-2` | 8px | Compact elements |
+| 3 | `p-3`, `m-3` | 12px | Default small |
+| 4 | `p-4`, `m-4` | 16px | Default medium |
+| 5 | `p-5`, `m-5` | 20px | Comfortable |
+| 6 | `p-6`, `m-6` | 24px | Section spacing |
+| 8 | `p-8`, `m-8` | 32px | Large spacing |
+| 10 | `p-10`, `m-10` | 40px | Extra large |
+| 12 | `p-12`, `m-12` | 48px | Page sections |
+
+### Component Spacing Guidelines
+
+| Context | Recommended |
+|---------|-------------|
+| Card padding | `p-4` to `p-6` |
+| Form field gap | `gap-4` |
+| Section gap | `gap-6` to `gap-8` |
+| Page padding | `p-6` to `p-8` |
+| Inline element gap | `gap-2` |
+
+---
+
+## Borders
+
+### Border Radius
+
+| Token | Class | Value | Usage |
+|-------|-------|-------|-------|
+| None | `rounded-none` | 0px | Sharp corners |
+| sm | `rounded-sm` | 2px | Subtle rounding |
+| Default | `rounded` | 4px | Standard elements |
+| md | `rounded-md` | 6px | Buttons, inputs |
+| lg | `rounded-lg` | 8px | Cards, modals |
+| xl | `rounded-xl` | 12px | Large cards |
+| full | `rounded-full` | 9999px | Avatars, pills |
+
+### Border Width
+
+| Token | Class | Usage |
+|-------|-------|-------|
+| Default | `border` | Standard borders |
+| 2 | `border-2` | Emphasis borders |
+| 0 | `border-0` | No border |
+
+### Border Colors
+
+| Token | Class | Usage |
+|-------|-------|-------|
+| Default | `border-gray-200 dark:border-gray-700` | Standard borders |
+| Focus | `border-primary` | Focus states |
+| Error | `border-danger` | Validation errors |
+
+---
+
+## Shadows
+
+| Token | Class | Usage |
+|-------|-------|-------|
+| sm | `shadow-sm` | Subtle elevation |
+| Default | `shadow` | Cards, dropdowns |
+| md | `shadow-md` | Modals, popovers |
+| lg | `shadow-lg` | Floating elements |
+| xl | `shadow-xl` | High elevation |
+| none | `shadow-none` | Flat elements |
+
+---
+
+## Transitions
+
+### Duration
+
+| Token | Class | Usage |
+|-------|-------|-------|
+| 75 | `duration-75` | Micro interactions |
+| 150 | `duration-150` | Default transitions |
+| 200 | `duration-200` | Standard animations |
+| 300 | `duration-300` | Emphasis animations |
+
+### Easing
+
+| Token | Class | Usage |
+|-------|-------|-------|
+| Default | `ease-in-out` | Standard transitions |
+| In | `ease-in` | Exit animations |
+| Out | `ease-out` | Enter animations |
+
+### Common Transition Patterns
+
+```blade
+<!-- Button hover -->
+<button class="transition-colors duration-150">
+
+<!-- Card hover -->
+<div class="transition-shadow duration-200 hover:shadow-lg">
+
+<!-- Dropdown -->
+<div x-show="open" x-transition:enter="transition ease-out duration-200">
+```
+
+---
+
+## Z-Index
+
+| Token | Class | Usage |
+|-------|-------|-------|
+| 0 | `z-0` | Base layer |
+| 10 | `z-10` | Raised elements |
+| 20 | `z-20` | Dropdowns |
+| 30 | `z-30` | Fixed headers |
+| 40 | `z-40` | Modals backdrop |
+| 50 | `z-50` | Modals, dialogs |
+
+---
+
+## Icons
+
+### KeenIcons Integration
+
+Icons use KeenIcons with consistent sizing:
+
+| Size | Class | Usage |
+|------|-------|-------|
+| Small | `text-sm` | Inline with small text |
+| Default | `text-lg` | Standard UI icons |
+| Large | `text-xl` | Emphasis, headers |
+
+```blade
+<i class="ki-outline ki-search text-lg text-gray-500"></i>
+```
+
+---
+
+## Implementation Notes
+
+### Tailwind Config
+
+Design tokens are defined in `tailwind.config.ts` and CSS custom properties in the main stylesheet.
+
+### Usage in Components
+
+Components should use these tokens consistently:
+
+```blade
+<!-- Good: Using design tokens -->
+<div class="bg-white dark:bg-gray-800 rounded-lg shadow p-6">
+
+<!-- Avoid: Arbitrary values -->
+<div class="bg-[#ffffff] rounded-[8px] p-[24px]">
+```
+
+### Extending Tokens
+
+New tokens should be added to Tailwind config and documented here before use in components.

--- a/.agent-os/specs/2025-08-28-design-system/sub-specs/page-patterns.md
+++ b/.agent-os/specs/2025-08-28-design-system/sub-specs/page-patterns.md
@@ -1,0 +1,318 @@
+# Page Patterns
+
+> Design System
+> Reference: @.agent-os/specs/2025-08-28-design-system/spec.md
+
+---
+
+## Overview
+
+This document defines common page layout patterns used throughout the application. Each pattern combines design system components into reusable page structures.
+
+---
+
+## Page Types
+
+### 1. List Page
+
+Displays a collection of entities with filtering and actions.
+
+**Use Cases:** Wrestlers index, Events list, Titles list
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Page Header                                                  │
+│ ┌─────────────────────────────────┐  ┌───────────────────┐  │
+│ │ Title + Breadcrumb              │  │ Primary Action    │  │
+│ └─────────────────────────────────┘  └───────────────────┘  │
+├─────────────────────────────────────────────────────────────┤
+│ Filters Bar                                                  │
+│ ┌─────────┐ ┌─────────┐ ┌─────────┐          ┌───────────┐ │
+│ │ Search  │ │ Filter  │ │ Filter  │          │ View Mode │ │
+│ └─────────┘ └─────────┘ └─────────┘          └───────────┘ │
+├─────────────────────────────────────────────────────────────┤
+│ Content Area                                                 │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ Table / Card Grid                                       │ │
+│ │                                                         │ │
+│ │ ┌─────┬─────────┬──────────┬──────────┬───────┐       │ │
+│ │ │     │ Name    │ Status   │ Details  │ Actions│       │ │
+│ │ ├─────┼─────────┼──────────┼──────────┼───────┤       │ │
+│ │ │     │         │          │          │       │       │ │
+│ │ └─────┴─────────┴──────────┴──────────┴───────┘       │ │
+│ └─────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────┤
+│ Pagination                                                   │
+│                    ┌─────────────────┐                      │
+│                    │ < 1 2 3 ... 10 >│                      │
+│                    └─────────────────┘                      │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Components Used:**
+- `layout.page-header`
+- `form.input` (search)
+- `form.select` (filters)
+- `display.table` or `display.card` grid
+- `navigation.pagination`
+- `interactive.button`
+- `interactive.dropdown` (row actions)
+
+---
+
+### 2. Detail Page
+
+Shows comprehensive information about a single entity.
+
+**Use Cases:** Wrestler profile, Event details, Title history
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Page Header                                                  │
+│ ┌─────────────────────────────────┐  ┌───────────────────┐  │
+│ │ ← Back   Entity Name            │  │ Edit  │  Actions ▼│  │
+│ └─────────────────────────────────┘  └───────────────────┘  │
+├─────────────────────────────────────────────────────────────┤
+│ ┌──────────────────────┐ ┌────────────────────────────────┐ │
+│ │ Profile Card         │ │ Quick Stats                    │ │
+│ │ ┌────┐               │ │ ┌──────┐ ┌──────┐ ┌──────┐    │ │
+│ │ │    │ Name          │ │ │ Stat │ │ Stat │ │ Stat │    │ │
+│ │ │    │ Status Badge  │ │ └──────┘ └──────┘ └──────┘    │ │
+│ │ └────┘ Key Info      │ │                                │ │
+│ └──────────────────────┘ └────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────┤
+│ Tabs                                                         │
+│ ┌─────────┬─────────┬─────────┬─────────┐                   │
+│ │ Overview│ History │ Matches │ Related │                   │
+│ └─────────┴─────────┴─────────┴─────────┘                   │
+├─────────────────────────────────────────────────────────────┤
+│ Tab Content                                                  │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ Content varies by tab                                   │ │
+│ │ - Overview: Description list, cards                     │ │
+│ │ - History: Timeline                                     │ │
+│ │ - Matches: Table                                        │ │
+│ │ - Related: Card grid                                    │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Components Used:**
+- `layout.page-header`
+- `entity.profile-card`
+- `display.stat-group`
+- `interactive.tabs`
+- `display.description-list`
+- `entity.timeline`
+- `display.table`
+
+---
+
+### 3. Form Page
+
+Create or edit an entity.
+
+**Use Cases:** Create wrestler, Edit event, Add match
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Page Header                                                  │
+│ ┌─────────────────────────────────┐                         │
+│ │ ← Back   Create/Edit Entity     │                         │
+│ └─────────────────────────────────┘                         │
+├─────────────────────────────────────────────────────────────┤
+│ Form                                                         │
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ Section: Basic Information                              │ │
+│ │ ┌───────────────────────┐ ┌───────────────────────┐    │ │
+│ │ │ Label                 │ │ Label                 │    │ │
+│ │ │ ┌───────────────────┐ │ │ ┌───────────────────┐ │    │ │
+│ │ │ │ Input             │ │ │ │ Input             │ │    │ │
+│ │ │ └───────────────────┘ │ │ └───────────────────┘ │    │ │
+│ │ │ Hint text             │ │ Error message         │    │ │
+│ │ └───────────────────────┘ └───────────────────────┘    │ │
+│ ├─────────────────────────────────────────────────────────┤ │
+│ │ Section: Additional Details                             │ │
+│ │ ...                                                     │ │
+│ └─────────────────────────────────────────────────────────┘ │
+├─────────────────────────────────────────────────────────────┤
+│ Actions                                                      │
+│                              ┌──────────┐ ┌──────────────┐  │
+│                              │ Cancel   │ │ Save Entity  │  │
+│                              └──────────┘ └──────────────┘  │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Components Used:**
+- `layout.page-header`
+- `layout.section`
+- `form.group`
+- `form.input`, `form.select`, `form.textarea`, etc.
+- `form.error`
+- `form.hint`
+- `interactive.button`
+
+---
+
+### 4. Dashboard Page
+
+Overview with key metrics and recent activity.
+
+**Use Cases:** Main dashboard, Roster overview
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│ Page Header                                                  │
+│ ┌─────────────────────────────────┐                         │
+│ │ Dashboard                       │                         │
+│ └─────────────────────────────────┘                         │
+├─────────────────────────────────────────────────────────────┤
+│ Stats Row                                                    │
+│ ┌───────────┐ ┌───────────┐ ┌───────────┐ ┌───────────┐    │
+│ │ Stat Card │ │ Stat Card │ │ Stat Card │ │ Stat Card │    │
+│ │   123     │ │    45     │ │    67     │ │    89     │    │
+│ │  Label    │ │  Label    │ │  Label    │ │  Label    │    │
+│ └───────────┘ └───────────┘ └───────────┘ └───────────┘    │
+├─────────────────────────────────────────────────────────────┤
+│ ┌─────────────────────────────┐ ┌─────────────────────────┐ │
+│ │ Recent Activity             │ │ Upcoming Events         │ │
+│ │ ┌─────────────────────────┐ │ │ ┌─────────────────────┐ │ │
+│ │ │ Activity Item           │ │ │ │ Event Card          │ │ │
+│ │ │ Activity Item           │ │ │ │ Event Card          │ │ │
+│ │ │ Activity Item           │ │ │ │ Event Card          │ │ │
+│ │ └─────────────────────────┘ │ │ └─────────────────────┘ │ │
+│ └─────────────────────────────┘ └─────────────────────────┘ │
+├─────────────────────────────────────────────────────────────┤
+│ ┌─────────────────────────────────────────────────────────┐ │
+│ │ Quick Actions or Alerts                                 │ │
+│ └─────────────────────────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Components Used:**
+- `layout.page-header`
+- `display.stat-group`
+- `display.card`
+- `entity.activity-feed`
+- `display.list`
+- `feedback.alert`
+
+---
+
+### 5. Auth Page
+
+Authentication pages (login, register, forgot password).
+
+**Use Cases:** Login, Register, Password reset
+
+**Structure:**
+```
+┌─────────────────────────────────────────────────────────────┐
+│                                                             │
+│                     ┌───────────────────┐                   │
+│                     │ Logo              │                   │
+│                     └───────────────────┘                   │
+│                                                             │
+│                     ┌───────────────────┐                   │
+│                     │ Auth Card         │                   │
+│                     │                   │                   │
+│                     │ ┌───────────────┐ │                   │
+│                     │ │ Title         │ │                   │
+│                     │ └───────────────┘ │                   │
+│                     │ ┌───────────────┐ │                   │
+│                     │ │ Email Input   │ │                   │
+│                     │ └───────────────┘ │                   │
+│                     │ ┌───────────────┐ │                   │
+│                     │ │ Password      │ │                   │
+│                     │ └───────────────┘ │                   │
+│                     │ ┌───────────────┐ │                   │
+│                     │ │ Submit Button │ │                   │
+│                     │ └───────────────┘ │                   │
+│                     │                   │                   │
+│                     │ Links (register,  │                   │
+│                     │ forgot password)  │                   │
+│                     └───────────────────┘                   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+**Components Used:**
+- `display.card`
+- `form.input`
+- `form.checkbox`
+- `form.error`
+- `interactive.button`
+
+---
+
+## Layout Grid
+
+### Standard Page Grid
+
+```blade
+<div class="grid grid-cols-1 lg:grid-cols-12 gap-6">
+    <!-- Full width -->
+    <div class="lg:col-span-12">...</div>
+
+    <!-- Two columns -->
+    <div class="lg:col-span-6">...</div>
+    <div class="lg:col-span-6">...</div>
+
+    <!-- Sidebar + Main -->
+    <div class="lg:col-span-4">...</div>
+    <div class="lg:col-span-8">...</div>
+
+    <!-- Main + Sidebar -->
+    <div class="lg:col-span-8">...</div>
+    <div class="lg:col-span-4">...</div>
+</div>
+```
+
+### Card Grid
+
+```blade
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+    <x-display.card>...</x-display.card>
+    <x-display.card>...</x-display.card>
+    <x-display.card>...</x-display.card>
+</div>
+```
+
+---
+
+## Responsive Breakpoints
+
+| Breakpoint | Width | Usage |
+|------------|-------|-------|
+| Default | < 640px | Mobile, single column |
+| `sm` | 640px+ | Large mobile |
+| `md` | 768px+ | Tablet, 2 columns |
+| `lg` | 1024px+ | Desktop, sidebar visible |
+| `xl` | 1280px+ | Wide desktop, more columns |
+| `2xl` | 1536px+ | Ultra-wide |
+
+---
+
+## Page Component Template
+
+```blade
+<x-layout.main>
+    <x-layout.page-header>
+        <x-slot:title>Page Title</x-slot:title>
+        <x-slot:breadcrumb>
+            <x-navigation.breadcrumb :items="$breadcrumbs" />
+        </x-slot:breadcrumb>
+        <x-slot:actions>
+            <x-interactive.button variant="primary">Action</x-interactive.button>
+        </x-slot:actions>
+    </x-layout.page-header>
+
+    <x-layout.section>
+        <!-- Page content -->
+    </x-layout.section>
+</x-layout.main>
+```

--- a/.agent-os/specs/2025-08-28-design-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2025-08-28-design-system/sub-specs/technical-spec.md
@@ -1,6 +1,7 @@
 # Technical Specification
 
-This is the technical specification for the spec detailed in @.agent-os/specs/2025-08-28-metronic-component-library/spec.md
+> Design System
+> Reference: @.agent-os/specs/2025-08-28-design-system/spec.md
 
 > Created: 2025-08-28
 > Version: 1.0.0

--- a/.agent-os/specs/2025-08-28-design-system/tasks.md
+++ b/.agent-os/specs/2025-08-28-design-system/tasks.md
@@ -1,6 +1,6 @@
-# Spec Tasks
+# Design System Tasks
 
-These are the tasks to be completed for the spec detailed in @.agent-os/specs/2025-08-28-metronic-component-library/spec.md
+> Reference: @.agent-os/specs/2025-08-28-design-system/spec.md
 
 > Created: 2025-08-28
 > Status: Ready for Implementation

--- a/.agent-os/specs/2025-08-28-login-page-completion/spec.md
+++ b/.agent-os/specs/2025-08-28-login-page-completion/spec.md
@@ -1,10 +1,14 @@
 # Login Page Completion Specification
 
-> Created: 2025-08-28  
-> Status: **COMPLETED** ✅  
-> Completed: 2025-09-01  
-> Priority: High  
+> Created: 2025-08-28
+> Status: **SUPERSEDED**
+> Completed: 2025-09-01
+> Priority: High
 > Actual Effort: 1 day
+>
+> **Note:** This spec has been superseded by the Design System spec (`2025-08-28-design-system`).
+> The login page will be redesigned as part of the comprehensive UI rethink using the new design system.
+> This spec is retained for historical reference of what was originally delivered.
 
 ## Overview
 

--- a/.agent-os/specs/2025-08-28-metronic-component-library/spec-lite.md
+++ b/.agent-os/specs/2025-08-28-metronic-component-library/spec-lite.md
@@ -1,8 +1,0 @@
-# Metronic Component Library - Lite Summary
-
-Create a comprehensive anonymous Blade component library based on the Metronic Tailwind template, following FluxUI architectural patterns and design principles. This component library will provide reusable, well-tested UI components that maintain Metronic's professional design while integrating seamlessly with Ringside's wrestling management system and existing Livewire + Tailwind 4.1 setup. The library will include layout, form, data display, interactive, and wrestling domain-specific components organized under the `<x-metronic.*>` namespace.
-
-## Key Points
-- Build comprehensive Blade component library based on Metronic Tailwind template design system
-- Follow FluxUI architectural patterns for component organization and API design consistency
-- Integrate seamlessly with existing Livewire + Tailwind 4.1 setup and wrestling domain requirements

--- a/.agent-os/specs/2026-01-15-unified-prd/spec-lite.md
+++ b/.agent-os/specs/2026-01-15-unified-prd/spec-lite.md
@@ -1,0 +1,3 @@
+# Spec Summary (Lite)
+
+Create a unified Product Requirements Document consolidating existing product documentation into a single authoritative source. The PRD will serve AI development context, contributor onboarding, and product planning. Deliverables include a comprehensive prd.md (~3000 words), condensed prd-lite.md for efficient AI loading, and the missing mission-lite.md file.

--- a/.agent-os/specs/2026-01-15-unified-prd/spec.md
+++ b/.agent-os/specs/2026-01-15-unified-prd/spec.md
@@ -1,0 +1,64 @@
+# Spec Requirements Document
+
+> Spec: Unified Product Requirements Document
+> Created: 2026-01-15
+> Status: **COMPLETED** ✅
+> Completed: 2026-01-15
+
+## Overview
+
+Create a comprehensive Product Requirements Document (PRD) that consolidates all existing product documentation into a single authoritative source, serving as the primary reference for AI development, contributor onboarding, and product planning decisions.
+
+## User Stories
+
+### Product Documentation Consolidation
+
+As a **developer or AI assistant**, I want to have a single comprehensive PRD document, so that I can understand the full product vision, features, and business rules without navigating multiple files.
+
+When working on Ringside, I need quick access to:
+- What the product does and why it exists
+- Who the target users are and their needs
+- What features are implemented vs. planned
+- The business rules and constraints
+- Technical architecture decisions
+
+### AI Context Optimization
+
+As an **AI development assistant (Claude)**, I want a condensed PRD-lite document, so that I can be loaded with essential product context efficiently without consuming excessive context window space.
+
+The prd-lite.md should provide enough context to:
+- Understand the domain (wrestling promotion management)
+- Know the key entities and their relationships
+- Understand business rules for employment/bookability
+- Make informed development decisions
+
+### Contributor Onboarding
+
+As a **new contributor**, I want comprehensive documentation, so that I can understand the product quickly and start contributing effectively.
+
+The PRD should help new contributors understand:
+- The problem being solved
+- The target audience
+- How features work together
+- Technical patterns and conventions
+
+## Spec Scope
+
+1. **Unified PRD Document** - Comprehensive 10-section document consolidating all existing product docs
+2. **Condensed PRD-Lite** - 1-2 page summary optimized for AI context loading
+3. **Mission-Lite File** - Quick-reference product mission summary (currently missing)
+4. **Cross-Reference Validation** - Ensure consistency across all product documentation
+
+## Out of Scope
+
+- Creating new feature specifications (those come after the PRD)
+- Modifying existing code or architecture
+- Creating visual diagrams or wireframes
+- User journey detailed documentation (separate spec)
+
+## Expected Deliverable
+
+1. `.agent-os/product/prd.md` - Complete PRD with all 10 sections (~3000-4000 words)
+2. `.agent-os/product/prd-lite.md` - Condensed PRD suitable for AI context injection
+3. `.agent-os/product/mission-lite.md` - Quick-reference mission summary
+4. All existing product documentation properly cross-referenced and consistent

--- a/.agent-os/specs/2026-01-16-events-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-events-system/spec-lite.md
@@ -1,0 +1,74 @@
+# Events System - Quick Reference
+
+> Organizational container for wrestling shows with venue management
+
+## Core Entities
+
+| Entity | Purpose |
+|--------|---------|
+| Event | Wrestling show/card container |
+| Venue | Physical location for events |
+
+## Event Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Event name |
+| date | datetime\|null | Scheduled date (null = unscheduled) |
+| venue_id | int\|null | Optional venue association |
+| preview | string\|null | Promotional preview text |
+| status | EventStatus | **Computed** from date |
+
+## Venue Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Venue name |
+| street_address | string | Street address |
+| city | string | City |
+| state | string | State |
+| zipcode | string | ZIP code |
+
+## Event Status (Computed)
+
+| Status | Condition |
+|--------|-----------|
+| Unscheduled | date IS NULL |
+| Scheduled | date IS NOT NULL AND date >= today |
+| Past | date IS NOT NULL AND date < today |
+
+## Key Relationships
+
+```
+Event
+├── venue (BelongsTo → Venue)
+└── matches (HasMany → EventMatch)
+
+Venue
+├── events (HasMany → Event)
+├── previousEvents - date < today
+└── futureEvents - date > today
+```
+
+## Query Scopes
+
+**Event:**
+- `scheduled()` - Has a date
+- `unscheduled()` - No date
+- `past()` - Date in the past
+- `withFutureDate()` - Scheduled with future date
+- `withPastDate()` - Scheduled with past date
+
+**Venue:**
+- `withEvents()` - Has hosted events
+- `withPastEvents()` - Has past events
+- `withFutureEvents()` - Has future events scheduled
+- `withoutEvents()` - No events yet
+
+## File Locations
+
+- `app/Models/Events/Event.php`
+- `app/Models/Events/Venue.php`
+- `app/Enums/EventStatus.php`
+- `app/Builders/Events/EventBuilder.php`
+- `app/Builders/Events/VenueBuilder.php`

--- a/.agent-os/specs/2026-01-16-events-system/spec.md
+++ b/.agent-os/specs/2026-01-16-events-system/spec.md
@@ -1,0 +1,104 @@
+# Spec Requirements Document
+
+> Spec: Events System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the Events System—the organizational container for wrestling shows. Events represent scheduled (or planned) shows that contain matches. Each event has a name, optional date, optional venue, and a collection of matches. This spec serves as the authoritative reference for event lifecycle, venue management, scheduling, and the relationship between events and matches.
+
+## User Stories
+
+### Event Creation
+
+As a **wrestling promoter**, I want to create events for my promotion, so that I can plan and organize wrestling shows.
+
+**Workflow:**
+1. Create event with name and optional preview text
+2. Optionally assign a venue
+3. Optionally schedule with a date
+4. Event starts as "unscheduled" if no date, "scheduled" if date provided
+
+### Event Scheduling
+
+As a **promoter**, I want to schedule events with dates, so that I can plan my promotion calendar.
+
+**Workflow:**
+1. Select unscheduled event
+2. Assign date
+3. Optionally assign venue
+4. Event status changes to "scheduled"
+5. Event becomes eligible for match booking
+
+### Venue Management
+
+As a **promoter**, I want to manage venues where events are held, so that I can track locations and their event history.
+
+**Workflow:**
+1. Create venue with address details
+2. Assign venues to events
+3. View venue's event history (past and future)
+4. Track venue utilization
+
+### Match Card Building
+
+As a **promoter**, I want to add matches to events, so that I can build compelling show cards.
+
+**Workflow:**
+1. Select scheduled event
+2. Add matches with competitors and referees
+3. Assign titles to title matches
+4. Build complete match card
+
+### Event History
+
+As a **promoter**, I want to view past events, so that I can track show history and results.
+
+**Workflow:**
+1. View list of past events
+2. See match results and outcomes
+3. Track venue usage history
+4. Review event performance
+
+## Spec Scope
+
+1. **Event Entity** - Core model with name, date, venue, preview
+2. **Venue Entity** - Location model with address details
+3. **Event Status** - Computed status (Unscheduled, Scheduled, Past)
+4. **Event-Match Relationship** - Events contain matches
+5. **Event-Venue Relationship** - Events belong to venues
+6. **Query Scopes** - Filtering by status, date, venue
+
+## Out of Scope
+
+- Match management (see Match System spec)
+- Competitor booking (see Match System spec)
+- Ticket sales and revenue tracking
+- Live event broadcasting
+
+## Expected Deliverable
+
+1. Complete event entity documentation with attributes
+2. Venue entity documentation
+3. EventStatus enum documentation
+4. Event-Match relationship documentation
+5. Event-Venue relationship documentation
+6. Query builder methods reference
+7. Action class reference
+
+## Key Distinctions
+
+**Events vs Matches:**
+- Events are containers; matches are the competitive content
+- Events have dates and venues; matches have types and stipulations
+- Events track scheduling status; matches track results
+
+**Event Status:**
+- Status is **computed**, never stored
+- Based on presence/absence of date and whether date is past
+- Three states: Unscheduled, Scheduled, Past
+
+**Venues:**
+- Venues exist independently of events
+- One venue can host many events
+- Venue history tracked through event relationships

--- a/.agent-os/specs/2026-01-16-events-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-events-system/sub-specs/technical-spec.md
@@ -1,0 +1,492 @@
+# Technical Specification
+
+> Events System
+> Reference: @.agent-os/specs/2026-01-16-events-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. Event
+
+**Model:** `App\Models\Events\Event`
+
+The core entity representing a wrestling show or card.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| name | string | Event name |
+| date | datetime\|null | Scheduled date (null = unscheduled) |
+| venue_id | int\|null | Foreign key to venue |
+| preview | string\|null | Promotional preview text |
+| status | EventStatus | **Computed** from date |
+
+#### Key Relationships
+```
+Event
+├── venue (BelongsTo → Venue)
+└── matches (HasMany → EventMatch)
+```
+
+#### Traits
+- `HasMatches` - Match collection relationship
+- `HasFactory` - Factory support
+- `SoftDeletes` - Soft deletion
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `isScheduled()` | bool | Has a date assigned |
+| `isUnscheduled()` | bool | No date assigned |
+| `hasFutureDate()` | bool | Date is in the future |
+| `hasPastDate()` | bool | Date is in the past |
+
+#### Status Computation
+
+Status is a **computed attribute**, never stored:
+
+```php
+protected function status(): Attribute
+{
+    return Attribute::make(
+        get: function (): EventStatus {
+            if ($this->isUnscheduled()) {
+                return EventStatus::Unscheduled;
+            }
+            return $this->hasPastDate() ? EventStatus::Past : EventStatus::Scheduled;
+        }
+    );
+}
+```
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   EVENT STATUS LOGIC                         │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  1. Is date NULL?                                           │
+│     YES → UNSCHEDULED                                       │
+│     NO  → Continue                                          │
+│                                                             │
+│  2. Is date in the past?                                    │
+│     YES → PAST                                              │
+│     NO  → SCHEDULED                                         │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 2. Venue
+
+**Model:** `App\Models\Events\Venue`
+
+Physical location where events are held.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| name | string | Venue name |
+| street_address | string | Street address |
+| city | string | City |
+| state | string | State |
+| zipcode | string | ZIP code |
+
+#### Key Relationships
+```
+Venue
+├── events (HasMany → Event)
+├── previousEvents (HasMany → Event where date < today)
+└── futureEvents (HasMany → Event where date > today)
+```
+
+#### Traits
+- `HoldsEvents` - Event collection relationships
+- `HasFactory` - Factory support
+- `SoftDeletes` - Soft deletion
+
+---
+
+## Enums
+
+### EventStatus
+
+**Location:** `App\Enums\EventStatus`
+
+Represents the scheduling state of an event.
+
+```php
+enum EventStatus: string {
+    case Past = 'past';
+    case Scheduled = 'scheduled';
+    case Unscheduled = 'unscheduled';
+}
+```
+
+#### Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `color()` | string | UI color (dark, success, danger) |
+| `label()` | string | Human-readable label |
+
+#### Status Colors
+| Status | Color | Usage |
+|--------|-------|-------|
+| Past | dark | Historical events |
+| Scheduled | success | Upcoming events |
+| Unscheduled | danger | Events needing scheduling |
+
+---
+
+## Traits
+
+### HasMatches
+
+**Location:** `App\Models\Concerns\HasMatches`
+
+Provides match relationships for the Event model.
+
+```php
+public function matches(): HasMany
+{
+    return $this->hasMany(EventMatch::class);
+}
+```
+
+**Used by:** Event model
+
+---
+
+### HoldsEvents
+
+**Location:** `App\Models\Concerns\HoldsEvents`
+
+Provides event relationships for models that host events.
+
+```php
+public function events(): HasMany
+{
+    return $this->hasMany(Event::class);
+}
+
+public function previousEvents(): HasMany
+{
+    return $this->events()->where('date', '<', today());
+}
+
+public function futureEvents(): HasMany
+{
+    return $this->events()->where('date', '>', today());
+}
+```
+
+**Used by:** Venue model
+
+---
+
+## Database Tables
+
+### Schema: events
+```sql
+id          BIGINT PRIMARY KEY
+name        VARCHAR(255)
+date        DATETIME NULLABLE
+venue_id    BIGINT NULLABLE FOREIGN KEY
+preview     TEXT NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+deleted_at  TIMESTAMP NULLABLE
+```
+
+### Schema: venues
+```sql
+id             BIGINT PRIMARY KEY
+name           VARCHAR(255)
+street_address VARCHAR(255)
+city           VARCHAR(255)
+state          VARCHAR(255)
+zipcode        VARCHAR(255)
+created_at     TIMESTAMP
+updated_at     TIMESTAMP
+deleted_at     TIMESTAMP NULLABLE
+```
+
+---
+
+## Query Builder Methods
+
+### EventBuilder
+
+**Location:** `App\Builders\Events\EventBuilder`
+
+Custom query builder for Event model.
+
+| Method | Description |
+|--------|-------------|
+| `scheduled()` | Events with a date assigned |
+| `unscheduled()` | Events without a date |
+| `past()` | Events with date in the past (no explicit null check) |
+| `withFutureDate()` | Events with date in the future (explicit null check) |
+| `withPastDate()` | Events with date in the past (explicit null check) |
+
+#### Scope Behavior Note
+
+The `past()` scope and `withPastDate()` scope have subtle differences:
+
+| Scope | NULL Check | Use Case |
+|-------|------------|----------|
+| `past()` | No | Quick filter, assumes scheduled events |
+| `withPastDate()` | Yes | Defensive, explicitly excludes unscheduled |
+
+In practice, both will exclude NULL dates (database comparison with NULL returns NULL, not true), but `withPastDate()` is more explicit and self-documenting.
+
+#### Implementation Details
+
+```php
+// scheduled() - has any date
+$this->whereNotNull('date');
+
+// unscheduled() - no date
+$this->whereNull('date');
+
+// past() - date before today
+$this->where('date', '<', now()->toDateString());
+
+// withFutureDate() - date today or later
+$this->whereNotNull('date')->where('date', '>=', now()->toDateString());
+
+// withPastDate() - date before today (with null check)
+$this->whereNotNull('date')->where('date', '<', now()->toDateString());
+```
+
+---
+
+### VenueBuilder
+
+**Location:** `App\Builders\Events\VenueBuilder`
+
+Custom query builder for Venue model.
+
+| Method | Description |
+|--------|-------------|
+| `withEvents()` | Venues that have hosted any events |
+| `withPastEvents()` | Venues with past event history |
+| `withFutureEvents()` | Venues with upcoming events |
+| `withoutEvents()` | Venues with no event history |
+
+---
+
+## Actions
+
+### CreateAction
+
+**Location:** `App\Actions\Events\CreateAction`
+
+Creates a new event.
+
+```php
+public function handle(EventData $eventData): Event
+```
+
+**Workflow:**
+1. Wrap in database transaction
+2. Create event with name, date, venue_id, preview
+3. Return created event
+
+---
+
+### UpdateAction
+
+**Location:** `App\Actions\Events\UpdateAction`
+
+Updates an existing event.
+
+```php
+public function handle(Event $event, EventData $eventData): Event
+```
+
+**Workflow:**
+1. Wrap in database transaction
+2. Update event attributes
+3. Return updated event
+
+---
+
+### DeleteAction
+
+**Location:** `App\Actions\Events\DeleteAction`
+
+Soft-deletes an event.
+
+```php
+public function handle(Event $event, ?Carbon $deletionDate = null): void
+```
+
+**Impact:**
+- Soft deletes the event record
+- Preserves match history for reporting
+- Does not affect venue availability
+- Allows future restoration
+
+---
+
+### RestoreAction
+
+**Location:** `App\Actions\Events\RestoreAction`
+
+Restores a soft-deleted event.
+
+```php
+public function handle(Event $event): Event
+```
+
+---
+
+## Venue Actions
+
+### Venues\CreateAction
+
+**Location:** `App\Actions\Venues\CreateAction`
+
+Creates a new venue.
+
+```php
+public function handle(VenueData $venueData): Venue
+```
+
+**Workflow:**
+1. Create venue with name, street_address, city, state, zipcode
+2. Return created venue
+
+---
+
+### Venues\UpdateAction
+
+**Location:** `App\Actions\Venues\UpdateAction`
+
+Updates an existing venue.
+
+```php
+public function handle(Venue $venue, VenueData $venueData): Venue
+```
+
+---
+
+### Venues\DeleteAction
+
+**Location:** `App\Actions\Venues\DeleteAction`
+
+Soft-deletes a venue.
+
+```php
+public function handle(Venue $venue): void
+```
+
+**Impact:**
+- Soft deletes the venue record
+- Does not affect associated events (venue_id preserved)
+- Allows future restoration
+
+---
+
+### Venues\RestoreAction
+
+**Location:** `App\Actions\Venues\RestoreAction`
+
+Restores a soft-deleted venue.
+
+```php
+public function handle(Venue $venue): Venue
+```
+
+---
+
+## Business Rules
+
+### Event Scheduling Rules
+
+- Events can be created without a date (unscheduled)
+- Events can be scheduled by assigning a date
+- Status is computed automatically based on date
+- Past events cannot be modified to future dates (recommended validation)
+
+### Venue Assignment Rules
+
+- Events can exist without a venue
+- One venue can host many events
+- Venue assignment does not affect event status
+- Deleting a venue does not cascade to events (venue_id becomes null via soft delete)
+
+### Match Booking Rules
+
+- Matches can only be added to events (see Match System spec)
+- Events provide the date context for match booking
+- Competitor double-booking is checked against the event date
+
+### Event Deletion Rules
+
+- Events use soft deletion
+- Deleted events preserve match history
+- Events can be restored after deletion
+- Venue relationships are preserved in history
+
+---
+
+## File Locations
+
+```
+app/
+├── Enums/
+│   └── EventStatus.php
+├── Models/Events/
+│   ├── Event.php
+│   └── Venue.php
+├── Models/Concerns/
+│   ├── HasMatches.php              # Used by Event model
+│   └── HoldsEvents.php             # Used by Venue model
+├── Builders/Events/
+│   ├── EventBuilder.php
+│   └── VenueBuilder.php
+├── Actions/Events/
+│   ├── CreateAction.php
+│   ├── UpdateAction.php
+│   ├── DeleteAction.php
+│   └── RestoreAction.php
+├── Actions/Venues/
+│   ├── CreateAction.php
+│   ├── UpdateAction.php
+│   ├── DeleteAction.php
+│   └── RestoreAction.php
+└── Data/Events/
+    ├── EventData.php
+    └── VenueData.php
+```
+
+---
+
+## Related Systems
+
+| System | Relationship |
+|--------|--------------|
+| Match System | Events contain matches |
+| Wrestlers | Compete in matches within events |
+| Tag Teams | Compete in matches within events |
+| Referees | Officiate matches within events |
+| Titles | Championships at stake in event matches |
+
+---
+
+## Terminology Note
+
+### Past vs Completed
+
+The Events System uses `Past` for the EventStatus enum value. Other systems (Wrestlers, Referees) have tasks to rename `previousMatches` to `completedMatches` for consistency. Consider whether EventStatus should also be renamed:
+
+| Current | Potential |
+|---------|-----------|
+| `EventStatus::Past` | `EventStatus::Completed` |
+
+This is documented as a consideration, not a required change. The current naming is clear and functional.

--- a/.agent-os/specs/2026-01-16-events-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-events-system/tasks.md
@@ -1,0 +1,100 @@
+# Events System Tasks
+
+## Pending
+
+### Add promotion_id foreign key for multi-tenant support
+
+**Priority:** Critical
+**Type:** Migration
+**Depends on:** Promotions System
+
+Add `promotion_id` foreign key to events table for multi-tenant architecture.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_events_table.php`
+- `app/Models/Event.php`
+
+**Changes required:**
+- Create migration adding `promotion_id` column with foreign key constraint
+- Add index on `promotion_id`
+- Add `BelongsToPromotion` trait to Event model
+- Add `promotion_id` to fillable array
+- Update EventFactory to include promotion
+- Update all event tests to set promotion context
+
+**Acceptance Criteria:**
+- [ ] Migration creates column with proper foreign key
+- [ ] Cascade delete when promotion is deleted
+- [ ] Model uses BelongsToPromotion trait
+- [ ] Global scope filters by current promotion
+- [ ] All existing tests pass with promotion context
+
+**Note:** Matches inherit promotion context from their parent Event, so no separate promotion_id needed on matches table.
+
+**Reference:** See @.agent-os/specs/2026-01-16-promotions-system/tasks.md for full multi-tenant implementation details.
+
+---
+
+### Consider renaming EventStatus::Past to EventStatus::Completed
+
+**Priority:** Low
+**Type:** Refactor (Consideration)
+
+Other systems have tasks to rename `previousMatches` to `completedMatches` for terminology consistency. Consider whether `EventStatus::Past` should follow the same pattern.
+
+| Current | Potential |
+|---------|-----------|
+| `EventStatus::Past` | `EventStatus::Completed` |
+
+**Pros:**
+- Consistent terminology across systems
+- "Completed" is more explicit than "Past"
+
+**Cons:**
+- "Past" is clear and functional
+- Change would require updates to all status checks
+- May be over-engineering for consistency's sake
+
+**Decision needed:** Is terminology consistency worth the refactoring effort?
+
+---
+
+### Add validation to prevent scheduling past dates
+
+**Priority:** Low
+**Type:** Enhancement
+
+Currently, events can be created or updated with dates in the past. Consider adding validation to prevent scheduling events for past dates.
+
+**Changes required:**
+- Add validation in `CreateAction` to reject past dates
+- Add validation in `UpdateAction` to reject past dates
+- Allow exception for administrative corrections
+
+**Note:** This may already be handled at the form/request level. Verify before implementing.
+
+---
+
+### Rename HoldsEvents::previousEvents to completedEvents
+
+**Priority:** Low
+**Type:** Refactor
+
+Align with the `previousMatches` → `completedMatches` rename pattern from other systems.
+
+| Current | New |
+|---------|-----|
+| `previousEvents` | `completedEvents` |
+
+**Changes required:**
+- Rename method in `HoldsEvents` trait
+- Update all callers (Venue model, etc.)
+- Update tests
+
+**Note:** This aligns with the Wrestlers System, Tag Teams System, Referees System, and Match System terminology changes.
+
+---
+
+## Completed
+
+_None yet_

--- a/.agent-os/specs/2026-01-16-managers-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-managers-system/spec-lite.md
@@ -1,0 +1,78 @@
+# Managers System - Quick Reference
+
+> Talent manager roster management (NOT bookable)
+
+## Core Entities
+
+| Entity | Purpose |
+|--------|---------|
+| Manager | Talent representative |
+| ManagerEmployment | Employment periods |
+| ManagerInjury | Injury tracking |
+| ManagerSuspension | Suspension tracking |
+| ManagerRetirement | Retirement tracking |
+
+## Manager Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| first_name | string | First name |
+| last_name | string | Last name |
+| displayName | string | **Computed** "FirstName LastName" |
+| status | EmploymentStatus | **Computed** from employment |
+
+## Employment Status (Computed)
+
+| Status | Condition |
+|--------|-----------|
+| Retired | Has active retirement |
+| Employed | Has current employment |
+| FutureEmployment | Signed but not started |
+| Released | Previously employed, now without |
+| Unemployed | Never employed |
+
+## Key Distinction: NOT Bookable
+
+Managers **cannot** be booked for matches. They manage wrestlers and tag teams but do not compete. No `isBookable()` method or booking scopes exist.
+
+## Key Relationships
+
+```
+Manager
+├── employments (HasMany → ManagerEmployment)
+├── injuries (HasMany → ManagerInjury)
+├── suspensions (HasMany → ManagerSuspension)
+├── retirements (HasMany → ManagerRetirement)
+├── wrestlers (BelongsToMany → Wrestler)
+│   ├── currentWrestlers - fired_at IS NULL
+│   └── previousWrestlers - fired_at IS NOT NULL
+└── tagTeams (BelongsToMany → TagTeam)
+    ├── currentTagTeams - fired_at IS NULL
+    └── previousTagTeams - fired_at IS NOT NULL
+```
+
+## Client Assignment Rules
+
+Both manager AND client must be:
+- Currently employed, OR
+- Have future employment scheduled
+
+This allows managers and clients to debut together.
+
+## Stable Association
+
+Managers are **indirectly** associated with stables through wrestlers/tag teams they manage. See Stables System spec.
+
+## Query Scopes
+
+**Employment:** `employed()`, `unemployed()`, `released()`, `futureEmployed()`
+
+**Availability:** `injured()`, `suspended()`, `retired()`, `available()`, `unavailable()`
+
+**No booking scopes** (managers are not bookable)
+
+## File Locations
+
+- `app/Models/Managers/Manager.php`
+- `app/Enums/Shared/EmploymentStatus.php`
+- `app/Builders/Roster/ManagerBuilder.php`

--- a/.agent-os/specs/2026-01-16-managers-system/spec.md
+++ b/.agent-os/specs/2026-01-16-managers-system/spec.md
@@ -1,0 +1,84 @@
+# Spec Requirements Document
+
+> Spec: Managers System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the Managers System—roster entities representing talent managers in Ringside. Managers represent wrestlers and tag teams but are **not bookable** for matches themselves. This spec serves as the authoritative reference for manager profiles, employment tracking, availability states (injuries, suspensions, retirements), and relationships with wrestlers and tag teams.
+
+## User Stories
+
+### Manager Profile Management
+
+As a **wrestling promoter**, I want to manage my roster of managers, so that I can track talent representatives in my promotion.
+
+**Workflow:**
+1. Create manager with profile (first name, last name)
+2. Hire manager (create employment)
+3. Assign manager to wrestlers or tag teams
+4. Track manager through their career
+5. Release or retire manager when appropriate
+
+### Employment Tracking
+
+As a **promoter**, I want to track manager employment status, so that I know who is currently under contract.
+
+**Workflow:**
+1. Hire manager with start date
+2. Track current and future employments
+3. Release manager (end employment)
+4. View employment history
+
+### Availability Management
+
+As a **promoter**, I want to track injuries, suspensions, and retirements, so that I know which managers are available for assignments.
+
+**Workflow:**
+1. Record injury when manager is hurt
+2. Clear injury when manager recovers
+3. Suspend manager for disciplinary reasons
+4. Lift suspension when served
+5. Retire manager when career ends
+6. Unretire for comebacks (rare)
+
+### Client Management
+
+As a **promoter**, I want to assign managers to wrestlers and tag teams, so that I can build storylines around manager-talent relationships.
+
+**Workflow:**
+1. Hire manager to represent a wrestler
+2. Hire manager to represent a tag team
+3. Fire manager from a client relationship
+4. Track management history
+
+## Spec Scope
+
+1. **Manager Entity** - Core model with profile attributes
+2. **Employment** - Hire/release lifecycle with temporal tracking
+3. **Injuries** - Injury tracking with recovery dates
+4. **Suspensions** - Suspension tracking with lift dates
+5. **Retirements** - Retirement tracking with comeback support
+6. **Wrestler Relationships** - Managing wrestlers
+7. **Tag Team Relationships** - Managing tag teams
+8. **Stable Association** - Indirect membership through managed talent
+
+## Out of Scope
+
+- Wrestler management (see Wrestlers System spec)
+- Tag team management (see Tag Teams System spec)
+- Stable management (see Stables System spec)
+- Match creation (Managers are not bookable)
+
+## Expected Deliverable
+
+1. Complete manager entity documentation with attributes
+2. Employment lifecycle documentation
+3. Availability state documentation (injuries, suspensions, retirements)
+4. Client relationship documentation (wrestlers, tag teams)
+5. Stable association documentation (indirect)
+6. Query method reference
+
+## Key Distinction
+
+**Managers are NOT bookable.** Unlike wrestlers and tag teams, managers do not participate in matches. They exist to represent talent and build storylines. The Manager model does not implement `BookableCompetitor` and the `ManagerBuilder` has no booking scopes.

--- a/.agent-os/specs/2026-01-16-managers-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-managers-system/sub-specs/technical-spec.md
@@ -1,0 +1,491 @@
+# Technical Specification
+
+> Managers System
+> Reference: @.agent-os/specs/2026-01-16-managers-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. Manager
+
+**Model:** `App\Models\Managers\Manager`
+
+The core entity representing a talent manager. Managers represent wrestlers and tag teams but are **not bookable** for matches.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| first_name | string | First name |
+| last_name | string | Last name |
+| displayName | string | **Computed** "FirstName LastName" |
+| status | EmploymentStatus | **Computed** from relationships |
+
+#### Key Relationships
+```
+Manager
+├── employments (HasMany → ManagerEmployment)
+│   ├── currentEmployment - ended_at IS NULL AND started_at <= now
+│   ├── futureEmployment - ended_at IS NULL AND started_at > now
+│   ├── previousEmployments - ended_at IS NOT NULL
+│   └── firstEmployment - earliest by started_at
+├── injuries (HasMany → ManagerInjury)
+│   ├── currentInjury - ended_at IS NULL
+│   └── previousInjuries - ended_at IS NOT NULL
+├── suspensions (HasMany → ManagerSuspension)
+│   ├── currentSuspension - ended_at IS NULL
+│   └── previousSuspensions - ended_at IS NOT NULL
+├── retirements (HasMany → ManagerRetirement)
+│   ├── currentRetirement - ended_at IS NULL
+│   └── previousRetirements - ended_at IS NOT NULL
+├── wrestlers (BelongsToMany → Wrestler)
+│   ├── currentWrestlers - fired_at IS NULL
+│   └── previousWrestlers - fired_at IS NOT NULL
+└── tagTeams (BelongsToMany → TagTeam)
+    ├── currentTagTeams - fired_at IS NULL
+    └── previousTagTeams - fired_at IS NOT NULL
+```
+
+#### Traits
+- `IsEmployable` - Employment lifecycle
+- `IsInjurable` - Injury tracking
+- `IsSuspendable` - Suspension tracking
+- `IsRetirable` - Retirement tracking
+- `DefinesManagedAliases` - Wrestler/TagTeam management relationships
+- `ProvidesDisplayName` - Display name from first_name + last_name
+- `ValidatesEmployment` - Employment validation
+- `ValidatesInjury` - Injury validation
+- `ValidatesSuspension` - Suspension validation
+- `ValidatesRetirement` - Retirement validation
+- `ValidatesRestoration` - Recovery validation
+- `SoftDeletes` - Soft deletion
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `getDisplayName()` | string | Returns "FirstName LastName" |
+| `isEmployed()` | bool | Has current employment |
+| `isUnemployed()` | bool | Never employed |
+| `isReleased()` | bool | Was employed, now without |
+| `hasFutureEmployment()` | bool | Signed for future |
+| `isInjured()` | bool | Currently injured |
+| `isSuspended()` | bool | Currently suspended |
+| `isRetired()` | bool | Currently retired |
+| `removeFromCurrentWrestlers()` | void | Fire from all wrestler clients |
+| `removeFromCurrentTagTeams()` | void | Fire from all tag team clients |
+
+#### NOT Implemented
+- `isBookable()` - Managers are not bookable
+- `BookableCompetitor` interface - Not applicable
+
+---
+
+### 2. ManagerEmployment
+
+**Model:** `App\Models\Managers\ManagerEmployment`
+
+Tracks employment periods for a manager.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| manager_id | int | Foreign key to manager |
+| started_at | datetime | Employment start date |
+| ended_at | datetime\|null | Employment end date (null = current) |
+
+#### Employment States
+| State | Condition |
+|-------|-----------|
+| Current | `started_at <= now AND ended_at IS NULL` |
+| Future | `started_at > now AND ended_at IS NULL` |
+| Ended | `ended_at IS NOT NULL` |
+
+---
+
+### 3. ManagerInjury
+
+**Model:** `App\Models\Managers\ManagerInjury`
+
+Tracks injury periods for a manager.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| manager_id | int | Foreign key to manager |
+| started_at | datetime | Injury start date |
+| ended_at | datetime\|null | Recovery date (null = currently injured) |
+
+---
+
+### 4. ManagerSuspension
+
+**Model:** `App\Models\Managers\ManagerSuspension`
+
+Tracks suspension periods for a manager.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| manager_id | int | Foreign key to manager |
+| started_at | datetime | Suspension start date |
+| ended_at | datetime\|null | Lift date (null = currently suspended) |
+
+---
+
+### 5. ManagerRetirement
+
+**Model:** `App\Models\Managers\ManagerRetirement`
+
+Tracks retirement periods for a manager.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| manager_id | int | Foreign key to manager |
+| started_at | datetime | Retirement start date |
+| ended_at | datetime\|null | Comeback date (null = currently retired) |
+
+---
+
+## Enums
+
+### EmploymentStatus
+
+**Location:** `App\Enums\Shared\EmploymentStatus`
+
+Shared enum used by Wrestlers, Tag Teams, Managers, and Referees.
+
+```php
+enum EmploymentStatus: string {
+    case Employed = 'employed';
+    case FutureEmployment = 'future_employment';
+    case Released = 'released';
+    case Retired = 'retired';
+    case Unemployed = 'unemployed';
+}
+```
+
+#### Status Computation Priority
+```
+┌─────────────────────────────────────────────────────────────┐
+│               EMPLOYMENT STATUS PRIORITY                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  1. RETIRED           (has active retirement)               │
+│       ↓                                                     │
+│  2. EMPLOYED          (has current employment)              │
+│       ↓                                                     │
+│  3. FUTURE_EMPLOYMENT (signed but not started)              │
+│       ↓                                                     │
+│  4. RELEASED          (was employed, now without)           │
+│       ↓                                                     │
+│  5. UNEMPLOYED        (never employed)                      │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Database Tables
+
+### Manager Tables
+| Table | Description |
+|-------|-------------|
+| `managers` | Core manager records |
+| `managers_employments` | Employment periods |
+| `managers_injuries` | Injury periods |
+| `managers_suspensions` | Suspension periods |
+| `managers_retirements` | Retirement periods |
+
+### Pivot Tables (defined in other systems)
+| Table | Description |
+|-------|-------------|
+| `wrestlers_managers` | Manager-Wrestler relationships |
+| `tag_teams_managers` | Manager-TagTeam relationships |
+
+### Schema: managers
+```sql
+id          BIGINT PRIMARY KEY
+first_name  VARCHAR(255)
+last_name   VARCHAR(255)
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+deleted_at  TIMESTAMP NULLABLE
+```
+
+### Schema: managers_employments
+```sql
+id          BIGINT PRIMARY KEY
+manager_id  BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: managers_injuries
+```sql
+id          BIGINT PRIMARY KEY
+manager_id  BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: managers_suspensions
+```sql
+id          BIGINT PRIMARY KEY
+manager_id  BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: managers_retirements
+```sql
+id          BIGINT PRIMARY KEY
+manager_id  BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+---
+
+## Query Builder Methods
+
+### Employment Scopes
+
+**Location:** `App\Builders\Roster\ManagerBuilder`
+
+**Extends:** `IndividualRosterMemberBuilder` (shared with Wrestler, Referee)
+
+| Method | Description |
+|--------|-------------|
+| `employed()` | Has current employment |
+| `unemployed()` | Never employed |
+| `released()` | Was employed, now without |
+| `futureEmployed()` | Has future employment scheduled |
+
+### Availability Scopes
+
+| Method | Description |
+|--------|-------------|
+| `injured()` | Currently injured |
+| `suspended()` | Currently suspended |
+| `retired()` | Currently retired |
+| `available()` | Employed + not injured + not suspended + not retired |
+| `unavailable()` | Inverse of available |
+
+### Search Scopes
+
+| Method | Description |
+|--------|-------------|
+| `whereNameLike(string $search)` | Search by first/last name |
+
+### NO Booking Scopes
+
+Managers are **not bookable**. The following scopes do NOT exist:
+- `bookable()`
+- `notBookedOn(Carbon $date)`
+
+### availableOn(Carbon $date) - API Consistency
+
+The `availableOn(Carbon $date)` method exists but **ignores the date parameter**:
+
+```php
+// From SingleRosterMemberBuilder
+public function availableOn(Carbon $date): static
+{
+    // Note: $date parameter is intentionally unused for managers/referees
+    // as they are not booked for matches. Method signature kept for consistency.
+    return $this->available();
+}
+```
+
+**Purpose:** API consistency. All roster builders have the same method signature for polymorphic use, even though managers/referees don't participate in matches.
+
+---
+
+## Lifecycle Validation
+
+**Traits:** `ValidatesEmployment`, `ValidatesInjury`, `ValidatesSuspension`, `ValidatesRetirement`, `ValidatesRestoration`
+
+### Employment Validation
+| Method | Checks |
+|--------|--------|
+| `canBeEmployed()` | Not already employed, not retired |
+| `ensureCanBeEmployed()` | Throws `CannotBeEmployedException` |
+
+### Release Validation
+| Method | Checks |
+|--------|--------|
+| `canBeReleased()` | Currently employed |
+| `ensureCanBeReleased()` | Throws `CannotBeReleasedException` |
+
+### Injury Validation
+| Method | Checks |
+|--------|--------|
+| `canBeInjured()` | Employed, not already injured |
+| `ensureCanBeInjured()` | Throws `CannotBeInjuredException` |
+
+### Recovery Validation
+| Method | Checks |
+|--------|--------|
+| `canBeCleared()` | Currently injured |
+| `ensureCanBeCleared()` | Throws `CannotBeClearedException` |
+
+### Suspension Validation
+| Method | Checks |
+|--------|--------|
+| `canBeSuspended()` | Employed, not already suspended |
+| `ensureCanBeSuspended()` | Throws `CannotBeSuspendedException` |
+
+### Reinstatement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeReinstated()` | Currently suspended, still employed |
+| `ensureCanBeReinstated()` | Throws `CannotBeReinstatedException` |
+
+### Retirement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeRetired()` | Not already retired, currently employed |
+| `ensureCanBeRetired()` | Throws `CannotBeRetiredException` |
+
+### Unretirement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeUnretired()` | Currently retired |
+| `ensureCanBeUnretired()` | Throws `CannotBeUnretiredException` |
+
+---
+
+## Business Rules
+
+### Employment Rules
+- Employment uses temporal tracking (`started_at`/`ended_at`)
+- Multiple employment periods allowed (rehires)
+- Cannot be employed while retired
+- Releasing a manager sets `ended_at` on current employment
+
+### Availability Rules
+- Injuries, suspensions, retirements all use same temporal pattern
+- Active state: `ended_at IS NULL`
+- Multiple periods allowed (multiple injuries, comebacks from retirement)
+- Status is computed, never stored
+
+### Client Assignment Rules
+
+#### Relationship Direction
+Managers are **hired by** wrestlers/tag teams. The pivot tables track "this wrestler/tag team has hired this manager."
+
+> **Note:** The relationship direction differs conceptually from the Wrestlers spec which says "wrestlers hire managers." From the Manager's perspective, the relationship is viewed as "manager manages wrestlers." Both are valid views of the same pivot data.
+
+#### Terminology
+| Field | Meaning |
+|-------|---------|
+| `hired_at` | Date the management relationship began |
+| `fired_at` | Date the management relationship ended (null = current) |
+
+#### Employment Requirement
+Both manager AND client (wrestler/tag team) must meet one of these conditions:
+- Currently employed
+- Has future employment scheduled
+
+This allows managers and clients to be paired before their debut, enabling them to debut together.
+
+#### Multiplicity
+- A manager can manage multiple wrestlers simultaneously
+- A manager can manage multiple tag teams simultaneously
+- A wrestler can have multiple managers simultaneously
+- A tag team can have multiple managers simultaneously
+
+### Relationship Persistence Rules
+
+**Management relationships are independent of employment status.** They persist until explicitly terminated (`fired_at` is set), regardless of either party's employment/retirement status.
+
+| Scenario | Relationship Status |
+|----------|---------------------|
+| Manager released | Client relationships persist (not auto-terminated) |
+| Manager retired | Client relationships persist (not auto-terminated) |
+| Client (wrestler/tag team) released | Management relationship persists |
+| Client (wrestler/tag team) retired | Management relationship persists |
+
+**Rationale:** Preserves historical context. You'd want to know "Bobby Heenan was still officially managing André the Giant when André retired" even though both have different employment statuses.
+
+**To end a relationship:** Explicitly set `fired_at` on the pivot record using the appropriate action/service.
+
+### Independent Retirement Model
+
+Manager retirement and client retirement are **independent**:
+- Manager retires → can still have "current" clients (relationships not auto-ended)
+- Client retires → can still have a "current" manager (relationship not auto-ended)
+- Manager comes out of retirement → still has their clients
+- Client comes out of retirement → still has their manager
+
+The `retired()` scope shows managers who are retired. It does NOT filter based on client retirement status.
+
+### Stable Association Rules
+Managers are **indirectly** associated with stables:
+- If a manager manages a wrestler who is in a stable, the manager is associated with that stable
+- If a manager manages a tag team whose wrestlers are in a stable, the manager is associated with that stable
+- Managers do NOT have direct stable membership
+- See Stables System spec for details
+
+### NOT Bookable
+- Managers do not participate in matches
+- No `isBookable()` method exists
+- No booking validation required
+- `available()` scope exists for assignment eligibility, not match booking
+
+---
+
+## File Locations
+
+```
+app/
+├── Enums/Shared/
+│   └── EmploymentStatus.php
+├── Models/Managers/
+│   ├── Manager.php
+│   ├── ManagerEmployment.php
+│   ├── ManagerInjury.php
+│   ├── ManagerSuspension.php
+│   └── ManagerRetirement.php
+├── Models/Concerns/
+│   ├── IsEmployable.php
+│   ├── IsInjurable.php
+│   ├── IsSuspendable.php
+│   ├── IsRetirable.php
+│   ├── DefinesManagedAliases.php
+│   ├── ProvidesDisplayName.php
+│   └── Validates*.php (multiple validation traits)
+└── Builders/Roster/
+    ├── ManagerBuilder.php
+    └── IndividualRosterMemberBuilder.php
+```
+
+---
+
+## Comparison with Other Roster Entities
+
+| Feature | Manager | Wrestler | Tag Team | Referee |
+|---------|---------|----------|----------|---------|
+| Employment | Yes | Yes | Yes | Yes |
+| Injuries | Yes | Yes | No | Yes |
+| Suspensions | Yes | Yes | Yes | Yes |
+| Retirements | Yes | Yes | Yes | Yes |
+| Bookable | **No** | Yes | Yes | Yes |
+| Manages Others | Yes | No | No | No |
+| Can Be Managed | No | Yes | Yes | No |
+| Name Fields | first/last | name | name | first/last |
+| Builder Base | Individual | Individual | Standalone | Individual |

--- a/.agent-os/specs/2026-01-16-managers-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-managers-system/tasks.md
@@ -1,0 +1,58 @@
+# Managers System Tasks
+
+## Pending
+
+### Add promotion_id foreign key for multi-tenant support
+
+**Priority:** Critical
+**Type:** Migration
+**Depends on:** Promotions System
+
+Add `promotion_id` foreign key to managers table for multi-tenant architecture.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_managers_table.php`
+- `app/Models/Manager.php`
+
+**Changes required:**
+- Create migration adding `promotion_id` column with foreign key constraint
+- Add index on `promotion_id`
+- Add `BelongsToPromotion` trait to Manager model
+- Add `promotion_id` to fillable array
+- Update ManagerFactory to include promotion
+- Update all manager tests to set promotion context
+
+**Acceptance Criteria:**
+- [ ] Migration creates column with proper foreign key
+- [ ] Cascade delete when promotion is deleted
+- [ ] Model uses BelongsToPromotion trait
+- [ ] Global scope filters by current promotion
+- [ ] All existing tests pass with promotion context
+
+**Reference:** See @.agent-os/specs/2026-01-16-promotions-system/tasks.md for full multi-tenant implementation details.
+
+---
+
+### Rename `SingleRosterMemberBuilder` to `IndividualRosterMemberBuilder`
+
+**Priority:** Low
+**Type:** Refactor
+
+More explicit naming for the shared query builder covering individual roster members.
+
+| Current | New |
+|---------|-----|
+| `SingleRosterMemberBuilder` | `IndividualRosterMemberBuilder` |
+
+**Changes required:**
+- Rename class file
+- Update namespace references
+- Update `ManagerBuilder` extends declaration
+
+**Note:** This is a shared task with Wrestlers System and Referees System. See Wrestlers System tasks.md for full details.
+
+---
+
+## Completed
+
+_None yet_

--- a/.agent-os/specs/2026-01-16-match-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-match-system/spec-lite.md
@@ -1,0 +1,92 @@
+# Match System - Quick Reference
+
+> Core competitive unit connecting competitors, officials, titles, and results
+
+## Core Entities
+
+| Entity | Purpose |
+|--------|---------|
+| EventMatch | Core match record within an event |
+| MatchCompetitor | Polymorphic pivot linking competitors to matches |
+| MatchStipulation | Special match rules (Steel Cage, Ladder, etc.) |
+| MatchResult | Outcome of a match with decision type |
+| MatchWinner | Individual winner record |
+| MatchLoser | Individual loser record |
+
+## EventMatch Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| event_id | int | Parent event |
+| match_number | int | Order in event card |
+| match_type | MatchType | Type enum (Singles, TagTeam, etc.) |
+| match_stipulation_id | int\|null | Optional special rules |
+| preview | string\|null | Promotional text |
+
+## Match Types (Enum)
+
+| Type | Sides | Competitor Types |
+|------|-------|------------------|
+| Singles | 2 | Wrestler only |
+| TagTeam | 2 | Wrestler + TagTeam |
+| TripleThreat | 3 | Wrestler + TagTeam |
+| Fatal4Way | 4 | Wrestler + TagTeam |
+| SixManTagTeam | 2 | Wrestler + TagTeam |
+| BattleRoyal | null | Wrestler + TagTeam |
+
+## Match Decisions (Enum)
+
+| Decision | Has Winners/Losers |
+|----------|-------------------|
+| Pinfall | Yes |
+| Submission | Yes |
+| Disqualification | Yes |
+| Countout | Yes |
+| Knockout | Yes |
+| Stipulation | Yes |
+| Forfeit | Yes |
+| TimeLimitDraw | No (draw) |
+| NoDecision | No |
+| ReverseDecision | No |
+
+## Key Relationships
+
+```
+EventMatch
+├── event (BelongsTo → Event)
+├── matchStipulation (BelongsTo → MatchStipulation)
+├── competitors (HasMany → MatchCompetitor)
+│   └── competitor (MorphTo → Wrestler|TagTeam)
+├── wrestlers (MorphToMany → Wrestler)
+├── tagTeams (MorphToMany → TagTeam)
+├── referees (BelongsToMany → Referee)
+├── titles (BelongsToMany → Title)
+├── result (HasOne → MatchResult)
+├── winners (HasManyThrough → MatchWinner)
+└── losers (HasManyThrough → MatchLoser)
+```
+
+## Side Assignment Pattern
+
+Competitors are grouped by `side_number` for team-based matches:
+- Side 1: Team A competitors
+- Side 2: Team B competitors
+- Side 3+: Additional sides for multi-way matches
+
+## Booking Rules
+
+**Competitors (Wrestlers/TagTeams):**
+- Must be bookable (employed, not injured/suspended/retired)
+- One match per event (double-booking restriction)
+
+**Referees:**
+- Must be bookable
+- Multiple matches per event allowed
+
+## File Locations
+
+- `app/Models/Matches/EventMatch.php`
+- `app/Models/Matches/MatchCompetitor.php`
+- `app/Enums/MatchType.php`
+- `app/Enums/MatchDecision.php`
+- `app/Actions/Matches/AddMatchForEventAction.php`

--- a/.agent-os/specs/2026-01-16-match-system/spec.md
+++ b/.agent-os/specs/2026-01-16-match-system/spec.md
@@ -1,0 +1,113 @@
+# Spec Requirements Document
+
+> Spec: Match System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the Match System—the core competitive unit of Ringside events. Matches represent individual contests within events, connecting competitors (wrestlers and tag teams), referees (officials), championship titles, and results. This spec serves as the authoritative reference for match creation, competitor assignment, officiating, match types, stipulations, decisions, and result tracking.
+
+## User Stories
+
+### Match Creation
+
+As a **wrestling promoter**, I want to create matches for events, so that I can build compelling match cards.
+
+**Workflow:**
+1. Select event to add match to
+2. Choose match type (Singles, Tag Team, Triple Threat, etc.)
+3. Optionally select match stipulation (Steel Cage, Ladder Match, etc.)
+4. Add preview text for promotional purposes
+5. Assign competitors to appropriate sides
+6. Assign referee(s) to officiate
+
+### Competitor Assignment
+
+As a **promoter**, I want to assign wrestlers and tag teams to matches, so that I can create competitive contests.
+
+**Workflow:**
+1. Select match to add competitors to
+2. Choose competitor type (wrestler or tag team)
+3. Assign competitors to sides (side 1, side 2, etc.)
+4. Validate competitors are bookable
+5. Check for double-booking conflicts
+
+### Match Officiating
+
+As a **promoter**, I want to assign referees to matches, so that matches have proper officiating.
+
+**Workflow:**
+1. Select match to assign officials
+2. Choose bookable referees
+3. Assign one or more referees to the match
+4. Referees can officiate multiple matches per event
+
+### Title Matches
+
+As a **promoter**, I want to put championships on the line in matches, so that titles can change hands.
+
+**Workflow:**
+1. Select match for title contest
+2. Assign active championship title(s)
+3. Ensure competitors are eligible challengers
+4. Track title implications based on result
+
+### Match Results
+
+As a **promoter**, I want to record match outcomes, so that I can track wins, losses, and championship changes.
+
+**Workflow:**
+1. Select completed match
+2. Choose match decision (Pinfall, Submission, DQ, etc.)
+3. Record winners and losers
+4. Handle special cases (draws, no contests)
+5. Process title changes if applicable
+
+## Spec Scope
+
+1. **EventMatch Entity** - Core match model with type, stipulation, preview
+2. **Match Types** - Enum defining Singles, Tag Team, Triple Threat, etc.
+3. **Match Stipulations** - Special rules (Steel Cage, Ladder, No DQ, etc.)
+4. **Competitors** - Polymorphic assignment of wrestlers and tag teams
+5. **Side Assignment** - Grouping competitors by sides for team-based matches
+6. **Officiating** - Referee assignment to matches
+7. **Titles** - Championship title association
+8. **Results** - Match outcomes with decisions, winners, and losers
+
+## Out of Scope
+
+- Event management (see Events System spec)
+- Wrestler/Tag Team management (see respective specs)
+- Referee management (see Referees System spec)
+- Title management (see Titles System spec)
+- Storyline/feud tracking
+
+## Expected Deliverable
+
+1. Complete match entity documentation with attributes
+2. Match type enum documentation
+3. Match decision enum documentation
+4. Match stipulation documentation
+5. Competitor assignment documentation (polymorphic, side-based)
+6. Officiating relationship documentation
+7. Result tracking documentation (winners/losers)
+8. Action class reference for match operations
+
+## Key Distinctions
+
+**Matches vs Events:**
+- Events contain multiple matches; matches belong to one event
+- Events have dates and venues; matches have types and stipulations
+- Events track status (scheduled, completed); matches track results (winners, losers)
+
+**Competitors vs Officials:**
+- Competitors (wrestlers, tag teams) compete in matches
+- Officials (referees) officiate matches
+- Both have bookability rules but different double-booking constraints
+- Competitors: one match per event; Referees: multiple matches per event
+
+**Match Results:**
+- Results record the outcome of a match
+- Winners and losers are tracked through the result
+- Decisions determine how the match ended (Pinfall, Submission, etc.)
+- Some decisions have no outcome (Time Limit Draw, No Decision)

--- a/.agent-os/specs/2026-01-16-match-system/sub-specs/match-types.md
+++ b/.agent-os/specs/2026-01-16-match-system/sub-specs/match-types.md
@@ -1,0 +1,327 @@
+# Match Types Reference
+
+> Match System
+> Reference: @.agent-os/specs/2026-01-16-match-system/spec.md
+
+---
+
+## Overview
+
+Ringside supports 14 distinct match types, each with specific rules for competitor counts, side assignments, and allowed participant types. This document details each match type's configuration.
+
+---
+
+## Standard Matches
+
+### Singles
+One-on-one competition between two wrestlers.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::Singles` |
+| Value | `'singles'` |
+| Sides | 2 |
+| Competitors per Side | 1 |
+| Allowed Types | Wrestler only |
+
+```
+Side 1: [Wrestler A]
+  vs
+Side 2: [Wrestler B]
+```
+
+---
+
+### Tag Team
+Traditional 2-on-2 tag team match.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::TagTeam` |
+| Value | `'tag-team'` |
+| Sides | 2 |
+| Competitors per Side | 2 wrestlers OR 1 tag team |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+Side 1: [Tag Team A] OR [Wrestler A + Wrestler B]
+  vs
+Side 2: [Tag Team B] OR [Wrestler C + Wrestler D]
+```
+
+---
+
+### Tornado Tag Team
+Tag team match where all participants are legal simultaneously.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::TornadoTagTeam` |
+| Value | `'tornado-tag-team'` |
+| Sides | 2 |
+| Competitors per Side | 2 wrestlers OR 1 tag team |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+Side 1: [Tag Team A] OR [Wrestler A + Wrestler B]
+  vs
+Side 2: [Tag Team B] OR [Wrestler C + Wrestler D]
+```
+
+---
+
+## Multi-Man Tag Team Matches
+
+### 6-Man Tag Team
+Three-on-three tag team competition.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::SixManTagTeam` |
+| Value | `'6-man-tag-team'` |
+| Sides | 2 |
+| Competitors per Side | 3 wrestlers OR tag team + wrestler |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+Side 1: [3 Wrestlers] OR [Tag Team + Wrestler]
+  vs
+Side 2: [3 Wrestlers] OR [Tag Team + Wrestler]
+```
+
+---
+
+### 8-Man Tag Team
+Four-on-four tag team competition.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::EightManTagTeam` |
+| Value | `'8-man-tag-team'` |
+| Sides | 2 |
+| Competitors per Side | 4 wrestlers OR 2 tag teams |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+Side 1: [4 Wrestlers] OR [Tag Team A + Tag Team B]
+  vs
+Side 2: [4 Wrestlers] OR [Tag Team C + Tag Team D]
+```
+
+---
+
+### 10-Man Tag Team
+Five-on-five tag team competition.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::TenManTagTeam` |
+| Value | `'10-man-tag-team'` |
+| Sides | 2 |
+| Competitors per Side | 5 wrestlers OR 2 tag teams + wrestler |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+Side 1: [5 Wrestlers] OR [2 Tag Teams + Wrestler]
+  vs
+Side 2: [5 Wrestlers] OR [2 Tag Teams + Wrestler]
+```
+
+---
+
+## Multi-Way Matches
+
+### Triple Threat
+Three-way competition, first to score wins.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::TripleThreat` |
+| Value | `'triple-threat'` |
+| Sides | 3 |
+| Competitors per Side | 1 |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+Side 1: [Competitor A]
+  vs
+Side 2: [Competitor B]
+  vs
+Side 3: [Competitor C]
+```
+
+---
+
+### Triangle
+Alternative name for three-way competition (often used for tag teams).
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::Triangle` |
+| Value | `'triangle'` |
+| Sides | 3 |
+| Competitors per Side | 1 tag team OR wrestler |
+| Allowed Types | Wrestler, TagTeam |
+
+---
+
+### Fatal 4-Way
+Four-way competition.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::Fatal4Way` |
+| Value | `'fatal-4-way'` |
+| Sides | 4 |
+| Competitors per Side | 1 |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+Side 1: [Competitor A]
+  vs
+Side 2: [Competitor B]
+  vs
+Side 3: [Competitor C]
+  vs
+Side 4: [Competitor D]
+```
+
+---
+
+## Handicap Matches
+
+### Two-on-One Handicap
+Two competitors against one.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::TwoOnOneHandicap` |
+| Value | `'two-on-one-handicap'` |
+| Sides | 2 |
+| Side 1 Competitors | 1 wrestler |
+| Side 2 Competitors | 2 wrestlers OR 1 tag team |
+| Allowed Types | Wrestler only |
+
+```
+Side 1: [Wrestler A]
+  vs
+Side 2: [Wrestler B + Wrestler C]
+```
+
+---
+
+### Three-on-Two Handicap
+Three competitors against two.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::ThreeOnTwoHandicap` |
+| Value | `'three-on-two-handicap'` |
+| Sides | 2 |
+| Side 1 Competitors | 2 wrestlers |
+| Side 2 Competitors | 3 wrestlers |
+| Allowed Types | Wrestler only |
+
+```
+Side 1: [Wrestler A + Wrestler B]
+  vs
+Side 2: [Wrestler C + Wrestler D + Wrestler E]
+```
+
+---
+
+## Large-Scale Matches
+
+### Battle Royal
+Multiple competitors, last one standing wins. No fixed sides.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::BattleRoyal` |
+| Value | `'battle-royal'` |
+| Sides | null (free-for-all) |
+| Minimum Competitors | 2 |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+All competitors: [A, B, C, D, E, F, ...]
+  - No sides assigned
+  - Elimination format
+```
+
+---
+
+### Royal Rumble
+Timed-entry battle royal format.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::RoyalRumble` |
+| Value | `'royal-rumble'` |
+| Sides | null (free-for-all) |
+| Minimum Competitors | 2 |
+| Allowed Types | Wrestler, TagTeam |
+
+```
+All competitors: [A, B, C, D, ...]
+  - Timed entries
+  - Over-the-top elimination
+```
+
+---
+
+### Gauntlet
+Sequential one-on-one matches, winner continues.
+
+| Property | Value |
+|----------|-------|
+| Enum | `MatchType::Gauntlet` |
+| Value | `'gauntlet'` |
+| Sides | 2 |
+| Format | Successive 1v1 matches |
+| Allowed Types | Wrestler only |
+
+```
+Match 1: [Wrestler A] vs [Wrestler B]
+  Winner faces:
+Match 2: [Winner] vs [Wrestler C]
+  Winner faces:
+Match 3: [Winner] vs [Wrestler D]
+  ...
+```
+
+---
+
+## Match Type Summary Table
+
+| Match Type | Sides | Min Competitors | Tag Teams Allowed |
+|------------|-------|-----------------|-------------------|
+| Singles | 2 | 2 | No |
+| Tag Team | 2 | 2 | Yes |
+| Tornado Tag | 2 | 2 | Yes |
+| 6-Man Tag | 2 | 6 | Yes |
+| 8-Man Tag | 2 | 8 | Yes |
+| 10-Man Tag | 2 | 10 | Yes |
+| Triple Threat | 3 | 3 | Yes |
+| Triangle | 3 | 3 | Yes |
+| Fatal 4-Way | 4 | 4 | Yes |
+| 2-on-1 Handicap | 2 | 3 | No |
+| 3-on-2 Handicap | 2 | 5 | No |
+| Battle Royal | null | 2 | Yes |
+| Royal Rumble | null | 2 | Yes |
+| Gauntlet | 2 | 2+ | No |
+
+---
+
+## Decision Types by Match Format
+
+| Decision | Standard | Multi-Way | Battle Royal |
+|----------|----------|-----------|--------------|
+| Pinfall | Yes | Yes | No |
+| Submission | Yes | Yes | No |
+| DQ | Yes | Varies | No |
+| Countout | Yes | Varies | No |
+| Knockout | Yes | Yes | No |
+| Stipulation | Yes | Yes | Yes |
+| Forfeit | Yes | Yes | Yes |
+| Elimination | No | No | Yes |

--- a/.agent-os/specs/2026-01-16-match-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-match-system/sub-specs/technical-spec.md
@@ -1,0 +1,660 @@
+# Technical Specification
+
+> Match System
+> Reference: @.agent-os/specs/2026-01-16-match-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. EventMatch
+
+**Model:** `App\Models\Matches\EventMatch`
+
+The core entity representing a competitive contest within an event.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| event_id | int | Foreign key to event |
+| match_number | int | Order in event card |
+| match_type | MatchType | Enum defining match structure |
+| match_stipulation_id | int\|null | Foreign key to stipulation |
+| preview | string\|null | Promotional preview text |
+
+#### Key Relationships
+```
+EventMatch
+├── event (BelongsTo → Event)
+├── matchStipulation (BelongsTo → MatchStipulation)
+├── competitors (HasMany → MatchCompetitor)
+├── wrestlers (MorphToMany → Wrestler)
+│   └── via events_matches_competitors with side_number
+├── tagTeams (MorphToMany → TagTeam)
+│   └── via events_matches_competitors with side_number
+├── referees (BelongsToMany → Referee)
+│   └── via events_matches_referees
+├── titles (BelongsToMany → Title)
+│   └── via events_matches_titles
+├── result (HasOne → MatchResult)
+├── winners (HasManyThrough → MatchWinner via MatchResult)
+└── losers (HasManyThrough → MatchLoser via MatchResult)
+```
+
+---
+
+### 2. MatchCompetitor
+
+**Model:** `App\Models\Matches\MatchCompetitor`
+
+Polymorphic pivot model linking competitors (Wrestler or TagTeam) to matches with side assignment.
+
+**Extends:** `MorphPivot`
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| match_id | int | Foreign key to EventMatch |
+| competitor_type | string | Morph type (Wrestler or TagTeam class) |
+| competitor_id | int | Foreign key to competitor |
+| side_number | int | Side/team assignment (1, 2, 3, etc.) |
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `competitor()` | MorphTo | Polymorphic relation to Wrestler or TagTeam |
+| `getCompetitor()` | Wrestler\|TagTeam | Type-safe competitor accessor |
+
+#### Side Number Pattern
+
+The `side_number` field groups competitors into teams/sides for the match:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    SIDE NUMBER PATTERN                       │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  Singles Match:                                             │
+│    Side 1: [Wrestler A]                                     │
+│    Side 2: [Wrestler B]                                     │
+│                                                             │
+│  Tag Team Match:                                            │
+│    Side 1: [TagTeam A] or [Wrestler A, Wrestler B]          │
+│    Side 2: [TagTeam B] or [Wrestler C, Wrestler D]          │
+│                                                             │
+│  Triple Threat:                                             │
+│    Side 1: [Wrestler A]                                     │
+│    Side 2: [Wrestler B]                                     │
+│    Side 3: [Wrestler C]                                     │
+│                                                             │
+│  Battle Royal (null sides):                                 │
+│    All competitors assigned, no side grouping               │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 3. MatchStipulation
+
+**Model:** `App\Models\Matches\MatchStipulation`
+
+Defines special rules or conditions for a match.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| name | string | Display name (e.g., "Steel Cage") |
+| slug | string | URL-safe identifier |
+| description | string\|null | Rule description |
+| is_active | bool | Whether stipulation is available for use |
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `isStandardMatch()` | bool | Check if slug is 'standard' |
+| `requiresSpecialSetup()` | bool | Needs special equipment (cage, ladder, etc.) |
+| `isHardcoreStipulation()` | bool | Involves weapons/hardcore elements |
+| `hasEliminationRules()` | bool | Uses elimination format |
+| `getDisplayName()` | string | Formatted name for display |
+
+#### Common Stipulations
+| Slug | Special Setup | Hardcore |
+|------|---------------|----------|
+| standard | No | No |
+| steel_cage | Yes | No |
+| ladder_match | Yes | No |
+| no_dq | No | Yes |
+| hardcore_match | No | Yes |
+| tlc_match | Yes | Yes |
+| hell_in_a_cell | Yes | No |
+| falls_count_anywhere | No | Yes |
+
+---
+
+### 4. MatchResult
+
+**Model:** `App\Models\Matches\MatchResult`
+
+Records the outcome of a completed match.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| match_id | int | Foreign key to EventMatch |
+| match_decision | MatchDecision | How the match ended |
+| winner_type | string | Morph type for primary winner |
+| winner_id | int | Foreign key to primary winner |
+
+#### Relationships
+```
+MatchResult
+├── match (BelongsTo → EventMatch)
+├── winners (HasMany → MatchWinner)
+├── losers (HasMany → MatchLoser)
+└── winner (MorphTo → Wrestler|TagTeam) - primary winner
+```
+
+---
+
+### 5. MatchWinner
+
+**Model:** `App\Models\Matches\MatchWinner`
+
+Individual winner record for a match, allowing multiple winners (e.g., tag team partners).
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| match_result_id | int | Foreign key to MatchResult |
+| match_competitor_id | int | Foreign key to MatchCompetitor |
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `matchResult()` | BelongsTo | Parent result |
+| `competitor()` | BelongsTo | Link to MatchCompetitor |
+| `winner()` | Wrestler\|TagTeam | Resolved winner entity |
+| `getWinner()` | Wrestler\|TagTeam | Type-safe winner accessor |
+
+---
+
+### 6. MatchLoser
+
+**Model:** `App\Models\Matches\MatchLoser`
+
+Individual loser record for a match, providing symmetric querying alongside MatchWinner.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| match_result_id | int | Foreign key to MatchResult |
+| match_competitor_id | int | Foreign key to MatchCompetitor |
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `matchResult()` | BelongsTo | Parent result |
+| `competitor()` | BelongsTo | Link to MatchCompetitor |
+| `loser()` | Wrestler\|TagTeam | Resolved loser entity |
+| `getLoser()` | Wrestler\|TagTeam | Type-safe loser accessor |
+
+---
+
+## Enums
+
+### MatchType
+
+**Location:** `App\Enums\MatchType`
+
+Defines the structure and competitor requirements for a match.
+
+```php
+enum MatchType: string {
+    case Singles = 'singles';
+    case TagTeam = 'tag-team';
+    case TripleThreat = 'triple-threat';
+    case Triangle = 'triangle';
+    case Fatal4Way = 'fatal-4-way';
+    case SixManTagTeam = '6-man-tag-team';
+    case EightManTagTeam = '8-man-tag-team';
+    case TenManTagTeam = '10-man-tag-team';
+    case TwoOnOneHandicap = 'two-on-one-handicap';
+    case ThreeOnTwoHandicap = 'three-on-two-handicap';
+    case BattleRoyal = 'battle-royal';
+    case RoyalRumble = 'royal-rumble';
+    case TornadoTagTeam = 'tornado-tag-team';
+    case Gauntlet = 'gauntlet';
+}
+```
+
+#### Match Type Properties
+
+| Type | Sides | Min Competitors | Allows TagTeams |
+|------|-------|-----------------|-----------------|
+| Singles | 2 | 2 | No |
+| TagTeam | 2 | 2 | Yes |
+| TripleThreat | 3 | 3 | Yes |
+| Triangle | 3 | 3 | Yes |
+| Fatal4Way | 4 | 4 | Yes |
+| SixManTagTeam | 2 | 2 | Yes |
+| EightManTagTeam | 2 | 2 | Yes |
+| TenManTagTeam | 2 | 2 | Yes |
+| TwoOnOneHandicap | 2 | 2 | No |
+| ThreeOnTwoHandicap | 2 | 2 | No |
+| BattleRoyal | null | 2 | Yes |
+| RoyalRumble | null | 2 | Yes |
+| TornadoTagTeam | 2 | 2 | Yes |
+| Gauntlet | 2 | 2 | No |
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `label()` | string | Human-readable name |
+| `numberOfSides()` | int\|null | Side count (null for battle royals) |
+| `getAllowedCompetitorTypes()` | array | ['wrestler'] or ['wrestler', 'tag_team'] |
+| `allowsWrestlers()` | bool | Always true |
+| `allowsTagTeams()` | bool | Match-type dependent |
+| `getMinimumCompetitors()` | int | Minimum required |
+| `getMaximumCompetitors()` | int | Maximum allowed |
+
+---
+
+### MatchDecision
+
+**Location:** `App\Enums\MatchDecision`
+
+Defines how a match concluded and whether it produced winners/losers.
+
+```php
+enum MatchDecision: string {
+    case Pinfall = 'pinfall';
+    case Submission = 'submission';
+    case Disqualification = 'disqualification';
+    case Countout = 'countout';
+    case Knockout = 'knockout';
+    case Stipulation = 'stipulation';
+    case Forfeit = 'forfeit';
+    case TimeLimitDraw = 'time-limit-draw';
+    case NoDecision = 'no-decision';
+    case ReverseDecision = 'reverse-decision';
+}
+```
+
+#### Decision Outcomes
+
+| Decision | Has Winners | Has Losers | Notes |
+|----------|-------------|------------|-------|
+| Pinfall | Yes | Yes | Standard finish |
+| Submission | Yes | Yes | Tap out / pass out |
+| Disqualification | Yes | Yes | Winner by opponent DQ |
+| Countout | Yes | Yes | Winner by opponent countout |
+| Knockout | Yes | Yes | TKO / referee stoppage |
+| Stipulation | Yes | Yes | Won via stipulation rules |
+| Forfeit | Yes | Yes | Opponent didn't compete |
+| TimeLimitDraw | **No** | **No** | Time expired, no winner |
+| NoDecision | **No** | **No** | Match thrown out |
+| ReverseDecision | **No** | **No** | Result overturned |
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `label()` | string | Human-readable name |
+| `hasWinners()` | bool | True if decision produces winners |
+| `hasLosers()` | bool | True if decision produces losers |
+| `hasNoOutcome()` | bool | True for draws/no contests |
+
+---
+
+## Database Tables
+
+### Match Tables
+| Table | Description |
+|-------|-------------|
+| `events_matches` | Core match records |
+| `events_matches_competitors` | Polymorphic competitor assignments |
+| `events_matches_referees` | Referee officiating assignments |
+| `events_matches_titles` | Championship title associations |
+| `events_matches_results` | Match outcomes |
+| `events_matches_winners` | Individual winner records |
+| `events_matches_losers` | Individual loser records |
+| `matches_stipulations` | Match stipulation definitions |
+
+### Schema: events_matches
+```sql
+id                   BIGINT PRIMARY KEY
+event_id             BIGINT FOREIGN KEY
+match_number         INT
+match_type           VARCHAR(255)  -- MatchType enum value
+match_stipulation_id BIGINT NULLABLE FOREIGN KEY
+preview              TEXT NULLABLE
+created_at           TIMESTAMP
+updated_at           TIMESTAMP
+```
+
+### Schema: events_matches_competitors
+```sql
+id              BIGINT PRIMARY KEY
+match_id        BIGINT FOREIGN KEY
+competitor_type VARCHAR(255)  -- Morph type
+competitor_id   BIGINT        -- Morph ID
+side_number     INT           -- Team/side assignment
+created_at      TIMESTAMP
+updated_at      TIMESTAMP
+```
+
+### Schema: events_matches_referees
+```sql
+match_id    BIGINT FOREIGN KEY
+referee_id  BIGINT FOREIGN KEY
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: events_matches_titles
+```sql
+match_id    BIGINT FOREIGN KEY
+title_id    BIGINT FOREIGN KEY
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: events_matches_results
+```sql
+id             BIGINT PRIMARY KEY
+match_id       BIGINT FOREIGN KEY
+match_decision VARCHAR(255)  -- MatchDecision enum value
+winner_type    VARCHAR(255)  -- Morph type
+winner_id      BIGINT        -- Morph ID
+created_at     TIMESTAMP
+updated_at     TIMESTAMP
+```
+
+### Schema: events_matches_winners
+```sql
+id                  BIGINT PRIMARY KEY
+match_result_id     BIGINT FOREIGN KEY
+match_competitor_id BIGINT FOREIGN KEY
+created_at          TIMESTAMP
+updated_at          TIMESTAMP
+```
+
+### Schema: events_matches_losers
+```sql
+id                  BIGINT PRIMARY KEY
+match_result_id     BIGINT FOREIGN KEY
+match_competitor_id BIGINT FOREIGN KEY
+created_at          TIMESTAMP
+updated_at          TIMESTAMP
+```
+
+### Schema: matches_stipulations
+```sql
+id          BIGINT PRIMARY KEY
+name        VARCHAR(255)
+slug        VARCHAR(255)
+description TEXT NULLABLE
+is_active   BOOLEAN DEFAULT TRUE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+---
+
+## Custom Collection
+
+### MatchCompetitorsCollection
+
+**Location:** `App\Collections\MatchCompetitorsCollection`
+
+Custom Eloquent collection for MatchCompetitor models with specialized methods.
+
+| Method | Return | Description |
+|--------|--------|-------------|
+| `sortBySideNumber()` | static | Sort by side_number ascending |
+| `sides()` | array | Get unique side numbers |
+| `countPerSide()` | Collection | Map side → count |
+| `countCompetitorsForSide(int)` | int | Count for specific side |
+| `hasTagTeamsOnSide(int)` | bool | Check for tag teams on side |
+| `allBookable()` | bool | All competitors bookable? |
+| `groupBySide()` | Collection | Group by side_number |
+| `mapToCompetitorInstances()` | Collection | Extract Wrestler/TagTeam models |
+| `onlyWrestlers()` | static | Filter to wrestlers |
+| `onlyTagTeams()` | static | Filter to tag teams |
+| `filterBySide(int)` | static | Filter by side number |
+| `pluckCompetitors()` | Collection | Get competitor models |
+| `pluckWrestlers()` | Collection | Get wrestler models only |
+| `pluckTagTeams()` | Collection | Get tag team models only |
+| `pluckCompetitorsBySide()` | Collection | Competitors grouped by side |
+| `getCompetitorsForSide(int)` | Collection | Get competitors for side |
+
+---
+
+## Actions
+
+### AddMatchForEventAction
+
+**Location:** `App\Actions\Matches\AddMatchForEventAction`
+
+Creates a complete match for an event with all components.
+
+```php
+public function handle(Event $event, EventMatchData $eventMatchData): EventMatch
+```
+
+**Workflow:**
+1. Validate event can accept matches
+2. Validate match data completeness
+3. Create base match record (in transaction)
+4. Add referees via `AddRefereesToMatchAction`
+5. Add titles via `AddTitlesToMatchAction`
+6. Add competitors via `AddCompetitorsToMatchAction`
+7. Return created match
+
+---
+
+### AddCompetitorsToMatchAction
+
+**Location:** `App\Actions\Matches\AddCompetitorsToMatchAction`
+
+Assigns competitors to match with side-based grouping.
+
+```php
+public function handle(EventMatch $eventMatch, Collection $competitors): void
+```
+
+**Parameters:**
+- `$competitors`: Collection keyed by side number, each containing `wrestlers` and `tag_teams` arrays
+
+**Example:**
+```php
+$competitors = collect([
+    1 => ['wrestlers' => [$wrestler1], 'tag_teams' => []],
+    2 => ['wrestlers' => [$wrestler2], 'tag_teams' => []]
+]);
+AddCompetitorsToMatchAction::run($match, $competitors);
+```
+
+**Validation:**
+- Must have at least 2 sides with competitors
+
+---
+
+### AddRefereesToMatchAction
+
+**Location:** `App\Actions\Matches\AddRefereesToMatchAction`
+
+Assigns referees to officiate a match.
+
+```php
+public function handle(EventMatch $eventMatch, Collection $referees): void
+```
+
+**Validation:**
+- Referees must be bookable (`isBookable()` returns true)
+- At least one eligible referee required
+
+---
+
+### AddWrestlersToMatchAction
+
+**Location:** `App\Actions\Matches\AddWrestlersToMatchAction`
+
+Adds wrestlers to a specific side of a match.
+
+```php
+public function handle(EventMatch $eventMatch, Collection $wrestlers, int $sideNumber): void
+```
+
+---
+
+### AddTagTeamsToMatchAction
+
+**Location:** `App\Actions\Matches\AddTagTeamsToMatchAction`
+
+Adds tag teams to a specific side of a match.
+
+```php
+public function handle(EventMatch $eventMatch, Collection $tagTeams, int $sideNumber): void
+```
+
+---
+
+### AddTitlesToMatchAction
+
+**Location:** `App\Actions\Matches\AddTitlesToMatchAction`
+
+Associates championship titles with a match.
+
+```php
+public function handle(EventMatch $eventMatch, Collection $titles): void
+```
+
+---
+
+## Business Rules
+
+### Competitor Booking Rules
+
+#### Double-Booking Restriction
+Competitors (wrestlers and tag teams) can only compete in **one match per event**:
+
+| Entity | Same-Event Booking |
+|--------|-------------------|
+| Wrestler | One match per event |
+| Tag Team | One match per event |
+| Referee | **Multiple matches per event** |
+
+**Rationale:** Wrestlers/tag teams compete; they need rest between matches. Referees officiate multiple matches on the same show.
+
+#### Bookability Requirements
+Competitors must be bookable to be assigned to a match:
+- Employed (not future employment)
+- Not injured
+- Not suspended
+- Not retired
+
+### Match Type Validation
+
+#### Competitor Type Restrictions
+Match types enforce which competitor types are allowed:
+
+```php
+// Singles matches only allow wrestlers
+MatchType::Singles->allowsTagTeams(); // false
+
+// Tag team matches allow both
+MatchType::TagTeam->allowsTagTeams(); // true
+MatchType::TagTeam->allowsWrestlers(); // true
+```
+
+#### Side Requirements
+Match types define expected number of sides:
+
+| Type | Expected Sides |
+|------|----------------|
+| Singles, TagTeam | 2 |
+| TripleThreat | 3 |
+| Fatal4Way | 4 |
+| BattleRoyal | null (no sides) |
+
+### Result Recording Rules
+
+#### Decision Outcomes
+- Decisions with outcomes (Pinfall, etc.) require winners and losers
+- Decisions without outcomes (TimeLimitDraw, etc.) have no winners/losers
+
+#### Winner/Loser Recording
+- Winners are recorded in `events_matches_winners`
+- Losers are recorded in `events_matches_losers`
+- Both reference `match_competitor_id` to link back to the original assignment
+
+### Title Match Rules
+
+- Title matches associate championships via `events_matches_titles`
+- Competitors in title matches should be eligible challengers
+- Title changes are processed based on match result
+- Active titles only can be put on the line
+
+---
+
+## File Locations
+
+```
+app/
+├── Enums/
+│   ├── MatchType.php
+│   └── MatchDecision.php
+├── Models/Matches/
+│   ├── EventMatch.php
+│   ├── MatchCompetitor.php
+│   ├── MatchStipulation.php
+│   ├── MatchResult.php
+│   ├── MatchWinner.php
+│   └── MatchLoser.php
+├── Models/Concerns/
+│   └── HasMatches.php              # Used by Event model (event has many matches)
+├── Collections/
+│   └── MatchCompetitorsCollection.php
+├── Actions/Matches/
+│   ├── AddMatchForEventAction.php
+│   ├── AddCompetitorsToMatchAction.php
+│   ├── AddRefereesToMatchAction.php
+│   ├── AddWrestlersToMatchAction.php
+│   ├── AddTagTeamsToMatchAction.php
+│   └── AddTitlesToMatchAction.php
+└── Data/Matches/
+    └── EventMatchData.php
+```
+
+---
+
+## Related Systems
+
+| System | Relationship |
+|--------|--------------|
+| Events | Matches belong to events |
+| Wrestlers | Compete as individual competitors |
+| Tag Teams | Compete as team competitors |
+| Referees | Officiate matches |
+| Titles | Championships at stake |
+
+---
+
+## Comparison: Competitors vs Officials
+
+| Aspect | Competitors | Officials |
+|--------|-------------|-----------|
+| Entities | Wrestler, TagTeam | Referee |
+| Interface | BookableCompetitor | BookableOfficial |
+| Relationship | MorphToMany (polymorphic) | BelongsToMany |
+| Pivot Table | events_matches_competitors | events_matches_referees |
+| Side Assignment | Yes (side_number) | No |
+| Double-Booking | One match per event | Multiple matches per event |
+| Role | Compete in match | Officiate match |

--- a/.agent-os/specs/2026-01-16-match-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-match-system/tasks.md
@@ -1,0 +1,190 @@
+# Match System Tasks
+
+## Pending
+
+### Fix incorrect pivot table name in IsBookableCompetitor trait
+
+**Priority:** High
+**Type:** Bug Fix
+
+The `IsBookableCompetitor` trait references the wrong pivot table name.
+
+**Current code:**
+```php
+return $this->morphToMany(EventMatch::class, 'competitor', 'event_match_competitors')
+```
+
+**Should be:**
+```php
+return $this->morphToMany(EventMatch::class, 'competitor', 'events_matches_competitors')
+```
+
+The migration creates `events_matches_competitors` (with underscores and plurals), but the trait uses `event_match_competitors`. The EventMatch model correctly uses `events_matches_competitors`.
+
+**Changes required:**
+- Update table name in `IsBookableCompetitor::matches()` method
+- Verify all tests pass after fix
+
+---
+
+### Fix incorrect competitor creation in AddTagTeamsToMatchAction
+
+**Priority:** High
+**Type:** Bug Fix
+
+The `AddTagTeamsToMatchAction` uses incorrect column names when creating competitors, inconsistent with the polymorphic pattern used in `AddWrestlersToMatchAction`.
+
+**Current code:**
+```php
+$eventMatch->competitors()->create([
+    'tag_team_id' => $tagTeam->id,
+    'side_number' => $sideNumber,
+]);
+```
+
+**Should be:**
+```php
+$eventMatch->competitors()->create([
+    'competitor_id' => $tagTeam->id,
+    'competitor_type' => TagTeam::class,
+    'side_number' => $sideNumber,
+]);
+```
+
+**Changes required:**
+- Update `AddTagTeamsToMatchAction::handle()` to use polymorphic columns
+- Verify tag team match creation works correctly after fix
+
+---
+
+### Add `upcomingMatches` relationship to IsBookableCompetitor trait
+
+**Priority:** Low
+**Type:** Enhancement
+
+Add relationship to view scheduled match assignments for competitors (wrestlers and tag teams).
+
+```php
+public function upcomingMatches(): MorphToMany
+{
+    return $this->matches()->whereHas('event', function ($query) {
+        $query->where('date', '>=', now());
+    });
+}
+```
+
+**Changes required:**
+- Add method to `IsBookableCompetitor` trait
+- Add tests for the new relationship
+
+**Note:** This is a shared task with Referees System (OfficiatesMatches trait). See Referees System tasks.md for the parallel task.
+
+---
+
+### Implement proper competitor side assignment in AddMatchForEventAction
+
+**Priority:** Medium
+**Type:** Enhancement
+
+The `transformCompetitorsStructure` method in `AddMatchForEventAction` currently assigns all competitors to side 1. This needs proper implementation based on match type and strategy.
+
+**Current behavior:**
+```php
+// For now, assume single side (side 1) for all competitors
+// This is a simplified transformation - a more complex implementation
+// would need to handle side assignment based on match type and strategy
+```
+
+**Changes required:**
+- Implement side assignment logic based on match type
+- Consider match type's `numberOfSides()` for proper distribution
+- Handle special cases like BattleRoyal (null sides)
+
+---
+
+### Implement event eligibility validation
+
+**Priority:** Medium
+**Type:** Enhancement
+
+The `isEventEligibleForMatches` method in `AddMatchForEventAction` always returns `true`. Should validate event state.
+
+**Current behavior:**
+```php
+private function isEventEligibleForMatches(Event $event): bool
+{
+    // Basic checks - event should be scheduled and not completed
+    return true;
+}
+```
+
+**Changes required:**
+- Check event status (should be scheduled, not completed)
+- Validate event date is in the future
+- Consider event capacity limits if applicable
+
+---
+
+### Add competitor double-booking validation
+
+**Priority:** High
+**Type:** Enhancement
+
+Currently there's no explicit validation preventing a wrestler or tag team from being booked in multiple matches at the same event.
+
+**Business Rule:** Competitors can only compete in one match per event.
+
+**Changes required:**
+- Add validation in `AddWrestlersToMatchAction` to check for existing bookings
+- Add validation in `AddTagTeamsToMatchAction` to check for existing bookings
+- Consider adding a dedicated validation service/action
+
+---
+
+### Expand MatchType maximum competitors logic
+
+**Priority:** Low
+**Type:** Enhancement
+
+The `getMaximumCompetitors()` method currently returns the same value as `getMinimumCompetitors()`.
+
+**Current behavior:**
+```php
+public function getMaximumCompetitors(): int
+{
+    // For now, assume same as minimum unless specified otherwise
+    return $this->getMinimumCompetitors();
+}
+```
+
+**Changes required:**
+- Define proper maximum competitor counts per match type
+- Handle variable competitor counts (e.g., Battle Royal can have many participants)
+- Consider adding validation against these limits
+
+---
+
+### Rename relationship methods for terminology consistency
+
+**Priority:** Low
+**Type:** Refactor
+
+Align with Events System terminology where `Past` → `Completed`:
+
+| Trait | Current | New |
+|-------|---------|-----|
+| `IsBookableCompetitor` | `previousMatches` | `completedMatches` |
+| `OfficiatesMatches` | `previousMatches` | `completedMatches` |
+
+**Note:** This is a shared task with Wrestlers System and Referees System. See those tasks.md files for the same item.
+
+**Changes required:**
+- Rename method in `IsBookableCompetitor` trait
+- Rename method in `OfficiatesMatches` trait
+- Update all callers and tests
+
+---
+
+## Completed
+
+_None yet_

--- a/.agent-os/specs/2026-01-16-promotions-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-promotions-system/spec-lite.md
@@ -1,0 +1,62 @@
+# Promotions System - Quick Reference
+
+> Parent: @.agent-os/specs/2026-01-16-promotions-system/spec.md
+
+## Core Concept
+
+Promotions are the multi-tenant ownership layer. Every roster entity, event, venue, and title belongs to exactly one Promotion.
+
+## Key Relationships
+
+```
+User (Promoter)
+  └── hasMany Promotion
+        ├── hasMany Wrestler
+        ├── hasMany TagTeam
+        ├── hasMany Manager
+        ├── hasMany Referee
+        ├── hasMany Stable
+        ├── hasMany Event
+        ├── hasMany Venue
+        └── hasMany Title
+```
+
+## Promotion Model
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | ulid | Primary key |
+| user_id | foreignId | Owner/Promoter |
+| name | string | Promotion name |
+| slug | string | URL-safe identifier |
+| settings | json | Promotion preferences |
+| timestamps | - | created_at, updated_at |
+
+## Entity Scoping
+
+All entities gain `promotion_id` foreign key:
+- Wrestlers, Tag Teams, Managers, Referees, Stables
+- Events, Venues
+- Titles
+
+## Global Scope Pattern
+
+```php
+// Applied to all promotion-owned models
+class PromotionScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        $builder->where('promotion_id', current_promotion_id());
+    }
+}
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `app/Models/Promotion.php` | Promotion model |
+| `app/Models/Scopes/PromotionScope.php` | Global scope |
+| `database/migrations/*_create_promotions_table.php` | Migration |
+| `database/migrations/*_add_promotion_id_to_*_tables.php` | FK migrations |

--- a/.agent-os/specs/2026-01-16-promotions-system/spec.md
+++ b/.agent-os/specs/2026-01-16-promotions-system/spec.md
@@ -1,0 +1,58 @@
+# Spec Requirements Document
+
+> Spec: Promotions System
+> Created: 2026-01-16
+> Status: Planning
+
+## Overview
+
+Create a multi-tenant Promotions system that serves as the ownership layer for all wrestling entities. Each Promotion represents a wrestling company owned by a User (Promoter), and owns all roster members, events, venues, and titles within its scope.
+
+## User Stories
+
+### Promoter Story
+
+As a promoter, I want to create and manage my wrestling promotion, so that I can organize my roster, schedule events, and track championships within my company's scope.
+
+**Detailed Workflow**: Promoters register an account, create their promotion with basic details (name, slug, settings), and then manage all roster entities (wrestlers, tag teams, managers, referees, stables), schedule events at venues, and establish championship titles - all scoped to their promotion.
+
+### Multi-Promotion Story
+
+As a promoter with multiple brands, I want to manage separate promotions under my account, so that I can run distinct wrestling companies with their own rosters and championships.
+
+**Detailed Workflow**: A single user account can own multiple promotions, each with completely separate rosters, events, and titles. Switching between promotions provides isolated management contexts.
+
+### Data Isolation Story
+
+As a promoter, I want my promotion's data to be completely isolated from other promotions, so that my roster, events, and business operations remain private and secure.
+
+**Detailed Workflow**: All queries are automatically scoped to the current promotion context. A promotion's wrestlers, events, titles, and other entities are never visible to or accessible by other promotions.
+
+## Spec Scope
+
+1. **Promotion Entity** - Core promotion model with name, slug, settings, and owner relationship
+2. **Ownership Model** - User (Promoter) ownership of one or more Promotions
+3. **Entity Scoping** - All roster and event entities belong to a Promotion via `promotion_id`
+4. **Promotion Context** - Session/request-level promotion scoping for multi-promotion users
+5. **Promotion Settings** - Configurable options per promotion (timezone, currency, display preferences)
+
+## Out of Scope
+
+- Cross-promotion talent sharing/loans (future feature)
+- Cross-promotion events (future feature)
+- Promotion federation/alliance systems
+- Public promotion directories or discovery
+- Promotion subscription/billing tiers
+
+## Expected Deliverable
+
+1. Promotion model with proper relationships to User (owner) and all owned entities
+2. Migration adding `promotion_id` foreign key to all entity tables
+3. Global scope or middleware ensuring promotion-level data isolation
+4. Promotion switching mechanism for multi-promotion users
+5. 100% test coverage for promotion ownership and scoping logic
+
+## Spec Documentation
+
+- Tasks: @.agent-os/specs/2026-01-16-promotions-system/tasks.md
+- Technical Specification: @.agent-os/specs/2026-01-16-promotions-system/sub-specs/technical-spec.md

--- a/.agent-os/specs/2026-01-16-promotions-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-promotions-system/sub-specs/technical-spec.md
@@ -1,0 +1,403 @@
+# Technical Specification: Promotions System
+
+> Reference: @.agent-os/specs/2026-01-16-promotions-system/spec.md
+
+---
+
+## Database Schema
+
+### Promotions Table
+
+```php
+Schema::create('promotions', function (Blueprint $table) {
+    $table->ulid('id')->primary();
+    $table->foreignUlid('user_id')->constrained()->cascadeOnDelete();
+    $table->string('name');
+    $table->string('slug')->unique();
+    $table->json('settings')->nullable();
+    $table->timestamps();
+
+    $table->index('user_id');
+    $table->index('slug');
+});
+```
+
+### Entity Foreign Keys
+
+All promotion-owned entities receive:
+
+```php
+// Added to each entity table migration
+$table->foreignUlid('promotion_id')->constrained()->cascadeOnDelete();
+$table->index('promotion_id');
+```
+
+**Affected Tables:**
+- wrestlers
+- tag_teams
+- managers
+- referees
+- stables
+- events
+- venues
+- titles
+
+---
+
+## Models
+
+### Promotion Model
+
+**Location:** `app/Models/Promotion.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Promotion extends Model
+{
+    use HasFactory;
+    use HasUlids;
+
+    protected $fillable = [
+        'user_id',
+        'name',
+        'slug',
+        'settings',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'settings' => 'array',
+        ];
+    }
+
+    // ==================== RELATIONSHIPS ====================
+
+    public function owner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function wrestlers(): HasMany
+    {
+        return $this->hasMany(Wrestler::class);
+    }
+
+    public function tagTeams(): HasMany
+    {
+        return $this->hasMany(TagTeam::class);
+    }
+
+    public function managers(): HasMany
+    {
+        return $this->hasMany(Manager::class);
+    }
+
+    public function referees(): HasMany
+    {
+        return $this->hasMany(Referee::class);
+    }
+
+    public function stables(): HasMany
+    {
+        return $this->hasMany(Stable::class);
+    }
+
+    public function events(): HasMany
+    {
+        return $this->hasMany(Event::class);
+    }
+
+    public function venues(): HasMany
+    {
+        return $this->hasMany(Venue::class);
+    }
+
+    public function titles(): HasMany
+    {
+        return $this->hasMany(Title::class);
+    }
+}
+```
+
+### BelongsToPromotion Trait
+
+**Location:** `app/Models/Concerns/BelongsToPromotion.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use App\Models\Promotion;
+use App\Models\Scopes\PromotionScope;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+trait BelongsToPromotion
+{
+    public static function bootBelongsToPromotion(): void
+    {
+        static::addGlobalScope(new PromotionScope());
+
+        static::creating(function ($model) {
+            if (empty($model->promotion_id)) {
+                $model->promotion_id = current_promotion_id();
+            }
+        });
+    }
+
+    public function promotion(): BelongsTo
+    {
+        return $this->belongsTo(Promotion::class);
+    }
+}
+```
+
+### PromotionScope Global Scope
+
+**Location:** `app/Models/Scopes/PromotionScope.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Scopes;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Scope;
+
+class PromotionScope implements Scope
+{
+    public function apply(Builder $builder, Model $model): void
+    {
+        if ($promotionId = current_promotion_id()) {
+            $builder->where($model->getTable().'.promotion_id', $promotionId);
+        }
+    }
+}
+```
+
+---
+
+## Promotion Context
+
+### Helper Function
+
+**Location:** `app/helpers.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+if (! function_exists('current_promotion_id')) {
+    function current_promotion_id(): ?string
+    {
+        return session('current_promotion_id');
+    }
+}
+
+if (! function_exists('current_promotion')) {
+    function current_promotion(): ?\App\Models\Promotion
+    {
+        if ($id = current_promotion_id()) {
+            return \App\Models\Promotion::find($id);
+        }
+        return null;
+    }
+}
+
+if (! function_exists('set_current_promotion')) {
+    function set_current_promotion(\App\Models\Promotion|string $promotion): void
+    {
+        $id = $promotion instanceof \App\Models\Promotion ? $promotion->id : $promotion;
+        session(['current_promotion_id' => $id]);
+    }
+}
+```
+
+### Middleware
+
+**Location:** `app/Http/Middleware/EnsurePromotionContext.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class EnsurePromotionContext
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $user = $request->user();
+
+        if ($user && ! current_promotion_id()) {
+            // Set default promotion (first owned, or most recently used)
+            $promotion = $user->promotions()->first();
+
+            if ($promotion) {
+                set_current_promotion($promotion);
+            }
+        }
+
+        return $next($request);
+    }
+}
+```
+
+---
+
+## User Model Changes
+
+### Updated Relationships
+
+```php
+// User model - REMOVE this relationship:
+// public function wrestlers(): HasMany
+
+// User model - ADD these relationships:
+public function promotions(): HasMany
+{
+    return $this->hasMany(Promotion::class);
+}
+
+public function currentPromotion(): ?Promotion
+{
+    return current_promotion();
+}
+```
+
+---
+
+## Promotion Settings Schema
+
+```php
+// Default settings structure
+[
+    'timezone' => 'America/New_York',
+    'currency' => 'USD',
+    'date_format' => 'M j, Y',
+    'time_format' => 'g:i A',
+    'default_match_duration' => 15, // minutes
+    'roster_display' => 'grid', // grid|list
+]
+```
+
+---
+
+## Testing Patterns
+
+### Promotion Factory
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+class PromotionFactory extends Factory
+{
+    public function definition(): array
+    {
+        $name = fake()->company() . ' Wrestling';
+
+        return [
+            'user_id' => User::factory(),
+            'name' => $name,
+            'slug' => Str::slug($name),
+            'settings' => null,
+        ];
+    }
+
+    public function withSettings(array $settings): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'settings' => $settings,
+        ]);
+    }
+}
+```
+
+### Test Helpers
+
+```php
+// In test setup
+protected function actingAsPromoter(User $user = null, Promotion $promotion = null): self
+{
+    $user ??= User::factory()->create();
+    $promotion ??= Promotion::factory()->for($user, 'owner')->create();
+
+    set_current_promotion($promotion);
+
+    return $this->actingAs($user);
+}
+```
+
+### Scoping Tests
+
+```php
+it('scopes wrestlers to current promotion', function () {
+    $promotion1 = Promotion::factory()->create();
+    $promotion2 = Promotion::factory()->create();
+
+    $wrestler1 = Wrestler::factory()->for($promotion1)->create();
+    $wrestler2 = Wrestler::factory()->for($promotion2)->create();
+
+    set_current_promotion($promotion1);
+
+    expect(Wrestler::all())->toHaveCount(1)
+        ->and(Wrestler::first()->id)->toBe($wrestler1->id);
+});
+```
+
+---
+
+## Migration Order
+
+1. Create promotions table
+2. Add promotion_id to all entity tables
+3. Backfill existing data (if needed)
+4. Add NOT NULL constraint after backfill
+
+---
+
+## File Locations Summary
+
+| File | Purpose |
+|------|---------|
+| `app/Models/Promotion.php` | Promotion model |
+| `app/Models/Concerns/BelongsToPromotion.php` | Trait for owned entities |
+| `app/Models/Scopes/PromotionScope.php` | Global scope for filtering |
+| `app/Http/Middleware/EnsurePromotionContext.php` | Context middleware |
+| `app/helpers.php` | Helper functions |
+| `database/factories/PromotionFactory.php` | Test factory |
+| `database/migrations/*_create_promotions_table.php` | Schema migration |
+| `database/migrations/*_add_promotion_id_to_entities.php` | FK migrations |
+| `tests/Unit/Models/PromotionTest.php` | Unit tests |
+| `tests/Feature/PromotionScopingTest.php` | Integration tests |

--- a/.agent-os/specs/2026-01-16-promotions-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-promotions-system/tasks.md
@@ -1,0 +1,397 @@
+# Implementation Tasks: Promotions System
+
+> Reference: @.agent-os/specs/2026-01-16-promotions-system/spec.md
+
+---
+
+## Phase 1: Core Infrastructure
+
+### Task 1.1: Create Promotions Migration
+**Priority:** Critical
+**Estimate:** Small
+
+Create the promotions table migration.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_create_promotions_table.php`
+
+**Acceptance Criteria:**
+- [ ] Migration creates promotions table with all fields
+- [ ] Proper indexes on user_id and slug
+- [ ] Slug has unique constraint
+- [ ] Cascade delete on user deletion
+
+---
+
+### Task 1.2: Create Promotion Model
+**Priority:** Critical
+**Estimate:** Small
+
+Create the Promotion model with relationships.
+
+**Files:**
+- `app/Models/Promotion.php`
+
+**Acceptance Criteria:**
+- [ ] Model uses HasUlids trait
+- [ ] All fillable fields defined
+- [ ] Settings cast to array
+- [ ] Owner relationship (belongsTo User)
+- [ ] All entity relationships defined (hasMany)
+
+---
+
+### Task 1.3: Create BelongsToPromotion Trait
+**Priority:** Critical
+**Estimate:** Small
+
+Create trait for promotion-owned entities.
+
+**Files:**
+- `app/Models/Concerns/BelongsToPromotion.php`
+
+**Acceptance Criteria:**
+- [ ] Boots global scope automatically
+- [ ] Auto-assigns promotion_id on creating
+- [ ] Defines promotion() relationship
+
+---
+
+### Task 1.4: Create PromotionScope
+**Priority:** Critical
+**Estimate:** Small
+
+Create global scope for promotion filtering.
+
+**Files:**
+- `app/Models/Scopes/PromotionScope.php`
+
+**Acceptance Criteria:**
+- [ ] Filters by current promotion context
+- [ ] Handles null context gracefully
+- [ ] Uses qualified column name (table.promotion_id)
+
+---
+
+### Task 1.5: Create Helper Functions
+**Priority:** Critical
+**Estimate:** Small
+
+Create promotion context helper functions.
+
+**Files:**
+- `app/helpers.php`
+- `composer.json` (autoload)
+
+**Acceptance Criteria:**
+- [ ] current_promotion_id() returns session value
+- [ ] current_promotion() returns Promotion model
+- [ ] set_current_promotion() updates session
+- [ ] Helpers autoloaded via Composer
+
+---
+
+## Phase 2: Entity Migrations
+
+### Task 2.1: Add promotion_id to Wrestlers
+**Priority:** Critical
+**Estimate:** Small
+
+Add promotion foreign key to wrestlers table.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_wrestlers_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds promotion_id column
+- [ ] Foreign key constraint to promotions
+- [ ] Index on promotion_id
+- [ ] Cascade delete
+
+---
+
+### Task 2.2: Add promotion_id to Tag Teams
+**Priority:** Critical
+**Estimate:** Small
+
+Add promotion foreign key to tag_teams table.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_tag_teams_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds promotion_id column
+- [ ] Foreign key constraint
+- [ ] Index on promotion_id
+
+---
+
+### Task 2.3: Add promotion_id to Managers
+**Priority:** Critical
+**Estimate:** Small
+
+Add promotion foreign key to managers table.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_managers_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds promotion_id column
+- [ ] Foreign key constraint
+- [ ] Index on promotion_id
+
+---
+
+### Task 2.4: Add promotion_id to Referees
+**Priority:** Critical
+**Estimate:** Small
+
+Add promotion foreign key to referees table.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_referees_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds promotion_id column
+- [ ] Foreign key constraint
+- [ ] Index on promotion_id
+
+---
+
+### Task 2.5: Add promotion_id to Stables
+**Priority:** Critical
+**Estimate:** Small
+
+Add promotion foreign key to stables table.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_stables_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds promotion_id column
+- [ ] Foreign key constraint
+- [ ] Index on promotion_id
+
+---
+
+### Task 2.6: Add promotion_id to Events
+**Priority:** Critical
+**Estimate:** Small
+
+Add promotion foreign key to events table.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_events_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds promotion_id column
+- [ ] Foreign key constraint
+- [ ] Index on promotion_id
+
+---
+
+### Task 2.7: Add promotion_id to Venues
+**Priority:** Critical
+**Estimate:** Small
+
+Add promotion foreign key to venues table.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_venues_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds promotion_id column
+- [ ] Foreign key constraint
+- [ ] Index on promotion_id
+
+**Note:** Consider if venues should be shared across promotions (future enhancement).
+
+---
+
+### Task 2.8: Add promotion_id to Titles
+**Priority:** Critical
+**Estimate:** Small
+
+Add promotion foreign key to titles table.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_titles_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds promotion_id column
+- [ ] Foreign key constraint
+- [ ] Index on promotion_id
+
+---
+
+## Phase 3: Model Updates
+
+### Task 3.1: Add BelongsToPromotion to Entity Models
+**Priority:** Critical
+**Estimate:** Medium
+
+Update all entity models to use BelongsToPromotion trait.
+
+**Files:**
+- `app/Models/Wrestler.php`
+- `app/Models/TagTeam.php`
+- `app/Models/Manager.php`
+- `app/Models/Referee.php`
+- `app/Models/Stable.php`
+- `app/Models/Event.php`
+- `app/Models/Venue.php`
+- `app/Models/Title.php`
+
+**Acceptance Criteria:**
+- [ ] Each model uses BelongsToPromotion trait
+- [ ] promotion_id added to fillable
+- [ ] Existing functionality unaffected
+
+---
+
+### Task 3.2: Update User Model
+**Priority:** Critical
+**Estimate:** Small
+
+Update User model relationships for promotion ownership.
+
+**Files:**
+- `app/Models/User.php`
+
+**Acceptance Criteria:**
+- [ ] Remove wrestlers() relationship
+- [ ] Add promotions() relationship
+- [ ] Add currentPromotion() accessor
+
+---
+
+## Phase 4: Middleware & Context
+
+### Task 4.1: Create EnsurePromotionContext Middleware
+**Priority:** High
+**Estimate:** Small
+
+Create middleware for setting promotion context.
+
+**Files:**
+- `app/Http/Middleware/EnsurePromotionContext.php`
+- `bootstrap/app.php` (register middleware)
+
+**Acceptance Criteria:**
+- [ ] Sets default promotion for authenticated users
+- [ ] Handles users with no promotions
+- [ ] Registered in web middleware group
+
+---
+
+### Task 4.2: Create Promotion Switcher Component
+**Priority:** Medium
+**Estimate:** Medium
+
+Create Livewire component for switching promotions.
+
+**Files:**
+- `app/Livewire/PromotionSwitcher.php`
+- `resources/views/livewire/promotion-switcher.blade.php`
+
+**Acceptance Criteria:**
+- [ ] Displays current promotion
+- [ ] Lists user's promotions
+- [ ] Switches context on selection
+- [ ] Redirects to dashboard after switch
+
+---
+
+## Phase 5: Testing
+
+### Task 5.1: Create Promotion Factory
+**Priority:** High
+**Estimate:** Small
+
+Create factory for Promotion model.
+
+**Files:**
+- `database/factories/PromotionFactory.php`
+
+**Acceptance Criteria:**
+- [ ] Generates valid promotion data
+- [ ] Creates associated user by default
+- [ ] State for custom settings
+
+---
+
+### Task 5.2: Create Promotion Unit Tests
+**Priority:** High
+**Estimate:** Medium
+
+Unit tests for Promotion model.
+
+**Files:**
+- `tests/Unit/Models/PromotionTest.php`
+
+**Acceptance Criteria:**
+- [ ] Tests all relationships
+- [ ] Tests settings casting
+- [ ] Tests slug uniqueness
+
+---
+
+### Task 5.3: Create Scoping Integration Tests
+**Priority:** High
+**Estimate:** Medium
+
+Integration tests for promotion scoping.
+
+**Files:**
+- `tests/Feature/PromotionScopingTest.php`
+
+**Acceptance Criteria:**
+- [ ] Tests entity scoping by promotion
+- [ ] Tests context switching
+- [ ] Tests auto-assignment on create
+- [ ] Tests cross-promotion isolation
+
+---
+
+### Task 5.4: Update Entity Factory Tests
+**Priority:** Medium
+**Estimate:** Medium
+
+Update existing entity tests for promotion context.
+
+**Files:**
+- All entity test files
+
+**Acceptance Criteria:**
+- [ ] Tests set promotion context
+- [ ] Factories create with promotion
+- [ ] Existing tests still pass
+
+---
+
+## Phase 6: Data Migration (If Existing Data)
+
+### Task 6.1: Create Data Migration Script
+**Priority:** High (if needed)
+**Estimate:** Medium
+
+Migrate existing data to promotion structure.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_migrate_existing_data_to_promotions.php`
+
+**Acceptance Criteria:**
+- [ ] Creates default promotion per user
+- [ ] Assigns all user's entities to promotion
+- [ ] Handles orphaned entities
+- [ ] Reversible migration
+
+---
+
+## Future Enhancements (Out of Scope)
+
+- [ ] Cross-promotion talent sharing/loans
+- [ ] Cross-promotion events
+- [ ] Shared venues across promotions
+- [ ] Promotion templates/presets
+- [ ] Promotion import/export

--- a/.agent-os/specs/2026-01-16-referees-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-referees-system/spec-lite.md
@@ -1,0 +1,75 @@
+# Referees System - Quick Reference
+
+> Match officials roster management (bookable for officiating)
+
+## Core Entities
+
+| Entity | Purpose |
+|--------|---------|
+| Referee | Match official |
+| RefereeEmployment | Employment periods |
+| RefereeInjury | Injury tracking |
+| RefereeSuspension | Suspension tracking |
+| RefereeRetirement | Retirement tracking |
+
+## Referee Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| first_name | string | First name |
+| last_name | string | Last name |
+| displayName | string | **Computed** "FirstName LastName" |
+| status | EmploymentStatus | **Computed** from employment |
+
+## Employment Status (Computed)
+
+| Status | Condition |
+|--------|-----------|
+| Retired | Has active retirement |
+| Employed | Has current employment |
+| FutureEmployment | Signed but not started |
+| Released | Previously employed, now without |
+| Unemployed | Never employed |
+
+## Bookability Rules
+
+Referee is bookable (for officiating) when ALL are true:
+- Currently employed (not future)
+- NOT injured
+- NOT suspended
+- NOT retired
+
+## Key Relationships
+
+```
+Referee
+├── employments (HasMany → RefereeEmployment)
+├── injuries (HasMany → RefereeInjury)
+├── suspensions (HasMany → RefereeSuspension)
+├── retirements (HasMany → RefereeRetirement)
+└── matches (BelongsToMany → EventMatch)
+    └── previousMatches - event date < now
+```
+
+## Key Distinction: Officials vs Competitors
+
+| Aspect | Referee | Wrestler |
+|--------|---------|----------|
+| Role | Officiates matches | Competes in matches |
+| Interface | `BookableOfficial` | `BookableCompetitor` |
+| Trait | `OfficiatesMatches` | `IsBookableCompetitor` |
+| Pivot Table | `events_matches_referees` | Polymorphic |
+
+## Query Scopes
+
+**Employment:** `employed()`, `unemployed()`, `released()`, `futureEmployed()`
+
+**Availability:** `injured()`, `suspended()`, `retired()`, `available()`, `unavailable()`
+
+**Booking:** `bookable()` (alias for `available()`)
+
+## File Locations
+
+- `app/Models/Referees/Referee.php`
+- `app/Enums/Shared/EmploymentStatus.php`
+- `app/Builders/Roster/RefereeBuilder.php`

--- a/.agent-os/specs/2026-01-16-referees-system/spec.md
+++ b/.agent-os/specs/2026-01-16-referees-system/spec.md
@@ -1,0 +1,88 @@
+# Spec Requirements Document
+
+> Spec: Referees System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the Referees System—roster entities representing match officials in Ringside. Referees **officiate matches** but do not compete. Unlike managers, referees ARE bookable (for officiating). This spec serves as the authoritative reference for referee profiles, employment tracking, availability states (injuries, suspensions, retirements), and match officiating relationships.
+
+## User Stories
+
+### Referee Profile Management
+
+As a **wrestling promoter**, I want to manage my roster of referees, so that I can track officials available for matches.
+
+**Workflow:**
+1. Create referee with profile (first name, last name)
+2. Hire referee (create employment)
+3. Track referee through their career
+4. Release or retire referee when appropriate
+
+### Employment Tracking
+
+As a **promoter**, I want to track referee employment status, so that I know who is currently under contract.
+
+**Workflow:**
+1. Hire referee with start date
+2. Track current and future employments
+3. Release referee (end employment)
+4. View employment history
+
+### Availability Management
+
+As a **promoter**, I want to track injuries, suspensions, and retirements, so that I know which referees are available for matches.
+
+**Workflow:**
+1. Record injury when referee is hurt
+2. Clear injury when referee recovers
+3. Suspend referee for disciplinary reasons
+4. Lift suspension when served
+5. Retire referee when career ends
+6. Unretire for comebacks (rare)
+
+### Match Officiating
+
+As a **promoter**, I want to assign referees to matches, so that matches have proper officiating.
+
+**Workflow:**
+1. Check referee availability (employed, not injured, not suspended)
+2. Assign bookable referees to matches
+3. Track officiating history per referee
+
+## Spec Scope
+
+1. **Referee Entity** - Core model with profile attributes
+2. **Employment** - Hire/release lifecycle with temporal tracking
+3. **Injuries** - Injury tracking with recovery dates
+4. **Suspensions** - Suspension tracking with lift dates
+5. **Retirements** - Retirement tracking with comeback support
+6. **Bookability** - Rules for match officiating eligibility
+7. **Match Officiating** - Relationship to matches
+
+## Out of Scope
+
+- Match creation (see Match System spec)
+- Event management (see Events System spec)
+- Wrestler/Tag Team management (referees don't manage or compete)
+
+## Expected Deliverable
+
+1. Complete referee entity documentation with attributes
+2. Employment lifecycle documentation
+3. Availability state documentation (injuries, suspensions, retirements)
+4. Bookability rules documentation
+5. Match officiating relationship documentation
+6. Query method reference
+
+## Key Distinctions
+
+**Referees vs Wrestlers:**
+- Referees **officiate** matches; wrestlers **compete** in matches
+- Referees implement `BookableOfficial`; wrestlers implement `BookableCompetitor`
+- Referees use `OfficiatesMatches` trait; wrestlers use `IsBookableCompetitor` trait
+
+**Referees vs Managers:**
+- Referees ARE bookable (for officiating); managers are NOT bookable
+- Referees have `isBookable()` method and `bookable()` scope
+- Referees cannot be managed; managers manage others

--- a/.agent-os/specs/2026-01-16-referees-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-referees-system/sub-specs/technical-spec.md
@@ -1,0 +1,570 @@
+# Technical Specification
+
+> Referees System
+> Reference: @.agent-os/specs/2026-01-16-referees-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. Referee
+
+**Model:** `App\Models\Referees\Referee`
+
+The core entity representing a match official. Referees **officiate matches** but do not compete.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| first_name | string | First name |
+| last_name | string | Last name |
+| displayName | string | **Computed** "FirstName LastName" |
+| status | EmploymentStatus | **Computed** from relationships |
+
+#### Key Relationships
+```
+Referee
+├── employments (HasMany → RefereeEmployment)
+│   ├── currentEmployment - ended_at IS NULL AND started_at <= now
+│   ├── futureEmployment - ended_at IS NULL AND started_at > now
+│   ├── previousEmployments - ended_at IS NOT NULL
+│   └── firstEmployment - earliest by started_at
+├── injuries (HasMany → RefereeInjury)
+│   ├── currentInjury - ended_at IS NULL
+│   └── previousInjuries - ended_at IS NOT NULL
+├── suspensions (HasMany → RefereeSuspension)
+│   ├── currentSuspension - ended_at IS NULL
+│   └── previousSuspensions - ended_at IS NOT NULL
+├── retirements (HasMany → RefereeRetirement)
+│   ├── currentRetirement - ended_at IS NULL
+│   └── previousRetirements - ended_at IS NOT NULL
+└── matches (BelongsToMany → EventMatch)
+    ├── upcomingMatches - event date >= now (PENDING - see tasks.md)
+    └── previousMatches - event date < now
+```
+
+#### Interfaces
+- `BookableOfficial` - Can be assigned to officiate matches
+- `Employable` - Employment lifecycle
+- `Injurable` - Injury tracking
+- `Suspendable` - Suspension tracking
+- `Retirable` - Retirement tracking
+- `HasDisplayName` - Display name support
+
+#### Traits
+- `HasMatches` - Base match relationship (used with trait resolution)
+- `OfficiatesMatches` - Match officiating relationship
+- `IsEmployable` - Employment lifecycle
+- `IsInjurable` - Injury tracking
+- `IsSuspendable` - Suspension tracking
+- `IsRetirable` - Retirement tracking
+- `ProvidesDisplayName` - Display name from first_name + last_name
+- `ValidatesEmployment` - Employment validation
+- `ValidatesInjury` - Injury validation
+- `ValidatesSuspension` - Suspension validation
+- `ValidatesRetirement` - Retirement validation
+- `SoftDeletes` - Soft deletion
+
+#### Trait Resolution
+The Referee model uses both `HasMatches` and `OfficiatesMatches` traits which have overlapping methods. PHP trait conflict resolution is used:
+
+```php
+use HasMatches, OfficiatesMatches {
+    OfficiatesMatches::matches insteadof HasMatches;
+    OfficiatesMatches::previousMatches insteadof HasMatches;
+}
+```
+
+This ensures `OfficiatesMatches` methods take precedence for the officiating relationship.
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `getDisplayName()` | string | Returns "FirstName LastName" |
+| `isBookable()` | bool | Can be assigned to officiate matches |
+| `isEmployed()` | bool | Has current employment |
+| `isUnemployed()` | bool | Never employed |
+| `isReleased()` | bool | Was employed, now without |
+| `hasFutureEmployment()` | bool | Signed for future |
+| `isInjured()` | bool | Currently injured |
+| `isSuspended()` | bool | Currently suspended |
+| `isRetired()` | bool | Currently retired |
+
+---
+
+### 2. RefereeEmployment
+
+**Model:** `App\Models\Referees\RefereeEmployment`
+
+Tracks employment periods for a referee.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| referee_id | int | Foreign key to referee |
+| started_at | datetime | Employment start date |
+| ended_at | datetime\|null | Employment end date (null = current) |
+
+#### Employment States
+| State | Condition |
+|-------|-----------|
+| Current | `started_at <= now AND ended_at IS NULL` |
+| Future | `started_at > now AND ended_at IS NULL` |
+| Ended | `ended_at IS NOT NULL` |
+
+---
+
+### 3. RefereeInjury
+
+**Model:** `App\Models\Referees\RefereeInjury`
+
+Tracks injury periods for a referee.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| referee_id | int | Foreign key to referee |
+| started_at | datetime | Injury start date |
+| ended_at | datetime\|null | Recovery date (null = currently injured) |
+
+---
+
+### 4. RefereeSuspension
+
+**Model:** `App\Models\Referees\RefereeSuspension`
+
+Tracks suspension periods for a referee.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| referee_id | int | Foreign key to referee |
+| started_at | datetime | Suspension start date |
+| ended_at | datetime\|null | Lift date (null = currently suspended) |
+
+---
+
+### 5. RefereeRetirement
+
+**Model:** `App\Models\Referees\RefereeRetirement`
+
+Tracks retirement periods for a referee.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| referee_id | int | Foreign key to referee |
+| started_at | datetime | Retirement start date |
+| ended_at | datetime\|null | Comeback date (null = currently retired) |
+
+---
+
+## Enums
+
+### EmploymentStatus
+
+**Location:** `App\Enums\Shared\EmploymentStatus`
+
+Shared enum used by all roster entities.
+
+```php
+enum EmploymentStatus: string {
+    case Employed = 'employed';
+    case FutureEmployment = 'future_employment';
+    case Released = 'released';
+    case Retired = 'retired';
+    case Unemployed = 'unemployed';
+}
+```
+
+#### Status Computation Priority
+```
+┌─────────────────────────────────────────────────────────────┐
+│               EMPLOYMENT STATUS PRIORITY                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  1. RETIRED           (has active retirement)               │
+│       ↓                                                     │
+│  2. EMPLOYED          (has current employment)              │
+│       ↓                                                     │
+│  3. FUTURE_EMPLOYMENT (signed but not started)              │
+│       ↓                                                     │
+│  4. RELEASED          (was employed, now without)           │
+│       ↓                                                     │
+│  5. UNEMPLOYED        (never employed)                      │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Database Tables
+
+### Referee Tables
+| Table | Description |
+|-------|-------------|
+| `referees` | Core referee records |
+| `referees_employments` | Employment periods |
+| `referees_injuries` | Injury periods |
+| `referees_suspensions` | Suspension periods |
+| `referees_retirements` | Retirement periods |
+
+### Match Officiating Pivot
+| Table | Description |
+|-------|-------------|
+| `events_matches_referees` | Referee-Match assignments |
+
+### Schema: referees
+```sql
+id          BIGINT PRIMARY KEY
+first_name  VARCHAR(255)
+last_name   VARCHAR(255)
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+deleted_at  TIMESTAMP NULLABLE
+```
+
+### Schema: referees_employments
+```sql
+id          BIGINT PRIMARY KEY
+referee_id  BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: referees_injuries
+```sql
+id          BIGINT PRIMARY KEY
+referee_id  BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: referees_suspensions
+```sql
+id          BIGINT PRIMARY KEY
+referee_id  BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: referees_retirements
+```sql
+id          BIGINT PRIMARY KEY
+referee_id  BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: events_matches_referees
+```sql
+match_id    BIGINT FOREIGN KEY
+referee_id  BIGINT FOREIGN KEY
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+---
+
+## Bookability Rules
+
+### isBookable() Logic
+```php
+public function isBookable(): bool
+{
+    return ! (
+        $this->isNotInEmployment() ||  // Must be employed
+        $this->isSuspended() ||         // Must not be suspended
+        $this->isInjured() ||           // Must not be injured
+        $this->hasFutureEmployment()    // Must have started employment
+    );
+}
+```
+
+### Bookability Conditions
+| Condition | Bookable? |
+|-----------|-----------|
+| Employed, healthy, not suspended | Yes |
+| Employed but injured | No |
+| Employed but suspended | No |
+| Future employment (not started) | No |
+| Released | No |
+| Unemployed | No |
+| Retired | No |
+
+### Officials vs Competitors
+
+Referees are **officials**, not competitors:
+
+| Aspect | Referee (Official) | Wrestler (Competitor) |
+|--------|-------------------|----------------------|
+| Interface | `BookableOfficial` | `BookableCompetitor` |
+| Trait | `OfficiatesMatches` | `IsBookableCompetitor` |
+| Match Role | Officiates | Competes |
+| Pivot Table | `events_matches_referees` | Polymorphic morph pivot |
+| Relationship | `BelongsToMany` | `MorphToMany` |
+
+---
+
+## Query Builder Methods
+
+### Employment Scopes
+
+**Location:** `App\Builders\Roster\RefereeBuilder`
+
+**Extends:** `IndividualRosterMemberBuilder` (shared with Wrestler, Manager)
+
+| Method | Description |
+|--------|-------------|
+| `employed()` | Has current employment |
+| `unemployed()` | Never employed |
+| `released()` | Was employed, now without |
+| `futureEmployed()` | Has future employment scheduled |
+
+### Availability Scopes
+
+| Method | Description |
+|--------|-------------|
+| `injured()` | Currently injured |
+| `suspended()` | Currently suspended |
+| `retired()` | Currently retired |
+| `available()` | Employed + not injured + not suspended + not retired |
+| `unavailable()` | Inverse of available |
+
+### Booking Scopes
+
+| Method | Description |
+|--------|-------------|
+| `bookable()` | Alias for `available()` |
+
+### availableOn(Carbon $date) - API Consistency
+
+The `availableOn(Carbon $date)` method exists but **ignores the date parameter**:
+
+```php
+// From SingleRosterMemberBuilder
+public function availableOn(Carbon $date): static
+{
+    // Date parameter unused - referees can officiate multiple matches per day
+    return $this->available();
+}
+```
+
+**Purpose:** API consistency across all roster builders.
+
+**Why date is ignored:** Unlike wrestlers/tag teams who can only compete in one match per event, referees CAN officiate multiple matches on the same date/event. Therefore, date-based conflict checking is not needed at the scope level.
+
+---
+
+## Lifecycle Validation
+
+**Traits:** `ValidatesEmployment`, `ValidatesInjury`, `ValidatesSuspension`, `ValidatesRetirement`
+
+### Employment Validation
+| Method | Checks |
+|--------|--------|
+| `canBeEmployed()` | Not already employed, not retired |
+| `ensureCanBeEmployed()` | Throws `CannotBeEmployedException` |
+
+### Release Validation
+| Method | Checks |
+|--------|--------|
+| `canBeReleased()` | Currently employed |
+| `ensureCanBeReleased()` | Throws `CannotBeReleasedException` |
+
+### Injury Validation
+| Method | Checks |
+|--------|--------|
+| `canBeInjured()` | Employed, not already injured |
+| `ensureCanBeInjured()` | Throws `CannotBeInjuredException` |
+
+### Recovery Validation
+| Method | Checks |
+|--------|--------|
+| `canBeCleared()` | Currently injured |
+| `ensureCanBeCleared()` | Throws `CannotBeClearedException` |
+
+### Suspension Validation
+| Method | Checks |
+|--------|--------|
+| `canBeSuspended()` | Employed, not already suspended |
+| `ensureCanBeSuspended()` | Throws `CannotBeSuspendedException` |
+
+### Reinstatement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeReinstated()` | Currently suspended, still employed |
+| `ensureCanBeReinstated()` | Throws `CannotBeReinstatedException` |
+
+### Retirement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeRetired()` | Not already retired, currently employed |
+| `ensureCanBeRetired()` | Throws `CannotBeRetiredException` |
+
+### Unretirement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeUnretired()` | Currently retired |
+| `ensureCanBeUnretired()` | Throws `CannotBeUnretiredException` |
+
+---
+
+## Match Officiating
+
+### OfficiatesMatches Trait
+
+**Location:** `App\Models\Concerns\OfficiatesMatches`
+
+```php
+public function matches(): BelongsToMany
+{
+    return $this->belongsToMany(EventMatch::class, 'events_matches_referees');
+}
+
+public function previousMatches(): BelongsToMany
+{
+    return $this->matches()->whereHas('event', function ($query) {
+        $query->where('date', '<', now());
+    });
+}
+```
+
+| Relationship | Description |
+|--------------|-------------|
+| `matches()` | All match assignments |
+| `previousMatches()` | Completed matches (event date < now) |
+
+> **Note:** `upcomingMatches()` is a pending enhancement. See tasks.md for implementation details.
+
+### Match Assignment Action
+
+**Location:** `App\Actions\Matches\AddRefereesToMatchAction`
+
+```php
+public function handle(EventMatch $match, Collection $referees): void
+```
+
+**Workflow:**
+1. Filter referees to ensure only eligible officials
+2. Validate referees are bookable (`isBookable()` returns true)
+3. Check for conflicts (double-booking)
+4. Execute in database transaction
+5. Attach eligible referees to match via pivot table
+
+---
+
+## Business Rules
+
+### Employment Rules
+- Employment uses temporal tracking (`started_at`/`ended_at`)
+- Multiple employment periods allowed (rehires)
+- Cannot be employed while retired
+- Releasing a referee sets `ended_at` on current employment
+
+### Availability Rules
+- Injuries, suspensions, retirements all use same temporal pattern
+- Active state: `ended_at IS NULL`
+- Multiple periods allowed (multiple injuries, comebacks from retirement)
+- Status is computed, never stored
+
+### Independent Retirement Model
+
+Referee retirement is independent and self-contained:
+- Referee retires → cannot officiate matches until unretired
+- Referee unretires → can be assigned to matches again
+- No cascading effects (referees have no clients, stables, or managed relationships)
+
+The `retired()` scope shows referees who are retired at the individual level.
+
+### Officiating Rules
+- Only bookable referees can be assigned to matches
+- Multiple referees can officiate a single match
+- A referee CAN officiate multiple matches on the same event/date (no double-booking restriction)
+- Match officiating history tracked via pivot table
+
+### No Double-Booking Restriction
+
+Unlike wrestlers/tag teams, referees have **no double-booking restriction**:
+
+| Entity | Same-Day Booking |
+|--------|------------------|
+| Wrestler | One match per event |
+| Tag Team | One match per event |
+| Referee | **Multiple matches per event** |
+
+**Rationale:** In real wrestling, the same referee often officiates multiple matches on a single show.
+
+### NOT Applicable to Referees
+- **Cannot be managed** - No manager relationship
+- **Cannot join stables** - No stable membership
+- **Cannot compete** - Officials only, not competitors
+- **Cannot win titles** - No championship relationships
+
+---
+
+## File Locations
+
+```
+app/
+├── Enums/Shared/
+│   └── EmploymentStatus.php
+├── Models/Referees/
+│   ├── Referee.php
+│   ├── RefereeEmployment.php
+│   ├── RefereeInjury.php
+│   ├── RefereeSuspension.php
+│   └── RefereeRetirement.php
+├── Models/Concerns/
+│   ├── OfficiatesMatches.php
+│   ├── IsEmployable.php
+│   ├── IsInjurable.php
+│   ├── IsSuspendable.php
+│   ├── IsRetirable.php
+│   ├── ProvidesDisplayName.php
+│   └── Validates*.php (multiple validation traits)
+├── Models/Contracts/
+│   ├── BookableOfficial.php
+│   ├── Bookable.php
+│   ├── Employable.php
+│   ├── Injurable.php
+│   ├── Suspendable.php
+│   └── Retirable.php
+├── Actions/Matches/
+│   └── AddRefereesToMatchAction.php
+└── Builders/Roster/
+    ├── RefereeBuilder.php
+    └── IndividualRosterMemberBuilder.php
+```
+
+---
+
+## Comparison with Other Roster Entities
+
+| Feature | Referee | Wrestler | Tag Team | Manager |
+|---------|---------|----------|----------|---------|
+| Employment | Yes | Yes | Yes | Yes |
+| Injuries | Yes | Yes | No | Yes |
+| Suspensions | Yes | Yes | Yes | Yes |
+| Retirements | Yes | Yes | Yes | Yes |
+| Bookable | Yes (official) | Yes (competitor) | Yes (competitor) | **No** |
+| Match Role | Officiates | Competes | Competes | N/A |
+| Can Be Managed | **No** | Yes | Yes | No |
+| Can Manage | No | No | No | Yes |
+| Stable Membership | **No** | Yes | Yes | Indirect |
+| Championships | **No** | Singles | Tag Team | No |
+| Name Fields | first/last | name | name | first/last |
+| Builder Base | Individual | Individual | Standalone | Individual |

--- a/.agent-os/specs/2026-01-16-referees-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-referees-system/tasks.md
@@ -1,0 +1,101 @@
+# Referees System Tasks
+
+## Pending
+
+### Add promotion_id foreign key for multi-tenant support
+
+**Priority:** Critical
+**Type:** Migration
+**Depends on:** Promotions System
+
+Add `promotion_id` foreign key to referees table for multi-tenant architecture.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_referees_table.php`
+- `app/Models/Referee.php`
+
+**Changes required:**
+- Create migration adding `promotion_id` column with foreign key constraint
+- Add index on `promotion_id`
+- Add `BelongsToPromotion` trait to Referee model
+- Add `promotion_id` to fillable array
+- Update RefereeFactory to include promotion
+- Update all referee tests to set promotion context
+
+**Acceptance Criteria:**
+- [ ] Migration creates column with proper foreign key
+- [ ] Cascade delete when promotion is deleted
+- [ ] Model uses BelongsToPromotion trait
+- [ ] Global scope filters by current promotion
+- [ ] All existing tests pass with promotion context
+
+**Reference:** See @.agent-os/specs/2026-01-16-promotions-system/tasks.md for full multi-tenant implementation details.
+
+---
+
+### Rename `previousMatches` to `completedMatches`
+
+**Priority:** Low
+**Type:** Refactor
+
+Align match relationship terminology with EventStatus rename (`Past` → `Completed`). Matches are "completed" events.
+
+| Current | New |
+|---------|-----|
+| `previousMatches` | `completedMatches` |
+
+**Changes required:**
+- Rename relationship method in `OfficiatesMatches` trait
+- Update all callers and tests
+
+**Note:** This aligns with the Events System, Wrestlers System, and Tag Teams System terminology changes.
+
+---
+
+### Add `upcomingMatches` relationship to OfficiatesMatches trait
+
+**Priority:** Low
+**Type:** Enhancement
+
+Add relationship to view scheduled match assignments for referees.
+
+```php
+public function upcomingMatches(): BelongsToMany
+{
+    return $this->matches()->whereHas('event', function ($query) {
+        $query->where('date', '>=', now());
+    });
+}
+```
+
+**Changes required:**
+- Add method to `OfficiatesMatches` trait
+- Add tests for the new relationship
+
+**Note:** Allows viewing referee's upcoming officiating schedule.
+
+---
+
+### Rename `SingleRosterMemberBuilder` to `IndividualRosterMemberBuilder`
+
+**Priority:** Low
+**Type:** Refactor
+
+More explicit naming for the shared query builder covering individual roster members.
+
+| Current | New |
+|---------|-----|
+| `SingleRosterMemberBuilder` | `IndividualRosterMemberBuilder` |
+
+**Changes required:**
+- Rename class file
+- Update namespace references
+- Update `RefereeBuilder` extends declaration
+
+**Note:** This is a shared task with Wrestlers System and Managers System. See Wrestlers System tasks.md for full details.
+
+---
+
+## Completed
+
+_None yet_

--- a/.agent-os/specs/2026-01-16-stables-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-stables-system/spec-lite.md
@@ -1,0 +1,60 @@
+# Stables System - Quick Reference
+
+> Wrestling faction/stable management
+
+## Core Entities
+
+| Entity | Purpose |
+|--------|---------|
+| Stable | Wrestling faction with members |
+| StableWrestler | Wrestler membership pivot |
+| StableTagTeam | Tag team membership pivot |
+| StableActivityPeriod | Establish/disband tracking |
+| StableRetirement | Retirement tracking |
+
+## Stable Status (Computed)
+
+| Status | Condition |
+|--------|-----------|
+| Unformed | No activity periods |
+| PendingEstablishment | Future activity scheduled |
+| Active | Currently established |
+| Inactive | Disbanded (was active) |
+| Retired | Permanently retired |
+
+## Key Relationships
+
+```
+Stable
+├── wrestlers (BelongsToMany → Wrestler)
+│   ├── currentWrestlers (left_at IS NULL)
+│   └── previousWrestlers (left_at IS NOT NULL)
+├── tagTeams (BelongsToMany → TagTeam)
+│   ├── currentTagTeams (left_at IS NULL)
+│   └── previousTagTeams (left_at IS NOT NULL)
+├── activityPeriods (HasMany → StableActivityPeriod)
+└── retirements (HasMany → StableRetirement)
+```
+
+## Member Counting
+
+```
+Total Members = (Tag Teams × 2) + Wrestlers + Managers
+Minimum Required = 3
+```
+
+## Query Scopes
+
+**Status:** `unestablished()`, `established()`, `disbanded()`, `withFutureEstablishment()`
+
+**Members:** `withMinimumMembers()`, `belowMinimumMembers()`, `withAvailableMembers()`
+
+**Availability:** `available()`, `unavailable()`, `availableForReunion()`
+
+## File Locations
+
+- `app/Models/Stables/Stable.php`
+- `app/Models/Stables/StableWrestler.php`
+- `app/Models/Stables/StableTagTeam.php`
+- `app/Enums/Stables/StableStatus.php`
+- `app/Builders/Roster/StableBuilder.php`

--- a/.agent-os/specs/2026-01-16-stables-system/spec.md
+++ b/.agent-os/specs/2026-01-16-stables-system/spec.md
@@ -1,0 +1,74 @@
+# Spec Requirements Document
+
+> Spec: Stables System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the complete Stables System—the faction management core of Ringside that handles wrestling stables/factions, their membership, and lifecycle. This spec serves as the authoritative reference for how stables work, including member management, minimum membership requirements, and the establish/disband lifecycle.
+
+## User Stories
+
+### Stable Creation
+
+As a **wrestling promoter**, I want to create stables (factions), so that I can group wrestlers and tag teams together for storyline purposes.
+
+**Workflow:**
+1. Create stable with a name
+2. Add wrestlers and/or tag teams as members
+3. Establish stable when ready (minimum 3 members)
+4. Stable becomes active for storylines
+
+### Membership Management
+
+As a **promoter**, I want to manage stable membership, so that I can add or remove wrestlers and tag teams over time.
+
+**Workflow:**
+1. Add wrestlers or tag teams to stable with join date
+2. Remove members when they leave (with leave date)
+3. Track complete membership history
+4. View current vs previous members
+
+### Stable Lifecycle
+
+As a **promoter**, I want to manage stable status (establish, disband, retire), so that I can handle faction storylines appropriately.
+
+**Workflow:**
+1. Establish stable for debut
+2. Disband stable when faction splits
+3. Reunite disbanded stable later
+4. Retire stable permanently when appropriate
+
+### Minimum Membership
+
+As a **promoter**, I want the system to enforce minimum membership rules, so that stables maintain legitimacy as factions.
+
+**Workflow:**
+1. Stable requires 3+ members to be established
+2. Tag teams count as 2 members each
+3. System tracks member count automatically
+4. Alerts when membership drops below threshold
+
+## Spec Scope
+
+1. **Stable Entity** - Core stable model with status tracking
+2. **Membership** - Wrestler and tag team membership with history
+3. **Stable Status** - Computed status (Unformed, PendingEstablishment, Active, Inactive, Retired)
+4. **Activity Periods** - Establish/disband lifecycle tracking
+5. **Member Counting** - Business rules for minimum membership
+6. **Availability** - When stables are available for storylines
+
+## Out of Scope
+
+- Wrestler/Tag Team employment (see Roster Management spec)
+- Manager relationships (managers can be associated but not covered here)
+- Match participation (stables don't compete directly)
+- UI/Livewire implementation details
+
+## Expected Deliverable
+
+1. Complete stable entity documentation with relationships
+2. Membership tracking documentation
+3. Status computation and lifecycle rules
+4. Member counting business rules
+5. Query method reference for stable data

--- a/.agent-os/specs/2026-01-16-stables-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-stables-system/sub-specs/technical-spec.md
@@ -1,0 +1,445 @@
+# Technical Specification
+
+> Stables System
+> Reference: @.agent-os/specs/2026-01-16-stables-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. Stable
+
+**Model:** `App\Models\Stables\Stable`
+
+The core stable/faction entity representing a wrestling group.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| name | string | Stable name |
+| user_id | int\|null | Owner reference |
+| status | StableStatus | **Computed** from activity periods |
+
+#### Key Relationships
+```
+Stable
+├── wrestlers (BelongsToMany → Wrestler)
+│   ├── currentWrestlers - left_at IS NULL (PRIMARY MEMBERS)
+│   └── previousWrestlers - left_at IS NOT NULL
+├── tagTeams (BelongsToMany → TagTeam)
+│   ├── currentTagTeams - left_at IS NULL (ANNOTATION ONLY)
+│   └── previousTagTeams - left_at IS NOT NULL
+│   └── Note: Tag teams don't count toward membership - historical record only
+├── managers (computed via wrestlers/tagTeams)
+│   └── Derived from managers of current wrestlers and tag teams
+│   └── NOT direct stable members - associated through managed entities
+├── activityPeriods (HasMany → StableActivityPeriod)
+│   ├── currentActivityPeriod - ended_at IS NULL, started_at <= now
+│   └── futureActivityPeriod - ended_at IS NULL, started_at > now
+├── retirements (HasMany → StableRetirement)
+│   └── currentRetirement - ended_at IS NULL
+└── statusChanges (HasMany → StableStatusChange)
+```
+
+#### Interfaces
+- `Debutable` - Can be debuted/established with activity periods
+
+#### Traits
+- `HasMembers` - Wrestler/tag team membership methods
+- `HasActivityPeriods` - Activity period lifecycle
+- `HasStatusHistory` - Status change audit trail
+- `IsRetirable` - Retirement handling
+- `ValidatesStableLifecycle` - Business rule validation
+
+#### Trait Resolution
+The Stable model uses both `HasActivityPeriods` and `HasStatusHistory` traits which have overlapping methods. PHP trait conflict resolution is used:
+
+```php
+use HasActivityPeriods, HasStatusHistory {
+    HasActivityPeriods::recordStatusChange insteadof HasStatusHistory;
+}
+```
+
+This ensures `HasActivityPeriods` methods take precedence for status change recording.
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `isActive()` | bool | Status is Active |
+| `isDisbanded()` | bool | Status is Inactive |
+| `hasFutureEstablishment()` | bool | Has scheduled future activity |
+| `hasCurrentMembers()` | bool | Has any current members |
+| `getCurrentMemberCount()` | int | Total current member count |
+| `getCurrentMembersData()` | StableMembershipData | DTO with all current members |
+| `getEmployedMembersData()` | StableMembershipData | Only employed current members |
+
+#### Constants
+```php
+public const int MIN_MEMBERS_COUNT = 3;
+```
+
+---
+
+### 2. StableWrestler
+
+**Model:** `App\Models\Stables\StableWrestler`
+
+Pivot model tracking wrestler membership in a stable.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| stable_id | int | Foreign key to stable |
+| wrestler_id | int | Foreign key to wrestler |
+| joined_at | datetime | When wrestler joined |
+| left_at | datetime\|null | When wrestler left (null = current) |
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `isActive()` | bool | left_at IS NULL |
+| `hasEnded()` | bool | left_at IS NOT NULL |
+
+---
+
+### 3. StableTagTeam
+
+**Model:** `App\Models\Stables\StableTagTeam`
+
+Pivot model tracking tag team membership in a stable.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| stable_id | int | Foreign key to stable |
+| tag_team_id | int | Foreign key to tag team |
+| joined_at | datetime | When tag team joined |
+| left_at | datetime\|null | When tag team left (null = current) |
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `isActive()` | bool | left_at IS NULL |
+| `hasEnded()` | bool | left_at IS NOT NULL |
+
+---
+
+### 4. StableActivityPeriod
+
+**Model:** `App\Models\Stables\StableActivityPeriod`
+
+Tracks when a stable is established (active).
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| stable_id | int | Foreign key to stable |
+| started_at | datetime | Establishment date |
+| ended_at | datetime\|null | Disbandment date |
+
+---
+
+### 5. StableRetirement
+
+**Model:** `App\Models\Stables\StableRetirement`
+
+Tracks permanent stable retirements.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| stable_id | int | Foreign key to stable |
+| started_at | datetime | Retirement start date |
+| ended_at | datetime\|null | Unretirement date (rare) |
+
+---
+
+## Enums
+
+### StableStatus
+```php
+enum StableStatus: string {
+    case Unformed = 'unformed';
+    case PendingEstablishment = 'pending_establishment';
+    case Active = 'active';
+    case Inactive = 'inactive';
+    case Retired = 'retired';
+}
+```
+
+#### Status Computation
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   STABLE STATUS PRIORITY                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  1. RETIRED              (has active retirement)            │
+│       ↓                                                     │
+│  2. ACTIVE               (has current activity period)      │
+│       ↓                                                     │
+│  3. PENDING_ESTABLISHMENT (future activity scheduled)       │
+│       ↓                                                     │
+│  4. INACTIVE             (was active, now disbanded)        │
+│       ↓                                                     │
+│  5. UNFORMED             (never established)                │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+### StableMemberType
+```php
+enum StableMemberType: string {
+    case WRESTLER = 'wrestlers';
+    case TAG_TEAM = 'tagTeams';
+}
+```
+
+> **Note:** No MANAGER case - managers are associated indirectly through wrestlers/tag teams.
+
+| Method | Description |
+|--------|-------------|
+| `fromModel(Model $model)` | Auto-detect type from model class |
+| `getRelationshipName()` | Get relationship property name |
+| `getCurrentRelationshipName()` | Get current members method |
+
+### StableMembershipAction
+```php
+enum StableMembershipAction: string {
+    case ADD = 'add';
+    case REMOVE = 'remove';
+}
+```
+
+---
+
+## Database Tables
+
+### Stable Tables
+| Table | Description |
+|-------|-------------|
+| `stables` | Core stable records |
+| `stables_wrestlers` | Wrestler membership pivot |
+| `stables_tag_teams` | Tag team membership pivot |
+| `stables_activations` | Activity periods |
+| `stables_retirements` | Retirement records |
+| `stables_status_changes` | Audit trail |
+
+> **Note:** No `stables_managers` table - managers are associated indirectly through wrestlers/tag teams they manage.
+
+### Schema: stables
+```sql
+id          BIGINT PRIMARY KEY
+name        VARCHAR(255)
+user_id     BIGINT NULLABLE FOREIGN KEY
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+deleted_at  TIMESTAMP NULLABLE
+```
+
+### Schema: stables_wrestlers
+```sql
+id          BIGINT PRIMARY KEY
+stable_id   BIGINT FOREIGN KEY
+wrestler_id BIGINT FOREIGN KEY
+joined_at   TIMESTAMP
+left_at     TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: stables_tag_teams
+```sql
+id          BIGINT PRIMARY KEY
+stable_id   BIGINT FOREIGN KEY
+tag_team_id BIGINT FOREIGN KEY
+joined_at   TIMESTAMP
+left_at     TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+---
+
+## Member Counting
+
+### Formula
+```
+Total Members = Wrestlers
+```
+
+**Wrestlers are the primary members.** Tag teams are tracked separately for historical context but do NOT count toward membership.
+
+### Membership Model
+```
+NWO Example:
+├── Wrestlers (counts toward minimum = 3)
+│   ├── Hulk Hogan
+│   ├── Kevin Nash
+│   └── Scott Hall
+└── Tag Teams (historical annotation, doesn't count)
+    └── The Outsiders (Nash + Hall)
+```
+
+### SQL Implementation
+```sql
+SELECT COUNT(*) FROM stables_wrestlers
+WHERE stable_id = stables.id AND left_at IS NULL
+```
+
+### Examples
+| Wrestlers | Tag Teams | Member Count | Valid? |
+|-----------|-----------|--------------|--------|
+| 3 | 0 | 3 | Yes |
+| 3 | 1 | 3 | Yes (tag team is annotation) |
+| 2 | 1 | 2 | No (only wrestlers count) |
+| 2 | 0 | 2 | No |
+
+### Why Tag Teams Don't Count
+- Avoids double-counting (Nash is 1 member, not 1 + part of tag team)
+- Tag teams are groupings OF wrestlers who are already members
+- Tag team entry answers: "Was The Outsiders part of NWO?" → Yes
+- But the count is based on unique wrestlers only
+
+---
+
+## Query Builder Methods
+
+### Status Scopes
+
+**Location:** `App\Builders\Roster\StableBuilder`
+
+| Method | Description |
+|--------|-------------|
+| `unestablished()` | Never had activity periods |
+| `established()` | Has current activity period |
+| `disbanded()` | Was active, no current activity |
+| `withFutureEstablishment()` | Future activity scheduled |
+
+### Member Scopes
+
+| Method | Description |
+|--------|-------------|
+| `withMinimumMembers()` | Has 3+ members |
+| `belowMinimumMembers()` | Has < 3 members |
+| `withMemberCount(int $min, ?int $max)` | Custom member range |
+| `withAvailableMembers()` | All members employed & healthy |
+| `activelyManaged()` | Has available manager(s) |
+
+### Availability Scopes
+
+| Method | Description |
+|--------|-------------|
+| `available()` | Established + minimum members + not retired |
+| `unavailable()` | Unestablished OR disbanded OR retired |
+| `availableForReunion()` | Disbanded but not retired |
+
+### Status Aliases
+| Alias | Maps To |
+|-------|---------|
+| `active()` | `established()` |
+| `inactive()` | `disbanded()` |
+| `unactivated()` | `unestablished()` |
+| `withFutureActivation()` | `withFutureEstablishment()` |
+
+---
+
+## Status Transitions
+
+```
+┌───────────────────────────────────────────────────────────────────────┐
+│                      STABLE STATUS TRANSITIONS                         │
+├───────────────────────────────────────────────────────────────────────┤
+│                                                                       │
+│   UNFORMED ───→ PENDING_ESTABLISHMENT ───→ ACTIVE ←───→ INACTIVE     │
+│       │                                      │             │          │
+│       └──────────────→ ACTIVE ───────────────┴─────────────┘          │
+│                          │                                            │
+│                          ▼                                            │
+│                      RETIRED ←─────────────────────────────┘          │
+│                          │                                            │
+│                          ▼                                            │
+│                   (unretire → ACTIVE)  [rare]                         │
+│                                                                       │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+| From | To | Action | Method |
+|------|----|--------|--------|
+| Unformed | PendingEstablishment | Schedule future establishment | `scheduleActivation()` |
+| Unformed | Active | Establish immediately | `activate()` |
+| PendingEstablishment | Active | Establishment date arrives | Automatic |
+| Active | Inactive | Disband stable | `deactivate()` |
+| Inactive | Active | Reunite stable | `activate()` |
+| Active | Retired | Retire stable | `retire()` |
+| Inactive | Retired | Retire stable | `retire()` |
+| Retired | Active | Unretire (rare) | `unretire()` |
+
+**Blocked Transitions:**
+- Unformed → Inactive (must establish first)
+- Unformed → Retired (must have been active)
+- PendingEstablishment → Retired (must establish first)
+
+---
+
+## Business Rules
+
+### Membership Rules
+- **Wrestlers are the primary members** - only wrestlers count toward minimum
+- Members tracked with join/leave dates (`joined_at`/`left_at`)
+- Members can rejoin after leaving (multiple memberships)
+- **Tag teams are historical annotation** - tracked but don't count toward membership
+- Managers are NOT direct members - associated through wrestlers/tag teams they manage
+
+### Establishment Rules
+- Minimum 3 members required to establish
+- Members don't need to be employed to count
+- Stable can exist (Unformed) without minimum members
+
+### Disbandment vs Retirement
+
+| State | Meaning | Members | Can Reunite? |
+|-------|---------|---------|--------------|
+| **Disbanded** | Split up, on hiatus | Remain as current members | Yes |
+| **Retired** | Permanently ended | Remain as current members | Rarely (unretire) |
+
+When a stable disbands or retires:
+- Members are **NOT** automatically removed
+- Members remain as "current members" of the disbanded/retired stable
+- This preserves the roster for potential reunion
+- Members must be explicitly removed if they leave the faction
+
+### Availability Rules
+A stable is **available** when:
+- Currently established (Active status)
+- Has minimum members (3+)
+- Not retired
+
+---
+
+## File Locations
+
+```
+app/
+├── Enums/Stables/
+│   ├── StableStatus.php
+│   ├── StableMemberType.php
+│   └── StableMembershipAction.php
+├── Models/Stables/
+│   ├── Stable.php
+│   ├── StableWrestler.php
+│   ├── StableTagTeam.php
+│   ├── StableActivityPeriod.php
+│   ├── StableRetirement.php
+│   └── StableStatusChange.php
+├── Models/Concerns/
+│   ├── HasMembers.php
+│   ├── HasActivityPeriods.php
+│   └── IsRetirable.php
+└── Builders/Roster/
+    └── StableBuilder.php
+```

--- a/.agent-os/specs/2026-01-16-stables-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-stables-system/tasks.md
@@ -1,0 +1,147 @@
+# Stables System Tasks
+
+## Pending
+
+### Add promotion_id foreign key for multi-tenant support
+
+**Priority:** Critical
+**Type:** Migration
+**Depends on:** Promotions System
+
+Add `promotion_id` foreign key to stables table for multi-tenant architecture.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_stables_table.php`
+- `app/Models/Stable.php`
+
+**Changes required:**
+- Create migration adding `promotion_id` column with foreign key constraint
+- Add index on `promotion_id`
+- Add `BelongsToPromotion` trait to Stable model
+- Add `promotion_id` to fillable array
+- Update StableFactory to include promotion
+- Update all stable tests to set promotion context
+
+**Acceptance Criteria:**
+- [ ] Migration creates column with proper foreign key
+- [ ] Cascade delete when promotion is deleted
+- [ ] Model uses BelongsToPromotion trait
+- [ ] Global scope filters by current promotion
+- [ ] All existing tests pass with promotion context
+
+**Reference:** See @.agent-os/specs/2026-01-16-promotions-system/tasks.md for full multi-tenant implementation details.
+
+---
+
+### Refactor member counting to wrestlers only
+
+**Priority:** Medium
+**Type:** Refactor
+
+Member counting should be based on wrestlers only. Tag teams are historical annotation and should not count toward the minimum membership requirement.
+
+**Current behavior:**
+```
+Total = (Tag Teams × 2) + Wrestlers
+```
+
+**New behavior:**
+```
+Total = Wrestlers
+```
+
+**Changes required:**
+- Update `StableBuilder::withMinimumMembers()` scope to count wrestlers only
+- Update `StableBuilder::belowMinimumMembers()` scope
+- Update `Stable::getCurrentMemberCount()` method
+- Update any related validation logic
+- Update tests
+
+**Rationale:**
+Tag teams are groupings of wrestlers who are already members. The Outsiders (Nash + Hall) in NWO = 2 wrestlers, not 2 wrestlers + 1 tag team (4). Counting tag teams separately causes double-counting.
+
+---
+
+### Remove direct manager-stable relationship
+
+**Priority:** Medium
+**Type:** Refactor
+
+Managers should be associated with stables indirectly through the wrestlers/tag teams they manage, not directly employed by stables.
+
+**Changes required:**
+- Remove `stables_managers` table (migration to drop)
+- Remove `StableManager` pivot model
+- Remove direct manager relationships from Stable model (`managers`, `currentManagers`, `previousManagers`)
+- Add computed relationship to get managers via wrestlers/tag teams they manage
+- Update member counting to exclude managers
+- Update any Livewire components or views that reference direct manager relationships
+- Update tests
+
+**Rationale:**
+In wrestling, managers manage wrestlers/tag teams, not stables. A manager is "part of" a stable because they manage someone who is in the stable.
+
+---
+
+### Rename StableStatus enum cases for clarity
+
+**Priority:** Low
+**Type:** Refactor
+
+Rename enum cases for clearer, more consistent terminology:
+
+| Current | New | Reason |
+|---------|-----|--------|
+| `Unformed` | `Draft` | Consistency with EventStatus |
+| `PendingEstablishment` | `Scheduled` | Shorter, same meaning |
+| `Inactive` | `Disbanded` | More specific to stables |
+
+**Changes required:**
+- `StableStatus::Unformed` → `StableStatus::Draft`
+- `StableStatus::PendingEstablishment` → `StableStatus::Scheduled`
+- `StableStatus::Inactive` → `StableStatus::Disbanded`
+- Update related scopes: `unestablished()` → `draft()`, `disbanded()` stays
+- Update all test references
+- Update Livewire table filters
+
+---
+
+### Rename methods to use establishment terminology
+
+**Priority:** Low
+**Type:** Refactor
+
+Methods currently use activation terminology but domain uses establishment terminology.
+
+| Current | New | Reason |
+|---------|-----|--------|
+| `activate()` | `establish()` | Domain terminology |
+| `deactivate()` | `disband()` | Domain terminology |
+| `scheduleActivation()` | `scheduleEstablishment()` | Domain terminology |
+
+**Changes required:**
+- Rename methods in Stable model and related traits
+- Update all callers
+- Consider keeping old methods as aliases for backward compatibility
+
+---
+
+### Rename StableActivityPeriod to StableActivePeriod
+
+**Priority:** Low
+**Type:** Refactor
+
+Rename for consistency with `TitleActivePeriod`.
+
+**Changes required:**
+- `StableActivityPeriod` → `StableActivePeriod`
+- `activityPeriods` relationship → `activePeriods`
+- `currentActivityPeriod` → `currentActivePeriod`
+- `futureActivityPeriod` → `futureActivePeriod`
+- Update all references in traits, tests, and documentation
+
+---
+
+## Completed
+
+_None yet_

--- a/.agent-os/specs/2026-01-16-tag-teams-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-tag-teams-system/spec-lite.md
@@ -1,0 +1,76 @@
+# Tag Teams System - Quick Reference
+
+> Paired wrestling talent management
+
+## Core Entities
+
+| Entity | Purpose |
+|--------|---------|
+| TagTeam | Paired wrestling talent unit |
+| TagTeamWrestler | Wrestler partnership pivot |
+| TagTeamEmployment | Employment periods |
+| TagTeamSuspension | Suspension tracking |
+| TagTeamRetirement | Retirement tracking |
+| TagTeamManager | Manager relationship pivot |
+
+## Tag Team Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Team name |
+| signature_move | string\|null | Signature finishing move |
+| status | EmploymentStatus | **Computed** from employment |
+| combinedWeight | int | **Computed** sum of wrestlers' weights |
+
+## Employment Status (Computed)
+
+| Status | Condition |
+|--------|-----------|
+| Retired | Has active retirement |
+| Employed | Has current employment |
+| FutureEmployment | Signed but not started |
+| Released | Previously employed, now without |
+| Unemployed | Never employed |
+
+## Bookability Rules
+
+Tag team is bookable when ALL are true:
+- Currently employed (not future)
+- NOT suspended
+- NOT retired
+- Has minimum 2 current wrestlers
+- ALL current wrestlers are bookable
+
+> **Key Difference:** Tag teams don't have injuries—bookability depends on individual wrestler availability.
+
+## Key Relationships
+
+```
+TagTeam
+├── wrestlers (BelongsToMany → Wrestler)
+│   ├── currentWrestlers - left_at IS NULL
+│   └── previousWrestlers - left_at IS NOT NULL
+├── employments (HasMany → TagTeamEmployment)
+├── suspensions (HasMany → TagTeamSuspension)
+├── retirements (HasMany → TagTeamRetirement)
+├── managers (BelongsToMany → Manager)
+├── stables (BelongsToMany → Stable)
+├── titleChampionships (MorphMany → TitleChampionship)
+└── matches (MorphToMany → EventMatch)
+```
+
+## Query Scopes
+
+**Employment:** `employed()`, `unemployed()`, `released()`, `futureEmployed()`
+
+**Availability:** `suspended()`, `available()`, `unavailable()`
+
+**Booking:** `bookable()`, `readyForBooking()`, `availableOn($date)`
+
+**Wrestlers:** `withAvailableWrestlers()`, `withMinimumWrestlers($count)`
+
+## File Locations
+
+- `app/Models/TagTeams/TagTeam.php`
+- `app/Enums/Shared/EmploymentStatus.php`
+- `app/Builders/Roster/TagTeamBuilder.php`

--- a/.agent-os/specs/2026-01-16-tag-teams-system/spec.md
+++ b/.agent-os/specs/2026-01-16-tag-teams-system/spec.md
@@ -1,0 +1,90 @@
+# Spec Requirements Document
+
+> Spec: Tag Teams System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the Tag Teams System—roster entities representing paired wrestling talent in Ringside. This spec serves as the authoritative reference for tag team management, including formation (wrestler partnerships), employment tracking, availability states (suspensions, retirements), relationships (managers, stables), and championship tracking.
+
+## User Stories
+
+### Tag Team Formation
+
+As a **wrestling promoter**, I want to form tag teams from my roster of wrestlers, so that I can book them as a unit.
+
+**Workflow:**
+1. Select two wrestlers to form a tag team
+2. Create tag team with name and optional signature move
+3. Track wrestler partnerships over time
+4. Replace partners when needed
+
+### Employment Tracking
+
+As a **promoter**, I want to track tag team employment status, so that I know which teams are under contract.
+
+**Workflow:**
+1. Hire tag team with start date
+2. Track current and future employments
+3. Release tag team (end employment)
+4. View employment history
+
+### Availability Management
+
+As a **promoter**, I want to track suspensions and retirements, so that I know which teams are available for matches.
+
+**Workflow:**
+1. Suspend tag team for disciplinary reasons
+2. Reinstate when suspension served
+3. Retire tag team when career ends
+4. Unretire for comebacks (rare)
+
+> **Note:** Tag teams do not have injuries—individual wrestlers get injured. A tag team's bookability depends on their wrestlers' individual availability.
+
+### Match Booking
+
+As a **promoter**, I want to know which tag teams are bookable, so that I can create match cards.
+
+**Workflow:**
+1. Check tag team availability (employed, not suspended, all wrestlers bookable)
+2. Assign bookable tag teams to matches
+3. Track match history per team
+
+### Relationship Management
+
+As a **promoter**, I want to track tag team relationships, so that I can manage storylines.
+
+**Workflow:**
+1. Assign managers to tag teams
+2. Add tag teams to stables
+3. Track tag team championship reigns
+
+## Spec Scope
+
+1. **Tag Team Entity** - Core model with profile attributes
+2. **Wrestler Partnerships** - Partner join/leave lifecycle
+3. **Employment** - Hire/release lifecycle with temporal tracking
+4. **Suspensions** - Suspension tracking with reinstatement dates
+5. **Retirements** - Retirement tracking with comeback support
+6. **Bookability** - Rules for match eligibility (includes partner requirements)
+7. **Manager Relationships** - Being managed by managers
+8. **Stable Membership** - Joining/leaving stables
+9. **Championships** - Holding tag team titles
+
+## Out of Scope
+
+- Individual wrestler management (see Wrestlers System spec)
+- Stable management (see Stables System spec)
+- Manager management (see Managers System spec)
+- Match creation (see Match System spec)
+- Championship management (see Championship System spec)
+
+## Expected Deliverable
+
+1. Complete tag team entity documentation with attributes
+2. Wrestler partnership documentation
+3. Employment lifecycle documentation
+4. Availability state documentation (suspensions, retirements)
+5. Bookability rules documentation (including partner requirements)
+6. Relationship documentation
+7. Query method reference

--- a/.agent-os/specs/2026-01-16-tag-teams-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-tag-teams-system/sub-specs/technical-spec.md
@@ -1,0 +1,568 @@
+# Technical Specification
+
+> Tag Teams System
+> Reference: @.agent-os/specs/2026-01-16-tag-teams-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. TagTeam
+
+**Model:** `App\Models\TagTeams\TagTeam`
+
+The core entity representing a paired wrestling talent unit.
+
+#### Constants
+```php
+const NUMBER_OF_WRESTLERS_ON_TEAM = 2;
+```
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| name | string | Team name |
+| signature_move | string\|null | Signature finishing move |
+| status | EmploymentStatus | **Computed** from relationships |
+| combinedWeight | int | **Computed** sum of current wrestlers' weights |
+
+#### Key Relationships
+```
+TagTeam
+├── wrestlers (BelongsToMany → Wrestler)
+│   ├── currentWrestlers - left_at IS NULL
+│   └── previousWrestlers - left_at IS NOT NULL
+├── employments (HasMany → TagTeamEmployment)
+│   ├── currentEmployment - ended_at IS NULL AND started_at <= now
+│   ├── futureEmployment - ended_at IS NULL AND started_at > now
+│   ├── previousEmployments - ended_at IS NOT NULL
+│   └── firstEmployment - earliest by started_at
+├── suspensions (HasMany → TagTeamSuspension)
+│   ├── currentSuspension - ended_at IS NULL
+│   └── previousSuspensions - ended_at IS NOT NULL
+├── retirements (HasMany → TagTeamRetirement)
+│   ├── currentRetirement - ended_at IS NULL
+│   └── previousRetirements - ended_at IS NOT NULL
+├── managers (BelongsToMany → Manager)
+│   ├── currentManagers - fired_at IS NULL
+│   └── previousManagers - fired_at IS NOT NULL
+├── stables (BelongsToMany → Stable)
+│   ├── currentStable - left_at IS NULL (one only)
+│   └── previousStables - left_at IS NOT NULL
+├── titleChampionships (MorphMany → TitleChampionship)
+│   ├── currentChampionships - lost_at IS NULL
+│   └── previousTitleChampionships - lost_at IS NOT NULL
+└── matches (MorphToMany → EventMatch)
+    └── previousMatches - event date < now
+```
+
+#### Traits
+- `ProvidesTagTeamWrestlers` - Wrestler partnership management
+- `IsEmployable` - Employment lifecycle
+- `IsSuspendable` - Suspension tracking
+- `IsRetirable` - Retirement tracking
+- `CanBeManaged` - Manager relationships
+- `CanJoinStables` - Stable membership
+- `CanWinTitles` - Championship relationships
+- `IsBookableCompetitor` - Match participation
+- `ValidatesTagTeamLifecycle` - Business rule validation
+- `SoftDeletes` - Soft deletion
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `isBookable()` | bool | Can be booked for matches |
+| `isUnbookable()` | bool | Cannot be booked |
+| `isEmployed()` | bool | Has current employment |
+| `isUnemployed()` | bool | Never employed |
+| `isReleased()` | bool | Was employed, now without |
+| `hasFutureEmployment()` | bool | Signed for future |
+| `isSuspended()` | bool | Currently suspended |
+| `isRetired()` | bool | Currently retired |
+| `isChampion()` | bool | Holds any title |
+
+---
+
+### 2. TagTeamWrestler (Pivot)
+
+**Model:** `App\Models\TagTeams\TagTeamWrestler`
+
+Pivot model tracking wrestler partnerships in a tag team.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| tag_team_id | int | Foreign key to tag team |
+| wrestler_id | int | Foreign key to wrestler |
+| joined_at | datetime | When wrestler joined the team |
+| left_at | datetime\|null | When wrestler left (null = current partner) |
+
+#### Partnership States
+| State | Condition |
+|-------|-----------|
+| Current Partner | `left_at IS NULL` |
+| Former Partner | `left_at IS NOT NULL` |
+
+---
+
+### 3. TagTeamEmployment
+
+**Model:** `App\Models\TagTeams\TagTeamEmployment`
+
+Tracks employment periods for a tag team.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| tag_team_id | int | Foreign key to tag team |
+| started_at | datetime | Employment start date |
+| ended_at | datetime\|null | Employment end date (null = current) |
+
+#### Employment States
+| State | Condition |
+|-------|-----------|
+| Current | `started_at <= now AND ended_at IS NULL` |
+| Future | `started_at > now AND ended_at IS NULL` |
+| Ended | `ended_at IS NOT NULL` |
+
+---
+
+### 4. TagTeamSuspension
+
+**Model:** `App\Models\TagTeams\TagTeamSuspension`
+
+Tracks suspension periods for a tag team.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| tag_team_id | int | Foreign key to tag team |
+| started_at | datetime | Suspension start date |
+| ended_at | datetime\|null | Reinstatement date (null = currently suspended) |
+
+---
+
+### 5. TagTeamRetirement
+
+**Model:** `App\Models\TagTeams\TagTeamRetirement`
+
+Tracks retirement periods for a tag team.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| tag_team_id | int | Foreign key to tag team |
+| started_at | datetime | Retirement start date |
+| ended_at | datetime\|null | Comeback date (null = currently retired) |
+
+---
+
+### 6. TagTeamManager (Pivot)
+
+**Model:** `App\Models\TagTeams\TagTeamManager`
+
+Pivot model for tag team-manager relationships.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| tag_team_id | int | Foreign key to tag team |
+| manager_id | int | Foreign key to manager |
+| hired_at | datetime | Management start date |
+| fired_at | datetime\|null | Management end date (null = current) |
+
+---
+
+## Enums
+
+### EmploymentStatus
+
+**Location:** `App\Enums\Shared\EmploymentStatus`
+
+Shared enum used by both Wrestlers and Tag Teams.
+
+```php
+enum EmploymentStatus: string {
+    case Employed = 'employed';
+    case FutureEmployment = 'future_employment';
+    case Released = 'released';
+    case Retired = 'retired';
+    case Unemployed = 'unemployed';
+}
+```
+
+#### Status Computation Priority
+```
+┌─────────────────────────────────────────────────────────────┐
+│               EMPLOYMENT STATUS PRIORITY                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  1. RETIRED           (has active retirement)               │
+│       ↓                                                     │
+│  2. EMPLOYED          (has current employment)              │
+│       ↓                                                     │
+│  3. FUTURE_EMPLOYMENT (signed but not started)              │
+│       ↓                                                     │
+│  4. RELEASED          (was employed, now without)           │
+│       ↓                                                     │
+│  5. UNEMPLOYED        (never employed)                      │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Database Tables
+
+### Tag Team Tables
+| Table | Description |
+|-------|-------------|
+| `tag_teams` | Core tag team records |
+| `tag_teams_wrestlers` | Wrestler partnership pivot |
+| `tag_teams_employments` | Employment periods |
+| `tag_teams_suspensions` | Suspension periods |
+| `tag_teams_retirements` | Retirement periods |
+| `tag_teams_managers` | Manager relationship pivot |
+
+### Schema: tag_teams
+```sql
+id              BIGINT PRIMARY KEY
+name            VARCHAR(255)
+signature_move  VARCHAR(255) NULLABLE
+created_at      TIMESTAMP
+updated_at      TIMESTAMP
+deleted_at      TIMESTAMP NULLABLE
+```
+
+### Schema: tag_teams_wrestlers
+```sql
+id           BIGINT PRIMARY KEY
+tag_team_id  BIGINT FOREIGN KEY
+wrestler_id  BIGINT FOREIGN KEY
+joined_at    TIMESTAMP
+left_at      TIMESTAMP NULLABLE
+created_at   TIMESTAMP
+updated_at   TIMESTAMP
+```
+
+### Schema: tag_teams_employments
+```sql
+id           BIGINT PRIMARY KEY
+tag_team_id  BIGINT FOREIGN KEY
+started_at   TIMESTAMP
+ended_at     TIMESTAMP NULLABLE
+created_at   TIMESTAMP
+updated_at   TIMESTAMP
+```
+
+### Schema: tag_teams_suspensions
+```sql
+id           BIGINT PRIMARY KEY
+tag_team_id  BIGINT FOREIGN KEY
+started_at   TIMESTAMP
+ended_at     TIMESTAMP NULLABLE
+created_at   TIMESTAMP
+updated_at   TIMESTAMP
+```
+
+### Schema: tag_teams_retirements
+```sql
+id           BIGINT PRIMARY KEY
+tag_team_id  BIGINT FOREIGN KEY
+started_at   TIMESTAMP
+ended_at     TIMESTAMP NULLABLE
+created_at   TIMESTAMP
+updated_at   TIMESTAMP
+```
+
+### Schema: tag_teams_managers
+```sql
+id           BIGINT PRIMARY KEY
+tag_team_id  BIGINT FOREIGN KEY
+manager_id   BIGINT FOREIGN KEY
+hired_at     TIMESTAMP
+fired_at     TIMESTAMP NULLABLE
+created_at   TIMESTAMP
+updated_at   TIMESTAMP
+```
+
+---
+
+## Bookability Rules
+
+### Current Implementation
+
+**Model `isBookable()` method:**
+```php
+public function isBookable(): bool
+{
+    return $this->currentWrestlers->every(fn (Wrestler $wrestler) => $wrestler->isBookable());
+}
+```
+Checks if all current wrestlers are bookable. Does **NOT** check team-level status.
+
+**Builder `available()` scope:**
+```php
+public function available(): static
+{
+    return $this->whereEmployed()
+                ->whereNotSuspended()
+                ->whereNotRetired();
+}
+```
+Checks team-level availability only.
+
+**Builder `readyForBooking()` / `bookable()` scope:**
+```php
+public function readyForBooking(): static
+{
+    return $this->available()->withMinimumWrestlers();
+}
+```
+Checks team availability + minimum wrestler count. Does **NOT** check individual wrestler bookability.
+
+**Builder `withAvailableWrestlers()` scope:**
+```php
+public function withAvailableWrestlers(): static
+{
+    // Checks wrestlers are employed + not injured + not suspended + not retired
+}
+```
+
+### Complete Bookability Check
+For a tag team to be truly bookable for a match, ALL must be true:
+1. Team is available (employed, not suspended, not retired)
+2. Has minimum 2 current wrestlers
+3. All current wrestlers are bookable
+
+> **Note:** See tasks.md for consistency improvement task.
+
+### Bookability Conditions
+| Condition | Bookable? |
+|-----------|-----------|
+| Employed, not suspended, 2 bookable wrestlers | Yes |
+| Employed but suspended | No |
+| Employed but 1 wrestler injured | No |
+| Employed but only 1 wrestler | No |
+| Future employment (not started) | No |
+| Released | No |
+| Unemployed | No |
+| Retired (team-level) | No |
+
+### Key Difference from Wrestlers
+Tag teams do **NOT** have injuries. A tag team's bookability depends on their individual wrestlers' availability. If one wrestler is injured, suspended, or unavailable, the tag team becomes unbookable.
+
+---
+
+## Query Builder Methods
+
+### Employment Scopes
+
+**Location:** `App\Builders\Roster\TagTeamBuilder`
+
+| Method | Description |
+|--------|-------------|
+| `employed()` | Has current employment |
+| `unemployed()` | Never employed |
+| `released()` | Was employed, now without |
+| `futureEmployed()` | Has future employment scheduled |
+
+### Availability Scopes
+
+| Method | Description |
+|--------|-------------|
+| `suspended()` | Currently suspended |
+| `retired()` | Currently retired (team-level) |
+| `available()` | Employed + not suspended + not retired |
+| `unavailable()` | Unemployed OR suspended OR retired |
+
+### Wrestler Scopes
+
+| Method | Description |
+|--------|-------------|
+| `withAvailableWrestlers()` | All current wrestlers are available |
+| `withMinimumWrestlers(int $count = 2)` | Has at least N current wrestlers |
+
+### Booking Scopes
+
+| Method | Description |
+|--------|-------------|
+| `readyForBooking()` | available() + withMinimumWrestlers() |
+| `bookable()` | Alias for readyForBooking() |
+| `unbookable()` | Alias for unavailable() |
+| `availableOn(Carbon $date)` | Bookable AND not booked on date |
+| `notBookedOn(Carbon $date)` | Not assigned to match on date |
+
+---
+
+## Lifecycle Validation
+
+**Trait:** `App\Models\Concerns\ValidatesTagTeamLifecycle`
+
+### Employment Validation
+| Method | Checks |
+|--------|--------|
+| `canBeEmployed()` | Not employed, not retired, has current partners, no employment conflicts |
+| `ensureCanBeEmployed()` | Throws `CannotBeEmployedException` |
+
+### Release Validation
+| Method | Checks |
+|--------|--------|
+| `canBeReleased()` | Currently employed |
+| `ensureCanBeReleased()` | Throws `CannotBeReleasedException` |
+
+### Suspension Validation
+| Method | Checks |
+|--------|--------|
+| `canBeSuspended()` | Employed, not already suspended |
+| `ensureCanBeSuspended()` | Throws `CannotBeSuspendedException` |
+
+### Reinstatement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeReinstated()` | Currently suspended, still employed |
+| `ensureCanBeReinstated()` | Throws `CannotBeReinstatedException` |
+
+### Retirement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeRetired()` | Not retired, currently employed |
+| `ensureCanBeRetired()` | Throws `CannotBeRetiredException` |
+
+### Unretirement Validation
+| Method | Checks |
+|--------|--------|
+| `canBeUnretired()` | Currently retired, no name conflicts, has available partners, min 2 wrestlers |
+| `ensureCanBeUnretired()` | Throws `CannotBeUnretiredException` |
+
+### Deletion Validation
+| Method | Checks |
+|--------|--------|
+| `canBeDeleted()` | Not employed, not suspended |
+| `ensureCanBeDeleted()` | Throws `CannotBeDeletedException` |
+
+### Restoration Validation
+| Method | Checks |
+|--------|--------|
+| `canBeRestored()` | Is soft deleted, no name conflicts with active teams |
+| `ensureCanBeRestored()` | Throws `CannotBeRestoredException` |
+
+---
+
+## Business Rules
+
+### Partnership Rules
+- Tag team requires minimum 2 wrestlers (`NUMBER_OF_WRESTLERS_ON_TEAM = 2`)
+- Wrestlers join with `joined_at` timestamp
+- Wrestlers leave with `left_at` timestamp
+- A wrestler can only be in ONE tag team at a time (enforced on Wrestler)
+- Partner changes are tracked historically
+
+### Employment Rules
+- Tag team employment is **independent** from individual wrestler employment
+- Tag team must have current partners (wrestlers who have joined and not left) to be employed
+- Employment uses temporal tracking (`started_at`/`ended_at`)
+- Multiple employment periods allowed (re-hiring)
+- Future employment blocks bookability until start date
+
+### Availability Rules
+- Suspensions and retirements use same temporal pattern
+- Active state: `ended_at IS NULL`
+- Multiple periods allowed (multiple suspensions, comebacks from retirement)
+- Status is computed, never stored
+- **No injuries** - tag teams don't get injured, wrestlers do
+
+### Independent Retirement Model
+Tag team retirement and individual wrestler retirement are **independent**:
+- Tag team retires → team can't compete as a unit, but wrestlers could continue singles careers
+- Wrestler retires → affects tag team bookability (wrestler not available), but team isn't "retired"
+- If both wrestlers want to reunite after individual retirements → they must explicitly unretire the tag team
+
+The `retired()` scope shows teams retired at the team level, not teams with retired wrestlers.
+
+### Manager Relationship Rules
+
+#### Relationship Direction
+Tag teams **hire** managers. The `TagTeamManager` pivot represents "this tag team has hired this manager."
+
+#### Employment Requirement
+Both tag team AND manager must meet one of these conditions:
+- Currently employed
+- Has future employment scheduled
+
+This allows tag teams and managers to be paired before debut.
+
+#### Multiplicity
+- A tag team can have multiple managers simultaneously
+- A manager can manage multiple tag teams simultaneously
+
+#### Stable Association
+Managers are **indirectly** associated with stables through tag teams they manage. See Stables System spec for details.
+
+### Stable Membership Rules
+- Tag team can be in ONE stable at a time
+- Track join/leave dates via `joined_at`/`left_at`
+- Tag teams are historical annotation only—the **wrestlers** in the tag team are what count toward stable membership minimum
+- See Stables System spec for member counting details
+
+### Championship Rules
+- Tag team titles only (singles titles go to Wrestler entity)
+- Championship tracked via polymorphic MorphMany
+- Current championship: `lost_at IS NULL`
+
+---
+
+## File Locations
+
+```
+app/
+├── Enums/Shared/
+│   └── EmploymentStatus.php
+├── Models/TagTeams/
+│   ├── TagTeam.php
+│   ├── TagTeamWrestler.php
+│   ├── TagTeamEmployment.php
+│   ├── TagTeamSuspension.php
+│   ├── TagTeamRetirement.php
+│   └── TagTeamManager.php
+├── Models/Concerns/
+│   ├── ProvidesTagTeamWrestlers.php
+│   ├── IsEmployable.php
+│   ├── IsSuspendable.php
+│   ├── IsRetirable.php
+│   ├── CanBeManaged.php
+│   ├── CanJoinStables.php
+│   ├── CanWinTitles.php
+│   ├── IsBookableCompetitor.php
+│   └── ValidatesTagTeamLifecycle.php
+├── Models/Contracts/
+│   ├── HasTagTeamWrestlers.php
+│   ├── CanBeATagTeamMember.php
+│   └── TagTeamMember.php
+└── Builders/Roster/
+    └── TagTeamBuilder.php
+```
+
+### Builder Note
+`TagTeamBuilder` is a standalone builder (does not extend a shared base like `IndividualRosterMemberBuilder`). Tag teams have unique query requirements (wrestler partnerships, combined availability checks) that differ from individual roster members.
+
+---
+
+## Comparison with Wrestlers System
+
+| Feature | Wrestler | Tag Team |
+|---------|----------|----------|
+| Injuries | Yes (`IsInjurable`) | No |
+| Suspensions | Yes | Yes |
+| Retirements | Yes | Yes |
+| Employment | Individual | Team-level |
+| Bookability Check | Own availability | Team + all wrestlers' availability |
+| Championships | Singles titles | Tag team titles |
+| Manager Relationship | Direct | Direct |
+| Stable Membership | Counted toward minimum | Historical annotation only |

--- a/.agent-os/specs/2026-01-16-tag-teams-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-tag-teams-system/tasks.md
@@ -1,0 +1,118 @@
+# Tag Teams System Tasks
+
+## Pending
+
+### Add promotion_id foreign key for multi-tenant support
+
+**Priority:** Critical
+**Type:** Migration
+**Depends on:** Promotions System
+
+Add `promotion_id` foreign key to tag_teams table for multi-tenant architecture.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_tag_teams_table.php`
+- `app/Models/TagTeam.php`
+
+**Changes required:**
+- Create migration adding `promotion_id` column with foreign key constraint
+- Add index on `promotion_id`
+- Add `BelongsToPromotion` trait to TagTeam model
+- Add `promotion_id` to fillable array
+- Update TagTeamFactory to include promotion
+- Update all tag team tests to set promotion context
+
+**Acceptance Criteria:**
+- [ ] Migration creates column with proper foreign key
+- [ ] Cascade delete when promotion is deleted
+- [ ] Model uses BelongsToPromotion trait
+- [ ] Global scope filters by current promotion
+- [ ] All existing tests pass with promotion context
+
+**Reference:** See @.agent-os/specs/2026-01-16-promotions-system/tasks.md for full multi-tenant implementation details.
+
+---
+
+### Rename `previousMatches` to `completedMatches`
+
+**Priority:** Low
+**Type:** Refactor
+
+Align match relationship terminology with EventStatus rename (`Past` → `Completed`). Matches are "completed" events.
+
+| Current | New |
+|---------|-----|
+| `previousMatches` | `completedMatches` |
+
+**Changes required:**
+- Rename relationship method in `IsBookableCompetitor` trait (shared with Wrestlers)
+- Update `TagTeamBuilder` scopes if applicable
+- Update all callers and tests
+
+**Note:** This aligns with the Events System and Wrestlers System terminology changes.
+
+---
+
+### Improve bookability consistency between model and builder
+
+**Priority:** Medium
+**Type:** Enhancement
+
+The model's `isBookable()` method and the builder's `bookable()` scope check different things:
+
+| Component | Checks |
+|-----------|--------|
+| Model `isBookable()` | All current wrestlers are bookable |
+| Builder `bookable()` | Team available + minimum wrestlers |
+
+For complete bookability, both conditions must be true. Options to improve:
+
+**Option A:** Update model `isBookable()` to also check team availability
+```php
+public function isBookable(): bool
+{
+    return $this->isEmployed() &&
+           ! $this->isSuspended() &&
+           ! $this->isRetired() &&
+           $this->currentWrestlers->count() >= self::NUMBER_OF_WRESTLERS_ON_TEAM &&
+           $this->currentWrestlers->every(fn ($wrestler) => $wrestler->isBookable());
+}
+```
+
+**Option B:** Update builder `bookable()` to include `withAvailableWrestlers()`
+```php
+public function bookable(): static
+{
+    return $this->available()
+                ->withMinimumWrestlers()
+                ->withAvailableWrestlers();
+}
+```
+
+**Option C:** Keep separate (document as intentional separation of concerns)
+
+**Recommendation:** Option A - model should be the source of truth for bookability.
+
+---
+
+### Add `retired()` scope to TagTeamBuilder
+
+**Priority:** Low
+**Type:** Enhancement
+
+Add a `retired()` scope for consistency with other availability scopes. Should filter tag teams that are retired at the team level.
+
+```php
+public function retired(): static
+{
+    return $this->whereHas('retirements', fn ($q) => $q->whereNull('ended_at'));
+}
+```
+
+**Note:** This is team-level retirement only. Teams with individually retired wrestlers are handled by bookability checks.
+
+---
+
+## Completed
+
+_None yet_

--- a/.agent-os/specs/2026-01-16-titles-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-titles-system/spec-lite.md
@@ -1,0 +1,117 @@
+# Titles System - Quick Reference
+
+> Championship management with activity lifecycle and reign tracking
+
+## Core Entities
+
+| Entity | Purpose |
+|--------|---------|
+| Title | Championship belt entity |
+| TitleChampionship | Championship reign record |
+| TitleActivityPeriod | Active/inactive period tracking |
+| TitleRetirement | Retirement period tracking |
+| TitleStatusChange | Status change history |
+
+## Title Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Title name |
+| type | TitleType | Singles or TagTeam |
+| status | TitleStatus | **Computed** from activity periods |
+
+## Championship Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| title_id | int | Foreign key to title |
+| champion_type | string | Polymorphic type (Wrestler/TagTeam) |
+| champion_id | int | Polymorphic ID |
+| won_at | datetime | Reign start date |
+| lost_at | datetime\|null | Reign end date (null = current) |
+| won_match_id | int\|null | Match where title was won |
+| lost_match_id | int\|null | Match where title was lost |
+
+## Title Status (Computed)
+
+| Status | Condition |
+|--------|-----------|
+| New | No activity periods (never debuted) |
+| PendingDebut | Future activity period scheduled |
+| Active | Current activity period exists |
+| Inactive | Previous activity but no current |
+
+## Title Type
+
+| Type | Champion Entity |
+|------|-----------------|
+| Singles | Wrestler |
+| TagTeam | TagTeam |
+
+## Key Relationships
+
+```
+Title
+├── activityPeriods (HasMany → TitleActivityPeriod)
+│   ├── currentActivityPeriod - ended_at IS NULL AND started_at <= now
+│   ├── futureActivityPeriod - ended_at IS NULL AND started_at > now
+│   └── previousActivityPeriods - ended_at IS NOT NULL
+├── championships (HasMany → TitleChampionship)
+│   ├── currentChampionship - lost_at IS NULL
+│   └── previous - lost_at IS NOT NULL
+├── retirements (HasMany → TitleRetirement)
+│   └── currentRetirement - ended_at IS NULL
+└── statusChanges (HasMany → TitleStatusChange)
+
+TitleChampionship
+├── title (BelongsTo → Title)
+├── champion (MorphTo → Wrestler|TagTeam)
+├── wonEventMatch (BelongsTo → EventMatch)
+└── lostEventMatch (BelongsTo → EventMatch)
+```
+
+## Query Scopes
+
+**Title:**
+- `active()` - Currently active
+- `inactive()` - Previously active but not now
+- `neverDebuted()` - No activity periods
+- `withPendingDebut()` - Future debut scheduled
+- `retired()` - Currently retired
+- `unretired()` - Not retired
+- `competable()` - Active and available
+- `vacant()` - Active but no current champion
+- `defended()` - Has championship history
+- `newTitles()` - No championship history
+
+**TitleChampionship:**
+- `current()` - Active reigns (lost_at IS NULL)
+- `previous()` - Ended reigns (lost_at IS NOT NULL)
+- `latestWon()` - Ordered by won_at DESC
+- `latestLost()` - Ordered by lost_at DESC
+- `withReignLength()` - Include computed reign length
+
+## Title Lifecycle Actions
+
+| Action | Purpose |
+|--------|---------|
+| CreateAction | Create new title |
+| DebutAction | First activation (new title) |
+| PullAction | Temporarily deactivate |
+| ReinstateAction | Reactivate pulled title |
+| RetireAction | Permanently retire |
+| UnretireAction | Bring back retired title |
+| ActivateAction | Smart activate (debut/reinstate/unretire) |
+| DeactivateAction | Alias for PullAction |
+
+## File Locations
+
+- `app/Models/Titles/Title.php`
+- `app/Models/Titles/TitleChampionship.php`
+- `app/Models/Titles/TitleActivityPeriod.php`
+- `app/Models/Titles/TitleRetirement.php`
+- `app/Models/Titles/TitleStatusChange.php`
+- `app/Enums/Titles/TitleStatus.php`
+- `app/Enums/Titles/TitleType.php`
+- `app/Builders/Titles/TitleBuilder.php`
+- `app/Builders/Titles/TitleChampionshipBuilder.php`

--- a/.agent-os/specs/2026-01-16-titles-system/spec.md
+++ b/.agent-os/specs/2026-01-16-titles-system/spec.md
@@ -1,0 +1,111 @@
+# Spec Requirements Document
+
+> Spec: Titles System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the Titles System—the championship management system for wrestling promotions. Titles represent championships that can be competed for and defended in matches. Each title has an activity lifecycle (debut, pull, reinstate, retire), a type (singles or tag team), and tracks championship reigns. This spec serves as the authoritative reference for title lifecycle, championship tracking, and title-match relationships.
+
+## User Stories
+
+### Title Creation
+
+As a **wrestling promoter**, I want to create championships for my promotion, so that I can feature title matches on events.
+
+**Workflow:**
+1. Create title with name and type (singles or tag team)
+2. Optionally schedule a debut date
+3. Title starts as "New" if no debut date, "Pending Debut" if future date, "Active" if current date
+
+### Title Debut
+
+As a **promoter**, I want to debut titles at events, so that I can introduce new championships.
+
+**Workflow:**
+1. Select a new title (never debuted)
+2. Set debut date
+3. Title becomes "Active" when debut date arrives
+4. Title is eligible for championship matches
+
+### Championship Management
+
+As a **promoter**, I want to track championship reigns, so that I can maintain title history.
+
+**Workflow:**
+1. Champion wins title in a match
+2. Championship reign is recorded with win date and match
+3. Champion defends title or loses to challenger
+4. All reigns tracked with win/loss dates and matches
+
+### Title Lifecycle
+
+As a **promoter**, I want to pull or retire titles, so that I can manage my championship roster.
+
+**Workflow:**
+1. **Pull**: Temporarily deactivate a title (can be reinstated)
+2. **Retire**: Permanently end a title's lineage (can be unretired)
+3. Retired titles end any current championship reign
+
+### Title History
+
+As a **promoter**, I want to view title history, so that I can see championship lineages.
+
+**Workflow:**
+1. View all championship reigns for a title
+2. See current champion (if any)
+3. View reign lengths and matches
+4. Track first, previous, and longest reigns
+
+## Spec Scope
+
+1. **Title Entity** - Core model with name, type, computed status
+2. **TitleChampionship Entity** - Championship reigns with polymorphic champion
+3. **TitleActivityPeriod Entity** - Activity periods for debut/pull/reinstate tracking
+4. **TitleRetirement Entity** - Retirement periods
+5. **TitleStatusChange Entity** - Status change history
+6. **Title Status** - Computed status (New, PendingDebut, Active, Inactive)
+7. **Title Type** - Singles or TagTeam
+8. **Query Scopes** - Filtering by status, activity, championship state
+
+## Out of Scope
+
+- Match management (see Match System spec)
+- Event management (see Events System spec)
+- Competitor management (see Wrestlers/Tag Teams System specs)
+
+## Expected Deliverable
+
+1. Complete title entity documentation with attributes
+2. TitleChampionship entity documentation
+3. TitleActivityPeriod entity documentation
+4. TitleRetirement entity documentation
+5. TitleStatus and TitleType enum documentation
+6. Title lifecycle action reference
+7. Query builder methods reference
+8. Championship tracking relationships
+
+## Key Distinctions
+
+**Titles vs Championships:**
+- Titles are the championship belts; championships are the reigns
+- Titles have status and activity; championships have win/loss dates
+- Titles are entities; championships are historical records
+
+**Title Status:**
+- Status is **computed**, never stored
+- Based on activity periods:
+  - **New**: No activity periods (never debuted)
+  - **PendingDebut**: Future activity period scheduled
+  - **Active**: Current activity period exists
+  - **Inactive**: Previous activity periods exist but no current
+
+**Activity vs Retirement:**
+- Activity periods track active/inactive state (temporary)
+- Retirement is a separate concern (more permanent)
+- Retired titles can be unretired; pulled titles can be reinstated
+
+**Title Types:**
+- Singles titles can only be held by Wrestlers
+- Tag Team titles can only be held by TagTeams
+- Type determines eligible champion entity

--- a/.agent-os/specs/2026-01-16-titles-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-titles-system/sub-specs/technical-spec.md
@@ -1,0 +1,813 @@
+# Technical Specification
+
+> Titles System
+> Reference: @.agent-os/specs/2026-01-16-titles-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. Title
+
+**Model:** `App\Models\Titles\Title`
+
+The core entity representing a wrestling championship.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| name | string | Title name |
+| type | TitleType | Singles or TagTeam |
+| status | TitleStatus | **Computed** from activity periods |
+
+#### Key Relationships
+```
+Title
+├── activityPeriods (HasMany → TitleActivityPeriod)
+│   ├── currentActivityPeriod - ended_at IS NULL AND started_at <= now
+│   ├── futureActivityPeriod - ended_at IS NULL AND started_at > now
+│   ├── previousActivityPeriods - ended_at IS NOT NULL
+│   ├── previousActivityPeriod - most recent ended
+│   └── firstActivityPeriod - earliest by started_at
+├── championships (HasMany → TitleChampionship)
+│   └── currentChampionship - lost_at IS NULL
+├── retirements (HasMany → TitleRetirement)
+│   ├── currentRetirement - ended_at IS NULL
+│   └── previousRetirements - ended_at IS NOT NULL
+└── statusChanges (HasMany → TitleStatusChange)
+    ├── debutStatusChange - first status change
+    └── latestStatusChange - most recent
+```
+
+#### Interfaces
+- `Debutable` - Can be debuted
+- `HasActivityPeriods` - Activity period tracking
+- `HasDisplayName` - Display name support
+- `Retirable` - Retirement tracking
+
+#### Traits
+- `HasActivityPeriods` - Activity period relationships and status checks
+- `HasChampionships` - Championship reign relationships
+- `HasStatusHistory` - Status change tracking
+- `HasStatusScopes` - Query scopes for activity-based filtering (on builder)
+- `IsRetirable` - Retirement relationships
+- `ProvidesDisplayName` - Display name (returns `name`)
+- `ValidatesRetirement` - Retirement validation
+- `ValidatesTitleLifecycle` - Debut/reinstate/pull validation
+- `SoftDeletes` - Soft deletion
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `isCurrentlyActive()` | bool | Has current activity period |
+| `hasFutureActivity()` | bool | Has scheduled future debut |
+| `hasActivityPeriods()` | bool | Has any activity periods |
+| `isInactive()` | bool | Not currently active |
+| `isUnactivated()` | bool | Never debuted |
+| `isRetired()` | bool | Currently retired |
+| `isSinglesTitle()` | bool | Type is Singles |
+| `isTagTeamTitle()` | bool | Type is TagTeam |
+| `isVacant()` | bool | No current champion |
+| `canBeDebuted()` | bool | Can be debuted (new, not retired) |
+| `canBeReinstated()` | bool | Can be reinstated (inactive, not retired) |
+| `canBePulled()` | bool | Can be pulled (active, not retired) |
+| `ensureCanBeDebuted()` | void | Throws if cannot be debuted |
+| `ensureCanBeReinstated()` | void | Throws if cannot be reinstated |
+| `ensureCanBePulled()` | void | Throws if cannot be pulled |
+
+#### Status Computation
+
+Status is a **computed attribute**, never stored:
+
+```php
+protected function status(): Attribute
+{
+    return Attribute::make(
+        get: function (): TitleStatus {
+            if ($this->isCurrentlyActive()) {
+                return TitleStatus::Active;
+            }
+            if ($this->hasFutureActivity()) {
+                return TitleStatus::PendingDebut;
+            }
+            if ($this->hasActivityPeriods()) {
+                return TitleStatus::Inactive;
+            }
+            return TitleStatus::New;
+        }
+    );
+}
+```
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   TITLE STATUS LOGIC                         │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  1. Has current activity period?                            │
+│     YES → ACTIVE                                            │
+│     NO  → Continue                                          │
+│                                                             │
+│  2. Has future activity period?                             │
+│     YES → PENDING_DEBUT                                     │
+│     NO  → Continue                                          │
+│                                                             │
+│  3. Has any activity periods?                               │
+│     YES → INACTIVE                                          │
+│     NO  → NEW                                               │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### 2. TitleChampionship
+
+**Model:** `App\Models\Titles\TitleChampionship`
+
+Tracks championship reigns with polymorphic champion (Wrestler or TagTeam).
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| title_id | int | Foreign key to title |
+| champion_type | string | Polymorphic type |
+| champion_id | int | Polymorphic ID |
+| won_at | datetime | Date reign started |
+| lost_at | datetime\|null | Date reign ended (null = current) |
+| won_match_id | int\|null | Match where title was won |
+| lost_match_id | int\|null | Match where title was lost |
+
+#### Key Relationships
+```
+TitleChampionship
+├── title (BelongsTo → Title)
+├── champion (MorphTo → Wrestler|TagTeam)
+├── wonEventMatch (BelongsTo → EventMatch)
+└── lostEventMatch (BelongsTo → EventMatch)
+```
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `lengthInDays()` | int | Reign length in days |
+
+---
+
+### 3. TitleActivityPeriod
+
+**Model:** `App\Models\Titles\TitleActivityPeriod`
+
+Tracks active/inactive periods for a title.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| title_id | int | Foreign key to title |
+| started_at | datetime | Period start date |
+| ended_at | datetime\|null | Period end date (null = current) |
+
+#### Table Name
+`titles_activations`
+
+#### Activity Period States
+| State | Condition |
+|-------|-----------|
+| Current | `started_at <= now AND ended_at IS NULL` |
+| Future | `started_at > now AND ended_at IS NULL` |
+| Ended | `ended_at IS NOT NULL` |
+
+---
+
+### 4. TitleRetirement
+
+**Model:** `App\Models\Titles\TitleRetirement`
+
+Tracks retirement periods for a title.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| title_id | int | Foreign key to title |
+| started_at | datetime | Retirement start date |
+| ended_at | datetime\|null | Unretirement date (null = current) |
+
+#### Table Name
+`titles_retirements`
+
+---
+
+### 5. TitleStatusChange
+
+**Model:** `App\Models\Titles\TitleStatusChange`
+
+Tracks status changes for historical reference.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| title_id | int | Foreign key to title |
+| status | ActivationStatus | Status at time of change |
+| changed_at | datetime | When status changed |
+
+#### Table Name
+`titles_status_changes`
+
+---
+
+## Enums
+
+### TitleStatus
+
+**Location:** `App\Enums\Titles\TitleStatus`
+
+Represents the computed status of a title.
+
+```php
+enum TitleStatus: string {
+    case New = 'new';                      // Title created, never debuted
+    case PendingDebut = 'pending_debut';   // Scheduled to debut in the future
+    case Active = 'active';                // Currently active and defendable
+    case Inactive = 'inactive';            // Temporarily out of circulation
+}
+```
+
+#### Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `color()` | string | UI color classes |
+| `label()` | string | Human-readable label |
+
+#### Status Colors
+| Status | Color | Usage |
+|--------|-------|-------|
+| New | gray | Titles never debuted |
+| PendingDebut | blue | Scheduled debuts |
+| Active | green | Active championships |
+| Inactive | yellow | Pulled/shelved titles |
+
+---
+
+### TitleType
+
+**Location:** `App\Enums\Titles\TitleType`
+
+Determines the champion entity type.
+
+```php
+enum TitleType: string {
+    case Singles = 'singles';
+    case TagTeam = 'tag-team';
+}
+```
+
+| Type | Champion Entity |
+|------|-----------------|
+| Singles | Wrestler |
+| TagTeam | TagTeam |
+
+---
+
+## Traits
+
+### HasActivityPeriods
+
+**Location:** `App\Models\Concerns\HasActivityPeriods`
+
+Provides activity period tracking for the Title model.
+
+#### Relationships
+| Method | Return | Description |
+|--------|--------|-------------|
+| `activityPeriods()` | HasMany | All activity periods |
+| `activations()` | HasMany | Alias for activityPeriods |
+| `currentActivityPeriod()` | HasOne | Current active period |
+| `futureActivityPeriod()` | HasOne | Scheduled future period |
+| `previousActivityPeriods()` | HasMany | All ended periods |
+| `previousActivityPeriod()` | HasOne | Most recently ended |
+| `firstActivityPeriod()` | HasOne | Earliest period |
+
+#### Status Checks
+| Method | Return | Description |
+|--------|--------|-------------|
+| `hasActivityPeriods()` | bool | Has any periods |
+| `isCurrentlyActive()` | bool | Has current period |
+| `hasFutureActivity()` | bool | Has future period |
+| `isNotCurrentlyActive()` | bool | Not active |
+| `isUnactivated()` | bool | No periods |
+| `isInactive()` | bool | Not currently active |
+
+**Used by:** Title model
+
+---
+
+### HasChampionships
+
+**Location:** `App\Models\Concerns\HasChampionships`
+
+Provides championship reign relationships for the Title model.
+
+#### Relationships
+| Method | Return | Description |
+|--------|--------|-------------|
+| `championships()` | HasMany | All championship reigns |
+| `currentChampionship()` | HasOne | Active reign (lost_at IS NULL) |
+
+#### Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `getCurrentChampionship()` | TitleChampionship\|null | Active championship |
+| `currentChampion()` | Model\|null | Current champion entity |
+| `previousChampionship()` | TitleChampionship\|null | Most recent ended reign |
+| `previousChampion()` | Model\|null | Previous champion entity |
+| `firstChampionship()` | TitleChampionship\|null | First reign ever |
+| `firstChampion()` | Model\|null | First champion ever |
+| `longestChampionship()` | TitleChampionship\|null | Longest reign |
+| `longestChampion()` | Model\|null | Longest reigning champion |
+| `reignCount()` | int | Total number of reigns |
+| `isVacant()` | bool | No current champion |
+
+**Used by:** Title model
+
+---
+
+### HasStatusScopes
+
+**Location:** `App\Builders\Concerns\HasStatusScopes`
+
+Provides query scopes for activity period-based filtering. Used by TitleBuilder.
+
+#### Scopes
+| Method | Description |
+|--------|-------------|
+| `currentlyActive()` | Models with current activity period |
+| `currentlyInactive()` | Models without current activity period |
+| `activeDuring(Carbon $start, Carbon $end)` | Active during date range |
+| `activatedAfter(Carbon $date)` | Activated after specified date |
+| `activatedBefore(Carbon $date)` | Activated before specified date |
+| `deactivatedAfter(Carbon $date)` | Deactivated after specified date |
+| `neverActivated()` | No activity periods |
+| `withMultiplePeriods(int $min = 2)` | Has multiple activity periods |
+
+**Used by:** TitleBuilder (also used by StableBuilder)
+
+---
+
+### ValidatesTitleLifecycle
+
+**Location:** `App\Models\Concerns\ValidatesTitleLifecycle`
+
+Provides title lifecycle validation for debut, reinstate, and pull operations.
+
+#### Validation Methods
+| Method | Return | Throws | Description |
+|--------|--------|--------|-------------|
+| `canBeDebuted()` | bool | - | Check if can be debuted |
+| `ensureCanBeDebuted()` | void | `CannotBeDebutedException` | Throws if cannot debut |
+| `canBeReinstated()` | bool | - | Check if can be reinstated |
+| `ensureCanBeReinstated()` | void | `CannotBeReinstatedException` | Throws if cannot reinstate |
+| `canBePulled()` | bool | - | Check if can be pulled |
+| `ensureCanBePulled()` | void | `CannotBePulledException` | Throws if cannot pull |
+
+**Used by:** Title model
+
+---
+
+## Database Tables
+
+### Schema: titles
+```sql
+id          BIGINT PRIMARY KEY
+name        VARCHAR(255)
+type        VARCHAR(255) -- 'singles' or 'tag-team'
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+deleted_at  TIMESTAMP NULLABLE
+```
+
+### Schema: titles_championships
+```sql
+id              BIGINT PRIMARY KEY
+title_id        BIGINT FOREIGN KEY
+champion_type   VARCHAR(255) -- polymorphic type
+champion_id     BIGINT       -- polymorphic ID
+won_at          TIMESTAMP
+lost_at         TIMESTAMP NULLABLE
+won_match_id    BIGINT NULLABLE FOREIGN KEY
+lost_match_id   BIGINT NULLABLE FOREIGN KEY
+created_at      TIMESTAMP
+updated_at      TIMESTAMP
+```
+
+### Schema: titles_activations
+```sql
+id          BIGINT PRIMARY KEY
+title_id    BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: titles_retirements
+```sql
+id          BIGINT PRIMARY KEY
+title_id    BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: titles_status_changes
+```sql
+id          BIGINT PRIMARY KEY
+title_id    BIGINT FOREIGN KEY
+status      VARCHAR(255) -- ActivationStatus enum value
+changed_at  TIMESTAMP
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+---
+
+## Query Builder Methods
+
+### TitleBuilder
+
+**Location:** `App\Builders\Titles\TitleBuilder`
+
+Custom query builder for Title model.
+
+#### Activity Scopes
+| Method | Description |
+|--------|-------------|
+| `neverDebuted()` | Titles with no activity periods |
+| `active()` | Titles with current activity period |
+| `inactive()` | Titles with previous but no current period |
+| `withPendingDebut()` | Titles with future activity period |
+
+#### Availability Scopes
+| Method | Description |
+|--------|-------------|
+| `available()` | Alias for `active()` |
+| `unavailable()` | Inactive, never debuted, or retired |
+| `competable()` | Alias for `active()` |
+
+#### Retirement Scopes
+| Method | Description |
+|--------|-------------|
+| `retired()` | Currently retired |
+| `unretired()` | Not currently retired |
+
+#### Championship Scopes
+| Method | Description |
+|--------|-------------|
+| `vacant()` | Active but no current champion |
+| `defended()` | Has championship history |
+| `newTitles()` | No championship history |
+
+#### Activity Period Scopes (from HasStatusScopes)
+| Method | Description |
+|--------|-------------|
+| `currentlyActive()` | Has current activity period |
+| `currentlyInactive()` | No current activity period |
+| `activeDuring(Carbon $start, Carbon $end)` | Active during date range |
+| `activatedAfter(Carbon $date)` | Activated after date |
+| `activatedBefore(Carbon $date)` | Activated before date |
+| `deactivatedAfter(Carbon $date)` | Deactivated after date |
+| `neverActivated()` | No activity periods |
+| `withMultiplePeriods(int $min)` | Has multiple activity periods |
+
+---
+
+### TitleChampionshipBuilder
+
+**Location:** `App\Builders\Titles\TitleChampionshipBuilder`
+
+Custom query builder for TitleChampionship model.
+
+| Method | Description |
+|--------|-------------|
+| `current()` | Active reigns (lost_at IS NULL) |
+| `previous()` | Ended reigns (lost_at IS NOT NULL) |
+| `latestWon()` | Ordered by won_at DESC |
+| `latestLost()` | Ordered by lost_at DESC |
+| `withReignLength()` | Select with computed reign length |
+
+---
+
+## Actions
+
+### CreateAction
+
+**Location:** `App\Actions\Titles\CreateAction`
+
+Creates a new title.
+
+```php
+public function handle(TitleData $titleData): Title
+```
+
+**Workflow:**
+1. Wrap in database transaction
+2. Create title with name and type
+3. If debut_date provided, create activity period
+4. Return created title
+
+---
+
+### DebutAction
+
+**Location:** `App\Actions\Titles\DebutAction`
+
+Debuts a title (first activation for new titles).
+
+```php
+public function handle(Title $title, ?Carbon $debutDate = null, ?string $notes = null): void
+```
+
+**Workflow:**
+1. Validate title can be debuted (`ensureCanBeDebuted`)
+2. Create activity period with debut date
+3. Title status becomes Active
+
+**Throws:** `CannotBeDebutedException`
+
+---
+
+### PullAction
+
+**Location:** `App\Actions\Titles\PullAction`
+
+Temporarily deactivates an active title.
+
+```php
+public function handle(Title $title, ?Carbon $pullDate = null, ?string $notes = null): void
+```
+
+**Workflow:**
+1. Validate title is currently active
+2. End current activity period (set ended_at)
+3. Title status becomes Inactive
+
+**Throws:** `CannotBePulledException`
+
+---
+
+### ReinstateAction
+
+**Location:** `App\Actions\Titles\ReinstateAction`
+
+Reactivates an inactive title.
+
+```php
+public function handle(Title $title, ?Carbon $reinstateDate = null, ?string $notes = null): void
+```
+
+**Workflow:**
+1. Validate title can be reinstated (`ensureCanBeReinstated`)
+2. Create new activity period
+3. Title status becomes Active
+
+**Throws:** `CannotBeReinstatedException`
+
+---
+
+### RetireAction
+
+**Location:** `App\Actions\Titles\RetireAction`
+
+Permanently retires a title.
+
+```php
+public function handle(Title $title, ?Carbon $retirementDate = null): void
+```
+
+**Workflow:**
+1. Validate title can be retired (`ensureCanBeRetired`)
+2. If active, end current activity period
+3. End current championship reign if any
+4. Create retirement record
+
+**Impact:**
+- Ends any active championship reign
+- Creates retirement record
+
+**Throws:** `CannotBeRetiredException`
+
+---
+
+### UnretireAction
+
+**Location:** `App\Actions\Titles\UnretireAction`
+
+Brings back a retired title.
+
+```php
+public function handle(Title $title, ?Carbon $unretiredDate = null): void
+```
+
+**Workflow:**
+1. Validate title can be unretired (`ensureCanBeUnretired`)
+2. End current retirement (set ended_at)
+3. Title is ready to be activated (requires separate reinstate)
+
+**Throws:** `CannotBeUnretiredException`
+
+---
+
+### ActivateAction
+
+**Location:** `App\Actions\Titles\ActivateAction`
+
+Smart activation that determines appropriate action.
+
+```php
+public function handle(Title $title, ?Carbon $activationDate = null): void
+```
+
+**Workflow:**
+1. If retired → unretire first
+2. If has activity periods → reinstate
+3. If never debuted → debut
+
+---
+
+### DeactivateAction
+
+**Location:** `App\Actions\Titles\DeactivateAction`
+
+Alias for PullAction (backward compatibility).
+
+```php
+public function handle(Title $title, ?Carbon $deactivationDate = null): void
+```
+
+---
+
+## Business Rules
+
+### Title Lifecycle Rules
+
+- Titles can be created without a debut date (status: New)
+- Titles can be scheduled for future debut (status: PendingDebut)
+- Active titles can be pulled to Inactive
+- Inactive titles can be reinstated to Active
+- Titles can be retired from any state
+- Retired titles can be unretired
+
+### Championship Rules
+
+- Singles titles can only be held by Wrestlers
+- Tag Team titles can only be held by TagTeams
+- Only one current championship per title
+- Championship reigns tracked with win/loss matches
+- Retiring a title ends any current championship
+
+### Activity Period Rules
+
+- Activity periods use temporal tracking (started_at/ended_at)
+- Multiple periods allowed (pull/reinstate cycles)
+- Current period: started_at <= now AND ended_at IS NULL
+- Future period: started_at > now AND ended_at IS NULL
+- Status is computed from activity periods, never stored
+
+### Retirement Rules
+
+- Retirement is separate from activity state
+- Multiple retirements allowed (retire/unretire cycles)
+- Current retirement: ended_at IS NULL
+- Retiring ends current activity and championship
+
+---
+
+## File Locations
+
+```
+app/
+├── Enums/Titles/
+│   ├── TitleStatus.php
+│   └── TitleType.php
+├── Models/Titles/
+│   ├── Title.php
+│   ├── TitleChampionship.php
+│   ├── TitleActivityPeriod.php
+│   ├── TitleRetirement.php
+│   └── TitleStatusChange.php
+├── Models/Concerns/
+│   ├── HasActivityPeriods.php
+│   ├── HasChampionships.php
+│   ├── HasStatusHistory.php
+│   ├── IsRetirable.php
+│   └── ValidatesTitleLifecycle.php
+├── Builders/Titles/
+│   ├── TitleBuilder.php
+│   └── TitleChampionshipBuilder.php
+├── Actions/Titles/
+│   ├── CreateAction.php
+│   ├── UpdateAction.php
+│   ├── DeleteAction.php
+│   ├── RestoreAction.php
+│   ├── DebutAction.php
+│   ├── PullAction.php
+│   ├── ReinstateAction.php
+│   ├── RetireAction.php
+│   ├── UnretireAction.php
+│   ├── ActivateAction.php
+│   └── DeactivateAction.php
+├── Data/Titles/
+│   └── TitleData.php
+└── Exceptions/Titles/
+    ├── CannotBeDebutedException.php
+    ├── CannotBePulledException.php
+    ├── CannotBeReinstatedException.php
+    ├── CannotBeRetiredException.php
+    └── CannotBeUnretiredException.php
+```
+
+---
+
+## Competitor-Side Relationships
+
+### CanWinTitles Trait
+
+**Location:** `App\Models\Concerns\CanWinTitles`
+
+**Used by:** `Wrestler`, `TagTeam`
+
+Provides championship relationships from the competitor perspective.
+
+#### Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `titleChampionships()` | MorphMany | All championship reigns |
+| `currentChampionships()` | MorphMany | Active reigns (lost_at IS NULL) |
+| `currentChampionship()` | MorphOne | Most recent active reign |
+| `previousTitleChampionships()` | MorphMany | Past reigns (lost_at IS NOT NULL) |
+| `isChampion()` | bool | Currently holds any title |
+
+#### Usage Examples
+```php
+// Get all titles ever held
+$wrestler->titleChampionships;
+
+// Get current titles
+$wrestler->currentChampionships;
+
+// Check if currently a champion
+if ($wrestler->isChampion()) {
+    // ...
+}
+
+// Tag team championships
+$tagTeam->titleChampionships;
+```
+
+---
+
+## Related Systems
+
+| System | Relationship |
+|--------|--------------|
+| Match System | Title matches, championship changes |
+| Wrestlers System | Singles title champions |
+| Tag Teams System | Tag team title champions |
+| Events System | Title matches at events |
+
+---
+
+## Lifecycle State Diagram
+
+```
+                    ┌─────────────┐
+                    │    NEW      │
+                    │ (no debut)  │
+                    └──────┬──────┘
+                           │ debut
+                           ▼
+    ┌──────────────────────────────────────────┐
+    │                                          │
+    │  ┌─────────────┐      ┌─────────────┐   │
+    │  │   ACTIVE    │◄────►│  INACTIVE   │   │
+    │  │ (current    │ pull │ (previous   │   │
+    │  │  period)    │      │  periods)   │   │
+    │  └──────┬──────┘reinst└──────┬──────┘   │
+    │         │                    │          │
+    └─────────┼────────────────────┼──────────┘
+              │                    │
+              │ retire             │ retire
+              ▼                    ▼
+         ┌────────────────────────────┐
+         │         RETIRED            │
+         │  (retirement record)       │
+         └────────────────────────────┘
+                    ▲
+                    │ unretire
+                    │ (goes to Inactive, needs reinstate)
+```

--- a/.agent-os/specs/2026-01-16-titles-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-titles-system/tasks.md
@@ -1,0 +1,112 @@
+# Titles System Tasks
+
+## Pending
+
+### Add promotion_id foreign key for multi-tenant support
+
+**Priority:** Critical
+**Type:** Migration
+**Depends on:** Promotions System
+
+Add `promotion_id` foreign key to titles table for multi-tenant architecture.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_titles_table.php`
+- `app/Models/Title.php`
+
+**Changes required:**
+- Create migration adding `promotion_id` column with foreign key constraint
+- Add index on `promotion_id`
+- Add `BelongsToPromotion` trait to Title model
+- Add `promotion_id` to fillable array
+- Update TitleFactory to include promotion
+- Update all title tests to set promotion context
+
+**Acceptance Criteria:**
+- [ ] Migration creates column with proper foreign key
+- [ ] Cascade delete when promotion is deleted
+- [ ] Model uses BelongsToPromotion trait
+- [ ] Global scope filters by current promotion
+- [ ] All existing tests pass with promotion context
+
+**Reference:** See @.agent-os/specs/2026-01-16-promotions-system/tasks.md for full multi-tenant implementation details.
+
+---
+
+### Rename `previousActivityPeriods` to `completedActivityPeriods`
+
+**Priority:** Low
+**Type:** Refactor
+
+Align with the `previousMatches` → `completedMatches` rename pattern from other systems.
+
+| Current | New |
+|---------|-----|
+| `previousActivityPeriods` | `completedActivityPeriods` |
+| `previousActivityPeriod` | `completedActivityPeriod` |
+
+**Changes required:**
+- Rename methods in `HasActivityPeriods` trait
+- Update all callers (Title model, etc.)
+- Update tests
+
+**Note:** This aligns with the Wrestlers, Tag Teams, Referees, and Match System terminology changes.
+
+---
+
+### Consider adding `Retired` to TitleStatus enum
+
+**Priority:** Low
+**Type:** Enhancement (Consideration)
+
+Currently, `TitleStatus` has: New, PendingDebut, Active, Inactive. Retirement is tracked separately via the `IsRetirable` trait but not reflected in the status enum.
+
+**Consideration:**
+Should `Retired` be added as a fifth status value?
+
+**Pros:**
+- Status fully represents all title states
+- Simpler status checks in UI/views
+- Consistent with other entities that include retirement in status
+
+**Cons:**
+- Adds complexity to status computation
+- Retirement is conceptually different from activity status
+- Current separation works well
+
+**Decision needed:** Is including retirement in status enum worth the complexity?
+
+---
+
+### Add validation for title type and champion entity match
+
+**Priority:** Medium
+**Type:** Enhancement
+
+Ensure Singles titles can only be won by Wrestlers and Tag Team titles can only be won by TagTeams.
+
+**Changes required:**
+- Add validation in championship assignment actions
+- Validate champion type matches title type
+- Add appropriate exception handling
+
+---
+
+### Consider renaming `titles_activations` table to `titles_activity_periods`
+
+**Priority:** Low
+**Type:** Refactor
+
+The model is `TitleActivityPeriod` but the table is `titles_activations`. Consider aligning table name with model name for consistency.
+
+| Current | Potential |
+|---------|-----------|
+| `titles_activations` | `titles_activity_periods` |
+
+**Note:** This would require a migration and updates to the model's `$table` property.
+
+---
+
+## Completed
+
+_None yet_

--- a/.agent-os/specs/2026-01-16-users-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-users-system/spec-lite.md
@@ -1,0 +1,63 @@
+# Users System - Quick Reference
+
+> Parent: @.agent-os/specs/2026-01-16-users-system/spec.md
+
+## Core Concept
+
+Users are account holders who own Promotions. Users do NOT directly own wrestlers or other roster entities - that ownership flows through Promotions.
+
+## Key Relationships
+
+```
+User
+  └── hasMany Promotion
+        └── (Promotion owns all entities)
+
+NOT:
+User
+  └── hasMany Wrestler (REMOVED)
+```
+
+## User Model
+
+| Field | Type | Description |
+|-------|------|-------------|
+| id | ulid | Primary key |
+| name | string | Display name |
+| email | string | Unique email |
+| email_verified_at | timestamp | Verification timestamp |
+| password | string | Hashed password |
+| role | Role | Admin or Promoter |
+| status | UserStatus | Active, Suspended, etc. |
+| remember_token | string | Session token |
+| timestamps | - | created_at, updated_at |
+
+## Enums
+
+### Role
+```php
+enum Role: string
+{
+    case Admin = 'admin';
+    case Promoter = 'promoter';
+}
+```
+
+### UserStatus
+```php
+enum UserStatus: string
+{
+    case Active = 'active';
+    case Suspended = 'suspended';
+    case Pending = 'pending';
+}
+```
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `app/Models/User.php` | User model |
+| `app/Enums/Role.php` | Role enum |
+| `app/Enums/UserStatus.php` | Status enum |
+| `database/migrations/*_add_role_status_to_users_table.php` | Schema updates |

--- a/.agent-os/specs/2026-01-16-users-system/spec.md
+++ b/.agent-os/specs/2026-01-16-users-system/spec.md
@@ -1,0 +1,57 @@
+# Spec Requirements Document
+
+> Spec: Users System
+> Created: 2026-01-16
+> Status: Planning
+
+## Overview
+
+Define the Users system that handles authentication, user profiles, and promotion ownership. Users serve as the account layer - they own Promotions, which in turn own all roster entities. Users do NOT directly own wrestlers or other roster members.
+
+## User Stories
+
+### Account Registration Story
+
+As a prospective promoter, I want to create an account with my email and password, so that I can start managing my wrestling promotion.
+
+**Detailed Workflow**: Users register with email, password, and basic profile information. Upon registration, they can create their first Promotion to begin managing roster and events.
+
+### Profile Management Story
+
+As a registered user, I want to manage my account profile and settings, so that I can keep my information current and customize my experience.
+
+**Detailed Workflow**: Users can update their name, email, password, and account preferences. Profile changes are separate from promotion-level settings.
+
+### Promotion Ownership Story
+
+As a user, I want to own one or more wrestling promotions, so that I can manage separate brands or companies under a single account.
+
+**Detailed Workflow**: Users create and own Promotions. All roster management (wrestlers, tag teams, etc.) happens at the Promotion level, not the User level.
+
+## Spec Scope
+
+1. **User Entity** - Core user model for authentication and profile
+2. **Authentication** - Login, logout, password reset using Laravel Breeze/Fortify
+3. **User Roles** - Admin and Promoter role distinction
+4. **User Status** - Account status (Active, Suspended, etc.)
+5. **Promotion Relationship** - User owns Promotions (no direct entity ownership)
+
+## Out of Scope
+
+- Social authentication (OAuth providers)
+- Two-factor authentication
+- Team/multi-user promotion management
+- User permissions beyond basic roles
+- User activity logging/audit trail
+
+## Expected Deliverable
+
+1. User model with proper relationships to Promotions only (no direct wrestler relationship)
+2. Role and UserStatus enums for type-safe status management
+3. Authentication scaffolding using Laravel's built-in tools
+4. 100% test coverage for user authentication and relationships
+
+## Spec Documentation
+
+- Tasks: @.agent-os/specs/2026-01-16-users-system/tasks.md
+- Technical Specification: @.agent-os/specs/2026-01-16-users-system/sub-specs/technical-spec.md

--- a/.agent-os/specs/2026-01-16-users-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-users-system/sub-specs/technical-spec.md
@@ -1,0 +1,398 @@
+# Technical Specification: Users System
+
+> Reference: @.agent-os/specs/2026-01-16-users-system/spec.md
+
+---
+
+## Database Schema
+
+### Users Table Updates
+
+```php
+// Migration to add role and status columns
+Schema::table('users', function (Blueprint $table) {
+    $table->string('role')->default('promoter')->after('password');
+    $table->string('status')->default('active')->after('role');
+
+    $table->index('role');
+    $table->index('status');
+});
+```
+
+**Final Users Table Structure:**
+| Column | Type | Description |
+|--------|------|-------------|
+| id | ulid | Primary key |
+| name | string | Display name |
+| email | string | Unique email address |
+| email_verified_at | timestamp | Email verification |
+| password | string | Bcrypt hashed |
+| role | string | Role enum value |
+| status | string | UserStatus enum value |
+| remember_token | string | Session persistence |
+| created_at | timestamp | Creation time |
+| updated_at | timestamp | Last update |
+
+---
+
+## Enums
+
+### Role Enum
+
+**Location:** `app/Enums/Role.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum Role: string
+{
+    case Admin = 'admin';
+    case Promoter = 'promoter';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Admin => 'Administrator',
+            self::Promoter => 'Promoter',
+        };
+    }
+
+    public function isAdmin(): bool
+    {
+        return $this === self::Admin;
+    }
+}
+```
+
+### UserStatus Enum
+
+**Location:** `app/Enums/UserStatus.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum UserStatus: string
+{
+    case Active = 'active';
+    case Suspended = 'suspended';
+    case Pending = 'pending';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::Active => 'Active',
+            self::Suspended => 'Suspended',
+            self::Pending => 'Pending Verification',
+        };
+    }
+
+    public function canLogin(): bool
+    {
+        return $this === self::Active;
+    }
+}
+```
+
+---
+
+## Models
+
+### User Model
+
+**Location:** `app/Models/User.php`
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use App\Enums\Role;
+use App\Enums\UserStatus;
+use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Concerns\HasUlids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Notifications\Notifiable;
+
+class User extends Authenticatable implements MustVerifyEmail
+{
+    use HasFactory;
+    use HasUlids;
+    use Notifiable;
+
+    protected $fillable = [
+        'name',
+        'email',
+        'password',
+        'role',
+        'status',
+    ];
+
+    protected $hidden = [
+        'password',
+        'remember_token',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
+            'role' => Role::class,
+            'status' => UserStatus::class,
+        ];
+    }
+
+    // ==================== RELATIONSHIPS ====================
+
+    /**
+     * Get the promotions owned by this user.
+     */
+    public function promotions(): HasMany
+    {
+        return $this->hasMany(Promotion::class);
+    }
+
+    // ==================== ACCESSORS ====================
+
+    /**
+     * Get the user's current/default promotion.
+     */
+    public function currentPromotion(): ?Promotion
+    {
+        return current_promotion();
+    }
+
+    // ==================== QUERY HELPERS ====================
+
+    /**
+     * Check if user is an administrator.
+     */
+    public function isAdmin(): bool
+    {
+        return $this->role->isAdmin();
+    }
+
+    /**
+     * Check if user can log in.
+     */
+    public function canLogin(): bool
+    {
+        return $this->status->canLogin();
+    }
+}
+```
+
+### Relationship Changes
+
+**IMPORTANT:** Remove the following from User model if it exists:
+
+```php
+// REMOVE THIS RELATIONSHIP
+public function wrestlers(): HasMany
+{
+    return $this->hasMany(Wrestler::class);
+}
+```
+
+Users no longer directly own Wrestlers. The ownership hierarchy is:
+
+```
+User → Promotion → Wrestler
+```
+
+---
+
+## Authentication
+
+### Login Validation
+
+Update login logic to check user status:
+
+**Location:** `app/Http/Requests/Auth/LoginRequest.php` or similar
+
+```php
+public function authenticate(): void
+{
+    $this->ensureIsNotRateLimited();
+
+    $user = User::where('email', $this->email)->first();
+
+    if ($user && ! $user->canLogin()) {
+        throw ValidationException::withMessages([
+            'email' => __('Your account is not active.'),
+        ]);
+    }
+
+    if (! Auth::attempt($this->only('email', 'password'), $this->boolean('remember'))) {
+        RateLimiter::hit($this->throttleKey());
+
+        throw ValidationException::withMessages([
+            'email' => trans('auth.failed'),
+        ]);
+    }
+
+    RateLimiter::clear($this->throttleKey());
+}
+```
+
+---
+
+## Authorization
+
+### Gates
+
+**Location:** `app/Providers/AppServiceProvider.php` or `AuthServiceProvider`
+
+```php
+use App\Models\User;
+use Illuminate\Support\Facades\Gate;
+
+// In boot() method:
+Gate::define('admin', function (User $user) {
+    return $user->isAdmin();
+});
+
+Gate::define('manage-promotion', function (User $user, Promotion $promotion) {
+    return $user->id === $promotion->user_id;
+});
+```
+
+---
+
+## Testing Patterns
+
+### User Factory
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Enums\Role;
+use App\Enums\UserStatus;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+
+class UserFactory extends Factory
+{
+    protected static ?string $password;
+
+    public function definition(): array
+    {
+        return [
+            'name' => fake()->name(),
+            'email' => fake()->unique()->safeEmail(),
+            'email_verified_at' => now(),
+            'password' => static::$password ??= Hash::make('password'),
+            'role' => Role::Promoter,
+            'status' => UserStatus::Active,
+            'remember_token' => Str::random(10),
+        ];
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => Role::Admin,
+        ]);
+    }
+
+    public function promoter(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => Role::Promoter,
+        ]);
+    }
+
+    public function suspended(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => UserStatus::Suspended,
+        ]);
+    }
+
+    public function pending(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'status' => UserStatus::Pending,
+        ]);
+    }
+
+    public function unverified(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'email_verified_at' => null,
+        ]);
+    }
+}
+```
+
+### Test Examples
+
+```php
+it('can create a promotion', function () {
+    $user = User::factory()->create();
+
+    $promotion = $user->promotions()->create([
+        'name' => 'Test Wrestling',
+        'slug' => 'test-wrestling',
+    ]);
+
+    expect($user->promotions)->toHaveCount(1)
+        ->and($promotion->owner->id)->toBe($user->id);
+});
+
+it('prevents suspended users from logging in', function () {
+    $user = User::factory()->suspended()->create();
+
+    expect($user->canLogin())->toBeFalse();
+});
+
+it('does not have direct wrestler relationship', function () {
+    $user = User::factory()->create();
+
+    expect(method_exists($user, 'wrestlers'))->toBeFalse();
+});
+```
+
+---
+
+## Migration Checklist
+
+1. Add role and status columns to users table
+2. Create Role enum
+3. Create UserStatus enum
+4. Update User model with new casts and relationships
+5. Remove wrestlers() relationship from User model
+6. Update UserFactory with role/status states
+7. Update login logic for status checking
+8. Add authorization gates
+
+---
+
+## File Locations Summary
+
+| File | Purpose |
+|------|---------|
+| `app/Models/User.php` | User model (updated) |
+| `app/Enums/Role.php` | Role enum |
+| `app/Enums/UserStatus.php` | User status enum |
+| `database/migrations/*_add_role_status_to_users_table.php` | Schema migration |
+| `database/factories/UserFactory.php` | Factory (updated) |
+| `tests/Unit/Models/UserTest.php` | Unit tests |
+| `tests/Feature/Auth/AuthenticationTest.php` | Auth tests |

--- a/.agent-os/specs/2026-01-16-users-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-users-system/tasks.md
@@ -1,0 +1,259 @@
+# Implementation Tasks: Users System
+
+> Reference: @.agent-os/specs/2026-01-16-users-system/spec.md
+
+---
+
+## Phase 1: Enums
+
+### Task 1.1: Create Role Enum
+**Priority:** Critical
+**Estimate:** Small
+
+Create the Role enum for user roles.
+
+**Files:**
+- `app/Enums/Role.php`
+
+**Acceptance Criteria:**
+- [ ] Enum has Admin and Promoter cases
+- [ ] label() method returns display name
+- [ ] isAdmin() helper method
+
+---
+
+### Task 1.2: Create UserStatus Enum
+**Priority:** Critical
+**Estimate:** Small
+
+Create the UserStatus enum for account status.
+
+**Files:**
+- `app/Enums/UserStatus.php`
+
+**Acceptance Criteria:**
+- [ ] Enum has Active, Suspended, Pending cases
+- [ ] label() method returns display name
+- [ ] canLogin() helper method
+
+---
+
+## Phase 2: Database Updates
+
+### Task 2.1: Add Role and Status to Users Table
+**Priority:** Critical
+**Estimate:** Small
+
+Migration to add role and status columns.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_role_status_to_users_table.php`
+
+**Acceptance Criteria:**
+- [ ] Adds role column with default 'promoter'
+- [ ] Adds status column with default 'active'
+- [ ] Indexes on both columns
+- [ ] Backfills existing users
+
+---
+
+## Phase 3: Model Updates
+
+### Task 3.1: Update User Model
+**Priority:** Critical
+**Estimate:** Medium
+
+Update User model with new fields and relationships.
+
+**Files:**
+- `app/Models/User.php`
+
+**Acceptance Criteria:**
+- [ ] role and status added to fillable
+- [ ] Casts for Role and UserStatus enums
+- [ ] promotions() relationship added
+- [ ] currentPromotion() accessor added
+- [ ] isAdmin() helper method
+- [ ] canLogin() helper method
+
+---
+
+### Task 3.2: Remove Wrestler Relationship from User
+**Priority:** Critical
+**Estimate:** Small
+
+Remove direct wrestler ownership from User model.
+
+**Files:**
+- `app/Models/User.php`
+
+**Acceptance Criteria:**
+- [ ] wrestlers() relationship removed
+- [ ] Any references to User->wrestlers updated
+- [ ] Tests updated to use Promotion->wrestlers
+
+**Breaking Change:** This removes `User::wrestlers()`. All code must use `Promotion::wrestlers()` instead.
+
+---
+
+## Phase 4: Factory Updates
+
+### Task 4.1: Update UserFactory
+**Priority:** High
+**Estimate:** Small
+
+Add role and status states to UserFactory.
+
+**Files:**
+- `database/factories/UserFactory.php`
+
+**Acceptance Criteria:**
+- [ ] Default role is Promoter
+- [ ] Default status is Active
+- [ ] admin() state method
+- [ ] promoter() state method
+- [ ] suspended() state method
+- [ ] pending() state method
+
+---
+
+## Phase 5: Authentication Updates
+
+### Task 5.1: Update Login Validation
+**Priority:** High
+**Estimate:** Small
+
+Add status check to login process.
+
+**Files:**
+- `app/Http/Requests/Auth/LoginRequest.php`
+
+**Acceptance Criteria:**
+- [ ] Check user status before authentication
+- [ ] Return appropriate error for suspended users
+- [ ] Return appropriate error for pending users
+
+---
+
+### Task 5.2: Add Authorization Gates
+**Priority:** Medium
+**Estimate:** Small
+
+Create gates for admin and promotion access.
+
+**Files:**
+- `app/Providers/AppServiceProvider.php`
+
+**Acceptance Criteria:**
+- [ ] 'admin' gate for admin-only actions
+- [ ] 'manage-promotion' gate for promotion ownership
+
+---
+
+## Phase 6: Testing
+
+### Task 6.1: Create User Unit Tests
+**Priority:** High
+**Estimate:** Medium
+
+Unit tests for User model.
+
+**Files:**
+- `tests/Unit/Models/UserTest.php`
+
+**Acceptance Criteria:**
+- [ ] Tests role enum casting
+- [ ] Tests status enum casting
+- [ ] Tests promotions relationship
+- [ ] Tests isAdmin() helper
+- [ ] Tests canLogin() helper
+- [ ] Tests that wrestlers() relationship does NOT exist
+
+---
+
+### Task 6.2: Create Enum Unit Tests
+**Priority:** Medium
+**Estimate:** Small
+
+Unit tests for Role and UserStatus enums.
+
+**Files:**
+- `tests/Unit/Enums/RoleTest.php`
+- `tests/Unit/Enums/UserStatusTest.php`
+
+**Acceptance Criteria:**
+- [ ] Tests all enum cases
+- [ ] Tests label() methods
+- [ ] Tests helper methods
+
+---
+
+### Task 6.3: Update Authentication Tests
+**Priority:** High
+**Estimate:** Medium
+
+Update auth tests for status checking.
+
+**Files:**
+- `tests/Feature/Auth/AuthenticationTest.php`
+
+**Acceptance Criteria:**
+- [ ] Test active user can login
+- [ ] Test suspended user cannot login
+- [ ] Test pending user cannot login
+- [ ] Test admin role check works
+
+---
+
+## Phase 7: Codebase Updates
+
+### Task 7.1: Update Wrestler Creation References
+**Priority:** Critical
+**Estimate:** Medium
+
+Update any code that creates wrestlers via User relationship.
+
+**Files:**
+- Various controllers, services, tests
+
+**Acceptance Criteria:**
+- [ ] Find all `$user->wrestlers()->create()` usages
+- [ ] Update to `$promotion->wrestlers()->create()`
+- [ ] Update related tests
+
+---
+
+### Task 7.2: Update Dashboard/Profile Views
+**Priority:** Medium
+**Estimate:** Small
+
+Update views that display user's wrestlers.
+
+**Files:**
+- Dashboard views
+- Profile views
+
+**Acceptance Criteria:**
+- [ ] Update to use promotion context
+- [ ] Display promotion selection if multiple
+- [ ] Show wrestler count from promotion
+
+---
+
+## Summary
+
+| Phase | Tasks | Priority |
+|-------|-------|----------|
+| 1. Enums | 2 | Critical |
+| 2. Database | 1 | Critical |
+| 3. Models | 2 | Critical |
+| 4. Factory | 1 | High |
+| 5. Auth | 2 | High/Medium |
+| 6. Testing | 3 | High/Medium |
+| 7. Codebase | 2 | Critical/Medium |
+
+**Total Tasks:** 13
+
+**Breaking Changes:**
+- `User::wrestlers()` relationship removed
+- All wrestler creation must go through Promotion

--- a/.agent-os/specs/2026-01-16-venues-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-venues-system/spec-lite.md
@@ -1,0 +1,43 @@
+# Venues System - Quick Reference
+
+> Location management for wrestling events
+
+## Core Entity
+
+| Entity | Purpose |
+|--------|---------|
+| Venue | Location where events are held |
+
+## Venue Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Venue name |
+| street_address | string | Street address |
+| city | string | City |
+| state | string | State |
+| zipcode | string | Postal code |
+
+## Key Relationships
+
+```
+Venue
+├── events (HasMany → Event)
+├── previousEvents (past dates)
+└── futureEvents (future dates)
+```
+
+## Query Scopes
+
+| Scope | Description |
+|-------|-------------|
+| `withEvents()` | Venues with any events |
+| `withPastEvents()` | Venues with past events |
+| `withFutureEvents()` | Venues with upcoming events |
+| `withoutEvents()` | Venues with no event history |
+
+## File Locations
+
+- `app/Models/Events/Venue.php`
+- `app/Builders/Events/VenueBuilder.php`
+- `app/Models/Concerns/HoldsEvents.php`

--- a/.agent-os/specs/2026-01-16-venues-system/spec.md
+++ b/.agent-os/specs/2026-01-16-venues-system/spec.md
@@ -1,0 +1,57 @@
+# Spec Requirements Document
+
+> Spec: Venues System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the Venues System—the location management component of Ringside that tracks where wrestling events are held. This spec serves as the authoritative reference for venue management, including address tracking, event history, and venue-event relationships.
+
+## User Stories
+
+### Venue Creation
+
+As a **wrestling promoter**, I want to create and manage venues, so that I can track where my events are held.
+
+**Workflow:**
+1. Create venue with name and full address
+2. Associate events with the venue
+3. Track event history at each venue
+
+### Event History
+
+As a **promoter**, I want to see the event history for each venue, so that I can track which shows have been held where.
+
+**Workflow:**
+1. View all events held at a venue
+2. Filter by past vs upcoming events
+3. Identify frequently used venues
+
+### Venue Selection
+
+As a **promoter**, I want to find suitable venues for events, so that I can book appropriate locations.
+
+**Workflow:**
+1. View all available venues
+2. Filter by event history (experienced vs new)
+3. Assign venue to event
+
+## Spec Scope
+
+1. **Venue Entity** - Core venue model with address attributes
+2. **Event Relationship** - How venues connect to events
+3. **Venue Queries** - Scopes for filtering by event history
+4. **Address Management** - Full address tracking
+
+## Out of Scope
+
+- Venue capacity tracking (future feature)
+- Venue availability calendars (future feature)
+- Venue booking/contracts (future feature)
+- Event management (see Events System spec)
+
+## Expected Deliverable
+
+1. Complete venue entity documentation with attributes
+2. Event relationship documentation
+3. Query method reference for venue data

--- a/.agent-os/specs/2026-01-16-venues-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-venues-system/sub-specs/technical-spec.md
@@ -1,0 +1,128 @@
+# Technical Specification
+
+> Venues System
+> Reference: @.agent-os/specs/2026-01-16-venues-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. Venue
+
+**Model:** `App\Models\Events\Venue`
+
+Location entity representing where wrestling events are held.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| name | string | Venue name |
+| street_address | string | Street address |
+| city | string | City |
+| state | string | State |
+| zipcode | string | ZIP code |
+
+> **Note:** Address format currently supports US addresses only. International address support may be added in the future.
+
+#### Key Relationships
+```
+Venue
+├── events (HasMany → Event)
+│   └── All events at this venue
+├── previousEvents (HasMany → Event)
+│   └── Events where date < today
+└── futureEvents (HasMany → Event)
+    └── Events where date > today
+```
+
+#### Traits
+- `HoldsEvents` - Event relationship methods
+- `SoftDeletes` - Soft deletion support
+
+---
+
+## Database Tables
+
+### Schema: venues
+```sql
+id              BIGINT PRIMARY KEY
+name            VARCHAR(255)
+street_address  VARCHAR(255)
+city            VARCHAR(255)
+state           VARCHAR(255)
+zipcode         VARCHAR(20)
+created_at      TIMESTAMP
+updated_at      TIMESTAMP
+deleted_at      TIMESTAMP NULLABLE
+```
+
+---
+
+## Query Builder Methods
+
+### Venue Scopes
+
+**Location:** `App\Builders\Events\VenueBuilder`
+
+| Method | Description |
+|--------|-------------|
+| `withEvents()` | Venues that have hosted any events |
+| `withPastEvents()` | Venues with events in the past |
+| `withFutureEvents()` | Venues with upcoming events |
+| `withoutEvents()` | Venues with no event history |
+
+#### Usage Examples
+```php
+// Find experienced venues
+Venue::query()->withPastEvents()->get();
+
+// Find venues with confirmed bookings
+Venue::query()->withFutureEvents()->get();
+
+// Find new/untapped venues
+Venue::query()->withoutEvents()->get();
+
+// Find venues with both past and upcoming events
+Venue::query()->withPastEvents()->withFutureEvents()->get();
+```
+
+---
+
+## Business Rules
+
+### Venue-Event Association
+- Venues can host multiple events
+- Events optionally reference a venue (nullable)
+- Deleting a venue does not delete associated events
+- Venue can be changed on an event after creation
+
+### No Status Computation
+Unlike other entities, Venues have no computed status. They are simple location records.
+
+---
+
+## File Locations
+
+```
+app/
+├── Models/Events/
+│   └── Venue.php
+├── Models/Concerns/
+│   └── HoldsEvents.php
+└── Builders/Events/
+    └── VenueBuilder.php
+```
+
+---
+
+## Future Considerations
+
+These features are out of scope but may be added later:
+
+| Feature | Description |
+|---------|-------------|
+| Capacity | Track venue capacity for event planning |
+| Availability | Calendar-based availability tracking |
+| Contracts | Venue booking/contract management |
+| Costs | Venue rental costs per event |

--- a/.agent-os/specs/2026-01-16-venues-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-venues-system/tasks.md
@@ -1,0 +1,68 @@
+# Venues System Tasks
+
+## Pending
+
+### Add promotion_id foreign key for multi-tenant support
+
+**Priority:** Critical
+**Type:** Migration
+**Depends on:** Promotions System
+
+Add `promotion_id` foreign key to venues table for multi-tenant architecture.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_venues_table.php`
+- `app/Models/Venue.php`
+
+**Changes required:**
+- Create migration adding `promotion_id` column with foreign key constraint
+- Add index on `promotion_id`
+- Add `BelongsToPromotion` trait to Venue model
+- Add `promotion_id` to fillable array
+- Update VenueFactory to include promotion
+- Update all venue tests to set promotion context
+
+**Acceptance Criteria:**
+- [ ] Migration creates column with proper foreign key
+- [ ] Cascade delete when promotion is deleted
+- [ ] Model uses BelongsToPromotion trait
+- [ ] Global scope filters by current promotion
+- [ ] All existing tests pass with promotion context
+
+**Future Consideration:** Venues might eventually be shared across promotions (e.g., Madison Square Garden can host events for multiple promotions). This would require:
+- Making `promotion_id` nullable
+- Adding a `shared` boolean flag
+- Creating a `venue_promotion` pivot table for shared venues
+- Updating the global scope to include shared venues
+
+For initial implementation, venues are promotion-specific.
+
+**Reference:** See @.agent-os/specs/2026-01-16-promotions-system/tasks.md for full multi-tenant implementation details.
+
+---
+
+### Rename event relationship methods for consistency
+
+**Priority:** Low
+**Type:** Refactor
+
+Align terminology with EventStatus rename (`Past` → `Completed`).
+
+| Current | New |
+|---------|-----|
+| `previousEvents` | `completedEvents` |
+| `futureEvents` | Keep as-is (or `upcomingEvents`?) |
+| `withPastEvents()` | `withCompletedEvents()` |
+
+**Changes required:**
+- Rename methods in `HoldsEvents` trait
+- Update `VenueBuilder` scopes
+- Update all callers and tests
+
+**Note:** This depends on EventStatus rename being completed first.
+
+---
+
+## Completed
+
+_None yet_

--- a/.agent-os/specs/2026-01-16-wrestlers-system/spec-lite.md
+++ b/.agent-os/specs/2026-01-16-wrestlers-system/spec-lite.md
@@ -1,0 +1,72 @@
+# Wrestlers System - Quick Reference
+
+> Individual wrestling talent management
+
+## Core Entity
+
+| Entity | Purpose |
+|--------|---------|
+| Wrestler | Individual wrestling talent |
+| WrestlerEmployment | Employment periods |
+| WrestlerInjury | Injury tracking |
+| WrestlerSuspension | Suspension tracking |
+| WrestlerRetirement | Retirement tracking |
+| WrestlerManager | Manager relationship pivot |
+
+## Wrestler Attributes
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Display name |
+| height | Height | Height value object |
+| weight | int | Weight in pounds |
+| hometown | string | Hometown |
+| signature_move | string\|null | Signature finishing move |
+| status | EmploymentStatus | **Computed** from employment |
+
+## Employment Status (Computed)
+
+| Status | Condition |
+|--------|-----------|
+| Retired | Has active retirement |
+| Employed | Has current employment |
+| FutureEmployment | Signed but not started |
+| Released | Previously employed, now without |
+| Unemployed | Never employed |
+
+## Bookability Rules
+
+Wrestler is bookable when ALL are true:
+- Currently employed (not future)
+- NOT injured
+- NOT suspended
+- NOT retired
+
+## Key Relationships
+
+```
+Wrestler
+├── employments (HasMany → WrestlerEmployment)
+├── injuries (HasMany → WrestlerInjury)
+├── suspensions (HasMany → WrestlerSuspension)
+├── retirements (HasMany → WrestlerRetirement)
+├── managers (BelongsToMany → Manager)
+├── tagTeams (BelongsToMany → TagTeam)
+├── stables (BelongsToMany → Stable)
+├── titleChampionships (MorphMany → TitleChampionship)
+└── matches (MorphToMany → EventMatch)
+```
+
+## Query Scopes
+
+**Employment:** `employed()`, `unemployed()`, `released()`, `futureEmployed()`
+
+**Availability:** `injured()`, `suspended()`, `retired()`
+
+**Booking:** `available()`, `unavailable()`, `bookable()`, `availableOn($date)`
+
+## File Locations
+
+- `app/Models/Wrestlers/Wrestler.php`
+- `app/Enums/Shared/EmploymentStatus.php`
+- `app/Builders/Roster/WrestlerBuilder.php`

--- a/.agent-os/specs/2026-01-16-wrestlers-system/spec.md
+++ b/.agent-os/specs/2026-01-16-wrestlers-system/spec.md
@@ -1,0 +1,91 @@
+# Spec Requirements Document
+
+> Spec: Wrestlers System Feature Documentation
+> Created: 2026-01-16
+
+## Overview
+
+Document the Wrestlers System—the foundational roster entity in Ringside representing individual wrestling talent. This spec serves as the authoritative reference for wrestler management, including employment tracking, availability states (injuries, suspensions, retirements), relationships (managers, tag teams, stables), and championship tracking.
+
+## User Stories
+
+### Wrestler Management
+
+As a **wrestling promoter**, I want to manage my roster of wrestlers, so that I can track all talent in my promotion.
+
+**Workflow:**
+1. Create wrestler with profile (name, height, weight, hometown, signature move)
+2. Hire wrestler (create employment)
+3. Track wrestler through their career
+4. Release or retire wrestler when appropriate
+
+### Employment Tracking
+
+As a **promoter**, I want to track wrestler employment status, so that I know who is currently under contract.
+
+**Workflow:**
+1. Hire wrestler with start date
+2. Track current and future employments
+3. Release wrestler (end employment)
+4. View employment history
+
+### Availability Management
+
+As a **promoter**, I want to track injuries, suspensions, and retirements, so that I know who is available for matches.
+
+**Workflow:**
+1. Record injury when wrestler is hurt
+2. Clear injury when wrestler recovers
+3. Suspend wrestler for disciplinary reasons
+4. Lift suspension when served
+5. Retire wrestler when career ends
+6. Unretire for comebacks (rare)
+
+### Match Booking
+
+As a **promoter**, I want to know which wrestlers are bookable, so that I can create match cards.
+
+**Workflow:**
+1. Check wrestler availability (employed, not injured, not suspended)
+2. Assign bookable wrestlers to matches
+3. Track match history per wrestler
+
+### Relationship Management
+
+As a **promoter**, I want to track wrestler relationships, so that I can manage storylines.
+
+**Workflow:**
+1. Assign managers to wrestlers
+2. Form tag teams with wrestlers
+3. Add wrestlers to stables
+4. Track championship reigns
+
+## Spec Scope
+
+1. **Wrestler Entity** - Core model with profile attributes
+2. **Employment** - Hire/release lifecycle with temporal tracking
+3. **Injuries** - Injury tracking with recovery dates
+4. **Suspensions** - Suspension tracking with lift dates
+5. **Retirements** - Retirement tracking with comeback support
+6. **Bookability** - Rules for match eligibility
+7. **Manager Relationships** - Being managed by managers
+8. **Tag Team Membership** - Joining/leaving tag teams
+9. **Stable Membership** - Joining/leaving stables
+10. **Championships** - Holding singles titles
+
+## Out of Scope
+
+- Tag team management (see Tag Teams System spec)
+- Stable management (see Stables System spec)
+- Manager management (see Managers System spec)
+- Match creation (see Match System spec)
+- Championship management (see Championship System spec)
+
+## Expected Deliverable
+
+1. Complete wrestler entity documentation with attributes
+2. Employment lifecycle documentation
+3. Availability state documentation (injuries, suspensions, retirements)
+4. Bookability rules documentation
+5. Relationship documentation
+6. Query method reference

--- a/.agent-os/specs/2026-01-16-wrestlers-system/sub-specs/technical-spec.md
+++ b/.agent-os/specs/2026-01-16-wrestlers-system/sub-specs/technical-spec.md
@@ -1,0 +1,450 @@
+# Technical Specification
+
+> Wrestlers System
+> Reference: @.agent-os/specs/2026-01-16-wrestlers-system/spec.md
+
+---
+
+## Entity Reference
+
+### 1. Wrestler
+
+**Model:** `App\Models\Wrestlers\Wrestler`
+
+The core entity representing an individual wrestling talent.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| name | string | Display name |
+| height | Height | Height value object (via HeightCast) |
+| weight | int | Weight in pounds |
+| hometown | string | Hometown |
+| signature_move | string\|null | Signature finishing move |
+| status | EmploymentStatus | **Computed** from relationships |
+
+#### Key Relationships
+```
+Wrestler
+├── employments (HasMany → WrestlerEmployment)
+│   ├── currentEmployment - ended_at IS NULL AND started_at <= now
+│   ├── futureEmployment - ended_at IS NULL AND started_at > now
+│   ├── previousEmployments - ended_at IS NOT NULL
+│   └── firstEmployment - earliest by started_at
+├── injuries (HasMany → WrestlerInjury)
+│   ├── currentInjury - ended_at IS NULL
+│   └── previousInjuries - ended_at IS NOT NULL
+├── suspensions (HasMany → WrestlerSuspension)
+│   ├── currentSuspension - ended_at IS NULL
+│   └── previousSuspensions - ended_at IS NOT NULL
+├── retirements (HasMany → WrestlerRetirement)
+│   ├── currentRetirement - ended_at IS NULL
+│   └── previousRetirements - ended_at IS NOT NULL
+├── managers (BelongsToMany → Manager)
+│   ├── currentManagers - fired_at IS NULL
+│   └── previousManagers - fired_at IS NOT NULL
+├── tagTeams (BelongsToMany → TagTeam)
+│   ├── currentTagTeam - left_at IS NULL (one only)
+│   └── previousTagTeams - left_at IS NOT NULL
+├── stables (BelongsToMany → Stable)
+│   ├── currentStable - left_at IS NULL (one only)
+│   └── previousStables - left_at IS NOT NULL
+├── titleChampionships (MorphMany → TitleChampionship)
+│   ├── currentChampionships - lost_at IS NULL
+│   └── previousTitleChampionships - lost_at IS NOT NULL
+└── matches (MorphToMany → EventMatch)
+    └── previousMatches - event date < now
+```
+
+#### Traits
+- `IsEmployable` - Employment lifecycle
+- `IsInjurable` - Injury tracking
+- `IsSuspendable` - Suspension tracking
+- `IsRetirable` - Retirement tracking
+- `CanBeManaged` - Manager relationships
+- `CanJoinTagTeams` - Tag team membership
+- `CanJoinStables` - Stable membership
+- `CanWinTitles` - Championship relationships
+- `IsBookableCompetitor` - Match participation
+- `SoftDeletes` - Soft deletion
+
+#### Key Methods
+| Method | Return | Description |
+|--------|--------|-------------|
+| `isBookable()` | bool | Can be booked for matches |
+| `isEmployed()` | bool | Has current employment |
+| `isUnemployed()` | bool | Never employed |
+| `isReleased()` | bool | Was employed, now without |
+| `hasFutureEmployment()` | bool | Signed for future |
+| `isInjured()` | bool | Currently injured |
+| `isSuspended()` | bool | Currently suspended |
+| `isRetired()` | bool | Currently retired |
+| `isChampion()` | bool | Holds any title |
+
+---
+
+### 2. WrestlerEmployment
+
+**Model:** `App\Models\Wrestlers\WrestlerEmployment`
+
+Tracks employment periods for a wrestler.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| wrestler_id | int | Foreign key to wrestler |
+| started_at | datetime | Employment start date |
+| ended_at | datetime\|null | Employment end date (null = current) |
+
+#### Employment States
+| State | Condition |
+|-------|-----------|
+| Current | `started_at <= now AND ended_at IS NULL` |
+| Future | `started_at > now AND ended_at IS NULL` |
+| Ended | `ended_at IS NOT NULL` |
+
+---
+
+### 3. WrestlerInjury
+
+**Model:** `App\Models\Wrestlers\WrestlerInjury`
+
+Tracks injury periods for a wrestler.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| wrestler_id | int | Foreign key to wrestler |
+| started_at | datetime | Injury start date |
+| ended_at | datetime\|null | Recovery date (null = currently injured) |
+
+---
+
+### 4. WrestlerSuspension
+
+**Model:** `App\Models\Wrestlers\WrestlerSuspension`
+
+Tracks suspension periods for a wrestler.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| wrestler_id | int | Foreign key to wrestler |
+| started_at | datetime | Suspension start date |
+| ended_at | datetime\|null | Lift date (null = currently suspended) |
+
+---
+
+### 5. WrestlerRetirement
+
+**Model:** `App\Models\Wrestlers\WrestlerRetirement`
+
+Tracks retirement periods for a wrestler.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| wrestler_id | int | Foreign key to wrestler |
+| started_at | datetime | Retirement start date |
+| ended_at | datetime\|null | Comeback date (null = currently retired) |
+
+---
+
+### 6. WrestlerManager (Pivot)
+
+**Model:** `App\Models\Wrestlers\WrestlerManager`
+
+Pivot model for wrestler-manager relationships.
+
+#### Attributes
+| Field | Type | Description |
+|-------|------|-------------|
+| id | int | Primary key |
+| wrestler_id | int | Foreign key to wrestler |
+| manager_id | int | Foreign key to manager |
+| hired_at | datetime | Management start date |
+| fired_at | datetime\|null | Management end date (null = current) |
+
+---
+
+## Enums
+
+### EmploymentStatus
+```php
+enum EmploymentStatus: string {
+    case Employed = 'employed';
+    case FutureEmployment = 'future_employment';
+    case Released = 'released';
+    case Retired = 'retired';
+    case Unemployed = 'unemployed';
+}
+```
+
+#### Status Computation Priority
+```
+┌─────────────────────────────────────────────────────────────┐
+│               EMPLOYMENT STATUS PRIORITY                     │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  1. RETIRED           (has active retirement)               │
+│       ↓                                                     │
+│  2. EMPLOYED          (has current employment)              │
+│       ↓                                                     │
+│  3. FUTURE_EMPLOYMENT (signed but not started)              │
+│       ↓                                                     │
+│  4. RELEASED          (was employed, now without)           │
+│       ↓                                                     │
+│  5. UNEMPLOYED        (never employed)                      │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Database Tables
+
+### Wrestler Tables
+| Table | Description |
+|-------|-------------|
+| `wrestlers` | Core wrestler records |
+| `wrestlers_employments` | Employment periods |
+| `wrestlers_injuries` | Injury periods |
+| `wrestlers_suspensions` | Suspension periods |
+| `wrestlers_retirements` | Retirement periods |
+| `wrestlers_managers` | Manager relationship pivot |
+
+### Schema: wrestlers
+```sql
+id              BIGINT PRIMARY KEY
+name            VARCHAR(255)
+height          INT
+weight          INT
+hometown        VARCHAR(255)
+signature_move  VARCHAR(255) NULLABLE
+created_at      TIMESTAMP
+updated_at      TIMESTAMP
+deleted_at      TIMESTAMP NULLABLE
+```
+
+### Schema: wrestlers_employments
+```sql
+id          BIGINT PRIMARY KEY
+wrestler_id BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: wrestlers_injuries
+```sql
+id          BIGINT PRIMARY KEY
+wrestler_id BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: wrestlers_suspensions
+```sql
+id          BIGINT PRIMARY KEY
+wrestler_id BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+### Schema: wrestlers_retirements
+```sql
+id          BIGINT PRIMARY KEY
+wrestler_id BIGINT FOREIGN KEY
+started_at  TIMESTAMP
+ended_at    TIMESTAMP NULLABLE
+created_at  TIMESTAMP
+updated_at  TIMESTAMP
+```
+
+---
+
+## Bookability Rules
+
+### isBookable() Logic
+```php
+public function isBookable(): bool
+{
+    return ! (
+        $this->isNotInEmployment() ||  // Must be employed
+        $this->isSuspended() ||         // Must not be suspended
+        $this->isInjured() ||           // Must not be injured
+        $this->hasFutureEmployment()    // Must have started employment
+    );
+}
+```
+
+### Bookability Conditions
+| Condition | Bookable? |
+|-----------|-----------|
+| Employed, healthy, not suspended | Yes |
+| Employed but injured | No |
+| Employed but suspended | No |
+| Future employment (not started) | No |
+| Released | No |
+| Unemployed | No |
+| Retired | No |
+
+---
+
+## Query Builder Methods
+
+### Employment Scopes
+
+**Location:** `App\Builders\Roster\WrestlerBuilder`
+
+| Method | Description |
+|--------|-------------|
+| `employed()` | Has current employment |
+| `unemployed()` | Never employed |
+| `released()` | Was employed, now without |
+| `futureEmployed()` | Has future employment scheduled |
+
+### Availability Scopes
+
+| Method | Description |
+|--------|-------------|
+| `injured()` | Currently injured |
+| `suspended()` | Currently suspended |
+| `retired()` | Currently retired |
+
+### Booking Scopes
+
+| Method | Description |
+|--------|-------------|
+| `available()` | Employed + not injured + not suspended + not retired |
+| `unavailable()` | Inverse of available |
+| `bookable()` | Alias for available |
+| `availableOn(Carbon $date)` | Available AND not booked on date |
+| `notBookedOn(Carbon $date)` | Not assigned to match on date |
+
+---
+
+## Business Rules
+
+### Employment Rules
+- Employment uses temporal tracking (`started_at`/`ended_at`)
+- Multiple employment periods allowed (rehires)
+- Future employment blocks bookability until start date
+- Releasing a wrestler sets `ended_at` on current employment
+
+### Availability Rules
+- Injuries, suspensions, retirements all use same temporal pattern
+- Active state: `ended_at IS NULL`
+- Multiple periods allowed (multiple injuries, comebacks from retirement)
+- Status is computed, never stored
+
+### Relationship Rules
+- Wrestler can have multiple managers simultaneously
+- Wrestler can be in ONE tag team at a time
+- Wrestler can be in ONE stable at a time
+- Wrestler can hold multiple titles simultaneously
+
+### Manager Relationship Rules
+
+#### Relationship Direction
+Wrestlers **hire** managers to represent them. The `WrestlerManager` pivot represents "this wrestler has hired this manager."
+
+#### Terminology
+| Field | Meaning |
+|-------|---------|
+| `hired_at` | Date wrestler hired the manager |
+| `fired_at` | Date wrestler fired the manager (null = current) |
+
+#### Employment Requirement
+Both wrestler AND manager must meet one of these conditions:
+- Currently employed (`started_at <= now AND ended_at IS NULL`)
+- Has future employment scheduled (`started_at > now AND ended_at IS NULL`)
+
+This allows wrestlers and managers to be paired before their debut, enabling them to debut together.
+
+#### Multiplicity
+- A wrestler can have multiple managers simultaneously
+- A manager can manage multiple wrestlers simultaneously
+
+#### Stable Association
+Managers are **indirectly** associated with stables through the wrestlers they manage. If a manager manages a wrestler who is in a stable, the manager is considered "part of" that stable. See Stables System spec for details.
+
+### Championship Rules
+- Singles titles only (tag team titles go to TagTeam entity)
+- Championship tracked via polymorphic MorphMany
+- Current championship: `lost_at IS NULL`
+
+---
+
+## File Locations
+
+```
+app/
+├── Enums/Shared/
+│   └── EmploymentStatus.php
+├── Models/Wrestlers/
+│   ├── Wrestler.php
+│   ├── WrestlerEmployment.php
+│   ├── WrestlerInjury.php
+│   ├── WrestlerSuspension.php
+│   ├── WrestlerRetirement.php
+│   └── WrestlerManager.php
+├── Models/Concerns/
+│   ├── IsEmployable.php
+│   ├── IsInjurable.php
+│   ├── IsSuspendable.php
+│   ├── IsRetirable.php
+│   ├── CanBeManaged.php
+│   ├── CanJoinTagTeams.php
+│   ├── CanJoinStables.php
+│   ├── CanWinTitles.php
+│   └── IsBookableCompetitor.php
+└── Builders/Roster/
+    ├── WrestlerBuilder.php
+    └── IndividualRosterMemberBuilder.php
+```
+
+---
+
+## Builder Hierarchy
+
+### IndividualRosterMemberBuilder
+
+**Location:** `App\Builders\Roster\IndividualRosterMemberBuilder`
+
+Shared query builder for individual roster members (single-person entities).
+
+#### Covered Entities
+| Entity | Builder |
+|--------|---------|
+| Wrestler | `WrestlerBuilder` extends `IndividualRosterMemberBuilder` |
+| Referee | `RefereeBuilder` extends `IndividualRosterMemberBuilder` |
+| Manager | `ManagerBuilder` extends `IndividualRosterMemberBuilder` |
+
+#### Purpose
+Provides common query scopes shared across all individual roster members:
+- Employment scopes (`employed()`, `unemployed()`, `released()`, `futureEmployed()`)
+- Availability scopes where applicable
+
+This separates individual roster members from group entities (TagTeam) which have different query requirements.
+
+### WrestlerBuilder
+
+**Location:** `App\Builders\Roster\WrestlerBuilder`
+
+Wrestler-specific query builder extending `IndividualRosterMemberBuilder`.
+
+Adds wrestler-specific scopes:
+- Availability scopes (`injured()`, `suspended()`, `retired()`)
+- Booking scopes (`available()`, `bookable()`, `availableOn()`)
+- Match-related scopes (`notBookedOn()`)

--- a/.agent-os/specs/2026-01-16-wrestlers-system/tasks.md
+++ b/.agent-os/specs/2026-01-16-wrestlers-system/tasks.md
@@ -1,0 +1,76 @@
+# Wrestlers System Tasks
+
+## Pending
+
+### Add promotion_id foreign key for multi-tenant support
+
+**Priority:** Critical
+**Type:** Migration
+**Depends on:** Promotions System
+
+Add `promotion_id` foreign key to wrestlers table for multi-tenant architecture.
+
+**Files:**
+- `database/migrations/YYYY_MM_DD_add_promotion_id_to_wrestlers_table.php`
+- `app/Models/Wrestler.php`
+
+**Changes required:**
+- Create migration adding `promotion_id` column with foreign key constraint
+- Add index on `promotion_id`
+- Add `BelongsToPromotion` trait to Wrestler model
+- Add `promotion_id` to fillable array
+- Update WrestlerFactory to include promotion
+- Update all wrestler tests to set promotion context
+
+**Acceptance Criteria:**
+- [ ] Migration creates column with proper foreign key
+- [ ] Cascade delete when promotion is deleted
+- [ ] Model uses BelongsToPromotion trait
+- [ ] Global scope filters by current promotion
+- [ ] All existing tests pass with promotion context
+
+**Reference:** See @.agent-os/specs/2026-01-16-promotions-system/tasks.md for full multi-tenant implementation details.
+
+---
+
+### Rename `previousMatches` to `completedMatches`
+
+**Priority:** Low
+**Type:** Refactor
+
+Align match relationship terminology with EventStatus rename (`Past` → `Completed`). Matches are "completed" events.
+
+| Current | New |
+|---------|-----|
+| `previousMatches` | `completedMatches` |
+
+**Changes required:**
+- Rename relationship method in `IsBookableCompetitor` trait
+- Update `WrestlerBuilder` scopes if applicable
+- Update all callers and tests
+
+**Note:** This aligns with the Events System terminology change.
+
+---
+
+### Rename `SingleRosterMemberBuilder` to `IndividualRosterMemberBuilder`
+
+**Priority:** Low
+**Type:** Refactor
+
+More explicit naming for the shared query builder covering individual roster members.
+
+| Current | New |
+|---------|-----|
+| `SingleRosterMemberBuilder` | `IndividualRosterMemberBuilder` |
+
+**Changes required:**
+- Rename class file
+- Update namespace references
+- Update all models that extend this builder (Wrestler, Referee, Manager)
+
+---
+
+## Completed
+
+_None yet_


### PR DESCRIPTION
## Summary

- Add **Promotions System** spec for multi-tenant architecture where each Promotion owns all roster entities
- Add **Users System** spec (simplified - User owns Promotions, not Wrestlers directly)
- Add unified PRD and product documentation
- Add feature specs: Wrestlers, Tag Teams, Managers, Referees, Stables, Events, Venues, Titles, Match System
- Rename `metronic-component-library` to `design-system` with new sub-specs (design tokens, page patterns)
- Mark `login-page-completion` as superseded by design-system
- Add multi-tenant migration tasks to all entity specs

## Architecture Change

```
Before: User → Wrestlers (direct ownership)
After:  User → Promotion → Wrestlers/TagTeams/Managers/etc.
```

Each Promotion will own:
- Wrestlers, Tag Teams, Managers, Referees, Stables
- Events, Venues
- Titles

## Files Changed

All changes are within `.agent-os/` directory:
- `.agent-os/product/` - PRD and mission docs
- `.agent-os/specs/` - All feature specifications

## Test Plan

- [ ] Review spec documentation for completeness
- [ ] Verify all cross-references between specs are correct
- [ ] Confirm multi-tenant tasks are added to all entity specs