### PR TITLE
fix: drop parens on currentInjury when calling toArray() in error logs

### DIFF
--- a/app/Livewire/Referees/Components/Actions.php
+++ b/app/Livewire/Referees/Components/Actions.php
@@ -342,7 +342,7 @@ class Actions extends Component
                     'first_name' => $this->referee->first_name,
                     'last_name' => $this->referee->last_name,
                     'is_injured' => $this->referee->isInjured(),
-                    'current_injury' => $this->referee->currentInjury()?->toArray(),
+                    'current_injury' => $this->referee->currentInjury?->toArray(),
                 ],
             ]);
 

--- a/app/Livewire/Wrestlers/Components/Actions.php
+++ b/app/Livewire/Wrestlers/Components/Actions.php
@@ -264,7 +264,7 @@ class Actions extends Component
                     'is_suspended' => $this->wrestler->isSuspended(),
                     'is_injured' => $this->wrestler->isInjured(),
                     'current_suspension' => $this->wrestler->currentSuspension?->toArray(),
-                    'current_injury' => $this->wrestler->currentInjury()?->toArray(),
+                    'current_injury' => $this->wrestler->currentInjury?->toArray(),
                 ],
             ]);
 
@@ -338,7 +338,7 @@ class Actions extends Component
                     'id' => $this->wrestler->id,
                     'name' => $this->wrestler->name,
                     'is_injured' => $this->wrestler->isInjured(),
-                    'current_injury' => $this->wrestler->currentInjury()?->toArray(),
+                    'current_injury' => $this->wrestler->currentInjury?->toArray(),
                 ],
             ]);
 


### PR DESCRIPTION
## Summary

`Referees/Components/Actions::handleException` and the equivalent in `Wrestlers/Components/Actions` were logging the current injury for context:

```php
'current_injury' => $this->referee->currentInjury()?->toArray(),
```

`currentInjury()` (with parens) returns the `HasOne` builder. The null-safe operator `?->` doesn't help here because the builder isn't null — calling `->toArray()` on the builder throws:

```
Call to undefined method Illuminate\Database\Eloquent\Relations\HasOne::toArray()
```

Eloquent's magic property accessor (no parens) resolves to the model instance (or null), which has `toArray()`:

```php
'current_injury' => $this->referee->currentInjury?->toArray(),
```

Three call sites updated:
- `app/Livewire/Referees/Components/Actions.php:345`
- `app/Livewire/Wrestlers/Components/Actions.php:267,341`

## Verification

- Full parallel suite: 166 → 163 failures (-3)