### PR TITLE
feat: add form input components (text, date, select, textarea, form-label)

### DIFF
--- a/resources/views/components/form/form-label.blade.php
+++ b/resources/views/components/form/form-label.blade.php
@@ -1,0 +1,6 @@
+@props([
+    'name' => null,
+    'label' => '',
+])
+
+<x-form.label :for="$name" {{ $attributes }}>{{ $label }}</x-form.label>

--- a/resources/views/components/form/inputs/date.blade.php
+++ b/resources/views/components/form/inputs/date.blade.php
@@ -1,0 +1,1 @@
+<x-form.input type="date" {{ $attributes }}>{{ $slot }}</x-form.input>

--- a/resources/views/components/form/inputs/select.blade.php
+++ b/resources/views/components/form/inputs/select.blade.php
@@ -1,0 +1,72 @@
+@props([
+    'name' => null,
+    'label' => null,
+    'description' => null,
+    'variant' => 'block',
+    'size' => 'md',
+    'options' => [],
+    'selected' => null,
+    'placeholder' => null,
+    'multiple' => false,
+])
+
+@php
+    $fieldName = $name ?? $attributes->whereStartsWith('wire:model')->first();
+    if ($fieldName && str_contains($fieldName, '=')) {
+        $fieldName = str($fieldName)->after('=')->trim('"\'')->toString();
+    }
+
+    $inputId = $attributes->get('id', $fieldName);
+
+    $selectClasses = collect([
+        'block w-full appearance-none outline-none',
+        'border border-solid border-[var(--input)] bg-background text-foreground',
+        'rounded-[calc(var(--radius)-2px)] shadow-[var(--tw-input-box-shadow)] transition-[color,box-shadow]',
+        'focus-visible:outline-none focus-visible:border-[var(--ring)] focus-visible:ring-2 focus-visible:ring-[color-mix(in_oklab,var(--ring)_30%,transparent)]',
+        $size === 'sm' ? 'h-[calc(var(--spacing)*7)] px-[calc(var(--spacing)*2.5)] text-xs' : null,
+        $size === 'md' ? 'h-[calc(var(--spacing)*8.5)] px-[calc(var(--spacing)*3)] text-2sm' : null,
+        $size === 'lg' ? 'h-[calc(var(--spacing)*10)] px-[calc(var(--spacing)*4)] text-sm' : null,
+    ])->filter()->implode(' ');
+
+    $selectAttributes = $attributes->except(['label', 'description', 'variant', 'name', 'size', 'options', 'selected', 'placeholder', 'multiple']);
+
+    $selectedValues = is_array($selected) ? $selected : ($selected !== null ? [$selected] : []);
+@endphp
+
+@if($label || $description)
+    <x-form.with-field
+        :label="$label"
+        :description="$description"
+        :variant="$variant"
+        :name="$fieldName">
+        <select
+            {{ $selectAttributes->merge([
+                'name' => $multiple ? "{$fieldName}[]" : $fieldName,
+                'id' => $inputId,
+                'class' => $selectClasses,
+                'multiple' => $multiple ?: null,
+            ]) }}>
+            @if($placeholder && !$multiple)
+                <option value="">{{ $placeholder }}</option>
+            @endif
+            @foreach($options as $value => $optionLabel)
+                <option value="{{ $value }}" @selected(in_array($value, $selectedValues))>{{ $optionLabel }}</option>
+            @endforeach
+        </select>
+    </x-form.with-field>
+@else
+    <select
+        {{ $selectAttributes->merge([
+            'name' => $multiple ? "{$fieldName}[]" : $fieldName,
+            'id' => $inputId,
+            'class' => $selectClasses,
+            'multiple' => $multiple ?: null,
+        ]) }}>
+        @if($placeholder && !$multiple)
+            <option value="">{{ $placeholder }}</option>
+        @endif
+        @foreach($options as $value => $optionLabel)
+            <option value="{{ $value }}" @selected(in_array($value, $selectedValues))>{{ $optionLabel }}</option>
+        @endforeach
+    </select>
+@endif

