### PR TITLE
feat: rebuild action views, replace Bootstrap grid, fix raw select in tag-team modal

### DIFF
--- a/resources/views/components/managers/form.blade.php
+++ b/resources/views/components/managers/form.blade.php
@@ -1,12 +1,7 @@
 <div class="mb-10">
-    <div class="mb-5 row gx-10">
-        <div class="col-lg-6">
-            <x-form.inputs.text label="First Name:" name="first_name" placeholder="First Name Here" :value="old('first_name', $manager->first_name)"/>
-        </div>
-
-        <div class="col-lg-6">
-            <x-form.inputs.text label="Last Name:" name="last_name" placeholder="Last Name Here" :value="old('last_name', $manager->last_name)"/>
-        </div>
+    <div class="mb-5 grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <x-form.inputs.text label="First Name:" name="first_name" placeholder="First Name Here" :value="old('first_name', $manager->first_name)"/>
+        <x-form.inputs.text label="Last Name:" name="last_name" placeholder="Last Name Here" :value="old('last_name', $manager->last_name)"/>
     </div>
 </div>
 

--- a/resources/views/components/referees/form.blade.php
+++ b/resources/views/components/referees/form.blade.php
@@ -1,11 +1,7 @@
 <div class="mb-10">
-    <div class="mb-5 row gx-10">
-        <div class="col-lg-6">
-            <x-form.inputs.text label="First Name:" name="first_name" placeholder="First Name Here" :value="old('first_name', $referee->first_name)" />
-        </div>
-        <div class="col-lg-6">
-            <x-form.inputs.text label="Last Name:" name="last_name" placeholder="Last Name Here" :value="old('last_name', $referee->last_name)" />
-        </div>
+    <div class="mb-5 grid grid-cols-1 lg:grid-cols-2 gap-5">
+        <x-form.inputs.text label="First Name:" name="first_name" placeholder="First Name Here" :value="old('first_name', $referee->first_name)" />
+        <x-form.inputs.text label="Last Name:" name="last_name" placeholder="Last Name Here" :value="old('last_name', $referee->last_name)" />
     </div>
 </div>
 

--- a/resources/views/components/venues/form.blade.php
+++ b/resources/views/components/venues/form.blade.php
@@ -7,17 +7,9 @@
 </div>
 
 <div class="mb-10">
-    <div class="mb-5 row gx-10">
-        <div class="col-lg-4">
-            <x-form.inputs.text label="City:" name="city" placeholder="Orlando" :value="old('city', $venue->city)"/>
-        </div>
-
-        <div class="col-lg-4">
-            <x-form.inputs.select label="State:" name="state" :options="$states" :selected="old('state', $venue->state)" />
-        </div>
-
-        <div class="col-lg-4">
-            <x-form.inputs.text label="Zip Code:" name="zipcode" placeholder="12345" :value="old('zipcode', $venue->zipcode)"/>
-        </div>
+    <div class="mb-5 grid grid-cols-1 lg:grid-cols-3 gap-5">
+        <x-form.inputs.text label="City:" name="city" placeholder="Orlando" :value="old('city', $venue->city)"/>
+        <x-form.inputs.select label="State:" name="state" :options="$states" :selected="old('state', $venue->state)" />
+        <x-form.inputs.text label="Zip Code:" name="zipcode" placeholder="12345" :value="old('zipcode', $venue->zipcode)"/>
     </div>
 </div>

--- a/resources/views/livewire/managers/components/actions.blade.php
+++ b/resources/views/livewire/managers/components/actions.blade.php
@@ -1,21 +1,37 @@
 <div class="flex flex-wrap gap-2">
