### PR TITLE
fix: restore spatie/pest-plugin-test-time and fix DateHelper namespace

### DIFF
--- a/app/Actions/Referees/CreateAction.php
+++ b/app/Actions/Referees/CreateAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Data\Referees\RefereeData;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 

--- a/app/Actions/Referees/DeleteAction.php
+++ b/app/Actions/Referees/DeleteAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Actions\Concerns\StatusTransitionPipeline;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;

--- a/app/Actions/Referees/HealAction.php
+++ b/app/Actions/Referees/HealAction.php
@@ -6,8 +6,8 @@ namespace App\Actions\Referees;
 
 use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 use Lorisleiva\Actions\Concerns\AsAction;
 

--- a/app/Actions/Referees/InjureAction.php
+++ b/app/Actions/Referees/InjureAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Exceptions\Roster\CannotBeInjuredException;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 use Lorisleiva\Actions\Concerns\AsAction;
 

--- a/app/Actions/Referees/ReinstateAction.php
+++ b/app/Actions/Referees/ReinstateAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Exceptions\Roster\CannotBeReinstatedException;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;

--- a/app/Actions/Referees/ReleaseAction.php
+++ b/app/Actions/Referees/ReleaseAction.php
@@ -6,8 +6,8 @@ namespace App\Actions\Referees;
 
 use App\Enums\Shared\EmploymentStatus;
 use App\Exceptions\Roster\CannotBeReleasedException;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;

--- a/app/Actions/Referees/RetireAction.php
+++ b/app/Actions/Referees/RetireAction.php
@@ -6,8 +6,8 @@ namespace App\Actions\Referees;
 
 use App\Enums\Shared\EmploymentStatus;
 use App\Exceptions\Roster\CannotBeRetiredException;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;

--- a/app/Actions/Referees/SuspendAction.php
+++ b/app/Actions/Referees/SuspendAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Exceptions\Roster\CannotBeSuspendedException;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 use Lorisleiva\Actions\Concerns\AsAction;
 

--- a/app/Actions/Referees/UnretireAction.php
+++ b/app/Actions/Referees/UnretireAction.php
@@ -6,8 +6,8 @@ namespace App\Actions\Referees;
 
 use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeUnretiredException;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 use Lorisleiva\Actions\Concerns\AsAction;
 

--- a/app/Actions/Referees/UpdateAction.php
+++ b/app/Actions/Referees/UpdateAction.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Data\Referees\RefereeData;
-use App\Helpers\DateHelper;
 use App\Models\Referees\Referee;
+use App\Support\DateHelper;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "phpstan/extension-installer": "^1.4",
         "povils/phpmnd": "^3.4",
         "rector/rector": "^2.0",
-        "spatie/laravel-ignition": "^2.11"
+        "spatie/laravel-ignition": "^2.11",
+        "spatie/pest-plugin-test-time": "^2.2"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "202b292f05b59f4d47cf3b60c2bb97ef",
+    "content-hash": "b2ea69541d8c7212d53e4d9040ae1740",
     "packages": [
         {
             "name": "ankurk91/laravel-eloquent-relationships",
@@ -13085,6 +13085,138 @@
                 }
             ],
             "time": "2026-03-17T12:20:04+00:00"
+        },
+        {
+            "name": "spatie/pest-plugin-test-time",
+            "version": "2.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/pest-plugin-test-time.git",
+                "reference": "6a49229563707377fb6886037206b4373cc985ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/pest-plugin-test-time/zipball/6a49229563707377fb6886037206b4373cc985ce",
+                "reference": "6a49229563707377fb6886037206b4373cc985ce",
+                "shasum": ""
+            },
+            "require": {
+                "nesbot/carbon": "^2.65|^3",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "php": "^8.1",
+                "spatie/test-time": "^1.3.2"
+            },
+            "require-dev": {
+                "spatie/ray": "^1.36"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-v2": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php"
+                ],
+                "psr-4": {
+                    "Spatie\\PestPluginTestTime\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A Pest plugin to  control the flow of time",
+            "homepage": "https://github.com/spatie/pest-plugin-test-time",
+            "keywords": [
+                "pest-plugin-test-time",
+                "spatie"
+            ],
+            "support": {
+                "source": "https://github.com/spatie/pest-plugin-test-time/tree/2.2.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-24T20:17:15+00:00"
+        },
+        {
+            "name": "spatie/test-time",
+            "version": "1.3.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/spatie/test-time.git",
+                "reference": "308242a6c7ce4af2455ee0ab61b7d3d627cb78fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/spatie/test-time/zipball/308242a6c7ce4af2455ee0ab61b7d3d627cb78fd",
+                "reference": "308242a6c7ce4af2455ee0ab61b7d3d627cb78fd",
+                "shasum": ""
+            },
+            "require": {
+                "nesbot/carbon": "^2.63|^3.0",
+                "php": "^7.3|^8.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Spatie\\TestTime\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Freek Van der Herten",
+                    "email": "freek@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Alex Vanderbist",
+                    "email": "alex@spatie.be",
+                    "homepage": "https://spatie.be",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small package to control the flow time",
+            "homepage": "https://github.com/spatie/test-time",
+            "keywords": [
+                "spatie",
+                "test-time"
+            ],
+            "support": {
+                "issues": "https://github.com/spatie/test-time/issues",
+                "source": "https://github.com/spatie/test-time/tree/1.3.3"
+            },
+            "funding": [
+                {
+                    "url": "https://spatie.be/open-source/support-us",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/spatie",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-02-05T13:30:14+00:00"
         },
         {
             "name": "staabm/side-effects-detector",


### PR DESCRIPTION
## Summary

Two unrelated issues clearing **303 failures in one sweep** (604 → 301), +303 passes, +1485 assertions.

## 1. Reinstall `spatie/pest-plugin-test-time`

523 test failures were `Call to undefined function Spatie\PestPluginTestTime\testTime()`. The package had been removed (likely during the dep cleanup that also dropped `wire-elements/modal`) but tests still call `testTime()` to control time flow during integration/unit tests.

Reinstalled `spatie/pest-plugin-test-time:^2.2` as a dev dependency.

## 2. Fix `DateHelper` namespace in 10 Referee Actions

The class lives at `App\Support\DateHelper` but 10 Referee Action classes imported it as `App\Helpers\DateHelper` — leftover from a refactor that moved the class.

```diff
-use App\Helpers\DateHelper;
+use App\Support\DateHelper;
```

Files updated:
- `app/Actions/Referees/{Create,Delete,Heal,Injure,Reinstate,Release,Retire,Suspend,Unretire,Update}Action.php`

## Verification

| Metric | Before | After |
|---|---|---|
| Full parallel suite failures | 604 | 301 |
| Full parallel suite passes | 2946 | 3249 |
| Assertions | 9141 | 10626 |

Pint passes.