### PR TITLE
fix: clear BadMethodCall, LogicException, and ArgumentCountError buckets

### DIFF
--- a/app/Livewire/Managers/Tables/PreviousStables.php
+++ b/app/Livewire/Managers/Tables/PreviousStables.php
@@ -44,8 +44,5 @@ class PreviousStables extends BasePreviousStablesTable
         ];
     }
 
-    public function configure(): void
-    {
-        $this->setAdditionalSelects([]);
-    }
+    public function configure(): void {}
 }

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -14,6 +14,7 @@ use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\Rules\Enum;
 
 /**
  * Livewire form component for managing event match creation and editing.
@@ -296,7 +297,7 @@ class CreateEditForm extends BaseForm
     {
         $baseRules = [
             // eventId removed - it's context from route model binding, not user input
-            'matchType' => ['required', 'enum:'.MatchType::class],
+            'matchType' => ['required', new Enum(MatchType::class)],
             'preview' => ['sometimes', 'string'],
             'referees' => ['sometimes', 'array'],
             'referees.*' => ['integer', 'exists:referees,id'],

--- a/app/Models/Concerns/ProvidesDisplayName.php
+++ b/app/Models/Concerns/ProvidesDisplayName.php
@@ -31,20 +31,24 @@ trait ProvidesDisplayName
      */
     public function getDisplayName(): string
     {
-        if ((array_key_exists('name', $this->getAttributes()) || property_exists($this, 'name')) && $this->getAttribute('name')) {
-            return $this->getAttribute('name');
+        if ((array_key_exists('name', $this->getAttributes()) || property_exists($this, 'name')) && ! empty($this->name)) {
+            return $this->name;
         }
 
-        if ((array_key_exists('full_name', $this->getAttributes()) || property_exists($this, 'full_name')) && $this->getAttribute('full_name')) {
-            return $this->getAttribute('full_name');
+        if ((array_key_exists('full_name', $this->getAttributes()) || property_exists($this, 'full_name')) && ! empty($this->full_name)) {
+            return $this->full_name;
         }
 
-        $firstName = $this->getAttribute('first_name');
-        $lastName = $this->getAttribute('last_name');
-        if ((array_key_exists('first_name', $this->getAttributes()) || property_exists($this, 'first_name')) &&
-            (array_key_exists('last_name', $this->getAttributes()) || property_exists($this, 'last_name')) &&
-            ($firstName !== null || $lastName !== null)) {
-            return mb_trim("{$firstName} {$lastName}");
+        $hasFirstName = array_key_exists('first_name', $this->getAttributes()) || property_exists($this, 'first_name');
+        $hasLastName = array_key_exists('last_name', $this->getAttributes()) || property_exists($this, 'last_name');
+        if ($hasFirstName && $hasLastName) {
+            $firstName = $this->first_name;
+            $lastName = $this->last_name;
+
+            // Both null → no display name available, fall through to exception.
+            if ($firstName !== null || $lastName !== null) {
+                return mb_trim(($firstName ?? '').' '.($lastName ?? ''));
+            }
         }
 
         throw new LogicException(sprintf(

--- a/app/Models/Validation/Strategies/IndividualSuspensionValidation.php
+++ b/app/Models/Validation/Strategies/IndividualSuspensionValidation.php
@@ -26,27 +26,27 @@ class IndividualSuspensionValidation implements SuspensionValidationStrategy
     public function validate(Model $entity): void
     {
         if ($this->isUnemployed($entity)) {
-            throw CannotBeSuspendedException::unemployed();
+            throw CannotBeSuspendedException::unemployed($entity);
         }
 
         if ($this->isReleased($entity)) {
-            throw CannotBeSuspendedException::released();
+            throw CannotBeSuspendedException::released($entity);
         }
 
         if (method_exists($entity, 'isRetired') && $entity->isRetired()) {
-            throw CannotBeSuspendedException::retired();
+            throw CannotBeSuspendedException::retired($entity);
         }
 
         if (method_exists($entity, 'hasFutureEmployment') && $entity->hasFutureEmployment()) {
-            throw CannotBeSuspendedException::hasFutureEmployment();
+            throw CannotBeSuspendedException::hasFutureEmployment($entity);
         }
 
         if (method_exists($entity, 'isSuspended') && $entity->isSuspended()) {
-            throw CannotBeSuspendedException::suspended();
+            throw CannotBeSuspendedException::suspended($entity);
         }
 
         if (method_exists($entity, 'isInjured') && $entity->isInjured()) {
-            throw CannotBeSuspendedException::injured();
+            throw CannotBeSuspendedException::injured($entity);
         }
     }
 


### PR DESCRIPTION
## Summary

Four small fixes that together clear three failure buckets. **22 failures cleared** (710 → 688), +22 passes, +59 assertions.

## 1. Laravel 13 dropped string-based `enum:` validation rule

`app/Livewire/Matches/Forms/CreateEditForm.php:299` had:

```php
'matchType' => ['required', 'enum:'.MatchType::class],
```

Laravel 13's Validator no longer has `validateEnum` matching that string syntax. Replaced with the Rule class:

```php
'matchType' => ['required', new Enum(MatchType::class)],
```

→ 9 BadMethodCallException failures cleared.

## 2. Dead Rappasoft `setAdditionalSelects([])` call

`app/Livewire/Managers/Tables/PreviousStables.php` had a no-op `$this->setAdditionalSelects([])` in `configure()` — a Rappasoft method the custom table system doesn't have, and passing an empty array would do nothing useful even if it existed. Removed.

→ 4 BadMethodCallException failures cleared.

## 3. ProvidesDisplayName trait read attributes for properties on anonymous models

The trait was checking `array_key_exists('name', $this->getAttributes()) || property_exists($this, 'name')` but then reading the value via `$this->getAttribute('name')`, which only reads the Eloquent `$attributes` array — not public properties. Anonymous Model subclasses in unit tests declare `public $name = '...'` which the property-existence check sees but the attribute read returns null on, falling through to `LogicException`.

Switched to direct `$this->name` access (works for both Eloquent magic `__get` and direct public properties), and explicitly distinguished null (triggers LogicException) from empty string (returns empty).

→ 7 LogicException failures cleared.

## 4. CannotBeSuspendedException factory methods need `Employable` argument

`app/Models/Validation/Strategies/IndividualSuspensionValidation.php` was calling exception factory methods without their required `Employable $entity` argument:

```php
throw CannotBeSuspendedException::injured();  // expects Employable, 0 passed
```

Each call now passes `$entity` through. The validate() method's `Model $entity` is duck-compatible (all callers pass Wrestler/Manager/Referee, all of which implement Employable).

→ 2 ArgumentCountError failures cleared.

## Verification

| Metric | Before | After |
|---|---|---|
| Full parallel suite failures | 710 | 688 |
| Full parallel suite passes | 2840 | 2862 |
| Assertions | 8848 | 8907 |

Pint passes. Imports cleaned up (Pint extracted the FQCN `Illuminate\Validation\Rules\Enum` into a `use` statement).