-    {{-- Manager Actions Component --}}
-    {{-- This component handles various manager management actions --}}
-    
-    {{-- Add action buttons here based on manager status and available actions --}}
-    {{-- Example structure for future implementation: --}}
-    {{-- 
-    @if($canEmploy)
+    @can('employ', $manager)
         <x-buttons.success wire:click="employ">{{ __('Employ') }}</x-buttons.success>
-    @endif
-    
-    @if($canRelease) 
+    @endcan
+
+    @can('release', $manager)
         <x-buttons.danger wire:click="release">{{ __('Release') }}</x-buttons.danger>
-    @endif
-    --}}
-    
-    {{-- Placeholder content for initial implementation --}}
-    <div class="text-sm text-gray-500">
-        Manager Actions Component
-    </div>
+    @endcan
+
+    @can('suspend', $manager)
+        <x-buttons.warning wire:click="suspend">{{ __('Suspend') }}</x-buttons.warning>
+    @endcan
+
+    @can('reinstate', $manager)
+        <x-buttons.success wire:click="reinstate">{{ __('Reinstate') }}</x-buttons.success>
+    @endcan
+
+    @can('injure', $manager)
+        <x-buttons.warning wire:click="injure">{{ __('Injure') }}</x-buttons.warning>
+    @endcan
+
+    @can('clearFromInjury', $manager)
+        <x-buttons.success wire:click="healFromInjury">{{ __('Heal') }}</x-buttons.success>
+    @endcan
+
+    @can('retire', $manager)
+        <x-buttons.danger wire:click="retire">{{ __('Retire') }}</x-buttons.danger>
+    @endcan
+
+    @can('unretire', $manager)
+        <x-buttons.success wire:click="unretire">{{ __('Unretire') }}</x-buttons.success>
+    @endcan
+
+    @can('restore', $manager)
+        <x-buttons.success wire:click="restore">{{ __('Restore') }}</x-buttons.success>
+    @endcan
 </div>

--- a/resources/views/livewire/referees/components/actions.blade.php
+++ b/resources/views/livewire/referees/components/actions.blade.php
@@ -1,21 +1,37 @@
 <div class="flex flex-wrap gap-2">
-    {{-- Referee Actions Component --}}
-    {{-- This component handles various referee management actions --}}
-    
-    {{-- Add action buttons here based on referee status and available actions --}}
-    {{-- Example structure for future implementation: --}}
-    {{-- 
-    @if($canEmploy)
+    @can('employ', $referee)
         <x-buttons.success wire:click="employ">{{ __('Employ') }}</x-buttons.success>
-    @endif
-    
-    @if($canRelease) 
+    @endcan
+
+    @can('release', $referee)
         <x-buttons.danger wire:click="release">{{ __('Release') }}</x-buttons.danger>
-    @endif
-    --}}
-    
-    {{-- Placeholder content for initial implementation --}}
-    <div class="text-sm text-gray-500">
-        Referee Actions Component
-    </div>
+    @endcan
+
+    @can('suspend', $referee)
+        <x-buttons.warning wire:click="suspend">{{ __('Suspend') }}</x-buttons.warning>
+    @endcan
+
+    @can('reinstate', $referee)
+        <x-buttons.success wire:click="reinstate">{{ __('Reinstate') }}</x-buttons.success>
+    @endcan
+
+    @can('injure', $referee)
+        <x-buttons.warning wire:click="injure">{{ __('Injure') }}</x-buttons.warning>
+    @endcan
+
+    @can('clearFromInjury', $referee)
+        <x-buttons.success wire:click="healFromInjury">{{ __('Heal') }}</x-buttons.success>
+    @endcan
+
+    @can('retire', $referee)
+        <x-buttons.danger wire:click="retire">{{ __('Retire') }}</x-buttons.danger>
+    @endcan
+
+    @can('unretire', $referee)
+        <x-buttons.success wire:click="unretire">{{ __('Unretire') }}</x-buttons.success>
+    @endcan
+
+    @can('restore', $referee)
+        <x-buttons.success wire:click="restore">{{ __('Restore') }}</x-buttons.success>
+    @endcan
 </div>

--- a/resources/views/livewire/tag-teams/components/actions.blade.php
+++ b/resources/views/livewire/tag-teams/components/actions.blade.php
@@ -1,45 +1,33 @@
 <div class="flex flex-wrap gap-2">
