### PR TITLE
fix: preserve SELECT * when applying additionalSelects in DataTableComponent

### DIFF
--- a/app/Livewire/Table/DataTableComponent.php
+++ b/app/Livewire/Table/DataTableComponent.php
@@ -136,7 +136,7 @@ abstract class DataTableComponent extends Component
         $query = $this->builder();
 
         if ($this->additionalSelects) {
-            $query->addSelect($this->additionalSelects);
+            $query->select('*')->addSelect($this->additionalSelects);
         }
 
         $this->applySearch($query);


### PR DESCRIPTION
## Summary

Fixes a real bug in the custom table system where calling `addAdditionalSelects()` on a query without an explicit prior `select()` silently dropped every column except the additional ones — including the primary key. **18 failures cleared, 18 pass gain, +140 assertions.**

## Root cause

`DataTableComponent::getRows()` did:

```php
$query = $this->builder();           // e.g. Event::query()
if ($this->additionalSelects) {
    $query->addSelect($this->additionalSelects);
}
```

Eloquent's `addSelect()` mutates the underlying QueryBuilder's `$columns` property. On a fresh builder with no prior `select()` call, `$columns` is null/empty — `addSelect(['events.venue_id'])` initializes it to `['events.venue_id']` rather than appending to a `*`. Eloquent only fills `*` in if `$columns` is still null at SQL-generation time, but `addSelect` sets it.

Tinker confirms:
```
$q = Event::query();
$q->addSelect(['events.venue_id']);
$q->toSql(); // => select `events`.`venue_id` from `events`
```

`id` was not in the result set. `$row->id` came back null. The action-column blade then called `route('events.show', null)` which threw:

```
Missing required parameter for [Route: events.show] [URI: events/{event}] [Missing parameter: event].
(View: resources/views/components/tables/columns/action-column.blade.php)
```

## Fix

```diff
 if ($this->additionalSelects) {
-    $query->addSelect($this->additionalSelects);
+    $query->select('*')->addSelect($this->additionalSelects);
 }
```

Explicit `select('*')` ensures the row select happens before columns are added. SQL becomes `select *, events.venue_id from events` — primary key and all other columns now included.

## Verification

| Metric | Before | After |
|---|---|---|
| `tests/Integration/Livewire/Events/Tables/MainTest` | 4 passed / 26 failed | 30/30 passed |
| Full parallel suite failures | 1145 | 1127 |
| Full parallel suite passes | 2405 | 2423 |
| Assertions | 7415 | 7555 |