### PR TITLE
fix: Stables RetireAction handles future dates and rejects future-only activations

### DIFF
--- a/app/Actions/Stables/RetireAction.php
+++ b/app/Actions/Stables/RetireAction.php
@@ -69,10 +69,16 @@ class RetireAction
 
         $retirementDate = $retirementDate ?? now();
 
-        DB::transaction(function () use ($stable, $retirementDate): void {
+        // Ending an activity period or removing members can't be back-dated to the
+        // future — those events represent past transitions. Cap the operational
+        // date at now() while still recording the user-supplied retirement date
+        // on the retirement record itself.
+        $operationalDate = $retirementDate->isFuture() ? now() : $retirementDate;
+
+        DB::transaction(function () use ($stable, $retirementDate, $operationalDate): void {
             // End activity if currently active using injected Action
             if ($stable->isCurrentlyActive()) {
-                $this->endActivityPeriodAction->handle($stable, $retirementDate);
+                $this->endActivityPeriodAction->handle($stable, $operationalDate);
             }
 
             // Get current members using enhanced model method
@@ -97,8 +103,8 @@ class RetireAction
                 }
             }
 
-            // Remove all current members using injected Action
-            $this->removeStableMembersAction->handle($stable, $currentMembers, $retirementDate);
+            // Remove all current members using injected Action.
+            $this->removeStableMembersAction->handle($stable, $currentMembers, $operationalDate);
 
             // Create retirement record directly
             $stable->retirements()->create([

--- a/app/Models/Concerns/ValidatesStableLifecycle.php
+++ b/app/Models/Concerns/ValidatesStableLifecycle.php
@@ -557,6 +557,12 @@ trait ValidatesStableLifecycle
             throw CannotBeRetiredException::notActive($this);
         }
 
+        // A stable scheduled to debut in the future is not yet retirable —
+        // it has no past or present activity to wind down.
+        if ($this->hasFutureActivation()) {
+            throw CannotBeRetiredException::notActive($this);
+        }
+
         // Additional business rule validations could be added here:
         // - Check for championship obligations
         // if ($this->hasCurrentChampionshipObligations()) {

--- a/tests/Integration/Actions/Stables/RetireActionTest.php
+++ b/tests/Integration/Actions/Stables/RetireActionTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Stables\RetireAction;
-use App\Exceptions\Roster\CannotBeRetiredException;
+use App\Exceptions\Roster\Stables\CannotBeRetiredException;
 use App\Models\Stables\Stable;
 
 use function Spatie\PestPluginTestTime\testTime;


### PR DESCRIPTION
## Summary

**Validation:**
- `ensureCanBeRetired` now throws when a stable has only future activations (no past or present activity to wind down) — closes the gap where `withFutureActivation` factory state slipped past validation

**Action:**
- Cap operational date at `now()` when `retirement_date` is in the future. `EndActivityPeriodAction` and `RemoveStableMembersAction` reject future dates because they record past transitions; the user-supplied future date still lands on the `retirement` record itself

**Tests:**
- Switch import from generic `Roster\CannotBeRetiredException` to the actual Stables-namespaced class thrown by `ValidatesStableLifecycle`

## Test plan
- [x] `php artisan test tests/Integration/Actions/Stables/RetireActionTest.php` — 8/8 passing