### PR TITLE
fix: align class docblocks with assertions in trait/base unit tests

### DIFF
--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -97,12 +97,6 @@ use Illuminate\Database\Eloquent\Model;
  * <button wire:click="modal.fillDummyFields">Fill Test Data</button>
  * ```
  */
-/**
- * @template TForm of BaseForm
- * @template TModel of Model
- *
- * @extends BaseModal<TForm, TModel>
- */
 abstract class BaseFormModal extends BaseModal
 {
     use GeneratesDummyData;

--- a/app/Livewire/Base/BaseModal.php
+++ b/app/Livewire/Base/BaseModal.php
@@ -30,7 +30,7 @@ use LivewireUI\Modal\ModalComponent;
  * - Consistent modal lifecycle management
  * - Type safety through generics
  *
- * @template TModelForm of \App\Livewire\Base\BaseForm
+ * @template TModelForm of BaseForm
  * @template TModelType of Model
  *
  * @see BaseForm For form integration requirements

--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -17,6 +17,9 @@ use Throwable;
  * The trait works with both direct property assignment and form object patterns,
  * making it flexible for different form architectures.
  *
+ * @author Ringside
+ *
+ * @since 1.0.0
  *
  * @example
  * ```php


### PR DESCRIPTION
## Summary

Three small docblock fixes for tests in `tests/Unit/Livewire/{Base,Concerns}/` that use reflection to assert specific tags exist on class docblocks.

### 1. BaseFormModal had two adjacent docblocks

Reflection only sees the docblock immediately preceding the class, so the detailed one (with `@see BaseModal`, `@see GeneratesDummyData`, `@example`) was being shadowed by a second short one underneath it (with just `@template`/`@extends`).

Merged into a single docblock by removing the redundant second one — the `@template`/`@extends` tags are already present in the detailed one.

### 2. BaseModal `@template TModelForm` used FQCN

```diff
- * @template TModelForm of \App\Livewire\Base\BaseForm
+ * @template TModelForm of BaseForm
```

Test uses `expect($docComment)->toContain('@template TModelForm of BaseForm')` as a substring check. The FQCN form doesn't match. `BaseForm` is already imported.

### 3. GeneratesDummyData missing `@author` and `@since`

The trait's class-level docblock lacked the `@author` and `@since` tags the test asserts. Added both.

## Verification

- Full parallel suite: 194 → 190 failures (-4)