### PR TITLE
fix: reject deletion/unretirement of already-deleted or retired entities

### DIFF
--- a/app/Actions/Wrestlers/DeleteAction.php
+++ b/app/Actions/Wrestlers/DeleteAction.php
@@ -8,6 +8,7 @@ use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Actions\Concerns\WrestlerDeletionCascadeStrategy;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
+use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
@@ -44,6 +45,10 @@ class DeleteAction
      */
     public function handle(Wrestler $wrestler, ?Carbon $deletionDate = null): void
     {
+        if ($wrestler->trashed()) {
+            throw new Exception("Wrestler '{$wrestler->name}' is already deleted.");
+        }
+
         if (method_exists($wrestler, 'ensureCanBeDeleted')) {
             $wrestler->ensureCanBeDeleted();
         }

--- a/app/Models/Concerns/ValidatesRetirement.php
+++ b/app/Models/Concerns/ValidatesRetirement.php
@@ -127,6 +127,10 @@ trait ValidatesRetirement
      */
     public function ensureCanBeUnretired(): void
     {
+        if (method_exists($this, 'trashed') && $this->trashed()) {
+            throw new Exception('Cannot unretire a deleted record.');
+        }
+
         if (! $this->isRetired()) {
             // Determine if this is a Title or Roster member and use appropriate exception
             if ($this instanceof Title) {

--- a/app/Models/Concerns/ValidatesTagTeamLifecycle.php
+++ b/app/Models/Concerns/ValidatesTagTeamLifecycle.php
@@ -12,6 +12,7 @@ use App\Exceptions\Roster\TagTeams\CannotBeRestoredException;
 use App\Exceptions\Roster\TagTeams\CannotBeRetiredException;
 use App\Exceptions\Roster\TagTeams\CannotBeSuspendedException;
 use App\Exceptions\Roster\TagTeams\CannotBeUnretiredException;
+use Exception;
 
 /**
  * Provides tag team lifecycle validation functionality for TagTeam models.
@@ -391,6 +392,14 @@ trait ValidatesTagTeamLifecycle
      */
     public function ensureCanBeDeleted(): void
     {
+        if ($this->trashed()) {
+            throw new Exception("Tag team '{$this->name}' is already deleted.");
+        }
+
+        if ($this->isRetired()) {
+            throw new Exception("Tag team '{$this->name}' is retired and cannot be deleted.");
+        }
+
         if ($this->isEmployed()) {
             throw CannotBeDeletedException::stillEmployed($this);
         }


### PR DESCRIPTION
## Summary

Four tests asserted that DeleteAction/UnretireAction throw when called on already-trashed or retired entities, but the actions just silently succeeded — `expect(fn () => DeleteAction::run($x))->toThrow(Exception::class)` failed with "Exception not thrown".

Added defensive precondition checks:

### Wrestler DeleteAction

```php
if ($wrestler->trashed()) {
    throw new Exception("Wrestler '{$wrestler->name}' is already deleted.");
}
```

### TagTeam ensureCanBeDeleted (in `ValidatesTagTeamLifecycle` trait)

```php
if ($this->trashed()) {
    throw new Exception("Tag team '{$this->name}' is already deleted.");
}
if ($this->isRetired()) {
    throw new Exception("Tag team '{$this->name}' is retired and cannot be deleted.");
}
```

### ensureCanBeUnretired (in `ValidatesRetirement` trait)

```php
if (method_exists($this, 'trashed') && $this->trashed()) {
    throw new Exception('Cannot unretire a deleted record.');
}
```

The `method_exists` guard on `trashed()` is because `ValidatesRetirement` is also used by Title which doesn't soft-delete (no SoftDeletes trait).

## Verification

- Full parallel suite: 190 → 186 failures (-4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation to prevent deletion of wrestlers that are already deleted.
  * Added validation to prevent unretiring of deleted records.
  * Added validation to prevent deletion of tag teams that are already deleted or retired.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->