--- a/resources/views/components/form/inputs/text.blade.php
+++ b/resources/views/components/form/inputs/text.blade.php
@@ -1,0 +1,1 @@
+<x-form.input type="text" {{ $attributes }}>{{ $slot }}</x-form.input>

--- a/resources/views/components/form/inputs/textarea.blade.php
+++ b/resources/views/components/form/inputs/textarea.blade.php
@@ -1,0 +1,54 @@
+@props([
+    'name' => null,
+    'label' => null,
+    'description' => null,
+    'variant' => 'block',
+    'size' => 'md',
+    'rows' => 4,
+])
+
+@php
+    $fieldName = $name ?? $attributes->whereStartsWith('wire:model')->first();
+    if ($fieldName && str_contains($fieldName, '=')) {
+        $fieldName = str($fieldName)->after('=')->trim('"\'')->toString();
+    }
+
+    $inputId = $attributes->get('id', $fieldName);
+
+    $textareaClasses = collect([
+        'block w-full appearance-none outline-none resize-y',
+        'border border-solid border-[var(--input)] bg-background text-foreground',
+        'rounded-[calc(var(--radius)-2px)] shadow-[var(--tw-input-box-shadow)] transition-[color,box-shadow]',
+        'placeholder-[var(--muted-foreground)]',
+        'focus-visible:outline-none focus-visible:border-[var(--ring)] focus-visible:ring-2 focus-visible:ring-[color-mix(in_oklab,var(--ring)_30%,transparent)]',
+        $size === 'sm' ? 'px-[calc(var(--spacing)*2.5)] py-[calc(var(--spacing)*1.5)] text-xs' : null,
+        $size === 'md' ? 'px-[calc(var(--spacing)*3)] py-[calc(var(--spacing)*2)] text-2sm' : null,
+        $size === 'lg' ? 'px-[calc(var(--spacing)*4)] py-[calc(var(--spacing)*2.5)] text-sm' : null,
+    ])->filter()->implode(' ');
+
+    $textareaAttributes = $attributes->except(['label', 'description', 'variant', 'name', 'size', 'rows']);
+@endphp
+
+@if($label || $description)
+    <x-form.with-field
+        :label="$label"
+        :description="$description"
+        :variant="$variant"
+        :name="$fieldName">
+        <textarea
+            {{ $textareaAttributes->merge([
+                'name' => $fieldName,
+                'id' => $inputId,
+                'rows' => $rows,
+                'class' => $textareaClasses,
+            ]) }}>{{ $slot }}</textarea>
+    </x-form.with-field>
+@else
+    <textarea
+        {{ $textareaAttributes->merge([
+            'name' => $fieldName,
+            'id' => $inputId,
+            'rows' => $rows,
+            'class' => $textareaClasses,
+        ]) }}>{{ $slot }}</textarea>
+@endif

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,90 +1,44 @@
-# Phase 4: Core UI Primitives
+# Phase 5: Form Input Components
 
 ## Plan
 
-### 1. Button System (main work)
+### Missing components (referenced but don't exist)
 
-**Create `components/button.blade.php`** — single canonical button component:
-- Props: `variant` (primary/success/danger/warning/info/light/secondary/link), `size` (xs/sm/md/lg), `iconOnly`
-- Uses existing CSS utility classes (`btn-primary-default btn-primary-states`, etc.)
-- Passes through all attributes (wire:click, @click, type, etc.)
+1. **`form/inputs/text.blade.php`** (54 references) — thin wrapper: `<x-form.input type="text">`
+2. **`form/inputs/date.blade.php`** (16 references) — thin wrapper: `<x-form.input type="date">`
+3. **`form/inputs/textarea.blade.php`** (3 references) — proper `<textarea>` with field wrapper, same styling pattern as input
+4. **`form/inputs/select.blade.php`** (51 references) — `<select>` with `:options`, `:selected`, `multiple` support
+5. **`form/form-label.blade.php`** (4 references in auth password pages) — simple label+for wrapper
 
