### PR TITLE
fix: end employment on retire and restart it on unretire (Manager)

### DIFF
--- a/app/Actions/Concerns/StatusTransitionPipeline.php
+++ b/app/Actions/Concerns/StatusTransitionPipeline.php
@@ -341,6 +341,14 @@ class StatusTransitionPipeline
      */
     protected function createRetirement(): void
     {
+        // End any active employment so the entity is no longer "employed" once retired.
+        if (method_exists($this->entity, 'isEmployed') && $this->entity->isEmployed()) {
+            $employmentTable = $this->getTableName('employments');
+            $this->entity->{$employmentTable}()->whereNull('ended_at')->update([
+                'ended_at' => $this->effectiveDate,
+            ]);
+        }
+
         $table = $this->getTableName('retirements');
         $this->entity->{$table}()->create([
             'started_at' => $this->effectiveDate,

--- a/app/Actions/Managers/UnretireAction.php
+++ b/app/Actions/Managers/UnretireAction.php
@@ -51,5 +51,12 @@ class UnretireAction
 
         // Use StatusTransitionPipeline for consistent unretirement handling
         StatusTransitionPipeline::unretire($manager, $unretiredDate)->execute();
+
+        // Restart employment from the unretirement date so the manager is
+        // available for wrestler/tag team assignments again.
+        $manager->employments()->create([
+            'started_at' => $unretiredDate,
+            'ended_at' => null,
+        ]);
     }
 }


### PR DESCRIPTION
## Summary

Two related lifecycle bugs in the manager retirement flow that left the employment state inconsistent and broke ~20 retire/unretire integration tests that asserted on `managers_employments` rows.

### 1. `createRetirement` now ends active employment

`StatusTransitionPipeline::createRetirement()` was creating the retirement record but not ending the existing employment. Result: a retired manager's `managers_employments.ended_at` stayed null, so they remained "employed" at the data level even though `isRetired()` returned true.

```diff
 protected function createRetirement(): void
 {
+    // End any active employment so the entity is no longer "employed" once retired.
+    if (method_exists($this->entity, 'isEmployed') && $this->entity->isEmployed()) {
+        $employmentTable = $this->getTableName('employments');
+        $this->entity->{$employmentTable}()->whereNull('ended_at')->update([
+            'ended_at' => $this->effectiveDate,
+        ]);
+    }
+
     $table = $this->getTableName('retirements');
     $this->entity->{$table}()->create([...]);
 }
```

The `method_exists($this->entity, 'isEmployed')` guard makes this safe for entities that don't track employment (Stable, Title) — they'll skip the employment update.

### 2. Manager UnretireAction creates a new employment record

`StatusTransitionPipeline::endRetirement()` (used by unretire) just nulls the retirement's `ended_at`. It doesn't restart employment. The Wrestler unretire flow uses a `WrestlerUnretirementCascadeStrategy::withEmployment()` cascade, but Manager had no equivalent cascade and just delegated to the bare pipeline.

Inlined the employment restart in `Manager\UnretireAction::handle()`:

```php
$manager->employments()->create([
    'started_at' => $unretiredDate,
    'ended_at' => null,
]);
```

Cleaner long-term would be a `ManagerUnretirementCascadeStrategy::withEmployment()`, but inline is enough to fix the broken contract.

## Verification

- Full parallel suite: 186 → 166 failures (-20)