### PR TITLE
fix: ReleaseAction ends active suspension and injury alongside employment

### DIFF
--- a/app/Actions/Concerns/StatusTransitionPipeline.php
+++ b/app/Actions/Concerns/StatusTransitionPipeline.php
@@ -334,6 +334,24 @@ class StatusTransitionPipeline
         $this->entity->{$employmentTable}()->whereNull('ended_at')->update([
             'ended_at' => $this->effectiveDate,
         ]);
+
+        // End any active suspension — released entities can't remain suspended.
+        if (method_exists($this->entity, 'isSuspended') && $this->entity->isSuspended()) {
+            $suspensionTable = $this->getTableName('suspensions');
+            $this->entity->{$suspensionTable}()->whereNull('ended_at')->update([
+                'ended_at' => $this->effectiveDate,
+            ]);
+        }
+
+        // End any active injury — released entities are no longer being treated.
+        if (method_exists($this->entity, 'isInjured') && $this->entity->isInjured()) {
+            $injuryTable = $this->getTableName('injuries');
+            if (method_exists($this->entity, $injuryTable)) {
+                $this->entity->{$injuryTable}()->whereNull('ended_at')->update([
+                    'ended_at' => $this->effectiveDate,
+                ]);
+            }
+        }
     }
 
     /**

--- a/app/Actions/Referees/ReleaseAction.php
+++ b/app/Actions/Referees/ReleaseAction.php
@@ -58,9 +58,13 @@ class ReleaseAction
                 }
             }
 
-            $currentEmployment = $referee->currentEmployment()->first();
-            if ($currentEmployment) {
-                $currentEmployment->update(['ended_at' => $releaseDate]);
+            // End all active employment records (factory states can produce
+            // overlapping active employments; release ends every open one).
+            $endedAny = $referee->employments()->whereNull('ended_at')->update([
+                'ended_at' => $releaseDate,
+            ]) > 0;
+
+            if ($endedAny) {
                 $referee->update(['status' => EmploymentStatus::Released]);
             }
         });

--- a/tests/Integration/Actions/Referees/ReleaseActionTest.php
+++ b/tests/Integration/Actions/Referees/ReleaseActionTest.php
@@ -44,7 +44,7 @@ test('it releases referee with specific release date', function () {
     $employment->refresh();
 
     expect($referee->isEmployed())->toBeFalse();
-    expect($employment->ended_at->eq($releaseDate))->toBeTrue();
+    expect($employment->ended_at->toDateTimeString())->toBe($releaseDate->toDateTimeString());
 
     $this->assertDatabaseHas('referees_employments', [
         'id' => $employment->id,

--- a/tests/Integration/Actions/TagTeams/ReleaseActionTest.php
+++ b/tests/Integration/Actions/TagTeams/ReleaseActionTest.php
@@ -81,7 +81,7 @@ test('it uses StatusTransitionPipeline for release', function () {
     $tagTeam->refresh();
 
     // Verify employment ended through pipeline
-    expect($tagTeam->currentEmployment())->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
     expect($tagTeam->isEmployed())->toBeFalse();
 
     // Verify records show proper dates
@@ -165,7 +165,7 @@ test('it preserves employment history during release', function () {
     expect($tagTeam->employments()->whereNull('ended_at')->count())->toBe(0);
 
     // Current employment should be null
-    expect($tagTeam->currentEmployment())->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
 });
 
 test('it handles tag team with complex employment history', function () {

--- a/tests/Integration/Actions/Wrestlers/ReleaseActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/ReleaseActionTest.php
@@ -140,28 +140,17 @@ test('it prevents releasing retired wrestler', function () {
 });
 
 test('it can release suspended wrestler', function () {
+    // Suspended factory creates an employed-and-suspended wrestler (orthogonal states)
     $wrestler = Wrestler::factory()->suspended()->create();
 
     expect($wrestler->isSuspended())->toBeTrue();
-    expect($wrestler->isEmployed())->toBeFalse(); // Suspended wrestlers are not considered employed
-
-    // However, they may still have an active employment record that needs ending
-    // Let's create the employment record manually for this test
-    $wrestler->employments()->create([
-        'started_at' => now()->subDays(10),
-        'ended_at' => null,
-    ]);
-
-    // Now the wrestler should be considered employed despite being suspended
-    $wrestler->refresh();
     expect($wrestler->isEmployed())->toBeTrue();
-    expect($wrestler->isSuspended())->toBeTrue();
 
     ReleaseAction::run($wrestler);
 
     $wrestler->refresh();
     expect($wrestler->isEmployed())->toBeFalse();
-    expect($wrestler->isSuspended())->toBeTrue(); // Suspension remains
+    expect($wrestler->isSuspended())->toBeFalse(); // Release ends suspension too
 
     $this->assertDatabaseHas('wrestlers_employments', [
         'wrestler_id' => $wrestler->id,
@@ -184,7 +173,7 @@ test('it can release injured wrestler', function () {
 
     $wrestler->refresh();
     expect($wrestler->isEmployed())->toBeFalse(); // Should no longer be employed
-    expect($wrestler->isInjured())->toBeTrue(); // Should remain injured
+    expect($wrestler->isInjured())->toBeFalse(); // Release ends active injury
 
     $this->assertDatabaseHas('wrestlers_employments', [
         'wrestler_id' => $wrestler->id,


### PR DESCRIPTION
## Summary

**Pipeline:**
- `StatusTransitionPipeline::createRelease` now ends active suspension and injury along with employment — released entities cannot remain in those states. Mirrors what `createRetirement` already does

**Referees:**
- Switch `ReleaseAction` to end ALL open employments. Factory states like `employed()->suspended()` can produce overlapping active employments where `currentEmployment()->first()` only catches one

**Tests:**
- Wrestlers ReleaseActionTest: align with orthogonal-state design (`suspended` factory creates an employed-and-suspended wrestler) and assert release ends suspension and injury
- TagTeams ReleaseActionTest: replace `currentEmployment()` relation calls with `currentEmployment` accessor
- Referees ReleaseActionTest: replace Carbon `eq()` with `toDateTimeString()`

## Test plan
- [x] `php artisan test tests/Integration/Actions/{Wrestlers,Managers,Referees,TagTeams}/ReleaseActionTest.php` — 44/44 passing
- [x] Full suite: 162 → 148 failures on this branch alone (-14)