-    {{-- Tag Team Actions Component --}}
-    {{-- This component handles various tag team management actions --}}
-    
-    {{-- Add action buttons here based on tag team status and available actions --}}
-    {{-- Example structure for future implementation: --}}
-    {{-- 
-    @if($canEmploy)
+    @can('employ', $tagTeam)
         <x-buttons.success wire:click="employ">{{ __('Employ') }}</x-buttons.success>
-    @endif
-    
-    @if($canRelease) 
+    @endcan
+
+    @can('release', $tagTeam)
         <x-buttons.danger wire:click="release">{{ __('Release') }}</x-buttons.danger>
-    @endif
-    
-    @if($canRetire)
-        <x-buttons.warning wire:click="retire">{{ __('Retire') }}</x-buttons.warning>
-    @endif
-    
-    @if($canUnretire)
-        <x-buttons.success wire:click="unretire">{{ __('Unretire') }}</x-buttons.success>
-    @endif
-    
-    @if($canSuspend)
+    @endcan
+
+    @can('suspend', $tagTeam)
         <x-buttons.warning wire:click="suspend">{{ __('Suspend') }}</x-buttons.warning>
-    @endif
-    
-    @if($canReinstate)
+    @endcan
+
+    @can('reinstate', $tagTeam)
         <x-buttons.success wire:click="reinstate">{{ __('Reinstate') }}</x-buttons.success>
-    @endif
-    
-    @if($canDelete)
+    @endcan
+
+    @can('retire', $tagTeam)
+        <x-buttons.warning wire:click="retire">{{ __('Retire') }}</x-buttons.warning>
+    @endcan
+
+    @can('unretire', $tagTeam)
+        <x-buttons.success wire:click="unretire">{{ __('Unretire') }}</x-buttons.success>
+    @endcan
+
+    @can('delete', $tagTeam)
         <x-buttons.danger wire:click="delete">{{ __('Delete') }}</x-buttons.danger>
-    @endif
-    
-    @if($canRestore)
+    @endcan
+
+    @can('restore', $tagTeam)
         <x-buttons.success wire:click="restore">{{ __('Restore') }}</x-buttons.success>
-    @endif
-    --}}
-    
-    {{-- Placeholder content for initial implementation --}}
-    <div class="text-sm text-gray-500">
-        Tag Team Actions Component
-    </div>
+    @endcan
 </div>

--- a/resources/views/livewire/tag-teams/modals/form-modal.blade.php
+++ b/resources/views/livewire/tag-teams/modals/form-modal.blade.php
@@ -22,20 +22,6 @@
     </x-form-modal.modal-input>
 
     <x-form-modal.modal-input>
-        <div class="flex flex-col space-y-2">
-            <label class="font-medium text-2sm leading-none text-gray-900">{{ __('tag-teams.managers') }}</label>
-            <select
-                class="font-medium text-2sm leading-none bg-light-active rounded-md h-10 ps-3 pe-3 border border-solid border-gray-300 text-gray-700 focus:border-primary"
-                wire:model="form.managers" multiple>
-                @if(isset($this->getManagers))
-                    @foreach ($this->getManagers as $key => $value)
-                        <option value="{{ $key }}">{{ $value }}</option>
-                    @endforeach
-                @endif
-            </select>
-            @error('form.managers')
-                <span class="text-red-500 text-sm">{{ $message }}</span>
-            @enderror
-        </div>
+        <x-form.inputs.select label="{{ __('tag-teams.managers') }}" wire:model="form.managers" :options="$this->getManagers" :multiple="true" />
     </x-form-modal.modal-input>
 </x-form-modal>

--- a/resources/views/livewire/titles/components/actions.blade.php
+++ b/resources/views/livewire/titles/components/actions.blade.php
@@ -1,21 +1,25 @@
 <div class="flex flex-wrap gap-2">
-    {{-- Title Actions Component --}}
-    {{-- This component handles various title management actions --}}
-    
-    {{-- Add action buttons here based on title status and available actions --}}
-    {{-- Example structure for future implementation: --}}
-    {{-- 
-    @if($canDebut)
+    @can('debut', $title)
         <x-buttons.success wire:click="debut">{{ __('Debut') }}</x-buttons.success>
-    @endif
-    
-    @if($canRetire) 
+    @endcan
+
+    @can('retire', $title)
         <x-buttons.danger wire:click="retire">{{ __('Retire') }}</x-buttons.danger>
-    @endif
-    --}}
-    
-    {{-- Placeholder content for initial implementation --}}
-    <div class="text-sm text-gray-500">
-        Title Actions Component
-    </div>
+    @endcan
+
+    @can('unretire', $title)
+        <x-buttons.success wire:click="unretire">{{ __('Unretire') }}</x-buttons.success>
+    @endcan
+
+    @can('pull', $title)
+        <x-buttons.warning wire:click="deactivate">{{ __('Deactivate') }}</x-buttons.warning>
+    @endcan
+
+    @can('reinstate', $title)
+        <x-buttons.success wire:click="reinstate">{{ __('Reinstate') }}</x-buttons.success>
+    @endcan
+
+    @can('restore', $title)
+        <x-buttons.success wire:click="restore">{{ __('Restore') }}</x-buttons.success>
+    @endcan
 </div>

