### PR TITLE
fix: pass entity to exception factories in lifecycle Validates traits

### DIFF
--- a/app/Models/Concerns/ValidatesEmployment.php
+++ b/app/Models/Concerns/ValidatesEmployment.php
@@ -92,10 +92,10 @@ trait ValidatesEmployment
     public function ensureCanBeEmployed(): void
     {
         if ($this->isEmployed()) {
-            throw CannotBeEmployedException::employed();
+            throw CannotBeEmployedException::employed($this);
         }
         if ($this->hasFutureEmployment()) {
-            throw CannotBeEmployedException::employed();
+            throw CannotBeEmployedException::employed($this);
         }
     }
 
@@ -144,15 +144,15 @@ trait ValidatesEmployment
     public function ensureCanBeReleased(): void
     {
         if ($this->isNotInEmployment()) {
-            throw CannotBeReleasedException::unemployed();
+            throw CannotBeReleasedException::unemployed($this);
         }
 
         if ($this->hasFutureEmployment()) {
-            throw CannotBeReleasedException::hasFutureEmployment();
+            throw CannotBeReleasedException::hasFutureEmployment($this);
         }
 
         if ($this->isRetired()) {
-            throw CannotBeReleasedException::retired();
+            throw CannotBeReleasedException::retired($this);
         }
     }
 }

--- a/app/Models/Concerns/ValidatesInjury.php
+++ b/app/Models/Concerns/ValidatesInjury.php
@@ -82,23 +82,23 @@ trait ValidatesInjury
     public function ensureCanBeInjured(): void
     {
         if ($this->isNotInEmployment()) {
-            throw CannotBeInjuredException::unemployed();
+            throw CannotBeInjuredException::unemployed($this);
         }
 
         if ($this->isRetired()) {
-            throw CannotBeInjuredException::retired();
+            throw CannotBeInjuredException::retired($this);
         }
 
         if ($this->hasFutureEmployment()) {
-            throw CannotBeInjuredException::hasFutureEmployment();
+            throw CannotBeInjuredException::hasFutureEmployment($this);
         }
 
         if ($this->isInjured()) {
-            throw CannotBeInjuredException::injured();
+            throw CannotBeInjuredException::injured($this);
         }
 
         if ($this->isSuspended()) {
-            throw CannotBeInjuredException::suspended();
+            throw CannotBeInjuredException::suspended($this);
         }
     }
 
@@ -142,7 +142,7 @@ trait ValidatesInjury
     public function ensureCanBeClearedFromInjury(): void
     {
         if (! $this->isInjured()) {
-            throw CannotBeClearedFromInjuryException::notInjured();
+            throw CannotBeClearedFromInjuryException::notInjured($this);
         }
     }
 

--- a/app/Models/Concerns/ValidatesSuspension.php
+++ b/app/Models/Concerns/ValidatesSuspension.php
@@ -140,28 +140,28 @@ trait ValidatesSuspension
     public function ensureCanBeReinstated(): void
     {
         if ($this instanceof Suspendable && ! $this->isSuspended()) {
-            throw CannotBeReinstatedException::available();
+            throw CannotBeReinstatedException::available($this);
         }
 
         if ($this->isNotInEmployment()) {
-            throw CannotBeReinstatedException::unemployed();
+            throw CannotBeReinstatedException::unemployed($this);
         }
 
         if ($this->hasFutureEmployment()) {
-            throw CannotBeReinstatedException::hasFutureEmployment();
+            throw CannotBeReinstatedException::hasFutureEmployment($this);
         }
 
         $type = RosterMemberType::fromModel($this);
         if ($type->canBeInjured() && ($this instanceof Injurable) && $this->isInjured()) {
-            throw CannotBeReinstatedException::injured();
+            throw CannotBeReinstatedException::injured($this);
         }
 
         if ($this->isRetired()) {
-            throw CannotBeReinstatedException::retired();
+            throw CannotBeReinstatedException::retired($this);
         }
 
         if ($this instanceof Bookable && $this->isBookable()) {
-            throw CannotBeReinstatedException::bookable();
+            throw CannotBeReinstatedException::bookable($this);
         }
     }
 


### PR DESCRIPTION
## Summary

Same pattern as the earlier `CannotBeSuspendedException` fix in `IndividualSuspensionValidation` (PR #602): the Wrestler/Manager/Referee `Validates*` traits call exception factory methods without their required `Employable $entity` argument:

```php
throw CannotBeInjuredException::unemployed();   // 0 passed, 1 expected
```

Caused `Too few arguments to function ::unemployed()` `ArgumentCountError` across ~23 tests that expected `Exception::class` to be thrown but got the PHP-level `ArgumentCountError` instead (which extends `Error`, not `Exception`).

Fixed in:
- `ValidatesEmployment` (`CannotBeEmployed/Released` exceptions)
- `ValidatesSuspension` (`CannotBeReinstated` exception)
- `ValidatesInjury` (`CannotBeInjured` exception)
- `ValidatesRetirement` (no changes needed in this trait)

Each bare `Exception::method()` call now passes `$this` (the entity using the trait) as the first argument. All affected factory signatures accept `Employable $entity`, which Wrestler/Manager/Referee all implement.

## Verification

- Full parallel suite: 225 → 202 failures (-23), 3325 → 3348 passes (+23)