### PR TITLE
fix: TagTeam EmployAction tests pass with proper factory setup

### DIFF
--- a/app/Models/Concerns/ValidatesTagTeamLifecycle.php
+++ b/app/Models/Concerns/ValidatesTagTeamLifecycle.php
@@ -100,9 +100,8 @@ trait ValidatesTagTeamLifecycle
             throw CannotBeEmployedException::alreadyEmployed($this);
         }
 
-        if ($this->isRetired()) {
-            throw CannotBeEmployedException::retired($this);
-        }
+        // Retired tag teams may be re-employed; the StatusTransitionPipeline ends the
+        // active retirement before creating a new employment record.
 
         // Check partner availability
         $currentPartners = $this->currentWrestlers;

--- a/tests/Integration/Actions/TagTeams/EmployActionTest.php
+++ b/tests/Integration/Actions/TagTeams/EmployActionTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
 });
 
 test('it employs an unemployed tag team', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
 
     expect($tagTeam->isEmployed())->toBeFalse();
 
@@ -30,7 +30,7 @@ test('it employs an unemployed tag team', function () {
 });
 
 test('it employs tag team with specific employment date', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
     $employmentDate = now()->subDays(7);
 
     EmployAction::run($tagTeam, $employmentDate);
@@ -73,16 +73,16 @@ test('it employs retired tag team by ending retirement', function () {
 });
 
 test('it uses StatusTransitionPipeline for employment', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
 
-    expect($tagTeam->currentEmployment())->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
 
     EmployAction::run($tagTeam);
 
     $tagTeam->refresh();
 
     // Verify employment created through pipeline
-    expect($tagTeam->currentEmployment())->not()->toBeNull();
+    expect($tagTeam->currentEmployment)->not()->toBeNull();
     expect($tagTeam->isEmployed())->toBeTrue();
 
     // Verify records show proper dates
@@ -103,7 +103,7 @@ test('it prevents employing already employed tag team', function () {
 });
 
 test('it handles database transactions correctly', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
 
     EmployAction::run($tagTeam);
 
@@ -120,7 +120,7 @@ test('it handles database transactions correctly', function () {
 });
 
 test('it creates new employment period', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
     $originalEmploymentCount = $tagTeam->employments()->count();
 
     EmployAction::run($tagTeam);
@@ -139,7 +139,7 @@ test('it creates new employment period', function () {
 });
 
 test('it uses DateHelper for consistent date handling', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
     $customEmploymentDate = now()->subDays(3)->startOfDay();
 
     EmployAction::run($tagTeam, $customEmploymentDate);
@@ -155,7 +155,7 @@ test('it uses DateHelper for consistent date handling', function () {
 });
 
 test('it handles multiple employment history correctly', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
 
     // Create employment history
     $tagTeam->employments()->create(['started_at' => now()->subDays(30), 'ended_at' => now()->subDays(25)]);
@@ -180,7 +180,7 @@ test('it handles multiple employment history correctly', function () {
 });
 
 test('it preserves employment history during new employment', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
 
     // Create historical employment
     $tagTeam->employments()->create(['started_at' => now()->subDays(20), 'ended_at' => now()->subDays(10)]);
@@ -197,11 +197,11 @@ test('it preserves employment history during new employment', function () {
     expect($tagTeam->employments()->where('ended_at', '!=', null)->count())->toBe(1);
 
     // Current employment should be active
-    expect($tagTeam->currentEmployment())->not()->toBeNull();
+    expect($tagTeam->currentEmployment)->not()->toBeNull();
 });
 
 test('it handles tag team with complex status history', function () {
-    $tagTeam = TagTeam::factory()->create();
+    $tagTeam = TagTeam::factory()->unemployed()->create();
 
     // Create complex employment/retirement history
     $tagTeam->employments()->create(['started_at' => now()->subDays(30), 'ended_at' => now()->subDays(25)]);


### PR DESCRIPTION
## Summary

- Tests now use `unemployed()` factory state (attaches 2 wrestlers without employment), satisfying the partner-availability validation
- Drop the retired-tag-team rejection from `ValidatesTagTeamLifecycle::ensureCanBeEmployed` — the StatusTransitionPipeline already ends active retirements before creating new employment, mirroring how individual entities (Wrestler/Manager/Referee) handle it via `ValidatesEmployment::ensureCanBeEmployed`
- Switch `currentEmployment()` relation calls to `currentEmployment` accessor where the test was checking for null

## Test plan
- [x] `php artisan test tests/Integration/Actions/TagTeams/EmployActionTest.php` — 11/11 passing
- [x] Full suite shows -9 failures (162 → 153)