--- a/resources/views/livewire/wrestlers/components/actions.blade.php
+++ b/resources/views/livewire/wrestlers/components/actions.blade.php
@@ -1,21 +1,37 @@
 <div class="flex flex-wrap gap-2">
-    {{-- Wrestler Actions Component --}}
-    {{-- This component handles various wrestler management actions --}}
-    
-    {{-- Add action buttons here based on wrestler status and available actions --}}
-    {{-- Example structure for future implementation: --}}
-    {{-- 
-    @if($canEmploy)
+    @can('employ', $wrestler)
         <x-buttons.success wire:click="employ">{{ __('Employ') }}</x-buttons.success>
-    @endif
-    
-    @if($canRelease) 
+    @endcan
+
+    @can('release', $wrestler)
         <x-buttons.danger wire:click="release">{{ __('Release') }}</x-buttons.danger>
-    @endif
-    --}}
-    
-    {{-- Placeholder content for initial implementation --}}
-    <div class="text-sm text-gray-500">
-        Wrestler Actions Component
-    </div>
+    @endcan
+
+    @can('suspend', $wrestler)
+        <x-buttons.warning wire:click="suspend">{{ __('Suspend') }}</x-buttons.warning>
+    @endcan
+
+    @can('reinstate', $wrestler)
+        <x-buttons.success wire:click="reinstate">{{ __('Reinstate') }}</x-buttons.success>
+    @endcan
+
+    @can('injure', $wrestler)
+        <x-buttons.warning wire:click="injure">{{ __('Injure') }}</x-buttons.warning>
+    @endcan
+
+    @can('clearFromInjury', $wrestler)
+        <x-buttons.success wire:click="healFromInjury">{{ __('Heal') }}</x-buttons.success>
+    @endcan
+
+    @can('retire', $wrestler)
+        <x-buttons.danger wire:click="retire">{{ __('Retire') }}</x-buttons.danger>
+    @endcan
+
+    @can('unretire', $wrestler)
+        <x-buttons.success wire:click="unretire">{{ __('Unretire') }}</x-buttons.success>
+    @endcan
+
+    @can('restore', $wrestler)
+        <x-buttons.success wire:click="restore">{{ __('Restore') }}</x-buttons.success>
+    @endcan
 </div>

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,44 +1,47 @@
-# Phase 5: Form Input Components
+# Phase 7: Form Modals + Action Components
 
 ## Plan
 
-### Missing components (referenced but don't exist)
+### 1. Rebuild action component views (5 files)
+All 5 were placeholder stubs — restored proper `@can` gated action buttons matching each Livewire class's methods.
 
-1. **`form/inputs/text.blade.php`** (54 references) — thin wrapper: `<x-form.input type="text">`
-2. **`form/inputs/date.blade.php`** (16 references) — thin wrapper: `<x-form.input type="date">`
-3. **`form/inputs/textarea.blade.php`** (3 references) — proper `<textarea>` with field wrapper, same styling pattern as input
-4. **`form/inputs/select.blade.php`** (51 references) — `<select>` with `:options`, `:selected`, `multiple` support
-5. **`form/form-label.blade.php`** (4 references in auth password pages) — simple label+for wrapper
+### 2. Replace Bootstrap grid classes in entity form components (3 files)
+- `managers/form.blade.php`, `referees/form.blade.php`, `venues/form.blade.php`
 
-### Design approach
-
-- Text and date are thin wrappers that delegate to the existing `form/input.blade.php`
-- Textarea and select need their own implementations, following the same patterns (field wrapper, error handling, Metronic styling)
-- All components support both Livewire (`wire:model`) and traditional (`name`/`:value`) usage
-- Use the same CSS token approach as `form/input.blade.php` for visual consistency
+### 3. Fix tag-team form modal raw select
+- Raw `<select>` for managers → `<x-form.inputs.select>`
 
 ## Tasks
 
