### PR TITLE
fix: align Livewire 4 property access patterns

### DIFF
--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -5,13 +5,12 @@ declare(strict_types=1);
 namespace App\Livewire\TagTeams\Modals;
 
 use App\Livewire\Base\BaseFormModal;
+use App\Livewire\Concerns\Data\PresentsManagersList;
 use App\Livewire\Concerns\Data\PresentsWrestlersList;
 use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\TagTeams\Forms\CreateEditForm;
-use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 
@@ -21,28 +20,8 @@ use Illuminate\View\View;
 class FormModal extends BaseFormModal
 {
     use GeneratesDummyData;
+    use PresentsManagersList;
     use PresentsWrestlersList;
-
-    /**
-     * @return Collection<int, Wrestler>
-     */
-    public function getWrestlersListProperty(): Collection
-    {
-        return Wrestler::all();
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    public function getManagersProperty(): array
-    {
-        return Manager::select('id', 'first_name', 'last_name')
-            ->get()
-            ->mapWithKeys(function (Manager $manager) {
-                return [$manager->id => $manager->first_name.' '.$manager->last_name];
-            })
-            ->toArray();
-    }
 
     protected function getFormClass(): string
     {

--- a/tests/Feature/Livewire/Wrestlers/Tables/WrestlersTableTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/WrestlersTableTest.php
@@ -118,10 +118,10 @@ describe('Main Component Feature Workflows', function () {
                 ->test(Main::class)
                 ->assertSee('Active Wrestler')
                 ->assertSee('Released Wrestler')
-                ->set('filterComponents.status', 'employed')
+                ->set('filterValues.status', 'employed')
                 ->assertSee('Active Wrestler')
                 ->assertDontSee('Released Wrestler')
-                ->set('filterComponents.status', 'released')
+                ->set('filterValues.status', 'released')
                 ->assertDontSee('Active Wrestler')
                 ->assertSee('Released Wrestler');
         });
@@ -150,14 +150,14 @@ describe('Main Component Feature Workflows', function () {
             $component = Livewire::actingAs($this->admin)
                 ->test(Main::class)
                 ->set('search', 'Test Search')
-                ->set('filterComponents.status', 'released');
+                ->set('filterValues.status', 'released');
 
             // Perform business operation
             $component->call('handleWrestlerAction', 'employ', $wrestler->id);
 
             // Component state should be maintained
             expect($component->get('search'))->toBe('Test Search');
-            expect($component->get('filterComponents.status'))->toBe('released');
+            expect($component->get('filterValues.status'))->toBe('released');
         });
 
         test('component handles concurrent user interactions', function () {

--- a/tests/Feature/Workflows/TitleManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/TitleManagementWorkflowTest.php
@@ -179,19 +179,19 @@ describe('Title Search and Filtering Workflow', function () {
         // When: Filtering by active status
         Livewire::actingAs($admin)
             ->test(Main::class)
-            ->set('filterComponents.status', 'active')
+            ->set('filterValues.status', 'active')
             ->assertSee('WWE Championship Title');
 
         // When: Filtering by retired status
         Livewire::actingAs($admin)
             ->test(Main::class)
-            ->set('filterComponents.status', 'retired')
+            ->set('filterValues.status', 'retired')
             ->assertSee('WCW Championship Title');
 
         // When: Clearing filters
         Livewire::actingAs($admin)
             ->test(Main::class)
-            ->set('filterComponents.status', '')
+            ->set('filterValues.status', '')
             ->set('search', '')
             ->assertSee('WWE Championship Title')
             ->assertSee('WCW Championship Title')

--- a/tests/Feature/Workflows/WrestlerManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/WrestlerManagementWorkflowTest.php
@@ -271,21 +271,21 @@ describe('Wrestler Search and Filtering Journey', function () {
         // When: Filtering by employment status
         Livewire::actingAs($admin)
             ->test(Main::class)
-            ->set('filterComponents.status', 'employed')
+            ->set('filterValues.status', 'employed')
             ->assertSee($bookableWrestler->name)
             ->assertDontSee($releasedWrestler->name);
 
         // When: Filtering by released status
         Livewire::actingAs($admin)
             ->test(Main::class)
-            ->set('filterComponents.status', 'released')
+            ->set('filterValues.status', 'released')
             ->assertSee($releasedWrestler->name)
             ->assertDontSee($bookableWrestler->name);
 
         // When: Clearing filters
         Livewire::actingAs($admin)
             ->test(Main::class)
-            ->set('filterComponents.status', '')
+            ->set('filterValues.status', '')
             ->set('search', '')
             ->assertSee($bookableWrestler->name)
             ->assertSee($releasedWrestler->name)


### PR DESCRIPTION
## Summary

Two surgical fixes for the Property/PublicPropertyNotFoundException bucket from the post-#598 sweep. Both fall under "Livewire 4 is stricter about property access."

| Issue | Failures cleared |
|---|---|
| TagTeams FormModal: stale `getManagersProperty()` shadowing trait | ~34 test instances (1 real bug × many) |
| Tests using stale Rappasoft `filterComponents` property | 4 |

Net suite delta: 983 → 974 failures, 2567 → 2576 passes, 8023 → 8056 assertions.

## 1. TagTeams FormModal — duplicated trait functionality with stale local methods

The component had its own `getManagersProperty()` (legacy `getXxxProperty` syntax) that returned the same shape as `PresentsManagersList::getManagers()` (the `#[Computed]` attribute version provided by the trait, which the component conspicuously did not `use`). But the blade template calls `\$this->getManagers` — which Livewire 4 only resolves via `#[Computed]`, not via legacy `getManagersProperty`. Result: `Property [\$getManagers] not found on component: [tag-teams.modals.form-modal]`.

Fix: drop the redundant local `getManagersProperty()` and `use PresentsManagersList;` to get the trait's `#[Computed] getManagers()` that the blade was always trying to access.

Also dropped `getWrestlersListProperty()` — fully dead code, the blade only references `\$this->getWrestlers` (from `PresentsWrestlersList`).

## 2. Test files calling stale Rappasoft `filterComponents` property

Three test files were calling `->set('filterComponents.status', ...)` — `filterComponents` was the Rappasoft DataTableComponent property for filter state. PR #582 replaced Rappasoft with the custom table system in `App\Livewire\Table\DataTableComponent`, which uses `\$filterValues` instead. Tests weren't updated, so Livewire 4 (stricter about property writes than v3) throws `Unable to set component data. Public property [\$filterComponents] not found`.

Fix: `filterComponents.status` → `filterValues.status` across all three files.

## Verification

- `tests/Integration/Livewire/TagTeams/Modals/FormModalTest`: 33 fail / 0 pass → 28 fail / 5 pass (the 5 newly-passing exercise the `getManagers` access)
- The 28 remaining failures in that file fall under different errors (`Form::setModel()`, `Form::\$wrestlerA`) — those are pre-existing BaseForm vs `Livewire\Form` type-hint issues that surfaced after the Modal layer started loading post-#598. Separate bucket.

## Heads up

Roughly ~970 failures remain. The next-largest tractable buckets are:

- **`Form::setModel()` / property-on-Livewire\Form errors** — the BaseForm vs `Livewire\Form` type hint issue. Touches `BaseModal::\$modelForm` and `BaseFormModal::\$form` plus the 12 `FormModal` subclasses. Likely 50-100 cleared.
- **Stale Rappasoft API calls** in table classes (`Column::format()`, `addExtraWithSum`) — handful of mechanical updates.
- **Business-logic exceptions** — pre-existing factory-state bugs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)