### PR TITLE
feat: replace Rappasoft with custom table system

### DIFF
--- a/app/Livewire/Base/Tables/BasePreviousManagersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousManagersTable.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\DataTableComponent;
 
 abstract class BasePreviousManagersTable extends DataTableComponent
 {

--- a/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
@@ -5,15 +5,15 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\ArrayColumn;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Referees\Referee;
 use App\Models\Titles\Title;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\ArrayColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 abstract class BasePreviousMatchesTable extends DataTableComponent
 {

--- a/app/Livewire/Base/Tables/BasePreviousStablesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousStablesTable.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\DataTableComponent;
 
 abstract class BasePreviousStablesTable extends DataTableComponent
 {

--- a/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\TagTeams\TagTeamWrestler;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 abstract class BasePreviousTagTeamsTable extends DataTableComponent
 {

--- a/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Titles\TitleChampionship;
 use Illuminate\Database\Eloquent\Model;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
 {

--- a/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\DataTableComponent;
 
 abstract class BasePreviousWrestlersTable extends DataTableComponent
 {

--- a/app/Livewire/Base/Tables/BaseTable.php
+++ b/app/Livewire/Base/Tables/BaseTable.php
@@ -6,33 +6,11 @@ namespace App\Livewire\Base\Tables;
 
 use App\Livewire\Concerns\BaseTableTrait;
 use App\Livewire\Concerns\Columns\HasActionColumn;
+use App\Livewire\Table\DataTableComponent;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Gate;
-use Livewire\Component;
 
-/**
- * Base class for all table components.
- *
- * This abstract class provides the foundation for all table components in the
- * application. It handles common table functionality including actions, deletion,
- * and integrates with the Laravel Livewire Tables package.
- *
- * The class supports both simple tables and tables with actions through the
- * HasActionColumn trait, which can be optionally enabled by setting the
- * $showActionColumn property to true in child classes.
- *
- * Key Features:
- * - Consistent table styling and behavior
- * - Optional action column support
- * - Standardized deletion handling with authorization
- * - Integration with Laravel Gates for permissions
- * - Event dispatching for real-time updates
- *
- * @author Your Name
- *
- * @since 1.0.0
- */
-abstract class BaseTable extends Component
+abstract class BaseTable extends DataTableComponent
 {
     use BaseTableTrait;
     use HasActionColumn;

--- a/app/Livewire/Components/Tables/Columns/FirstActivityPeriodColumn.php
+++ b/app/Livewire/Components/Tables/Columns/FirstActivityPeriodColumn.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Livewire\Components\Tables\Columns;
 
+use App\Livewire\Table\Column;
 use App\Models\Stables\Stable;
 use App\Models\Titles\Title;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class FirstActivityPeriodColumn extends Column
 {

--- a/app/Livewire/Components/Tables/Columns/FirstEmploymentDateColumn.php
+++ b/app/Livewire/Components/Tables/Columns/FirstEmploymentDateColumn.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Livewire\Components\Tables\Columns;
 
+use App\Livewire\Table\Column;
 use App\Models\Managers\Manager;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class FirstEmploymentDateColumn extends Column
 {

--- a/app/Livewire/Components/Tables/Filters/FirstActivityPeriodFilter.php
+++ b/app/Livewire/Components/Tables/Filters/FirstActivityPeriodFilter.php
@@ -4,21 +4,12 @@ declare(strict_types=1);
 
 namespace App\Livewire\Components\Tables\Filters;
 
+use App\Livewire\Table\Filters\DateRangeFilter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\Views\Filters\DateRangeFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HandlesDates;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasConfig;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasOptions;
-use Rappasoft\LaravelLivewireTables\Views\Traits\Core\HasWireables;
 
 class FirstActivityPeriodFilter extends DateRangeFilter
 {
-    use HandlesDates,
-        HasConfig,
-        HasOptions,
-        HasWireables;
-
     public string $filterRelationshipName = '';
 
     public string $filterStartField = '';
@@ -40,9 +31,7 @@ class FirstActivityPeriodFilter extends DateRangeFilter
             ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
             ->filter(function (Builder $query, array $dateRange): void {
                 $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
-                    /**
-                     * @var array{'minDate': string, 'maxDate': string} $dateRange
-                     */
+                    /** @var array{'minDate': string, 'maxDate': string} $dateRange */
                     $query
                         ->where(function (Builder $query) use ($dateRange): void {
                             $query->whereBetween(

--- a/app/Livewire/Components/Tables/Filters/FirstEmploymentFilter.php
+++ b/app/Livewire/Components/Tables/Filters/FirstEmploymentFilter.php
@@ -4,21 +4,12 @@ declare(strict_types=1);
 
 namespace App\Livewire\Components\Tables\Filters;
 
+use App\Livewire\Table\Filters\DateRangeFilter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\Views\Filters\DateRangeFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HandlesDates;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasConfig;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasOptions;
-use Rappasoft\LaravelLivewireTables\Views\Traits\Core\HasWireables;
 
 class FirstEmploymentFilter extends DateRangeFilter
 {
-    use HandlesDates,
-        HasConfig,
-        HasOptions,
-        HasWireables;
-
     public string $filterRelationshipName = '';
 
     public string $filterStartField = '';
@@ -39,9 +30,7 @@ class FirstEmploymentFilter extends DateRangeFilter
         ])
             ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
             ->filter(function (Builder $query, array $dateRange): void {
-                /**
-                 * @var array{'minDate': string, 'maxDate': string} $dateRange
-                 */
+                /** @var array{'minDate': string, 'maxDate': string} $dateRange */
                 $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
                     $query
                         ->where(function (Builder $query) use ($dateRange): void {

--- a/app/Livewire/Concerns/BaseTableTrait.php
+++ b/app/Livewire/Concerns/BaseTableTrait.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Concerns;
 
 use App\Livewire\Concerns\Columns\HasActionColumn;
-use Rappasoft\LaravelLivewireTables\Views\Column;
+use App\Livewire\Table\Column;
 
 trait BaseTableTrait
 {

--- a/app/Livewire/Concerns/Columns/HasActionColumn.php
+++ b/app/Livewire/Concerns/Columns/HasActionColumn.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Concerns\Columns;
 
-use Rappasoft\LaravelLivewireTables\Views\Column;
+use App\Livewire\Table\Column;
 
 /**
  * Provides action column functionality for Livewire table components.

--- a/app/Livewire/Concerns/Columns/HasStatusColumn.php
+++ b/app/Livewire/Concerns/Columns/HasStatusColumn.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Concerns\Columns;
 
-use Rappasoft\LaravelLivewireTables\Views\Column;
+use App\Livewire\Table\Column;
 
 /** @phpstan-ignore-next-line trait.unused */
 trait HasStatusColumn

--- a/app/Livewire/Concerns/Filters/HasStatusFilter.php
+++ b/app/Livewire/Concerns/Filters/HasStatusFilter.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Livewire\Concerns\Filters;
 
+use App\Livewire\Table\Filter;
+use App\Livewire\Table\Filters\SelectFilter;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 /** @phpstan-ignore-next-line trait.unused */
 trait HasStatusFilter

--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -7,18 +7,18 @@ namespace App\Livewire\Events\Tables;
 use App\Actions\Events\RestoreAction;
 use App\Builders\Events\EventBuilder;
 use App\Livewire\Base\Tables\BaseTable;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\Filter;
+use App\Livewire\Table\Filters\DateRangeFilter;
+use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
-use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\DateRangeFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class Main extends BaseTable
 {

--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -27,13 +27,13 @@ use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
 use App\Livewire\Managers\Components\Actions;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Filter;
+use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Managers\Manager;
 use Exception;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class Main extends BaseTable
 {

--- a/app/Livewire/Managers/Tables/PreviousStables.php
+++ b/app/Livewire/Managers/Tables/PreviousStables.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Livewire\Managers\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
+use App\Livewire\Table\Column;
 use App\Models\Stables\Stable;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class PreviousStables extends BasePreviousStablesTable
 {

--- a/app/Livewire/Managers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeams.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Livewire\Managers\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\TagTeams\TagTeamManager;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
 
 class PreviousTagTeams extends DataTableComponent
 {

--- a/app/Livewire/Managers/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlers.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Livewire\Managers\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Wrestlers\WrestlerManager;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
 
 class PreviousWrestlers extends DataTableComponent
 {

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace App\Livewire\Matches\Tables;
 
 use App\Livewire\Base\Tables\BaseTable;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\LinkColumn;
 use App\Models\Matches\EventMatch;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 class Main extends BaseTable
 {

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace App\Livewire\Matches\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\ArrayColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Referees\Referee;
@@ -12,9 +15,6 @@ use App\Models\Titles\Title;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\ArrayColumn;
 
 class MatchesTable extends DataTableComponent
 {

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -27,14 +27,14 @@ use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
 use App\Livewire\Referees\Components\Actions;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Filter;
+use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Referees\Referee;
 use Exception;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class Main extends BaseTable
 {

--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -17,13 +17,13 @@ use App\Exceptions\Roster\Stables\CannotBeEstablishedException;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstActivityPeriodColumn;
 use App\Livewire\Components\Tables\Filters\FirstActivityPeriodFilter;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Filter;
+use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Stables\Stable;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class Main extends BaseTable
 {

--- a/app/Livewire/Stables/Tables/PreviousManagers.php
+++ b/app/Livewire/Stables/Tables/PreviousManagers.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace App\Livewire\Stables\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousManagersTable;
+use App\Livewire\Table\Column;
 use App\Models\Managers\Manager;
 use App\Models\Stables\Stable;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class PreviousManagers extends BasePreviousManagersTable
 {

--- a/app/Livewire/Stables/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Stables/Tables/PreviousTagTeams.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace App\Livewire\Stables\Tables;
 
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Stables\StableTagTeam;
 use App\Models\TagTeams\TagTeam;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 class PreviousTagTeams extends DataTableComponent
 {

--- a/app/Livewire/Stables/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Stables/Tables/PreviousWrestlers.php
@@ -4,15 +4,15 @@ declare(strict_types=1);
 
 namespace App\Livewire\Stables\Tables;
 
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Stables\StableWrestler;
 use App\Models\Wrestlers\Wrestler;
 use Carbon\Carbon;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 class PreviousWrestlers extends DataTableComponent
 {

--- a/app/Livewire/Table/Column.php
+++ b/app/Livewire/Table/Column.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Table;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+
+class Column
+{
+    protected string $field;
+
+    protected bool $searchable = false;
+
+    protected bool $sortable = false;
+
+    protected bool $isHtml = false;
+
+    protected bool $excludedFromColumnSelect = false;
+
+    protected ?Closure $labelCallback = null;
+
+    protected ?string $viewPath = null;
+
+    public function __construct(
+        protected string $title,
+        ?string $from = null,
+    ) {
+        $this->field = $from ?? str($title)->snake()->toString();
+    }
+
+    public static function make(string $title, ?string $from = null): static
+    {
+        return new static($title, $from);
+    }
+
+    public function searchable(): static
+    {
+        $this->searchable = true;
+
+        return $this;
+    }
+
+    public function sortable(): static
+    {
+        $this->sortable = true;
+
+        return $this;
+    }
+
+    public function html(): static
+    {
+        $this->isHtml = true;
+
+        return $this;
+    }
+
+    public function label(Closure $callback): static
+    {
+        $this->labelCallback = $callback;
+
+        return $this;
+    }
+
+    public function view(string $viewPath): static
+    {
+        $this->viewPath = $viewPath;
+
+        return $this;
+    }
+
+    public function excludeFromColumnSelect(): static
+    {
+        $this->excludedFromColumnSelect = true;
+
+        return $this;
+    }
+
+    public function getTitle(): string
+    {
+        return $this->title;
+    }
+
+    public function getField(): string
+    {
+        return $this->field;
+    }
+
+    public function isSearchable(): bool
+    {
+        return $this->searchable;
+    }
+
+    public function isSortable(): bool
+    {
+        return $this->sortable;
+    }
+
+    public function isHtml(): bool
+    {
+        return $this->isHtml;
+    }
+
+    /**
+     * Resolve the display value for a given row.
+     */
+    public function resolveValue(mixed $row): string
+    {
+        if ($this->viewPath) {
+            $view = view($this->viewPath, ['row' => $row]);
+
+            return $view instanceof View ? $view->render() : (string) $view;
+        }
+
+        if ($this->labelCallback) {
+            $result = ($this->labelCallback)($row, $this);
+
+            return $result instanceof View ? $result->render() : (string) $result;
+        }
+
+        return (string) data_get($row, $this->field, '');
+    }
+}

--- a/app/Livewire/Table/Columns/ArrayColumn.php
+++ b/app/Livewire/Table/Columns/ArrayColumn.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Table\Columns;
+
+use App\Livewire\Table\Column;
+use Closure;
+
+class ArrayColumn extends Column
+{
+    protected ?Closure $dataCallback = null;
+
+    protected ?Closure $outputFormatCallback = null;
+
+    protected string $separator = ', ';
+
+    protected string $emptyValue = '';
+
+    public function data(Closure $callback): static
+    {
+        $this->dataCallback = $callback;
+
+        return $this;
+    }
+
+    public function outputFormat(Closure $callback): static
+    {
+        $this->outputFormatCallback = $callback;
+
+        return $this;
+    }
+
+    public function separator(string $separator): static
+    {
+        $this->separator = $separator;
+
+        return $this;
+    }
+
+    public function emptyValue(string $value): static
+    {
+        $this->emptyValue = $value;
+
+        return $this;
+    }
+
+    public function resolveValue(mixed $row): string
+    {
+        $items = $this->dataCallback
+            ? ($this->dataCallback)(null, $row)
+            : collect();
+
+        if ($items->isEmpty()) {
+            return $this->emptyValue;
+        }
+
+        if ($this->outputFormatCallback) {
+            return $items->map(fn (mixed $item, int $index) => ($this->outputFormatCallback)($index, $item))
+                ->implode($this->separator);
+        }
+
+        return $items->implode($this->separator);
+    }
+
+    public function isHtml(): bool
+    {
+        return true;
+    }
+}

--- a/app/Livewire/Table/Columns/DateColumn.php
+++ b/app/Livewire/Table/Columns/DateColumn.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Table\Columns;
+
+use App\Livewire\Table\Column;
+use Carbon\Carbon;
+
+class DateColumn extends Column
+{
+    protected string $inputFormat = 'Y-m-d H:i:s';
+
+    protected string $outputFormat = 'Y-m-d';
+
+    protected string $emptyValue = '';
+
+    public function inputFormat(string $format): static
+    {
+        $this->inputFormat = $format;
+
+        return $this;
+    }
+
+    public function outputFormat(string $format): static
+    {
+        $this->outputFormat = $format;
+
+        return $this;
+    }
+
+    public function emptyValue(string $value): static
+    {
+        $this->emptyValue = $value;
+
+        return $this;
+    }
+
+    public function resolveValue(mixed $row): string
+    {
+        $value = data_get($row, $this->getField());
+
+        if ($value === null || $value === '') {
+            return $this->emptyValue;
+        }
+
+        $date = $value instanceof Carbon
+            ? $value
+            : Carbon::createFromFormat($this->inputFormat, (string) $value);
+
+        return $date ? $date->format($this->outputFormat) : $this->emptyValue;
+    }
+}

--- a/app/Livewire/Table/Columns/LinkColumn.php
+++ b/app/Livewire/Table/Columns/LinkColumn.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Table\Columns;
+
+use App\Livewire\Table\Column;
+use Closure;
+
+class LinkColumn extends Column
+{
+    protected ?Closure $titleCallback = null;
+
+    protected ?Closure $locationCallback = null;
+
+    public function title(Closure $callback): static
+    {
+        $this->titleCallback = $callback;
+
+        return $this;
+    }
+
+    public function location(Closure $callback): static
+    {
+        $this->locationCallback = $callback;
+
+        return $this;
+    }
+
+    public function resolveValue(mixed $row): string
+    {
+        $title = $this->titleCallback ? ($this->titleCallback)($row) : '';
+        $location = $this->locationCallback ? ($this->locationCallback)($row) : '';
+
+        if ($location === '' || $location === null) {
+            return (string) $title;
+        }
+
+        return '<a href="'.e($location).'">'.e($title).'</a>';
+    }
+
+    public function isHtml(): bool
+    {
+        return true;
+    }
+}

--- a/app/Livewire/Table/DataTableComponent.php
+++ b/app/Livewire/Table/DataTableComponent.php
@@ -1,0 +1,353 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Table;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Livewire\Component;
+use Livewire\WithPagination;
+
+abstract class DataTableComponent extends Component
+{
+    use WithPagination;
+
+    public string $search = '';
+
+    public string $sortField = '';
+
+    public string $sortDirection = 'asc';
+
+    /** @var array<string, mixed> */
+    public array $filterValues = [];
+
+    public int $perPage = 10;
+
+    /** @var array<int, int> */
+    protected array $perPageAccepted = [5, 10, 25, 50, 100];
+
+    protected string $primaryKey = 'id';
+
+    protected string $searchPlaceholder = 'Search...';
+
+    /** @var array<string> */
+    protected array $additionalSelects = [];
+
+    protected bool $paginationEnabled = true;
+
+    protected bool $filtersEnabled = true;
+
+    protected ?string $beforeWrapperView = null;
+
+    /**
+     * Return the query builder for the table data.
+     *
+     * @return Builder<Model>
+     */
+    abstract public function builder(): Builder;
+
+    /**
+     * Return the column definitions for the table.
+     *
+     * @return array<int, Column>
+     */
+    abstract public function columns(): array;
+
+    /**
+     * Configure the table component. Called during mount.
+     */
+    public function configure(): void {}
+
+    /**
+     * Return filter definitions for the table.
+     *
+     * @return array<int, Filter>
+     */
+    public function filters(): array
+    {
+        return [];
+    }
+
+    public function mount(): void
+    {
+        $this->configure();
+        $this->initializeFilterValues();
+    }
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedFilterValues(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedPerPage(): void
+    {
+        $this->resetPage();
+    }
+
+    public function sort(string $field): void
+    {
+        if ($this->sortField === $field) {
+            $this->sortDirection = $this->sortDirection === 'asc' ? 'desc' : 'asc';
+        } else {
+            $this->sortField = $field;
+            $this->sortDirection = 'asc';
+        }
+    }
+
+    public function render(): View
+    {
+        return view('livewire.table.data-table', [
+            'columns' => $this->getColumns(),
+            'rows' => $this->getRows(),
+            'filters' => $this->filters(),
+            'perPageOptions' => $this->perPageAccepted,
+            'searchPlaceholder' => $this->searchPlaceholder,
+            'beforeWrapperView' => $this->beforeWrapperView,
+        ]);
+    }
+
+    /**
+     * @return array<int, Column>
+     */
+    protected function getColumns(): array
+    {
+        $columns = $this->columns();
+
+        if (method_exists($this, 'appendColumns')) {
+            $columns = array_merge($columns, $this->appendColumns());
+        }
+
+        return $columns;
+    }
+
+    /**
+     * @return LengthAwarePaginator<int, Model>
+     */
+    protected function getRows(): LengthAwarePaginator
+    {
+        $query = $this->builder();
+
+        if ($this->additionalSelects) {
+            $query->addSelect($this->additionalSelects);
+        }
+
+        $this->applySearch($query);
+        $this->applyFilters($query);
+        $this->applySorting($query);
+
+        return $query->paginate($this->perPage);
+    }
+
+    /**
+     * @param  Builder<Model>  $query
+     */
+    protected function applySearch(Builder $query): void
+    {
+        if ($this->search === '') {
+            return;
+        }
+
+        $searchTerm = $this->search;
+        $searchableColumns = collect($this->getColumns())->filter(fn (Column $col) => $col->isSearchable());
+
+        if ($searchableColumns->isEmpty()) {
+            return;
+        }
+
+        $query->where(function (Builder $q) use ($searchableColumns, $searchTerm): void {
+            foreach ($searchableColumns as $column) {
+                $q->orWhere($column->getField(), 'like', "%{$searchTerm}%");
+            }
+        });
+    }
+
+    /**
+     * @param  Builder<Model>  $query
+     */
+    protected function applyFilters(Builder $query): void
+    {
+        foreach ($this->filters() as $filter) {
+            $value = $this->filterValues[$filter->getKey()] ?? $filter->getDefaultValue();
+            $filter->apply($query, $value);
+        }
+    }
+
+    /**
+     * @param  Builder<Model>  $query
+     */
+    protected function applySorting(Builder $query): void
+    {
+        if ($this->sortField !== '') {
+            $query->orderBy($this->sortField, $this->sortDirection);
+        }
+    }
+
+    protected function initializeFilterValues(): void
+    {
+        foreach ($this->filters() as $filter) {
+            if (! isset($this->filterValues[$filter->getKey()])) {
+                $this->filterValues[$filter->getKey()] = $filter->getDefaultValue();
+            }
+        }
+    }
+
+    /* Configuration methods for compatibility with existing code */
+
+    protected function setPrimaryKey(string $key): static
+    {
+        $this->primaryKey = $key;
+
+        return $this;
+    }
+
+    protected function setColumnSelectDisabled(): static
+    {
+        return $this;
+    }
+
+    protected function setPaginationEnabled(): static
+    {
+        $this->paginationEnabled = true;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<string>  $selects
+     */
+    protected function addAdditionalSelects(array $selects): static
+    {
+        $this->additionalSelects = array_merge($this->additionalSelects, $selects);
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, int>  $accepted
+     */
+    protected function setPerPageAccepted(array $accepted): static
+    {
+        $this->perPageAccepted = $accepted;
+
+        return $this;
+    }
+
+    protected function setLoadingPlaceholderContent(string $content): static
+    {
+        return $this;
+    }
+
+    protected function setLoadingPlaceholderEnabled(): static
+    {
+        return $this;
+    }
+
+    protected function setFiltersStatus(bool $status): static
+    {
+        $this->filtersEnabled = $status;
+
+        return $this;
+    }
+
+    protected function setSearchPlaceholder(string $placeholder): static
+    {
+        $this->searchPlaceholder = $placeholder;
+
+        return $this;
+    }
+
+    protected function setSearchIcon(string $icon): static
+    {
+        return $this;
+    }
+
+    /**
+     * @param  array<string, mixed>|callable  $attributes
+     */
+    protected function setSearchFieldAttributes(array|callable $attributes): static
+    {
+        return $this;
+    }
+
+    /**
+     * @param  array<string, string>  $areas
+     */
+    protected function setConfigurableAreas(array $areas): static
+    {
+        if (isset($areas['before-wrapper'])) {
+            $this->beforeWrapperView = $areas['before-wrapper'];
+        }
+
+        return $this;
+    }
+
+    /* Styling no-ops — our Blade views handle styling directly */
+
+    /** @param  array<string, mixed>  $attributes */
+    protected function setPerPageFieldAttributes(array $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>  $attributes */
+    protected function setTableWrapperAttributes(array $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>  $attributes */
+    protected function setTableAttributes(array $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>  $attributes */
+    protected function setTheadAttributes(array $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>|callable  $attributes */
+    protected function setThAttributes(array|callable $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>|callable  $attributes */
+    protected function setThSortButtonAttributes(array|callable $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>  $attributes */
+    protected function setTbodyAttributes(array $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>|callable  $attributes */
+    protected function setTrAttributes(array|callable $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>|callable  $attributes */
+    protected function setTdAttributes(array|callable $attributes): static
+    {
+        return $this;
+    }
+
+    /** @param  array<string, mixed>  $attributes */
+    protected function setPaginationWrapperAttributes(array $attributes): static
+    {
+        return $this;
+    }
+}

--- a/app/Livewire/Table/Filter.php
+++ b/app/Livewire/Table/Filter.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Table;
+
+use Closure;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+abstract class Filter
+{
+    protected ?Closure $filterCallback = null;
+
+    protected string $pillTitle = '';
+
+    public function __construct(
+        protected string $name,
+        protected ?string $key = null,
+    ) {
+        $this->key = $key ?? str($name)->snake()->toString();
+    }
+
+    public function filter(Closure $callback): static
+    {
+        $this->filterCallback = $callback;
+
+        return $this;
+    }
+
+    public function setFilterPillTitle(string $title): static
+    {
+        $this->pillTitle = $title;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getKey(): string
+    {
+        return $this->key ?? str($this->name)->snake()->toString();
+    }
+
+    public function getPillTitle(): string
+    {
+        return $this->pillTitle ?: $this->name;
+    }
+
+    /**
+     * Apply this filter to the query builder.
+     *
+     * @param  Builder<Model>  $builder
+     */
+    public function apply(Builder $builder, mixed $value): void
+    {
+        if ($this->filterCallback && $value !== '' && $value !== null) {
+            ($this->filterCallback)($builder, $value);
+        }
+    }
+
+    /**
+     * Get the default value for this filter.
+     */
+    abstract public function getDefaultValue(): mixed;
+}

--- a/app/Livewire/Table/Filters/DateRangeFilter.php
+++ b/app/Livewire/Table/Filters/DateRangeFilter.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Table\Filters;
+
+use App\Livewire\Table\Filter;
+
+class DateRangeFilter extends Filter
+{
+    /** @var array<string, mixed> */
+    protected array $config = [];
+
+    /** @var array<int, string> */
+    protected array $pillValues = [];
+
+    public static function make(string $name, ?string $key = null): static
+    {
+        return new static($name, $key);
+    }
+
+    /**
+     * @param  array<string, mixed>  $config
+     */
+    public function config(array $config): static
+    {
+        $this->config = $config;
+
+        return $this;
+    }
+
+    /**
+     * @param  array<int, string>  $values
+     */
+    public function setFilterPillValues(array $values): static
+    {
+        $this->pillValues = $values;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getConfig(): array
+    {
+        return $this->config;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getDefaultValue(): array
+    {
+        return [];
+    }
+}

--- a/app/Livewire/Table/Filters/SelectFilter.php
+++ b/app/Livewire/Table/Filters/SelectFilter.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Table\Filters;
+
+use App\Livewire\Table\Filter;
+
+class SelectFilter extends Filter
+{
+    /** @var array<string, string> */
+    protected array $options = [];
+
+    public static function make(string $name, ?string $key = null): static
+    {
+        return new static($name, $key);
+    }
+
+    /**
+     * @param  array<string, string>  $options
+     */
+    public function options(array $options): static
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
+    }
+
+    public function getDefaultValue(): string
+    {
+        return '';
+    }
+}

--- a/app/Livewire/TagTeams/Tables/Main.php
+++ b/app/Livewire/TagTeams/Tables/Main.php
@@ -22,13 +22,13 @@ use App\Exceptions\Status\CannotBeReinstatedException;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Filter;
+use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\TagTeams\TagTeam;
 use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class Main extends BaseTable
 {

--- a/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace App\Livewire\TagTeams\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\TagTeams\TagTeamWrestler;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 class PreviousWrestlers extends DataTableComponent
 {

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -13,15 +13,15 @@ use App\Builders\Titles\TitleBuilder;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstActivityPeriodColumn;
 use App\Livewire\Components\Tables\Filters\FirstActivityPeriodFilter;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Filter;
+use App\Livewire\Table\Filters\SelectFilter;
 use App\Livewire\Titles\Components\Actions;
 use App\Models\Titles\Title;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 /**
  * Livewire table component for managing championship titles.

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace App\Livewire\Titles\Tables;
 
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class PreviousTitleChampionships extends DataTableComponent
 {

--- a/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
+++ b/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\Livewire\Titles\Tables;
 
+use App\Livewire\Table\Column;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Titles\Title;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class TitleChampionshipsTable extends DataTableComponent
 {

--- a/app/Livewire/Users/Tables/Main.php
+++ b/app/Livewire/Users/Tables/Main.php
@@ -7,8 +7,8 @@ namespace App\Livewire\Users\Tables;
 use App\Builders\Users\UserBuilder;
 use App\Enums\Users\Role;
 use App\Livewire\Base\Tables\BaseTable;
+use App\Livewire\Table\Column;
 use App\Models\Users\User;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class Main extends BaseTable
 {

--- a/app/Livewire/Venues/Tables/Main.php
+++ b/app/Livewire/Venues/Tables/Main.php
@@ -6,11 +6,11 @@ namespace App\Livewire\Venues\Tables;
 
 use App\Actions\Venues\RestoreAction;
 use App\Livewire\Base\Tables\BaseTable;
+use App\Livewire\Table\Column;
 use App\Models\Events\Venue;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class Main extends BaseTable
 {

--- a/app/Livewire/Venues/Tables/PreviousEvents.php
+++ b/app/Livewire/Venues/Tables/PreviousEvents.php
@@ -6,12 +6,12 @@ namespace App\Livewire\Venues\Tables;
 
 use App\Builders\Events\EventBuilder;
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Models\Events\Event;
 use Exception;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 class PreviousEvents extends DataTableComponent
 {

--- a/app/Livewire/Wrestlers/Tables/Main.php
+++ b/app/Livewire/Wrestlers/Tables/Main.php
@@ -10,13 +10,13 @@ use App\Enums\Shared\EmploymentStatus;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Filter;
+use App\Livewire\Table\Filters\SelectFilter;
 use App\Livewire\Wrestlers\Components\Actions;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
-use Rappasoft\LaravelLivewireTables\Views\Column;
-use Rappasoft\LaravelLivewireTables\Views\Filter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\SelectFilter;
 
 class Main extends BaseTable
 {

--- a/app/View/Columns/FirstActivationDateColumn.php
+++ b/app/View/Columns/FirstActivationDateColumn.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace App\View\Columns;
 
+use App\Livewire\Table\Column;
 use App\Models\Stables\Stable;
 use App\Models\Titles\Title;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class FirstActivationDateColumn extends Column
 {

--- a/app/View/Columns/FirstEmploymentDateColumn.php
+++ b/app/View/Columns/FirstEmploymentDateColumn.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\View\Columns;
 
+use App\Livewire\Table\Column;
 use App\Models\Managers\Manager;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
-use Rappasoft\LaravelLivewireTables\Views\Column;
 
 class FirstEmploymentDateColumn extends Column
 {

--- a/app/View/Filters/FirstActivationFilter.php
+++ b/app/View/Filters/FirstActivationFilter.php
@@ -4,21 +4,12 @@ declare(strict_types=1);
 
 namespace App\View\Filters;
 
+use App\Livewire\Table\Filters\DateRangeFilter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\Views\Filters\DateRangeFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HandlesDates;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasConfig;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasOptions;
-use Rappasoft\LaravelLivewireTables\Views\Traits\Core\HasWireables;
 
 class FirstActivationFilter extends DateRangeFilter
 {
-    use HandlesDates,
-        HasConfig,
-        HasOptions,
-        HasWireables;
-
     public string $filterRelationshipName = '';
 
     public string $filterStartField = '';
@@ -40,9 +31,7 @@ class FirstActivationFilter extends DateRangeFilter
             ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
             ->filter(function (Builder $query, array $dateRange): void {
                 $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
-                    /**
-                     * @var array{'minDate': string, 'maxDate': string} $dateRange
-                     */
+                    /** @var array{'minDate': string, 'maxDate': string} $dateRange */
                     $query
                         ->where(function (Builder $query) use ($dateRange): void {
                             $query->whereBetween(

--- a/app/View/Filters/FirstEmploymentFilter.php
+++ b/app/View/Filters/FirstEmploymentFilter.php
@@ -4,21 +4,12 @@ declare(strict_types=1);
 
 namespace App\View\Filters;
 
+use App\Livewire\Table\Filters\DateRangeFilter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Rappasoft\LaravelLivewireTables\Views\Filters\DateRangeFilter;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HandlesDates;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasConfig;
-use Rappasoft\LaravelLivewireTables\Views\Filters\Traits\HasOptions;
-use Rappasoft\LaravelLivewireTables\Views\Traits\Core\HasWireables;
 
 class FirstEmploymentFilter extends DateRangeFilter
 {
-    use HandlesDates,
-        HasConfig,
-        HasOptions,
-        HasWireables;
-
     public string $filterRelationshipName = '';
 
     public string $filterStartField = '';
@@ -39,9 +30,7 @@ class FirstEmploymentFilter extends DateRangeFilter
         ])
             ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
             ->filter(function (Builder $query, array $dateRange): void {
-                /**
-                 * @var array{'minDate': string, 'maxDate': string} $dateRange
-                 */
+                /** @var array{'minDate': string, 'maxDate': string} $dateRange */
                 $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
                     $query
                         ->where(function (Builder $query) use ($dateRange): void {

--- a/resources/views/livewire/table/data-table.blade.php
+++ b/resources/views/livewire/table/data-table.blade.php
@@ -1,0 +1,125 @@
+<div>
+    {{-- Before wrapper (configurable area for page header / add buttons) --}}
+    @if($beforeWrapperView)
+        @include($beforeWrapperView)
+    @endif
+
+    {{-- Card wrapper --}}
+    <div class="bg-white rounded-lg border border-gray-200 shadow-light">
+        {{-- Search and Filters --}}
+        <div class="flex items-center justify-between gap-4 px-5 py-4 border-b border-gray-200">
+            {{-- Search --}}
+            <div class="flex items-center gap-2 bg-light-active rounded-md border border-gray-300 px-3 h-9 w-64">
+                <x-heroicon-o-magnifying-glass class="size-4 text-gray-500 shrink-0" />
+                <input
+                    type="text"
+                    wire:model.live.debounce.300ms="search"
+                    placeholder="{{ $searchPlaceholder }}"
+                    class="grow bg-transparent border-none text-xs outline-none placeholder:text-gray-500 focus:ring-0 p-0 m-0"
+                />
+                @if($search)
+                    <button wire:click="$set('search', '')" class="text-gray-400 hover:text-gray-600">
+                        <x-heroicon-o-x-mark class="size-3.5" />
+                    </button>
+                @endif
+            </div>
+
+            {{-- Filters --}}
+            @if(count($filters) > 0)
+                <div class="flex items-center gap-3">
+                    @foreach($filters as $filter)
+                        @if($filter instanceof \App\Livewire\Table\Filters\SelectFilter)
+                            <select
+                                wire:model.live="filterValues.{{ $filter->getKey() }}"
+                                class="appearance-none bg-light-active rounded-md border border-gray-300 font-medium text-xs h-9 px-2.5 text-gray-600 focus:border-primary focus:ring-0"
+                            >
+                                @foreach($filter->getOptions() as $value => $label)
+                                    <option value="{{ $value }}">{{ $label }}</option>
+                                @endforeach
+                            </select>
+                        @endif
+                    @endforeach
+                </div>
+            @endif
+        </div>
+
+        {{-- Table --}}
+        <div class="overflow-x-auto">
+            <table class="table-auto w-full text-left text-gray-700 font-medium text-sm border-collapse">
+                <thead>
+                    <tr>
+                        @foreach($columns as $column)
+                            <th class="bg-gray-100 text-gray-600 font-medium text-2sm align-middle py-2.5 px-4 border-b border-gray-200
+                                {{ !$loop->last ? 'border-e border-e-gray-200' : '' }}
+                                {{ $column->getTitle() === __('core.actions') ? 'w-[60px]' : '' }}"
+                            >
+                                @if($column->isSortable())
+                                    <button wire:click="sort('{{ $column->getField() }}')" class="flex items-center gap-1 hover:text-gray-900">
+                                        {{ $column->getTitle() }}
+                                        @if($sortField === $column->getField())
+                                            @if($sortDirection === 'asc')
+                                                <x-heroicon-s-chevron-up class="size-3" />
+                                            @else
+                                                <x-heroicon-s-chevron-down class="size-3" />
+                                            @endif
+                                        @endif
+                                    </button>
+                                @else
+                                    {{ $column->getTitle() }}
+                                @endif
+                            </th>
+                        @endforeach
+                    </tr>
+                </thead>
+                <tbody>
+                    @forelse($rows as $row)
+                        <tr wire:key="row-{{ $row->{$this->primaryKey ?? 'id'} }}" class="border-b border-gray-200">
+                            @foreach($columns as $column)
+                                <td class="py-3 px-4
+                                    {{ !$loop->last ? 'border-e border-e-gray-200' : '' }}"
+                                >
+                                    @if($column->isHtml())
+                                        {!! $column->resolveValue($row) !!}
+                                    @else
+                                        {{ $column->resolveValue($row) }}
+                                    @endif
+                                </td>
+                            @endforeach
+                        </tr>
+                    @empty
+                        <tr>
+                            <td colspan="{{ count($columns) }}" class="py-8 px-4 text-center text-gray-500">
+                                No records found.
+                            </td>
+                        </tr>
+                    @endforelse
+                </tbody>
+            </table>
+        </div>
+
+        {{-- Pagination --}}
+        @if($rows->hasPages())
+            <div class="flex items-center justify-between px-5 py-4 border-t border-gray-200">
+                <div class="flex items-center gap-2 text-xs text-gray-600">
+                    <span>Per page:</span>
+                    <select
+                        wire:model.live="perPage"
+                        class="appearance-none bg-light-active rounded-md border border-gray-300 font-medium text-xs h-8 px-2.5 w-16 focus:border-primary focus:ring-0"
+                    >
+                        @foreach($perPageOptions as $option)
+                            <option value="{{ $option }}">{{ $option }}</option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="flex items-center gap-1">
+                    {{ $rows->links() }}
+                </div>
+            </div>
+        @endif
+    </div>
+
+    {{-- Loading overlay --}}
+    <div wire:loading.delay class="fixed inset-0 bg-white/50 z-50 flex items-center justify-center">
+        <div class="text-gray-500 text-sm">Loading...</div>
+    </div>
+</div>


### PR DESCRIPTION
## Summary

Phase 2 of the UI rebuild. Replaces the missing Rappasoft Laravel Livewire Tables dependency with a lightweight custom table system.

Rappasoft was referenced in 39 PHP files but was not in `composer.json` or installed — all tables were broken. Rather than re-installing it, this builds a drop-in replacement under `App\Livewire\Table` that gives us full control over the table UI.

### New classes (`app/Livewire/Table/`)
- **`DataTableComponent`** — base Livewire component with search, sorting, filtering, and pagination
- **`Column`** — column definition with `searchable()`, `sortable()`, `label()`, `html()`, `view()` support
- **`Columns\DateColumn`** — date formatting with `inputFormat()`, `outputFormat()`, `emptyValue()`
- **`Columns\LinkColumn`** — clickable links with `title()`, `location()`
- **`Columns\ArrayColumn`** — collection rendering with `data()`, `outputFormat()`, `separator()`
- **`Filter`** — abstract base filter
- **`Filters\SelectFilter`** — dropdown filter with `options()`
- **`Filters\DateRangeFilter`** — date range filter with `config()`

### Updated files (39 table files)
- All `use Rappasoft\...` imports replaced with `use App\Livewire\Table\...`
- The public API (`columns()`, `filters()`, `builder()`, `configure()`) is unchanged
- `BaseTable` now extends `DataTableComponent` instead of `Component`
- Custom column/filter classes (`FirstEmploymentDateColumn`, `FirstActivityPeriodFilter`, etc.) updated to extend new base classes
- Rappasoft styling no-ops preserved in `DataTableComponent` so `BaseTableTrait` configuration calls don't break

### New Blade view
- `resources/views/livewire/table/data-table.blade.php` — table rendering with Heroicons for search/sort, Metronic-aligned styling

### Zero Rappasoft references remain
```
grep -r "Rappasoft" app/ → No files found
```

## Test plan
- [ ] Verify all table classes autoload: `php -r "require 'vendor/autoload.php'; echo class_exists('App\Livewire\Table\Column');"`
- [ ] `npm run build` passes
- [ ] Visual test: navigate to wrestlers index page and verify table renders with data, search, and pagination
- [ ] Verify sorting works by clicking column headers
- [ ] Verify select filters work on tables that have them (wrestlers, events)