### PR TITLE
fix: restore parens on relation accessor in trait unit tests

### DIFF
--- a/tests/Unit/Models/Concerns/IsEmployableTest.php
+++ b/tests/Unit/Models/Concerns/IsEmployableTest.php
@@ -125,7 +125,7 @@ describe('IsEmployable Trait Unit Tests', function () {
                     return FakeEmploymentModel::class;
                 }
             };
-            $relation = $model->currentEmployment;
+            $relation = $model->currentEmployment();
             expect($relation)->toBeInstanceOf(HasOne::class);
             expect($relation->getRelated())->toBeInstanceOf(FakeEmploymentModel::class);
         });
@@ -337,7 +337,7 @@ describe('IsEmployable Trait Unit Tests', function () {
                     return FakeEmploymentModel::class;
                 }
             };
-            $relation = $model->currentEmployment;
+            $relation = $model->currentEmployment();
             $wheres = $relation->getQuery()->getQuery()->wheres;
             $hasWhereNull = collect($wheres)->contains(function ($where) {
                 return ($where['type'] ?? null) === 'Null' && ($where['column'] ?? null) === 'ended_at';

--- a/tests/Unit/Models/Concerns/IsInjurableTest.php
+++ b/tests/Unit/Models/Concerns/IsInjurableTest.php
@@ -103,7 +103,7 @@ describe('IsInjurable Trait Unit Tests', function () {
                     return FakeInjuryModel::class;
                 }
             };
-            $relation = $model->currentInjury;
+            $relation = $model->currentInjury();
             expect($relation)->toBeInstanceOf(HasOne::class);
             expect($relation->getRelated())->toBeInstanceOf(FakeInjuryModel::class);
         });
@@ -250,7 +250,7 @@ describe('IsInjurable Trait Unit Tests', function () {
                 }
             };
 
-            $relation = $model->currentInjury;
+            $relation = $model->currentInjury();
 
             // The trait should add a whereNull('ended_at') constraint
             expect($relation)->toBeInstanceOf(HasOne::class);

--- a/tests/Unit/Models/Concerns/IsRetirableTest.php
+++ b/tests/Unit/Models/Concerns/IsRetirableTest.php
@@ -102,7 +102,7 @@ describe('IsRetirable Trait Unit Tests', function () {
                     return FakeRetirementModel::class;
                 }
             };
-            $relation = $model->currentRetirement;
+            $relation = $model->currentRetirement();
             expect($relation)->toBeInstanceOf(HasOne::class);
             expect($relation->getRelated())->toBeInstanceOf(FakeRetirementModel::class);
         });
@@ -224,7 +224,7 @@ describe('IsRetirable Trait Unit Tests', function () {
                     return FakeRetirementModel::class;
                 }
             };
-            $relation = $model->currentRetirement;
+            $relation = $model->currentRetirement();
             $wheres = $relation->getQuery()->getQuery()->wheres;
             $hasWhereNull = collect($wheres)->contains(function ($where) {
                 return ($where['type'] ?? null) === 'Null' && ($where['column'] ?? null) === 'ended_at';

--- a/tests/Unit/Models/Concerns/IsSuspendableTest.php
+++ b/tests/Unit/Models/Concerns/IsSuspendableTest.php
@@ -99,7 +99,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
                     return FakeSuspensionModel::class;
                 }
             };
-            $relation = $model->currentSuspension;
+            $relation = $model->currentSuspension();
             expect($relation)->toBeInstanceOf(HasOne::class);
             expect($relation->getRelated())->toBeInstanceOf(FakeSuspensionModel::class);
         });
@@ -221,7 +221,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
                     return FakeSuspensionModel::class;
                 }
             };
-            $relation = $model->currentSuspension;
+            $relation = $model->currentSuspension();
             $wheres = $relation->getQuery()->getQuery()->wheres;
             $hasWhereNull = collect($wheres)->contains(function ($where) {
                 return ($where['type'] ?? null) === 'Null' && ($where['column'] ?? null) === 'ended_at';


### PR DESCRIPTION
## Summary

The earlier HasOne-accessor cleanup (PR #609) over-corrected on four trait unit tests. Those tests specifically check that the trait's relation method returns a HasOne builder:

```php
$relation = $model->currentEmployment;       // magic accessor: returns model or null
expect($relation)->toBeInstanceOf(HasOne::class);   // fails — null is not HasOne
```

Reverted the parens drop on these tests where the assertion explicitly wants the HasOne builder:

```php
$relation = $model->currentEmployment();     // method call: returns HasOne
expect($relation)->toBeInstanceOf(HasOne::class);   // works
```

Files:
- `IsEmployableTest`, `IsRetirableTest`, `IsInjurableTest`, `IsSuspendableTest`

Application code and other test files where the assignment was followed by property access (model attributes) are correctly using the magic accessor and stay as-is.

## Verification

- Full parallel suite: 202 → 194 failures (-8), 3348 → 3356 passes (+8)