### PR TITLE
fix: Manager Retire/Restore tests pass with consistent retire and delete semantics

### DIFF
--- a/app/Actions/Concerns/StatusTransitionPipeline.php
+++ b/app/Actions/Concerns/StatusTransitionPipeline.php
@@ -349,6 +349,24 @@ class StatusTransitionPipeline
             ]);
         }
 
+        // End any active suspension — a retired entity cannot also be suspended.
+        if (method_exists($this->entity, 'isSuspended') && $this->entity->isSuspended()) {
+            $suspensionTable = $this->getTableName('suspensions');
+            $this->entity->{$suspensionTable}()->whereNull('ended_at')->update([
+                'ended_at' => $this->effectiveDate,
+            ]);
+        }
+
+        // End any active injury — a retired entity is no longer being treated.
+        if (method_exists($this->entity, 'isInjured') && $this->entity->isInjured()) {
+            $injuryTable = $this->getTableName('injuries');
+            if (method_exists($this->entity, $injuryTable)) {
+                $this->entity->{$injuryTable}()->whereNull('ended_at')->update([
+                    'ended_at' => $this->effectiveDate,
+                ]);
+            }
+        }
+
         $table = $this->getTableName('retirements');
         $this->entity->{$table}()->create([
             'started_at' => $this->effectiveDate,

--- a/tests/Integration/Actions/Managers/RestoreActionTest.php
+++ b/tests/Integration/Actions/Managers/RestoreActionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Actions\Managers\DeleteAction;
 use App\Actions\Managers\RestoreAction;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
@@ -88,8 +89,9 @@ test('it does not automatically restore employment relationships', function () {
     // Verify manager was employed before deletion
     expect($manager->isEmployed())->toBeTrue();
 
-    // Soft delete the manager
-    $manager->delete();
+    // Delete via the action so employment is properly ended (status cleanup),
+    // not just the soft-delete column flipped.
+    DeleteAction::run($manager);
 
     // Restore the manager
     $deletedManager = Manager::onlyTrashed()->find($managerId);
@@ -118,8 +120,8 @@ test('it does not automatically restore management relationships', function () {
 
     $managerId = $manager->id;
 
-    // Soft delete the manager
-    $manager->delete();
+    // Delete via the action so management relationships are ended
+    DeleteAction::run($manager);
 
     // Restore the manager
     $deletedManager = Manager::onlyTrashed()->find($managerId);
@@ -214,8 +216,8 @@ test('it allows separate employment after restoration', function () {
     $manager = Manager::factory()->employed()->create();
     $managerId = $manager->id;
 
-    // Soft delete the manager
-    $manager->delete();
+    // Delete via the action so employment is properly ended
+    DeleteAction::run($manager);
 
     // Restore the manager
     $deletedManager = Manager::onlyTrashed()->find($managerId);

--- a/tests/Integration/Actions/Managers/RetireActionTest.php
+++ b/tests/Integration/Actions/Managers/RetireActionTest.php
@@ -156,7 +156,7 @@ test('it uses StatusTransitionPipeline with cascade strategy', function () {
     // Set up management relationship
     $manager->wrestlers()->attach($wrestler->id, ['hired_at' => now()->subDay()]);
 
-    expect($manager->currentRetirement())->toBeNull();
+    expect($manager->currentRetirement)->toBeNull();
     expect($manager->currentWrestlers)->toHaveCount(1);
 
     RetireAction::run($manager);
@@ -164,7 +164,7 @@ test('it uses StatusTransitionPipeline with cascade strategy', function () {
     $manager->refresh();
 
     // Verify retirement created through pipeline
-    expect($manager->currentRetirement())->not()->toBeNull();
+    expect($manager->currentRetirement)->not()->toBeNull();
     expect($manager->isRetired())->toBeTrue();
 
     // Verify cascade strategy ended relationships


### PR DESCRIPTION
## Summary

**Pipeline:**
- `StatusTransitionPipeline::createRetirement` now ends active suspension and injury alongside employment (same change duplicated in PR #620 — will be subsumed when that lands)

**Tests:**
- Managers RetireActionTest: replace `currentRetirement()` relation calls with the accessor in null-checks (HasOne builder is never null)
- Managers RestoreActionTest: switch from raw `$manager->delete()` to `DeleteAction::run` so employment/management relationships are properly ended via the pipeline before soft-delete; restoration then leaves the manager unemployed as the test asserts

## Test plan
- [x] `php artisan test tests/Integration/Actions/Managers/RetireActionTest.php tests/Integration/Actions/Managers/RestoreActionTest.php` — 20/20 passing