-**Create `components/buttons/` wrappers** — backward-compat for the 35+ references:
-- `primary.blade.php`, `danger.blade.php`, `success.blade.php`, `warning.blade.php`
-- `info.blade.php`, `light.blade.php`, `link.blade.php`
-- `delete-selected.blade.php` (special bulk action component)
-- Each just delegates to `<x-button variant="X">`
+### Design approach
 
-### 2. KeenIcon Cleanup (incidental)
-- Modal header close button (`modal/header.blade.php`) — `ki-cross` → Heroicon `x-mark`
-- Menu form remove button (`menu/menu-form.blade.php`) — `ki-trash` → Heroicon `trash`
-- Form input password toggle (`form/input.blade.php`) — `ki-eye`/`ki-eye-slash` → Heroicons
-
-### 3. Remove Dead UI Components
-- Remove `ui/button.blade.php` (KeenIcon-based, replaced by new button)
-- Remove `ui/icon.blade.php` (KeenIcon wrapper, no longer needed)
-- Update 5 auth pages from `<x-ui.button>` → `<x-button>`
-
-### 4. Card Cleanup
-- Remove `card/index.blade.php` (dead code — `card.blade.php` takes precedence)
-- Remove `card/footer-borderless.blade.php` (unused anywhere)
-- Remove `card/toolbar/` directory (unused anywhere)
-- **Keep**: `card.blade.php`, `card/header.blade.php`, `card/body.blade.php`, `card/footer.blade.php`, `card/title.blade.php`, `card/general-info/`
-
-### 5. Components That Are Already Good (no changes needed)
-- **Badge** (`badge.blade.php`) — 6 colors, 2 sizes, clean implementation
-- **Route link** (`route-link.blade.php`) — simple, works
-- **Application logo** (`application-logo.blade.php`) — SVG, fine
-- **Page components** (`page/header.blade.php`, `page/heading.blade.php`, `page/description.blade.php`) — clean
+- Text and date are thin wrappers that delegate to the existing `form/input.blade.php`
+- Textarea and select need their own implementations, following the same patterns (field wrapper, error handling, Metronic styling)
+- All components support both Livewire (`wire:model`) and traditional (`name`/`:value`) usage
+- Use the same CSS token approach as `form/input.blade.php` for visual consistency
 
 ## Tasks
 
-- [x] Create `button.blade.php` — canonical button with variant/size props
-- [x] Create `buttons/` wrappers (primary, danger, success, warning, info, light, link, delete-selected)
-- [x] Update modal header close — KeenIcon → Heroicon
-- [x] Update menu-form — KeenIcon → Heroicon
-- [x] Update auth pages from `x-ui.button` → `x-button`
-- [x] Replace `x-ui.icon` in form/input.blade.php with Heroicons
-- [x] Remove dead `ui/button.blade.php` and `ui/icon.blade.php`
-- [x] Clean up dead card files (card/index, footer-borderless, toolbar)
-- [x] Replace remaining KeenIcons in table action columns, menu, and header mega-menu components
+- [x] Create `form/inputs/text.blade.php`
+- [x] Create `form/inputs/date.blade.php`
+- [x] Create `form/inputs/textarea.blade.php`
+- [x] Create `form/inputs/select.blade.php`
+- [x] Create `form/form-label.blade.php`
 - [x] Run tests — pre-existing migration failure only, no new regressions
 
 ## Review
 
 ### Changes Summary
 