-- [x] Create `form/inputs/text.blade.php`
-- [x] Create `form/inputs/date.blade.php`
-- [x] Create `form/inputs/textarea.blade.php`
-- [x] Create `form/inputs/select.blade.php`
-- [x] Create `form/form-label.blade.php`
+- [x] Rebuild wrestlers action view (employ, release, suspend, reinstate, injure, heal, retire, unretire, restore)
+- [x] Rebuild managers action view (same actions as wrestlers)
+- [x] Rebuild referees action view (same actions as wrestlers)
+- [x] Rebuild tag-teams action view (employ, release, suspend, reinstate, retire, unretire, delete, restore)
+- [x] Rebuild titles action view (debut, retire, unretire, deactivate, reinstate, restore)
+- [x] Replace Bootstrap grid in managers/form, referees/form, venues/form
+- [x] Fix tag-team form modal raw select → x-form.inputs.select
 - [x] Run tests — pre-existing migration failure only, no new regressions
 
 ## Review
 
 ### Changes Summary
 
-**New files (5):**
-- `form/inputs/text.blade.php` — thin wrapper delegating to `<x-form.input type="text">` (satisfies 54 references)
-- `form/inputs/date.blade.php` — thin wrapper delegating to `<x-form.input type="date">` (satisfies 16 references)
-- `form/inputs/textarea.blade.php` — proper `<textarea>` with Metronic-styled classes, field wrapper, label/error support, configurable rows (satisfies 3 references)
-- `form/inputs/select.blade.php` — `<select>` with `:options` array rendering, `:selected` state, `multiple` attribute, placeholder support (satisfies 51 references)
-- `form/form-label.blade.php` — thin wrapper delegating to `<x-form.label>` with `name`/`label` props (satisfies 4 references)
+**Modified files (9):**
 
-### Design decisions
-- Textarea and select follow the exact same pattern as `form/input.blade.php`: same CSS tokens, same field wrapper, same Livewire/traditional dual support
-- Text and date are one-line delegators — no duplication of input logic
-- Select handles both associative arrays (`[value => label]`) and `multiple` mode
-- All 124 missing component references are now satisfied
+Action views (5) — replaced placeholder stubs with proper `@can`-gated buttons:
+- `livewire/wrestlers/components/actions.blade.php` — 9 actions
+- `livewire/managers/components/actions.blade.php` — 9 actions
+- `livewire/referees/components/actions.blade.php` — 9 actions
+- `livewire/tag-teams/components/actions.blade.php` — 8 actions (no injure/heal, has delete)
+- `livewire/titles/components/actions.blade.php` — 6 actions (debut/retire/unretire/deactivate/reinstate/restore)
+
+Entity forms (3) — Bootstrap `row gx-10` / `col-lg-*` → Tailwind `grid grid-cols-*`:
+- `components/managers/form.blade.php`
+- `components/referees/form.blade.php`
+- `components/venues/form.blade.php`
+
+Form modal (1) — raw HTML select → component:
+- `livewire/tag-teams/modals/form-modal.blade.php` — managers field now uses `<x-form.inputs.select>`
+
+### Zero Bootstrap grid classes remaining in blade files
+### Zero raw HTML selects remaining where component should be used


### PR DESCRIPTION
## Summary

- **5 action views rebuilt**: Replaced placeholder stubs with proper `@can`-gated buttons matching each Livewire class's methods (wrestlers 9 actions, managers 9, referees 9, tag-teams 8, titles 6)
- **3 entity forms cleaned**: Replaced Bootstrap grid classes (`row gx-10`, `col-lg-*`) with Tailwind (`grid grid-cols-*`) in managers, referees, and venues form components
- **Tag-team modal fixed**: Raw HTML `<select>` for managers field replaced with `<x-form.inputs.select>` component

## Test plan

- [x] Zero Bootstrap grid classes remaining in blade files
- [x] Zero raw HTML selects remaining where component should be used
- [x] Test suite run — only pre-existing migration failure (MatchType), no new regressions