### PR TITLE
fix: treat injury and suspension as orthogonal states

### DIFF
--- a/app/Models/Concerns/ValidatesInjury.php
+++ b/app/Models/Concerns/ValidatesInjury.php
@@ -57,8 +57,7 @@ trait ValidatesInjury
         return ! $this->isNotInEmployment()
             && ! $this->isRetired()
             && ! $this->hasFutureEmployment()
-            && ! $this->isInjured()
-            && ! $this->isSuspended();
+            && ! $this->isInjured();
     }
 
     /**
@@ -97,9 +96,7 @@ trait ValidatesInjury
             throw CannotBeInjuredException::injured($this);
         }
 
-        if ($this->isSuspended()) {
-            throw CannotBeInjuredException::suspended($this);
-        }
+        // Injury and suspension are orthogonal — both can apply simultaneously.
     }
 
     /**

--- a/app/Models/Validation/Strategies/IndividualSuspensionValidation.php
+++ b/app/Models/Validation/Strategies/IndividualSuspensionValidation.php
@@ -45,9 +45,8 @@ class IndividualSuspensionValidation implements SuspensionValidationStrategy
             throw CannotBeSuspendedException::suspended($entity);
         }
 
-        if (method_exists($entity, 'isInjured') && $entity->isInjured()) {
-            throw CannotBeSuspendedException::injured($entity);
-        }
+        // Injury and suspension are orthogonal — an injured roster member can still
+        // be suspended for disciplinary reasons; both states coexist.
     }
 
     /**

--- a/tests/Integration/Actions/Managers/SuspendActionTest.php
+++ b/tests/Integration/Actions/Managers/SuspendActionTest.php
@@ -49,14 +49,14 @@ test('it suspends manager with specific suspension date', function () {
 test('it uses StatusTransitionPipeline for suspension', function () {
     $manager = Manager::factory()->employed()->create();
 
-    expect($manager->currentSuspension())->toBeNull();
+    expect($manager->currentSuspension)->toBeNull();
 
     SuspendAction::run($manager);
 
     $manager->refresh();
 
     // Verify suspension was created through pipeline
-    expect($manager->currentSuspension())->not()->toBeNull();
+    expect($manager->currentSuspension)->not()->toBeNull();
     expect($manager->isSuspended())->toBeTrue();
 
     // Verify suspension record shows proper start date
@@ -124,14 +124,17 @@ test('it maintains employment status during suspension', function () {
     expect($employment->ended_at)->toBeNull();
 });
 
-test('it prevents suspending injured manager', function () {
+test('it can suspend injured manager (suspension and injury are orthogonal)', function () {
     $manager = Manager::factory()->employed()->injured()->create();
 
     expect($manager->isInjured())->toBeTrue();
     expect($manager->isSuspended())->toBeFalse();
 
-    expect(fn () => SuspendAction::run($manager))
-        ->toThrow(Exception::class);
+    SuspendAction::run($manager);
+
+    $manager->refresh();
+    expect($manager->isSuspended())->toBeTrue();
+    expect($manager->isInjured())->toBeTrue();
 });
 
 test('it uses DateHelper for consistent date handling', function () {

--- a/tests/Integration/Actions/Referees/SuspendActionTest.php
+++ b/tests/Integration/Actions/Referees/SuspendActionTest.php
@@ -108,6 +108,6 @@ test('it creates suspension record with correct structure', function () {
 
     expect($suspension)->not->toBeNull();
     expect($suspension->referee_id)->toBe($referee->id);
-    expect($suspension->started_at->eq($suspensionDate))->toBeTrue();
+    expect($suspension->started_at->toDateTimeString())->toBe($suspensionDate->toDateTimeString());
     expect($suspension->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/TagTeams/SuspendActionTest.php
+++ b/tests/Integration/Actions/TagTeams/SuspendActionTest.php
@@ -51,14 +51,14 @@ test('it suspends tag team with specific suspension date', function () {
 test('it uses StatusTransitionPipeline for suspension', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
 
-    expect($tagTeam->currentSuspension())->toBeNull();
+    expect($tagTeam->currentSuspension)->toBeNull();
 
     SuspendAction::run($tagTeam);
 
     $tagTeam->refresh();
 
     // Verify suspension created through pipeline
-    expect($tagTeam->currentSuspension())->not()->toBeNull();
+    expect($tagTeam->currentSuspension)->not()->toBeNull();
     expect($tagTeam->isSuspended())->toBeTrue();
     expect($tagTeam->isEmployed())->toBeTrue();
 
@@ -212,7 +212,7 @@ test('it preserves suspension history during new suspension', function () {
     expect($tagTeam->suspensions()->where('ended_at', '!=', null)->count())->toBe(1);
 
     // Current suspension should be active
-    expect($tagTeam->currentSuspension())->not()->toBeNull();
+    expect($tagTeam->currentSuspension)->not()->toBeNull();
 });
 
 test('it handles tag team with complex employment history', function () {

--- a/tests/Integration/Actions/Wrestlers/SuspendActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/SuspendActionTest.php
@@ -21,7 +21,7 @@ test('it suspends an employed wrestler', function () {
 
     $wrestler->refresh();
     expect($wrestler->isSuspended())->toBeTrue();
-    expect($wrestler->isEmployed())->toBeFalse(); // Should no longer be employed when suspended
+    expect($wrestler->isEmployed())->toBeTrue(); // Suspension preserves employment, only restricts availability
 
     $this->assertDatabaseHas('wrestlers_suspensions', [
         'wrestler_id' => $wrestler->id,
@@ -46,11 +46,10 @@ test('it suspends wrestler with specific suspension date', function () {
     ]);
 });
 
-test('it suspends wrestler with notes', function () {
+test('it suspends wrestler with current timestamp by default', function () {
     $wrestler = Wrestler::factory()->employed()->create();
-    $notes = 'Suspended for violating wellness policy';
 
-    SuspendAction::run($wrestler, null, $notes);
+    SuspendAction::run($wrestler);
 
     $wrestler->refresh();
     expect($wrestler->isSuspended())->toBeTrue();
@@ -59,21 +58,20 @@ test('it suspends wrestler with notes', function () {
         'wrestler_id' => $wrestler->id,
         'started_at' => now()->toDateTimeString(),
         'ended_at' => null,
-        'notes' => $notes,
     ]);
 });
 
 test('it uses StatusTransitionPipeline for suspension', function () {
     $wrestler = Wrestler::factory()->employed()->create();
 
-    expect($wrestler->currentSuspension())->toBeNull();
+    expect($wrestler->currentSuspension)->toBeNull();
 
     SuspendAction::run($wrestler);
 
     $wrestler->refresh();
 
     // Verify suspension created through pipeline
-    expect($wrestler->currentSuspension())->not()->toBeNull();
+    expect($wrestler->currentSuspension)->not()->toBeNull();
     expect($wrestler->isSuspended())->toBeTrue();
 
     $this->assertDatabaseHas('wrestlers_suspensions', [
@@ -105,7 +103,6 @@ test('it handles multiple suspension scenarios', function () {
     $wrestler->suspensions()->create([
         'started_at' => now()->subDays(30),
         'ended_at' => now()->subDays(20),
-        'notes' => 'Previous suspension',
     ]);
 
     // Employ the wrestler
@@ -117,7 +114,7 @@ test('it handles multiple suspension scenarios', function () {
     expect($wrestler->isEmployed())->toBeTrue();
     expect($wrestler->isSuspended())->toBeFalse();
 
-    SuspendAction::run($wrestler, null, 'Current suspension');
+    SuspendAction::run($wrestler);
 
     $wrestler->refresh();
     expect($wrestler->isSuspended())->toBeTrue();
@@ -127,7 +124,6 @@ test('it handles multiple suspension scenarios', function () {
         'wrestler_id' => $wrestler->id,
         'started_at' => now()->toDateTimeString(),
         'ended_at' => null,
-        'notes' => 'Current suspension',
     ]);
 
     // Old suspension should remain unchanged
@@ -135,7 +131,6 @@ test('it handles multiple suspension scenarios', function () {
         'wrestler_id' => $wrestler->id,
         'started_at' => now()->subDays(30)->toDateTimeString(),
         'ended_at' => now()->subDays(20)->toDateTimeString(),
-        'notes' => 'Previous suspension',
     ]);
 });
 
@@ -177,15 +172,16 @@ test('it can suspend injured employed wrestler', function () {
     expect($wrestler->isEmployed())->toBeTrue();
     expect($wrestler->isInjured())->toBeTrue();
 
-    SuspendAction::run($wrestler, null, 'Suspended while injured');
+    SuspendAction::run($wrestler);
 
     $wrestler->refresh();
     expect($wrestler->isSuspended())->toBeTrue();
     expect($wrestler->isInjured())->toBeTrue(); // Should remain injured
-    expect($wrestler->isEmployed())->toBeFalse(); // Should no longer be employed
+    expect($wrestler->isEmployed())->toBeTrue(); // Suspension preserves employment
 
     $this->assertDatabaseHas('wrestlers_suspensions', [
         'wrestler_id' => $wrestler->id,
-        'notes' => 'Suspended while injured',
+        'started_at' => now()->toDateTimeString(),
+        'ended_at' => null,
     ]);
 });

--- a/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
+++ b/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
@@ -235,18 +235,18 @@ describe('Wrestler Employment Workflows', function () {
             EmployAction::run($wrestler, Carbon::now());
             $employed = $wrestler->fresh();
 
-            // Test mutually exclusive statuses - injured wrestler cannot be suspended
+            // Injury and suspension are orthogonal — both can apply simultaneously
             InjureAction::run($employed, Carbon::now());
             $injured = $wrestler->fresh();
-            expect($injured->canBeSuspended())->toBeFalse();
+            expect($injured->canBeSuspended())->toBeTrue();
             expect($injured->isEmployed())->toBeTrue();
             expect($injured->isInjured())->toBeTrue();
 
-            // Heal wrestler, then test suspended wrestler cannot be injured
+            // Heal wrestler, then suspend
             HealAction::run($injured, Carbon::now());
             SuspendAction::run($wrestler->fresh(), Carbon::now());
             $suspended = $wrestler->fresh();
-            expect($suspended->canBeInjured())->toBeFalse();
+            expect($suspended->canBeInjured())->toBeTrue();
             expect($suspended->isEmployed())->toBeTrue();
             expect($suspended->isSuspended())->toBeTrue();
 


### PR DESCRIPTION
## Summary

**Validation layer:**
- Drop `isInjured()` rejection from `IndividualSuspensionValidation`; an injured roster member can still be suspended for disciplinary reasons
- Drop `isSuspended()` rejection from `ValidatesInjury` (`canBeInjured` + `ensureCanBeInjured`); a suspended member can still be flagged as injured

**Test alignment:**
- Wrestlers SuspendActionTest: assert `isEmployed()` stays `true` after suspension (matches the documented "Maintains employment status" behavior); drop `notes` parameter and assertions since the schema has no notes column; replace `currentSuspension()` relation calls with `currentSuspension` accessor in null checks
- Managers SuspendActionTest: invert `prevents suspending injured manager` to confirm the new orthogonal behavior; same `currentSuspension` parens fix
- Referees SuspendActionTest: replace Carbon `eq()` with `toDateTimeString` comparison for second-truncated DB values
- TagTeams SuspendActionTest: same `currentSuspension` parens fix
- Workflows/Wrestlers/EmploymentTest: update `status combination workflow` to expect injured wrestlers can still be suspended (and vice versa)

## Test plan
- [x] `php artisan test tests/Integration/Actions/{Wrestlers,Managers,Referees,TagTeams}/SuspendActionTest.php` — 41/41 passing
- [x] Full suite: 162 → 155 failures on this branch alone (-7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Injury and suspension are now independent states—models can be both injured and suspended simultaneously, rather than being mutually exclusive.
  * Employment status is preserved when suspending an employed model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->