### PR TITLE
fix: Referee unretire creates new employment record

### DIFF
--- a/app/Actions/Referees/UnretireAction.php
+++ b/app/Actions/Referees/UnretireAction.php
@@ -51,5 +51,12 @@ class UnretireAction
 
         // Use StatusTransitionPipeline for consistent unretirement handling
         StatusTransitionPipeline::unretire($referee, $unretiredDate)->execute();
+
+        // Coming out of retirement should restore the referee to employed status
+        // so they're immediately available for match assignments.
+        $referee->employments()->create([
+            'started_at' => $unretiredDate,
+            'ended_at' => null,
+        ]);
     }
 }

--- a/tests/Integration/Actions/Referees/UnretireActionTest.php
+++ b/tests/Integration/Actions/Referees/UnretireActionTest.php
@@ -49,7 +49,7 @@ test('it unretires referee with specific unretirement date', function () {
 
     expect($referee->isRetired())->toBeFalse();
     expect($referee->isEmployed())->toBeTrue();
-    expect($retirement->ended_at->eq($unretiredDate))->toBeTrue();
+    expect($retirement->ended_at->toDateTimeString())->toBe($unretiredDate->toDateTimeString());
 
     $this->assertDatabaseHas('referees_retirements', [
         'id' => $retirement->id,
@@ -149,6 +149,6 @@ test('it creates new employment after unretirement', function () {
 
     expect($employment)->not->toBeNull();
     expect($employment->referee_id)->toBe($referee->id);
-    expect($employment->started_at->eq(now()))->toBeTrue();
+    expect($employment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });


### PR DESCRIPTION
## Summary
- After ending retirement via `StatusTransitionPipeline`, also create a fresh employment record so the referee is immediately available for match assignments — parallels how Manager `UnretireAction` already works
- Compare timestamps via `toDateTimeString()` instead of Carbon `eq()`; stored DB values are truncated to seconds and don't match microsecond-preserving in-memory Carbon instances even with frozen `testTime`

## Test plan
- [x] `php artisan test tests/Integration/Actions/Referees/UnretireActionTest.php` — 8/8 passing