### PR TITLE
fix: guard injuries() relation call in reinstatement pipeline

### DIFF
--- a/app/Actions/Concerns/StatusTransitionPipeline.php
+++ b/app/Actions/Concerns/StatusTransitionPipeline.php
@@ -365,7 +365,8 @@ class StatusTransitionPipeline
      */
     protected function createReinstatement(): void
     {
-        // End current suspension/injury
+        // End current suspension/injury (injuries only apply to entities that
+        // can be injured — wrestlers, managers, referees — not tag teams).
         $suspensionTable = $this->getTableName('suspensions');
         $injuryTable = $this->getTableName('injuries');
 
@@ -373,9 +374,11 @@ class StatusTransitionPipeline
             'ended_at' => $this->effectiveDate,
         ]);
 
-        $this->entity->{$injuryTable}()->whereNull('ended_at')->update([
-            'ended_at' => $this->effectiveDate,
-        ]);
+        if (method_exists($this->entity, $injuryTable)) {
+            $this->entity->{$injuryTable}()->whereNull('ended_at')->update([
+                'ended_at' => $this->effectiveDate,
+            ]);
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

`StatusTransitionPipeline::createReinstatement()` blindly calls `$this->entity->injuries()` to end any active injury records. But TagTeam doesn't have an `injuries()` relationship — only individual roster entities (wrestlers, managers, referees) do. TagTeams can be suspended but never injured, by business rule.

Result: `Call to undefined method App\Models\TagTeams\TagTeam::injuries()` across all 9 `Tests\Integration\Actions\TagTeams\ReinstateActionTest` cases.

The deletion path (`createDeletion()`) already guards each status-cleanup block with `method_exists($this->entity, 'isInjured')` etc. This PR mirrors the same defensive pattern on the injury cleanup in reinstatement, leaving the suspension cleanup unconditional since suspension is universal across all statusable entities.

## Verification

- Full parallel suite: 271 → 265 failures (-6)