### PR TITLE
fix: declare concrete form types on FormModal subclasses for Livewire 4

### DIFF
--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -6,7 +6,6 @@ namespace App\Livewire\Base;
 
 use App\Livewire\Concerns\GeneratesDummyData;
 use Illuminate\Database\Eloquent\Model;
-use Livewire\Form;
 
 /**
  * Base class for all form modals with essential functionality.
@@ -218,12 +217,13 @@ abstract class BaseFormModal extends BaseModal
      */
     abstract protected function getModalPath(): string;
 
-    /**
-     * The form instance for this modal.
-     *
-     * @var TForm|null
+    /*
+     * The concrete form property is declared by each subclass so that PHP
+     * (which enforces invariant property types between parent and child)
+     * and Livewire 4 (which uses the declared type to rehydrate the form
+     * instance between requests) can work with a concrete BaseForm
+     * subclass — e.g. `public WrestlerForm $form;`.
      */
-    public Form $form;
 
     /**
      * Indicates if the modal is currently open.

--- a/app/Livewire/Base/BaseModal.php
+++ b/app/Livewire/Base/BaseModal.php
@@ -8,7 +8,6 @@ use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
-use Livewire\Form;
 use LivewireUI\Modal\ModalComponent;
 
 /**
@@ -47,7 +46,7 @@ abstract class BaseModal extends ModalComponent
     /**
      * @var TModelForm|null
      */
-    protected Form $modelForm;
+    protected BaseForm $modelForm;
 
     /**
      * @var TModelType

--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -20,6 +20,8 @@ class FormModal extends BaseFormModal
 {
     use PresentsVenuesList;
 
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -26,6 +26,8 @@ class FormModal extends BaseFormModal
         $this->titleField = 'full_name';
     }
 
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -73,6 +73,8 @@ class FormModal extends BaseFormModal
      *
      * @return class-string<CreateEditForm> The fully qualified class name of CreateEditForm
      */
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -24,6 +24,8 @@ class FormModal extends BaseFormModal
      */
     public ?array $originalModelData = null;
 
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/Stables/Modals/FormModal.php
+++ b/app/Livewire/Stables/Modals/FormModal.php
@@ -24,6 +24,8 @@ class FormModal extends BaseFormModal
     use PresentsTagTeamsList;
     use PresentsWrestlersList;
 
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -23,6 +23,8 @@ class FormModal extends BaseFormModal
     use PresentsManagersList;
     use PresentsWrestlersList;
 
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -19,6 +19,8 @@ class FormModal extends BaseFormModal
 {
     use GeneratesDummyData;
 
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/Users/Modals/FormModal.php
+++ b/app/Livewire/Users/Modals/FormModal.php
@@ -15,6 +15,8 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/Venues/Modals/FormModal.php
+++ b/app/Livewire/Venues/Modals/FormModal.php
@@ -15,6 +15,8 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;

--- a/app/Livewire/Wrestlers/Modals/FormModal.php
+++ b/app/Livewire/Wrestlers/Modals/FormModal.php
@@ -18,6 +18,8 @@ class FormModal extends BaseFormModal
 {
     use GeneratesDummyData;
 
+    public CreateEditForm $form;
+
     protected function getFormClass(): string
     {
         return CreateEditForm::class;


### PR DESCRIPTION
## Summary

Largest single fix this session — **186 failures cleared, +186 passes, +563 assertions** (974 → 788, 2576 → 2762, 8056 → 8619).

## Root cause

`BaseFormModal::\$form` was declared `public Livewire\Form \$form;` (the parent abstract type). The actual instance assigned at mount time is always a concrete `CreateEditForm` (which extends `BaseForm` which extends `Livewire\Form`).

Livewire 3 was permissive — the concrete instance survived hydration even when the declared type was the loose `Form` parent. Livewire 4 is strict: during rehydration it reads the declared property type and instantiates *that* class. With `Livewire\Form`, it instantiates the base `Form` rather than the concrete subclass, losing methods like `setModel()`, `store()`, and the form's own properties.

This manifested as ~186 test failures across the FormModal test files:
- `Call to undefined method Livewire\Form::setModel()`
- `Call to undefined method Livewire\Form::store()`
- `Property Livewire\Form::\$wrestlerA does not exist` (and similar for every form-specific property)

## Why a simple type narrowing doesn't work

PHP enforces invariant property types — a child class cannot narrow `public Livewire\Form \$form;` to `public CreateEditForm \$form;`. Attempting that yields:

```
Type of App\Livewire\Events\Modals\FormModal::\$form must be Livewire\Form
(as in class App\Livewire\Base\BaseFormModal)
```

## Fix

1. **Drop the `\$form` property declaration entirely from `BaseFormModal`.** A docblock replaces it explaining that subclasses must declare the property.
2. **Each of the 10 `FormModal` subclasses declares `public CreateEditForm \$form;`** with their own namespace's concrete form class (the import was already there).
3. **`BaseModal::\$modelForm` is changed from `Livewire\Form` to `BaseForm`**. This is a `protected` property only assigned via `\$this->modelForm = \$this->form` in `BaseFormModal::mount()`. Safe because PHP allows `BaseForm` (which extends `Form`) to hold a `CreateEditForm` instance, and Livewire 4 doesn't try to rehydrate `protected` properties through this path.

## Verification

| Metric | Before | After |
|---|---|---|
| `tests/Integration/Livewire/Events/Modals/FormModalTest` | 0/28 passing | **28/28 passing** |
| Full parallel suite failures | 974 | 788 |
| Full parallel suite passes | 2576 | 2762 |
| Assertions | 8056 | 8619 |

Pint passes on all 12 changed files.

## Heads up

CI is still red (788 remaining). The next-largest tractable buckets:

- **ViewException (~135 unique)** — split between route-parameter errors (PR #596 in flight fixes a chunk) and stale Rappasoft API calls in table classes (`Column::format()`, `addExtraWithSum`)
- **Business-logic exceptions** — pre-existing factory-state bugs in stable/wrestler lifecycle
- **Browser/Playwright tests** — environment-specific

Each is a separate follow-up. None block this merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)