### PR TITLE
fix: attach wrestlers to TagTeam unemployed factory state

### DIFF
--- a/database/factories/TagTeams/TagTeamFactory.php
+++ b/database/factories/TagTeams/TagTeamFactory.php
@@ -110,7 +110,9 @@ class TagTeamFactory extends Factory
 
     public function unemployed(): static
     {
-        return $this->state(fn () => []);
+        $wrestlers = Wrestler::factory()->count(2)->create();
+
+        return $this->withCurrentWrestlers($wrestlers);
     }
 
     public function released(): static


### PR DESCRIPTION
## Summary

The `unemployed()` factory state on `TagTeamFactory` returned an empty state, so created tag teams had no `currentWrestlers`. Tests calling `EmployAction::run()` on these tag teams hit `CannotBeEmployedException::partnersUnavailable` from the lifecycle validator, which requires the team to have current partners before it can be employed.

Compare to `released()` (which creates 2 wrestlers and attaches via `withCurrentWrestlers`) — the `unemployed` state needs the same partners, just no employment record.

```diff
 public function unemployed(): static
 {
-    return \$this->state(fn () => []);
+    \$wrestlers = Wrestler::factory()->count(2)->create();
+
+    return \$this->withCurrentWrestlers(\$wrestlers);
 }
```

## Verification

- `tests/Integration/Workflows/TagTeams/EmploymentTest`: 7 fail → 4 fail / 5 pass
  (remaining 4 are unrelated — `hasExclusivityConflicts` method missing on
  Wrestler, plus a couple of assertion failures, separate buckets)
- Full parallel suite: 710 → 702 failures (-8), 2840 → 2848 passes (+8),
  8848 → 8878 assertions (+30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the factory method for creating unemployed tag teams. Tag teams now include default wrestler assignments when generated, with simplified relationship handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->