### PR TITLE
fix: schema column drift in stables actions and matches table

### DIFF
--- a/app/Actions/Stables/RetireAction.php
+++ b/app/Actions/Stables/RetireAction.php
@@ -102,7 +102,8 @@ class RetireAction
 
             // Create retirement record directly
             $stable->retirements()->create([
-                'retired_at' => $retirementDate,
+                'started_at' => $retirementDate,
+                'ended_at' => null,
             ]);
 
             // Update status to retired

--- a/app/Actions/Stables/UnretireAction.php
+++ b/app/Actions/Stables/UnretireAction.php
@@ -85,11 +85,11 @@ class UnretireAction
         DB::transaction(function () use ($stable, $unretiredDate, $unretireMembers, $establishImmediately, &$successCount, &$failureCount): void {
             // End the current retirement record directly
             $currentRetirement = $stable->retirements()
-                ->whereNull('unretired_at')
+                ->whereNull('ended_at')
                 ->first();
 
             if ($currentRetirement) {
-                $currentRetirement->update(['unretired_at' => $unretiredDate]);
+                $currentRetirement->update(['ended_at' => $unretiredDate]);
             }
 
             // Attempt to unretire available former members

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -8,6 +8,7 @@ use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 
@@ -27,7 +28,7 @@ class Main extends BaseTable
     public function builder(): Builder
     {
         return EventMatch::query()
-            ->with(['event', 'matchType', 'competitors', 'result.winner', 'result.decision'])
+            ->with(['event', 'competitors', 'result.winner'])
             ->orderBy('events_matches.created_at', 'desc');
     }
 
@@ -37,7 +38,7 @@ class Main extends BaseTable
 
         $this->addAdditionalSelects([
             'events_matches.event_id',
-            'events_matches.match_type_id',
+            'events_matches.match_type',
         ]);
     }
 
@@ -52,7 +53,8 @@ class Main extends BaseTable
                 ->location(fn (EventMatch $row) => route('events.show', $row->event)),
             Column::make(__('event-matches.match_number'), 'match_number')
                 ->searchable(),
-            Column::make(__('event-matches.match_type'), 'matchType.name')
+            Column::make(__('event-matches.match_type'), 'match_type')
+                ->label(fn (EventMatch $row) => $row->match_type->label())
                 ->searchable(),
             Column::make(__('event-matches.competitors'))
                 ->label(fn (EventMatch $row) => $row->competitors->map(fn (MatchCompetitor $competitor) => $competitor->getCompetitor()->name)->join(' vs ')),
@@ -61,7 +63,7 @@ class Main extends BaseTable
                     $winner = $row->result?->winner;
 
                     if ($winner) {
-                        return $winner->name.' by '.$row->result?->decision->name;
+                        return $winner->name.' by '.$row->result?->match_decision->label();
                     }
 
                     return 'N/A';

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -39,7 +39,7 @@ class MatchesTable extends DataTableComponent
         }
 
         return EventMatch::query()
-            ->with(['event', 'titles', 'competitors', 'result.winner', 'result.decision'])
+            ->with(['event', 'titles', 'competitors', 'result.winner'])
             ->where('event_id', $this->eventId);
     }
 