-**New files (10):**
-- `components/button.blade.php` — canonical button with variant/size/iconOnly props, uses CSS utility classes
-- `components/buttons/primary.blade.php` — wrapper → `<x-button variant="primary">`
-- `components/buttons/danger.blade.php` — wrapper → `<x-button variant="danger">`
-- `components/buttons/success.blade.php` — wrapper → `<x-button variant="success">`
-- `components/buttons/warning.blade.php` — wrapper → `<x-button variant="warning">`
-- `components/buttons/info.blade.php` — wrapper → `<x-button variant="info">`
-- `components/buttons/light.blade.php` — wrapper → `<x-button variant="light">`
-- `components/buttons/link.blade.php` — wrapper → `<x-button variant="link">`
-- `components/buttons/delete-selected.blade.php` — bulk delete action component
+**New files (5):**
+- `form/inputs/text.blade.php` — thin wrapper delegating to `<x-form.input type="text">` (satisfies 54 references)
+- `form/inputs/date.blade.php` — thin wrapper delegating to `<x-form.input type="date">` (satisfies 16 references)
+- `form/inputs/textarea.blade.php` — proper `<textarea>` with Metronic-styled classes, field wrapper, label/error support, configurable rows (satisfies 3 references)
+- `form/inputs/select.blade.php` — `<select>` with `:options` array rendering, `:selected` state, `multiple` attribute, placeholder support (satisfies 51 references)
+- `form/form-label.blade.php` — thin wrapper delegating to `<x-form.label>` with `name`/`label` props (satisfies 4 references)
 
-**Modified files (12):**
-- `modal/header.blade.php` — `ki-cross` → `heroicon-m-x-mark`
-- `menu/menu-form.blade.php` — `ki-trash` → `heroicon-m-trash`
-- `form/input.blade.php` — `x-ui.icon eye/eye-slash` → `heroicon-s-eye/eye-slash`
-- `auth/login.blade.php` — `x-ui.button` → `x-button`
-- `auth/forgot-password.blade.php` — `x-ui.button` → `x-button`
-- `auth/register.blade.php` — `x-ui.button` → `x-button`
-- `auth/passwords/reset.blade.php` — `x-ui.button` → `x-button`
-- `auth/passwords/email.blade.php` — `x-ui.button` → `x-button`
-- `tables/columns/action-column.blade.php` — all KeenIcons → Heroicons
-- `tables/columns/wrestler-actions.blade.php` — all KeenIcons → Heroicons
-- `menu/menu-toggle.blade.php`, `menu-icon.blade.php`, `menu-arrow.blade.php` — KeenIcons → Heroicons
-- `header/mega-menu-dropdown.blade.php`, `mega-menu-dropdown-item.blade.php`, `mega-menu-dropdown-submenu.blade.php` — KeenIcons → Heroicons
-
-**Deleted files (5):**
-- `ui/button.blade.php` — replaced by canonical `button.blade.php`
-- `ui/icon.blade.php` — KeenIcon wrapper, no longer needed
-- `card/index.blade.php` — dead code (overridden by `card.blade.php`)
-- `card/footer-borderless.blade.php` — unused
-- `card/toolbar/` directory — unused (index.blade.php, actions.blade.php)
-
-### Zero KeenIcon references remaining in blade files
-### Pre-existing test failure (MatchType migration) — unrelated to this work
+### Design decisions
+- Textarea and select follow the exact same pattern as `form/input.blade.php`: same CSS tokens, same field wrapper, same Livewire/traditional dual support
+- Text and date are one-line delegators — no duplication of input logic
+- Select handles both associative arrays (`[value => label]`) and `multiple` mode
+- All 124 missing component references are now satisfied


### PR DESCRIPTION
## Summary

- **Text input** (`form/inputs/text.blade.php`): Thin wrapper delegating to existing `form/input` component — satisfies 54 references across Livewire modals and traditional forms
- **Date input** (`form/inputs/date.blade.php`): Thin wrapper with `type="date"` — satisfies 16 references
- **Select input** (`form/inputs/select.blade.php`): Full `<select>` with `:options` array rendering, `:selected` state, `multiple` attribute, and placeholder support — satisfies 51 references
- **Textarea** (`form/inputs/textarea.blade.php`): Proper `<textarea>` with Metronic-styled classes, field wrapper, and configurable rows — satisfies 3 references
- **Form label** (`form/form-label.blade.php`): Label wrapper for auth password pages — satisfies 4 references

All 124 missing `x-form.inputs.*` and `x-form.form-label` references are now resolved.

## Test plan

- [x] All new components follow existing Metronic styling patterns from `form/input.blade.php`
- [x] Both Livewire (`wire:model`) and traditional (`name`/`:value`) usage supported
- [x] Test suite run — only pre-existing migration failure (MatchType), no new regressions