### PR TITLE
fix: ValidatesRestoration should allow restoring soft-deleted entities

### DIFF
--- a/app/Models/Concerns/ValidatesRestoration.php
+++ b/app/Models/Concerns/ValidatesRestoration.php
@@ -5,41 +5,32 @@ declare(strict_types=1);
 namespace App\Models\Concerns;
 
 use App\Exceptions\Data\CannotBeRestoredException;
-use App\Models\Wrestlers\Wrestler;
 
 trait ValidatesRestoration
 {
     /**
-     * Check if the entity can be restored to a tag team.
+     * Check if a soft-deleted entity can be restored.
+     *
+     * The entity must exist in the database and currently be soft-deleted
+     * (otherwise there's nothing to restore). All relationship state
+     * (employment, tag teams, stables) is restored separately by the
+     * action's caller via dedicated actions, not part of this validation.
      */
     public function canBeRestored(bool $forceReunite = false): bool
     {
-        // Basic availability checks
-        if (! $this->exists || $this->trashed()) {
+        if (! $this->exists) {
             return false;
         }
 
-        if ($this->isRetired() || ! $this->isEmployed()) {
+        if (! $this->trashed()) {
             return false;
-        }
-
-        if ($this->isInjured()) {
-            return false;
-        }
-
-        // Handle tag team conflicts (only for wrestlers who can be tag team members)
-        if ($this instanceof Wrestler) {
-            $currentTagTeam = $this->currentTagTeam()->first();
-            if ($currentTagTeam !== null && ! $forceReunite) {
-                return false;
-            }
         }
 
         return true;
     }
 
     /**
-     * Ensure the entity can be restored to a tag team.
+     * Ensure the entity can be restored from soft delete.
      *
      * @throws CannotBeRestoredException
      */


### PR DESCRIPTION
## Summary

The `ValidatesRestoration` trait's `canBeRestored()` had **inverted logic**: it returned `false` when the entity was trashed, meaning soft-deleted records could never be restored. But every caller of `ensureCanBeRestored()` is a `RestoreAction` (Wrestlers, Managers, Referees, Stables, TagTeams) restoring a soft-deleted record — exactly the scenario the old logic blocked.

Plus the old logic checked employment/retirement/injury/tag-team state on the trashed model, which is a separate concept from "can the soft-deleted record be un-trashed". Those relationship states are re-established separately by the action's caller after restore (per the action docblock: "All relationships must be re-established separately using appropriate actions").

```diff
 public function canBeRestored(bool $forceReunite = false): bool
 {
-    if (! $this->exists || $this->trashed()) {
+    if (! $this->exists) {
         return false;
     }
+    if (! $this->trashed()) {
+        return false;
+    }
-    if ($this->isRetired() || ! $this->isEmployed()) { return false; }
-    if ($this->isInjured()) { return false; }
-    if ($this instanceof Wrestler) {
-        $currentTagTeam = $this->currentTagTeam()->first();
-        if ($currentTagTeam !== null && ! $forceReunite) { return false; }
-    }
     return true;
 }
```

## Verification

- Full parallel suite: 700 → 698 failures (-2)