@@ -60,7 +60,9 @@ class MatchesTable extends DataTableComponent
     public function columns(): array
     {
         return [
-            Column::make(__('matches.match_type'), 'matchType.name')->searchable(),
+            Column::make(__('matches.match_type'), 'match_type')
+                ->label(fn (EventMatch $row) => $row->match_type->label())
+                ->searchable(),
             ArrayColumn::make(__('matches.competitors'))
                 ->data(fn (mixed $value, EventMatch $row) => ($row->competitors))
                 ->outputFormat(function (int $index, MatchCompetitor $value): string {
@@ -92,7 +94,7 @@ class MatchesTable extends DataTableComponent
                         if ($winner) {
                             $type = str($winner->getMorphClass())->kebab()->plural();
 
-                            return '<a href="'.route($type.'.show', $winner->id).'">'.$winner->name.'</a> by '.$row->result?->decision->name;
+                            return '<a href="'.route($type.'.show', $winner->id).'">'.$winner->name.'</a> by '.$row->result?->match_decision->label();
                         }
 
                         return 'N/A';

--- a/tests/Integration/Actions/TagTeams/DeleteActionTest.php
+++ b/tests/Integration/Actions/TagTeams/DeleteActionTest.php
@@ -83,13 +83,13 @@ test('it handles cascade deletion of relationships', function () {
     $wrestlerB = Wrestler::factory()->create();
 
     $tagTeam->wrestlers()->attach($wrestlerA->id, [
-        'started_at' => now()->subDays(5),
-        'ended_at' => null,
+        'joined_at' => now()->subDays(5),
+        'left_at' => null,
     ]);
 
     $tagTeam->wrestlers()->attach($wrestlerB->id, [
-        'started_at' => now()->subDays(3),
-        'ended_at' => null,
+        'joined_at' => now()->subDays(3),
+        'left_at' => null,
     ]);
 
     expect($tagTeam->wrestlers()->count())->toBe(2);
@@ -165,8 +165,8 @@ test('it handles tag team with ended relationships', function () {
 
     // Add ended partnership
     $tagTeam->wrestlers()->attach($wrestler->id, [
-        'started_at' => now()->subDays(10),
-        'ended_at' => now()->subDays(5),
+        'joined_at' => now()->subDays(10),
+        'left_at' => now()->subDays(5),
     ]);
 
     DeleteAction::run($tagTeam);

--- a/tests/Integration/Actions/TagTeams/RestoreActionTest.php
+++ b/tests/Integration/Actions/TagTeams/RestoreActionTest.php
@@ -92,8 +92,8 @@ test('it restores tag team with partnership history', function () {
 
     // Create partnership history
     $tagTeam->wrestlers()->attach($wrestler->id, [
-        'started_at' => now()->subDays(10),
-        'ended_at' => now()->subDays(5),
+        'joined_at' => now()->subDays(10),
+        'left_at' => now()->subDays(5),
     ]);
 
     expect($tagTeam->wrestlers()->count())->toBe(1);


### PR DESCRIPTION
## Summary

Three independent correctness bugs that have been silently broken in `development`. All produced failing tests in the QueryException bucket of the post-#590 test sweep.

### 1. Stables retire/unretire used non-existent columns

`stables_retirements` schema is `started_at` (NOT NULL) and `ended_at`. Service file `StableLifecycleService` was already correct, but the action classes were not:

- `RetireAction.php:104-106` wrote `'retired_at' => $retirementDate`. Since `retired_at` isn't in `\$fillable`, mass-assignment dropped the value silently, leaving the NOT NULL `started_at` column unset and crashing every stable retirement insert.
- `UnretireAction.php:87-92` queried `whereNull('unretired_at')` and updated `unretired_at`. No such column existed, so any stable unretire was either a no-op or a SQL error depending on environment.

### 2. Tag-team test pivot attachments used wrong column names

`tag_teams_wrestlers` pivot schema is `joined_at`/`left_at` (and the model + factory both already used those names correctly). But `Delete/RestoreActionTest.php` had four `$tagTeam->wrestlers()->attach(...)` calls passing `started_at`/`ended_at`, causing `SQLSTATE[HY000]: General error: 1 table tag_teams_wrestlers has no column named started_at`.

### 3. MatchesTable Livewire components had leftover model-style references

PR #572 converted `MatchType` and `MatchDecision` from Eloquent models to PHP enums. PR #590 fixed migrations, factories, and most consumers, but missed:

- `app/Livewire/Matches/Tables/Main.php`: eager-loaded the dead `matchType` and `result.decision` relations, selected the dead `events_matches.match_type_id` column, and rendered `'matchType.name'` (causing `no such column: matchType.name` SQL) plus `\$row->result?->decision->name`.
- `app/Livewire/Matches/Tables/MatchesTable.php`: same eager-load and column issues.

These are now using `match_type` / `match_decision` directly with `->label()` callbacks for human-readable display via the enum's `label()` method. Search on the match-type column now works against the raw enum value (e.g. `singles`); searching on labels remains a future enhancement.

## Local verification

Each fix verified by running its targeted test class sequentially:

| Fix | Test class | Before | After |
|---|---|---|---|
| Stables retire/unretire | `LifecycleTest` | 2× `stables_retirements.started_at NOT NULL` violations | 0 |
| Tag-team test attachments | `Delete/RestoreActionTest` | 4× `tag_teams_wrestlers.started_at` errors | 0 |
| Matches table | `MatchesTableTest` | 2× `matchType.name` errors | 0 (remaining failures are ViewException/minDate, unrelated) |

Other failures in those classes (CannotBeUnretiredException namespace mismatches, ViewException/minDate) are pre-existing unrelated bugs and are out of scope.

`vendor/bin/pint` passes on all 919 files.

## Heads up

CI on `development` is still red overall — this PR clears small, real bugs but the dominant failure bucket (~700+ ViewException/minDate from the Rappasoft-replacement table system in #582) is unaffected and is being triaged separately by a scheduled remote agent on May 8.

## Test plan

- [ ] CI runs and the previously-cited QueryException failures (`stables_retirements.started_at`, `tag_teams_wrestlers.started_at`, `matchType.name`) no longer appear in the failure list
- [ ] No new regressions introduced (failure counts in unrelated test classes shouldn't go up)
- [ ] Spot-check the `MatchesTable` UI in the browser to confirm the match-type column still displays human labels (e.g., "Tag Team" not `tag-team`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)