### PR TITLE
fix: short-circuit DateRangeFilter::apply when minDate/maxDate aren't set

### DIFF
--- a/app/Livewire/Table/Filters/DateRangeFilter.php
+++ b/app/Livewire/Table/Filters/DateRangeFilter.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Livewire\Table\Filters;
 
 use App\Livewire\Table\Filter;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 
 class DateRangeFilter extends Filter
 {
@@ -53,5 +55,28 @@ class DateRangeFilter extends Filter
     public function getDefaultValue(): array
     {
         return [];
+    }
+
+    /**
+     * Apply this filter to the query builder.
+     *
+     * Only invokes the user-provided filter callback when the value is an
+     * array with non-empty `minDate` and `maxDate` entries. Without this
+     * guard, the default empty-array value bypasses the parent class's
+     * `!== ''/!== null` check and reaches callbacks that read those keys.
+     *
+     * @param  Builder<Model>  $builder
+     */
+    public function apply(Builder $builder, mixed $value): void
+    {
+        if (! is_array($value)) {
+            return;
+        }
+
+        if (empty($value['minDate']) || empty($value['maxDate'])) {
+            return;
+        }
+
+        parent::apply($builder, $value);
     }
 }


### PR DESCRIPTION
## Summary

Clears the **ViewException/minDate bucket** that has dominated CI failures since PR #582. **146 failures cleared** in the parallel run (1291 → 1145), 146 net pass gain (2259 → 2405), 622 more assertions running.

## Root cause

`Filter::apply()` only short-circuits the user-provided callback when the value is `''` or `null`:

```php
public function apply(Builder $builder, mixed $value): void
{
    if (\$this->filterCallback && \$value !== '' && \$value !== null) {
        (\$this->filterCallback)(\$builder, \$value);
    }
}
```

The default value for `DateRangeFilter` is `[]`, which is neither `''` nor `null`, so the callback runs against an empty array. Filter callbacks (`FirstActivityPeriodFilter`, `FirstEmploymentFilter`, `FirstActivationFilter`) read `\$dateRange['minDate']` and `\$dateRange['maxDate']`, producing `Undefined array key "minDate"` whenever a table renders without an active date filter — i.e., almost every test.

This was new behavior introduced when PR #582 replaced Rappasoft DataTables with the custom table system. Rappasoft's `DateRangeFilter` either guaranteed the keys or skipped the callback when unset; the new system didn't preserve that guard.

## Fix

Override `DateRangeFilter::apply()` to require both `minDate` and `maxDate` to be non-empty before delegating to `parent::apply()`:

```php
public function apply(Builder \$builder, mixed \$value): void
{
    if (! is_array(\$value)) {
        return;
    }

    if (empty(\$value['minDate']) || empty(\$value['maxDate'])) {
        return;
    }

    parent::apply(\$builder, \$value);
}
```

This matches what `setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])` implies the contract is — those are the array keys the callback expects. The user-facing filter behavior is unchanged: when both dates are set the filter applies; when either is missing, it doesn't.

Surgical change. No consumer updates needed. The callback signature (`function (Builder \$query, array \$dateRange)` reading `\$dateRange['minDate']` / `\$dateRange['maxDate']`) keeps working unchanged for the case where it's actually invoked.

## Verification

| Metric | Before | After |
|---|---|---|
| `tests/Integration/Livewire/Titles/Tables/MainTest` | 14 failed (ViewException) | 14 passed |
| Full parallel run failures | 1291 | 1145 |
| Full parallel run passes | 2259 | 2405 |
| Assertions made | 6793 | 7415 |

## Heads up — deeper bugs revealed

Clearing this bucket exposed two further issues that were previously masked. Out of scope for this PR but worth flagging for follow-up:

1. **`Class "LivewireUI\\Modal\\ModalComponent" not found`** in `app/Livewire/Base/BaseModal.php:40`. The `wire-elements/modal` package was uninstalled but `BaseModal` still extends it. This breaks every modal test (and probably the modals at runtime, not just in tests).
2. **`Missing required parameter for [Route: events.show] [URI: events/{event}] [Missing parameter: event]`** in `resources/views/components/tables/columns/action-column.blade.php`. The action-column blade generates URLs without the route parameter.

Each is a separate, substantial fix. The May 8 scheduled triage agent has been disabled (`enabled: false`) since this PR took on the bucket it was scheduled to address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)