### PR TITLE
feat: rebuild layout shell with Heroicons and real navigation

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -17,8 +17,16 @@ document.addEventListener('livewire:init', () => {
     // Global sidebar state store
     Alpine.store('sidebar', {
         expanded: true,
+        hovered: false,
+        mobileOpen: false,
         toggle() {
             this.expanded = !this.expanded;
+        },
+        openMobile() {
+            this.mobileOpen = true;
+        },
+        closeMobile() {
+            this.mobileOpen = false;
         },
     });
 

--- a/resources/views/components/layouts/partials/footer.blade.php
+++ b/resources/views/components/layouts/partials/footer.blade.php
@@ -1,16 +1,14 @@
 <footer class="footer">
-    <!-- Container -->
     <x-container-fixed>
         <div class="flex flex-col md:flex-row justify-center md:justify-between items-center gap-3 py-5">
             <div class="flex order-2 md:order-1 gap-2 font-normal text-2sm">
                 <span class="text-gray-500">
-                    2024&copy;
+                    {{ date('Y') }}&copy;
                 </span>
-                <a class="text-gray-600 hover:text-primary" href="https://keenthemes.com">
+                <span class="text-gray-600">
                     Jeffrey Davidson
-                </a>
+                </span>
             </div>
         </div>
     </x-container-fixed>
-    <!-- End of Container -->
 </footer>

--- a/resources/views/components/layouts/partials/header.blade.php
+++ b/resources/views/components/layouts/partials/header.blade.php
@@ -3,21 +3,21 @@
     :class="(atTop === false) ? 'shadow-sm' : ''">
     <!-- Container -->
     <x-container-fixed class="flex justify-between items-stretch lg:gap-4">
-        <!-- Mobile Logo -->
+        <!-- Mobile Logo & Menu Toggle -->
         <div class="flex gap-1 lg:hidden items-center -ms-1">
             <a class="shrink-0" href="{{ route('dashboard') }}">
-                <img class="max-h-[25px] w-full" src="{{ Vite::image('app/mini-logo.svg') }}" />
+                <span class="text-lg font-bold text-gray-900">Ringside</span>
             </a>
             <div class="flex items-center">
                 <button
-                    class="inline-flex items-center cursor-pointer leading-none rounded-md border border-solid border-transparent outline-none justify-center shrink-0 p-0 gap-0 size-8 bg-transparent text-gray-700 ps-3 pe-3 font-medium text-xs">
-                    <i class="ki-menu text-lg text-gray-600 leading-none"></i>
+                    @click="$store.sidebar && $store.sidebar.openMobile()"
+                    class="inline-flex items-center cursor-pointer leading-none rounded-md border border-transparent justify-center shrink-0 size-8 text-gray-700"
+                >
+                    <x-heroicon-o-bars-3 class="size-5 text-gray-600" />
                 </button>
             </div>
         </div>
         <!-- Topbar -->
         <x-topbar />
-        <!-- End of Topbar -->
     </x-container-fixed>
-    <!-- End of Container -->
 </header>

--- a/resources/views/components/sidebar/index.blade.php
+++ b/resources/views/components/sidebar/index.blade.php
@@ -44,8 +44,8 @@
                    focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
                    cursor-pointer transition-colors"
         >
-            <i class="ki-filled ki-black-left-line text-base text-muted-foreground transition-all duration-300"
-               :class="expanded ? '' : 'rotate-180'"></i>
+            <x-heroicon-s-chevron-left class="size-4 text-muted-foreground transition-all duration-300"
+               x-bind:class="expanded ? '' : 'rotate-180'" />
         </button>
     </div>
 
@@ -103,7 +103,7 @@
                        focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary focus-visible:ring-offset-2
                        cursor-pointer transition-colors"
             >
-                <i class="ki-outline ki-cross text-lg"></i>
+                <x-heroicon-o-x-mark class="size-5" />
             </button>
         </div>
 

--- a/resources/views/components/sidebar/menu-accordion.blade.php
+++ b/resources/views/components/sidebar/menu-accordion.blade.php
@@ -13,8 +13,8 @@
         class="flex items-center grow cursor-pointer border border-transparent gap-[10px] ps-[10px] pe-[10px] py-[6px]"
     >
         @if($icon)
-            <span class="flex items-center text-gray-500 w-[20px]">
-                <i class="ki-filled ki-{{ $icon }} text-lg"></i>
+            <span class="flex items-center text-gray-500 w-[20px] shrink-0">
+                {{ $icon }}
             </span>
         @endif
 
@@ -25,12 +25,10 @@
 
         <span class="flex text-muted-foreground w-[20px] shrink-0 justify-end ms-auto me-[-10px]
                      group-data-[collapsed=true]:opacity-0 group-hover:opacity-100 transition-opacity duration-200">
-            <span class="inline-flex" x-show="!open">
-                <i class="ki-filled ki-plus text-[11px]"></i>
-            </span>
-            <span class="inline-flex" x-show="open" x-cloak>
-                <i class="ki-filled ki-minus text-[11px]"></i>
-            </span>
+            <x-heroicon-s-chevron-down
+                class="size-3 transition-transform duration-200"
+                x-bind:class="open ? 'rotate-180' : ''"
+            />
         </span>
     </div>
 

--- a/resources/views/components/sidebar/menu-item.blade.php
+++ b/resources/views/components/sidebar/menu-item.blade.php
@@ -43,11 +43,8 @@
             class="flex items-center grow cursor-pointer border border-transparent gap-[10px] ps-[10px] pe-[10px] py-[6px]"
         >
             @if($icon)
-                <span class="flex items-center text-gray-500 w-[20px]">
-                    <i @class([
-                        "ki-filled ki-{$icon} text-lg",
-                        'text-primary' => $active,
-                    ])></i>
+                <span class="flex items-center text-gray-500 w-[20px] shrink-0">
+                    {{ $icon }}
                 </span>
             @endif
 

--- a/resources/views/components/sidebar/menu-label.blade.php
+++ b/resources/views/components/sidebar/menu-label.blade.php
@@ -28,8 +28,8 @@
         tabindex="0"
     >
         @if($icon)
-            <span class="flex items-center text-gray-500 w-[20px]">
-                <i class="ki-filled ki-{{ $icon }} text-lg"></i>
+            <span class="flex items-center text-gray-500 w-[20px] shrink-0">
+                {{ $icon }}
             </span>
         @endif
 

--- a/resources/views/components/sidebar/menu-show-more.blade.php
+++ b/resources/views/components/sidebar/menu-show-more.blade.php
@@ -25,12 +25,10 @@
 
         {{-- Expand/Collapse Arrow --}}
         <span class="flex text-muted-foreground w-[20px] shrink-0 justify-end ms-auto me-[-10px]">
-            <span class="inline-flex" x-show="!open">
-                <i class="ki-filled ki-plus text-[11px]"></i>
-            </span>
-            <span class="inline-flex" x-show="open" x-cloak>
-                <i class="ki-filled ki-minus text-[11px]"></i>
-            </span>
+            <x-heroicon-s-chevron-down
+                class="size-3 transition-transform duration-200"
+                x-bind:class="open ? 'rotate-180' : ''"
+            />
         </span>
     </div>
 

--- a/resources/views/components/sidebar/menu-sub-accordion.blade.php
+++ b/resources/views/components/sidebar/menu-sub-accordion.blade.php
@@ -22,12 +22,10 @@
 
         {{-- Expand/Collapse Arrow --}}
         <span class="flex text-muted-foreground w-[20px] shrink-0 justify-end ms-auto me-[-10px]">
-            <span class="inline-flex" x-show="!open">
-                <i class="ki-filled ki-plus text-[11px]"></i>
-            </span>
-            <span class="inline-flex" x-show="open" x-cloak>
-                <i class="ki-filled ki-minus text-[11px]"></i>
-            </span>
+            <x-heroicon-s-chevron-down
+                class="size-3 transition-transform duration-200"
+                x-bind:class="open ? 'rotate-180' : ''"
+            />
         </span>
     </div>
 

--- a/resources/views/components/sidebar/menu.blade.php
+++ b/resources/views/components/sidebar/menu.blade.php
@@ -1,215 +1,111 @@
-<nav class="flex flex-col grow" data-menu="true">
-    {{-- ========================================
-         SECTION 1: No Heading
-         ======================================== --}}
+<nav class="flex flex-col grow gap-0.5" data-menu="true">
+    {{-- Dashboard --}}
+    <x-sidebar.menu-item
+        href="{{ route('dashboard') }}"
+        :active="request()->routeIs('dashboard')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-squares-2x2 class="size-5" />
+        </x-slot:icon>
+        Dashboard
+    </x-sidebar.menu-item>
 
-    {{-- Dashboards --}}
-    <x-sidebar.menu-accordion title="Dashboards" icon="element-11" :open="true">
-        <x-sidebar.menu-item href="#" :nested="true" :active="true">Light Sidebar</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Dark Sidebar</x-sidebar.menu-item>
-    </x-sidebar.menu-accordion>
+    {{-- Roster --}}
+    <x-sidebar.menu-heading>Roster</x-sidebar.menu-heading>
 
-    {{-- ========================================
-         SECTION 2: User Heading
-         ======================================== --}}
+    <x-sidebar.menu-item
+        href="{{ route('wrestlers.index') }}"
+        :active="request()->routeIs('wrestlers.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-user-group class="size-5" />
+        </x-slot:icon>
+        Wrestlers
+    </x-sidebar.menu-item>
 
-    <x-sidebar.menu-heading>User</x-sidebar.menu-heading>
+    <x-sidebar.menu-item
+        href="{{ route('tag-teams.index') }}"
+        :active="request()->routeIs('tag-teams.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-users class="size-5" />
+        </x-slot:icon>
+        Tag Teams
+    </x-sidebar.menu-item>
 
-    {{-- Public Profile --}}
-    <x-sidebar.menu-accordion title="Public Profile" icon="profile-circle">
-        {{-- Profiles Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Profiles">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Default</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Creator</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Company</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">NFT</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Blogger</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">CRM</x-sidebar.menu-item>
-            <x-sidebar.menu-show-more :count="4" :deep="true">
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Gamer</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Feeds</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Plain</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Modal</x-sidebar.menu-item>
-            </x-sidebar.menu-show-more>
-        </x-sidebar.menu-sub-accordion>
+    <x-sidebar.menu-item
+        href="{{ route('managers.index') }}"
+        :active="request()->routeIs('managers.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-briefcase class="size-5" />
+        </x-slot:icon>
+        Managers
+    </x-sidebar.menu-item>
 
-        {{-- Projects Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Projects">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">3 Columns</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">2 Columns</x-sidebar.menu-item>
-        </x-sidebar.menu-sub-accordion>
+    <x-sidebar.menu-item
+        href="{{ route('referees.index') }}"
+        :active="request()->routeIs('referees.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-hand-raised class="size-5" />
+        </x-slot:icon>
+        Referees
+    </x-sidebar.menu-item>
 
-        <x-sidebar.menu-item href="#" :nested="true">Works</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Teams</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Network</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Activity</x-sidebar.menu-item>
+    <x-sidebar.menu-item
+        href="{{ route('stables.index') }}"
+        :active="request()->routeIs('stables.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-shield-check class="size-5" />
+        </x-slot:icon>
+        Stables
+    </x-sidebar.menu-item>
 
-        <x-sidebar.menu-show-more :count="3">
-            <x-sidebar.menu-item href="#" :nested="true">Campaigns - Card</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true">Campaigns - List</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true">Empty</x-sidebar.menu-item>
-        </x-sidebar.menu-show-more>
-    </x-sidebar.menu-accordion>
+    {{-- Events --}}
+    <x-sidebar.menu-heading>Events</x-sidebar.menu-heading>
 
-    {{-- My Account --}}
-    <x-sidebar.menu-accordion title="My Account" icon="setting-2">
-        {{-- Account Home Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Account Home">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Get Started</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">User Profile</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Company Profile</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Settings - With Sidebar</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Settings - Enterprise</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Settings - Plain</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Settings - Modal</x-sidebar.menu-item>
-        </x-sidebar.menu-sub-accordion>
+    <x-sidebar.menu-item
+        href="{{ route('events.index') }}"
+        :active="request()->routeIs('events.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-calendar-days class="size-5" />
+        </x-slot:icon>
+        Events
+    </x-sidebar.menu-item>
 
-        {{-- Billing Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Billing">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Billing - Basic</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Billing - Enterprise</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Plans</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Billing History</x-sidebar.menu-item>
-        </x-sidebar.menu-sub-accordion>
+    <x-sidebar.menu-item
+        href="{{ route('titles.index') }}"
+        :active="request()->routeIs('titles.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-trophy class="size-5" />
+        </x-slot:icon>
+        Titles
+    </x-sidebar.menu-item>
 
-        {{-- Security Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Security">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Get Started</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Security Overview</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Allowed IP Addresses</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Privacy Settings</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Device Management</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Backup & Recovery</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Current Sessions</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Security Log</x-sidebar.menu-item>
-        </x-sidebar.menu-sub-accordion>
+    <x-sidebar.menu-item
+        href="{{ route('venues.index') }}"
+        :active="request()->routeIs('venues.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-building-office class="size-5" />
+        </x-slot:icon>
+        Venues
+    </x-sidebar.menu-item>
 
-        {{-- Members & Roles Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Members & Roles">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Teams Starter</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Teams</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Team Info</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Members Starter</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Team Members</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Import Members</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Roles</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Permissions - Toggler</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Permissions - Check</x-sidebar.menu-item>
-        </x-sidebar.menu-sub-accordion>
+    {{-- Admin --}}
+    <x-sidebar.menu-heading>Admin</x-sidebar.menu-heading>
 
-        <x-sidebar.menu-item href="#" :nested="true">Integrations</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Notifications</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">API Keys</x-sidebar.menu-item>
-
-        <x-sidebar.menu-show-more :count="3">
-            <x-sidebar.menu-item href="#" :nested="true">Appearance</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true">Invite a Friend</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true">Activity</x-sidebar.menu-item>
-        </x-sidebar.menu-show-more>
-    </x-sidebar.menu-accordion>
-
-    {{-- Network --}}
-    <x-sidebar.menu-accordion title="Network" icon="users">
-        <x-sidebar.menu-item href="#" :nested="true">Get Started</x-sidebar.menu-item>
-
-        {{-- User Cards Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="User Cards">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Mini Cards</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Team Crew</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Author</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">NFT</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Social</x-sidebar.menu-item>
-        </x-sidebar.menu-sub-accordion>
-
-        {{-- User Table Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="User Table">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Team Crew</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">App Roster</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Market Authors</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">SaaS Users</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Store Clients</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Visitors</x-sidebar.menu-item>
-        </x-sidebar.menu-sub-accordion>
-
-        <x-sidebar.menu-label :nested="true" badge="Soon">Cooperations</x-sidebar.menu-label>
-        <x-sidebar.menu-label :nested="true" badge="Soon">Leads</x-sidebar.menu-label>
-        <x-sidebar.menu-label :nested="true" badge="Soon">Donators</x-sidebar.menu-label>
-    </x-sidebar.menu-accordion>
-
-    {{-- Authentication --}}
-    <x-sidebar.menu-accordion title="Authentication" icon="security-user">
-        {{-- Classic Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Classic">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Sign In</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Sign Up</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">2FA</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Check Email</x-sidebar.menu-item>
-            {{-- Reset Password Nested Sub-Accordion --}}
-            <x-sidebar.menu-sub-accordion title="Reset Password">
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Enter Email</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Check Email</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Change Password</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Password is Changed</x-sidebar.menu-item>
-            </x-sidebar.menu-sub-accordion>
-        </x-sidebar.menu-sub-accordion>
-
-        {{-- Branded Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Branded">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Sign In</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Sign Up</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">2FA</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Check Email</x-sidebar.menu-item>
-            {{-- Reset Password Nested Sub-Accordion --}}
-            <x-sidebar.menu-sub-accordion title="Reset Password">
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Enter Email</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Check Email</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Change Password</x-sidebar.menu-item>
-                <x-sidebar.menu-item href="#" :nested="true" :deep="true">Password is Changed</x-sidebar.menu-item>
-            </x-sidebar.menu-sub-accordion>
-        </x-sidebar.menu-sub-accordion>
-
-        <x-sidebar.menu-item href="#" :nested="true">Welcome Message</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Account Deactivated</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Error 404</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Error 500</x-sidebar.menu-item>
-    </x-sidebar.menu-accordion>
-
-    {{-- ========================================
-         SECTION 3: Apps Heading
-         ======================================== --}}
-
-    <x-sidebar.menu-heading>Apps</x-sidebar.menu-heading>
-
-    {{-- Store - Client --}}
-    <x-sidebar.menu-accordion title="Store - Client" icon="users">
-        <x-sidebar.menu-item href="#" :nested="true">Home</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Search Results - Grid</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Search Results - List</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Product Details</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Shopping Cart</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Wishlist</x-sidebar.menu-item>
-
-        {{-- Checkout Sub-Accordion --}}
-        <x-sidebar.menu-sub-accordion title="Checkout">
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Order Summary</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Shipping Info</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Payment Method</x-sidebar.menu-item>
-            <x-sidebar.menu-item href="#" :nested="true" :deep="true">Order Placed</x-sidebar.menu-item>
-        </x-sidebar.menu-sub-accordion>
-
-        <x-sidebar.menu-item href="#" :nested="true">My Orders</x-sidebar.menu-item>
-        <x-sidebar.menu-item href="#" :nested="true">Order Receipt</x-sidebar.menu-item>
-    </x-sidebar.menu-accordion>
-
-    {{-- Store - Admin (Soon) --}}
-    <x-sidebar.menu-label icon="setting" badge="Soon">Store - Admin</x-sidebar.menu-label>
-
-    {{-- Store - Services (Soon) --}}
-    <x-sidebar.menu-label icon="python" badge="Soon">Store - Services</x-sidebar.menu-label>
-
-    {{-- AI Prompt (Soon) --}}
-    <x-sidebar.menu-label icon="artificial-intelligence" badge="Soon">AI Prompt</x-sidebar.menu-label>
-
-    {{-- Invoice Generator (Soon) --}}
-    <x-sidebar.menu-label icon="cheque" badge="Soon">Invoice Generator</x-sidebar.menu-label>
+    <x-sidebar.menu-item
+        href="{{ route('users.index') }}"
+        :active="request()->routeIs('users.*')"
+    >
+        <x-slot:icon>
+            <x-heroicon-o-cog-6-tooth class="size-5" />
+        </x-slot:icon>
+        Users
+    </x-sidebar.menu-item>
 </nav>

--- a/resources/views/components/topbar/profile.blade.php
+++ b/resources/views/components/topbar/profile.blade.php
@@ -1,57 +1,41 @@
-<!-- Profile -->
-<!-- Popover -->
 <div x-popover class="relative">
-    <!-- Menu Toggle -->
+    {{-- Profile Toggle --}}
     <button x-ref="button" type="button" x-popover:button
-        class="relative inline-flex items-center cursor-pointer leading-none h-10 ps-4 pe-4 border border-solid border-transparent font-medium text-2xs outline-none grow rounded-full">
-        <img class="size-9 rounded-full border-2 border-success shrink-0"
-            src="{{ Vite::image('avatars/' . Auth::user()->getAvatar()) }}">
-        </img>
+        class="relative inline-flex items-center cursor-pointer leading-none h-10 px-4 border border-transparent font-medium text-2xs outline-none grow rounded-full">
+        <div class="size-9 rounded-full border-2 border-success bg-gray-200 flex items-center justify-center shrink-0">
+            <x-heroicon-s-user class="size-5 text-gray-500" />
+        </div>
     </button>
-    <!-- Menu Dropdown -->
+
+    {{-- Dropdown --}}
     <div x-popover:panel x-transition.origin.top.right x-cloak
-        class="absolute right-0 origin-top-left p-0 m-0 flex flex-col border border-solid border-gray-300 shadow-[0_7px_18px_0px_rgba(0,0,0,0.09)] bg-white rounded-xl w-screen max-w-[250px] py-2.5">
-        <div class="flex items-center justify-between px-5 py-1.5 gap-1.5">
-            <div class="flex items-center gap-2">
-                <img alt="" class="size-9 rounded-full border-2 border-success"
-                    src="{{ Vite::image('avatars/' . Auth::user()->getAvatar()) }}">
-                <div class="flex flex-col gap-1.5">
-                    <span class="text-sm text-gray-800 font-semibold leading-none">
-                        {{ Auth::user()->full_name }}
-                    </span>
-                    <span class="text-xs text-gray-600 font-medium leading-none">
-                        {{ Auth::user()->email }}
-                    </span>
-                </div>
-                </img>
+        class="absolute right-0 origin-top-left flex flex-col border border-gray-300 shadow-default bg-white rounded-xl w-screen max-w-[250px] py-2.5">
+        {{-- User Info --}}
+        <div class="flex items-center px-5 py-1.5 gap-2">
+            <div class="size-9 rounded-full border-2 border-success bg-gray-200 flex items-center justify-center shrink-0">
+                <x-heroicon-s-user class="size-5 text-gray-500" />
+            </div>
+            <div class="flex flex-col gap-1.5">
+                <span class="text-sm text-gray-800 font-semibold leading-none">
+                    {{ Auth::user()->full_name }}
+                </span>
+                <span class="text-xs text-gray-600 font-medium leading-none">
+                    {{ Auth::user()->email }}
+                </span>
             </div>
         </div>
-        <div class="border-b border-dropdown my-2.5"></div>
-        <div class="flex flex-col p-0 m-0">
-            <div class="group flex items-center grow ms-2.5 me-2.5 p-2.5 rounded-md cursor-pointer hover:bg-gray-100">
-                <span class="flex items-center shrink-0 me-2.5">
-                    <i class="ki-image text-lg text-gray-500 group-hover:text-primary"></i>
-                </span>
-                <span class="flex items-center grow leading-4.25 font-medium text-2sm font-gray-800">
-                    Language
-                </span>
-                <div
-                    class="flex items-center gap-1.5 rounded-md border border-gray-300 text-gray-600 p-1.5 text-2xs font-medium shrink-0">
-                    English
-                    <img alt="" class="inline-block size-3.5 rounded-full"
-                        src="{{ Vite::image('flags/united-states.svg') }}">
-                </div>
-            </div>
-        </div>
-        <div class="border-b border-dropdown my-2.5"></div>
-        <div class="flex flex-col">
-            <!-- Menu Item -->
-            <div class="flex flex-col m-0 px-4 py-1.5">
-                <form action="{{ route('logout') }}" method="post">
-                    @csrf
-                    <x-buttons.light size="sm" class="justify-center w-full">Log out</x-buttons.light>
-                </form>
-            </div>
+
+        <div class="border-b border-gray-200 my-2.5"></div>
+
+        {{-- Logout --}}
+        <div class="flex flex-col px-4 py-1.5">
+            <form action="{{ route('logout') }}" method="post">
+                @csrf
+                <button type="submit"
+                    class="btn-light-default btn-light-states w-full justify-center rounded-md px-3 py-2 text-xs font-medium">
+                    Log out
+                </button>
+            </form>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary

Phase 3 of the UI rebuild. Replaces all KeenIcons in the layout shell with Heroicons and replaces Metronic demo sidebar content with actual Ringside navigation.

### Sidebar changes
- **`menu.blade.php`**: Replaced 215 lines of Metronic demo content with real Ringside navigation organized into sections:
  - **Dashboard** — home page
  - **Roster** — Wrestlers, Tag Teams, Managers, Referees, Stables
  - **Events** — Events, Titles, Venues
  - **Admin** — Users
  - Each item has route-based active state detection via `request()->routeIs()`
- **`menu-item.blade.php`**: Changed `icon` prop from KeenIcons class string to a Blade slot that accepts Heroicon components
- **`menu-accordion.blade.php`**: Replaced `ki-plus`/`ki-minus` with `heroicon-s-chevron-down` with rotate animation
- **`menu-sub-accordion.blade.php`**: Same chevron replacement
- **`menu-show-more.blade.php`**: Same chevron replacement
- **`menu-label.blade.php`**: Changed icon prop to slot (matching menu-item pattern)
- **`index.blade.php`**: Replaced `ki-black-left-line` toggle with `heroicon-s-chevron-left`, `ki-cross` close with `heroicon-o-x-mark`

### Header/Topbar changes
- **`header.blade.php`**: Replaced `ki-menu` hamburger with `heroicon-o-bars-3`, wired mobile toggle to `$store.sidebar.openMobile()`
- **`topbar/profile.blade.php`**: Replaced avatar images with `heroicon-s-user` placeholder, replaced `x-buttons.light` (missing component) with plain button using CSS utility classes, removed language selector

### Other changes
- **`footer.blade.php`**: Dynamic year with `date('Y')`
- **`app.js`**: Added `hovered`, `mobileOpen`, `openMobile()`, `closeMobile()` to Alpine sidebar store

### Zero KeenIcons in layout files
All sidebar, header, topbar, and footer components now use Heroicons exclusively.

## Test plan
- [ ] `npm run build` passes
- [ ] Navigate to any authenticated page — sidebar shows real Ringside navigation
- [ ] Active state highlights current page in sidebar
- [ ] Sidebar collapse/expand toggle works
- [ ] Mobile hamburger menu opens sidebar drawer
- [ ] Profile dropdown shows user name/email and logout button
- [ ] Logout works from profile dropdown