### PR TITLE
fix: align Wrestler/TagTeam action tests with orthogonal-state design

### DIFF
--- a/app/Actions/Concerns/StatusTransitionPipeline.php
+++ b/app/Actions/Concerns/StatusTransitionPipeline.php
@@ -334,6 +334,24 @@ class StatusTransitionPipeline
         $this->entity->{$employmentTable}()->whereNull('ended_at')->update([
             'ended_at' => $this->effectiveDate,
         ]);
+
+        // End any active suspension — released entities can't remain suspended.
+        if (method_exists($this->entity, 'isSuspended') && $this->entity->isSuspended()) {
+            $suspensionTable = $this->getTableName('suspensions');
+            $this->entity->{$suspensionTable}()->whereNull('ended_at')->update([
+                'ended_at' => $this->effectiveDate,
+            ]);
+        }
+
+        // End any active injury — released entities are no longer being treated.
+        if (method_exists($this->entity, 'isInjured') && $this->entity->isInjured()) {
+            $injuryTable = $this->getTableName('injuries');
+            if (method_exists($this->entity, $injuryTable)) {
+                $this->entity->{$injuryTable}()->whereNull('ended_at')->update([
+                    'ended_at' => $this->effectiveDate,
+                ]);
+            }
+        }
     }
 
     /**
@@ -347,6 +365,24 @@ class StatusTransitionPipeline
             $this->entity->{$employmentTable}()->whereNull('ended_at')->update([
                 'ended_at' => $this->effectiveDate,
             ]);
+        }
+
+        // End any active suspension — a retired entity cannot also be suspended.
+        if (method_exists($this->entity, 'isSuspended') && $this->entity->isSuspended()) {
+            $suspensionTable = $this->getTableName('suspensions');
+            $this->entity->{$suspensionTable}()->whereNull('ended_at')->update([
+                'ended_at' => $this->effectiveDate,
+            ]);
+        }
+
+        // End any active injury — a retired entity is no longer being treated.
+        if (method_exists($this->entity, 'isInjured') && $this->entity->isInjured()) {
+            $injuryTable = $this->getTableName('injuries');
+            if (method_exists($this->entity, $injuryTable)) {
+                $this->entity->{$injuryTable}()->whereNull('ended_at')->update([
+                    'ended_at' => $this->effectiveDate,
+                ]);
+            }
         }
 
         $table = $this->getTableName('retirements');

--- a/app/Actions/Wrestlers/EmployAction.php
+++ b/app/Actions/Wrestlers/EmployAction.php
@@ -41,6 +41,11 @@ class EmployAction
      */
     public function handle(Wrestler $wrestler, ?Carbon $employmentDate = null): void
     {
+        // Idempotent: re-employing an already-employed wrestler is a no-op.
+        if ($wrestler->isEmployed()) {
+            return;
+        }
+
         $wrestler->ensureCanBeEmployed();
 
         $employmentDate = DateHelper::resolveDate($employmentDate);

--- a/app/Models/Concerns/ValidatesInjury.php
+++ b/app/Models/Concerns/ValidatesInjury.php
@@ -57,8 +57,7 @@ trait ValidatesInjury
         return ! $this->isNotInEmployment()
             && ! $this->isRetired()
             && ! $this->hasFutureEmployment()
-            && ! $this->isInjured()
-            && ! $this->isSuspended();
+            && ! $this->isInjured();
     }
 
     /**
@@ -97,9 +96,7 @@ trait ValidatesInjury
             throw CannotBeInjuredException::injured($this);
         }
 
-        if ($this->isSuspended()) {
-            throw CannotBeInjuredException::suspended($this);
-        }
+        // Injury and suspension are orthogonal — both can apply simultaneously.
     }
 
     /**

--- a/tests/Integration/Actions/TagTeams/ReleaseActionTest.php
+++ b/tests/Integration/Actions/TagTeams/ReleaseActionTest.php
@@ -81,7 +81,7 @@ test('it uses StatusTransitionPipeline for release', function () {
     $tagTeam->refresh();
 
     // Verify employment ended through pipeline
-    expect($tagTeam->currentEmployment())->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
     expect($tagTeam->isEmployed())->toBeFalse();
 
     // Verify records show proper dates
@@ -165,7 +165,7 @@ test('it preserves employment history during release', function () {
     expect($tagTeam->employments()->whereNull('ended_at')->count())->toBe(0);
 
     // Current employment should be null
-    expect($tagTeam->currentEmployment())->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
 });
 
 test('it handles tag team with complex employment history', function () {

--- a/tests/Integration/Actions/TagTeams/RetireActionTest.php
+++ b/tests/Integration/Actions/TagTeams/RetireActionTest.php
@@ -94,15 +94,15 @@ test('it uses StatusTransitionPipeline for retirement', function () {
     // Get current employment to verify it gets ended
     $currentEmployment = $tagTeam->currentEmployment;
     expect($currentEmployment)->not()->toBeNull();
-    expect($tagTeam->currentRetirement())->toBeNull();
+    expect($tagTeam->currentRetirement)->toBeNull();
 
     RetireAction::run($tagTeam);
 
     $tagTeam->refresh();
 
     // Verify employment ended and retirement created through pipeline
-    expect($tagTeam->currentEmployment())->toBeNull();
-    expect($tagTeam->currentRetirement())->not()->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
+    expect($tagTeam->currentRetirement)->not()->toBeNull();
     expect($tagTeam->isRetired())->toBeTrue();
     expect($tagTeam->isEmployed())->toBeFalse();
 });
@@ -232,6 +232,6 @@ test('it preserves employment and retirement history', function () {
     expect($tagTeam->retirements()->count())->toBe($originalRetirementCount + 1);
 
     // Current employment should be ended, current retirement should be active
-    expect($tagTeam->currentEmployment())->toBeNull();
-    expect($tagTeam->currentRetirement())->not()->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
+    expect($tagTeam->currentRetirement)->not()->toBeNull();
 });

--- a/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
@@ -156,7 +156,7 @@ test('it uses StatusTransitionPipeline with cascade strategies', function () {
     ]);
 
     // Verify manager relationship ended through cascade strategy
-    $this->assertDatabaseHas('wrestler_managers', [
+    $this->assertDatabaseHas('wrestlers_managers', [
         'wrestler_id' => $wrestler->id,
         'manager_id' => $manager->id,
         'fired_at' => now()->toDateTimeString(),
@@ -251,7 +251,7 @@ test('it maintains relationship history integrity', function () {
     expect($wrestler->trashed())->toBeTrue();
 
     // Old relationship should remain unchanged
-    $this->assertDatabaseHas('wrestler_managers', [
+    $this->assertDatabaseHas('wrestlers_managers', [
         'wrestler_id' => $wrestler->id,
         'manager_id' => $manager->id,
         'hired_at' => now()->subDays(30)->toDateTimeString(),
@@ -259,7 +259,7 @@ test('it maintains relationship history integrity', function () {
     ]);
 
     // Current relationship should be ended
-    $this->assertDatabaseHas('wrestler_managers', [
+    $this->assertDatabaseHas('wrestlers_managers', [
         'wrestler_id' => $wrestler->id,
         'manager_id' => $manager->id,
         'hired_at' => now()->subDays(10)->toDateTimeString(),

--- a/tests/Integration/Actions/Wrestlers/EmployActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/EmployActionTest.php
@@ -45,56 +45,35 @@ test('it employs wrestler with specific employment date', function () {
     ]);
 });
 
-test('it employs suspended wrestler and ends suspension', function () {
+test('it is idempotent when called on suspended-but-employed wrestler', function () {
+    // Suspended factory creates an employed-and-suspended wrestler (orthogonal states)
     $wrestler = Wrestler::factory()->suspended()->create();
+    $employmentCount = $wrestler->employments()->count();
 
     expect($wrestler->isSuspended())->toBeTrue();
-    expect($wrestler->isEmployed())->toBeFalse();
+    expect($wrestler->isEmployed())->toBeTrue();
 
     EmployAction::run($wrestler);
 
     $wrestler->refresh();
     expect($wrestler->isEmployed())->toBeTrue();
-    expect($wrestler->isSuspended())->toBeFalse();
-
-    // Suspension should be ended
-    $this->assertDatabaseHas('wrestlers_suspensions', [
-        'wrestler_id' => $wrestler->id,
-        'ended_at' => now()->toDateTimeString(),
-    ]);
-
-    // Employment should be created
-    $this->assertDatabaseHas('wrestlers_employments', [
-        'wrestler_id' => $wrestler->id,
-        'started_at' => now()->toDateTimeString(),
-        'ended_at' => null,
-    ]);
+    expect($wrestler->isSuspended())->toBeTrue();
+    expect($wrestler->employments()->count())->toBe($employmentCount);
 });
 
-test('it employs injured wrestler and ends injury', function () {
+test('it is idempotent when called on injured-but-employed wrestler', function () {
     $wrestler = Wrestler::factory()->injured()->create();
+    $employmentCount = $wrestler->employments()->count();
 
     expect($wrestler->isInjured())->toBeTrue();
-    expect($wrestler->isEmployed())->toBeFalse();
+    expect($wrestler->isEmployed())->toBeTrue();
 
     EmployAction::run($wrestler);
 
     $wrestler->refresh();
     expect($wrestler->isEmployed())->toBeTrue();
-    expect($wrestler->isInjured())->toBeFalse();
-
-    // Injury should be ended
-    $this->assertDatabaseHas('wrestlers_injuries', [
-        'wrestler_id' => $wrestler->id,
-        'ended_at' => now()->toDateTimeString(),
-    ]);
-
-    // Employment should be created
-    $this->assertDatabaseHas('wrestlers_employments', [
-        'wrestler_id' => $wrestler->id,
-        'started_at' => now()->toDateTimeString(),
-        'ended_at' => null,
-    ]);
+    expect($wrestler->isInjured())->toBeTrue();
+    expect($wrestler->employments()->count())->toBe($employmentCount);
 });
 
 test('it employs wrestler and also employs unemployed managers', function () {

--- a/tests/Integration/Actions/Wrestlers/InjureActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/InjureActionTest.php
@@ -49,14 +49,14 @@ test('it injures wrestler with specific injury date', function () {
 test('it uses StatusTransitionPipeline for injury', function () {
     $wrestler = Wrestler::factory()->employed()->create();
 
-    expect($wrestler->currentInjury())->toBeNull();
+    expect($wrestler->currentInjury)->toBeNull();
 
     InjureAction::run($wrestler);
 
     $wrestler->refresh();
 
     // Verify injury created through pipeline
-    expect($wrestler->currentInjury())->not()->toBeNull();
+    expect($wrestler->currentInjury)->not()->toBeNull();
     expect($wrestler->isInjured())->toBeTrue();
 
     $this->assertDatabaseHas('wrestlers_injuries', [
@@ -141,22 +141,10 @@ test('it prevents injuring unemployed wrestler', function () {
 });
 
 test('it can injure suspended wrestler', function () {
+    // Suspended factory creates an employed-and-suspended wrestler (orthogonal states)
     $wrestler = Wrestler::factory()->suspended()->create();
 
     expect($wrestler->isSuspended())->toBeTrue();
-    expect($wrestler->isEmployed())->toBeFalse();
-
-    // Note: This test may need adjustment based on business rules
-    // Some promotions might allow injuring suspended wrestlers, others might not
-    // For now, assuming suspended wrestlers can get injured
-
-    // First, let's make them employed (suspended but still under contract)
-    $wrestler->employments()->create([
-        'started_at' => now()->subDays(10),
-        'ended_at' => null,
-    ]);
-
-    $wrestler->refresh();
     expect($wrestler->isEmployed())->toBeTrue();
 
     InjureAction::run($wrestler);

--- a/tests/Integration/Actions/Wrestlers/RetireActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/RetireActionTest.php
@@ -49,14 +49,14 @@ test('it retires wrestler with specific retirement date', function () {
 test('it uses StatusTransitionPipeline for retirement', function () {
     $wrestler = Wrestler::factory()->employed()->create();
 
-    expect($wrestler->currentRetirement())->toBeNull();
+    expect($wrestler->currentRetirement)->toBeNull();
 
     RetireAction::run($wrestler);
 
     $wrestler->refresh();
 
     // Verify retirement created through pipeline
-    expect($wrestler->currentRetirement())->not()->toBeNull();
+    expect($wrestler->currentRetirement)->not()->toBeNull();
     expect($wrestler->isRetired())->toBeTrue();
 
     $this->assertDatabaseHas('wrestlers_retirements', [
@@ -162,17 +162,18 @@ test('it prevents retiring unemployed wrestler', function () {
 });
 
 test('it can retire suspended wrestler', function () {
+    // Suspended factory creates an employed-and-suspended wrestler (orthogonal states)
     $wrestler = Wrestler::factory()->suspended()->create();
 
     expect($wrestler->isSuspended())->toBeTrue();
-    expect($wrestler->isEmployed())->toBeFalse();
+    expect($wrestler->isEmployed())->toBeTrue();
 
-    // Suspended wrestlers can be retired (career-ending situation)
     RetireAction::run($wrestler);
 
     $wrestler->refresh();
     expect($wrestler->isRetired())->toBeTrue();
-    expect($wrestler->isSuspended())->toBeTrue(); // Suspension record remains
+    expect($wrestler->isSuspended())->toBeFalse(); // Retirement ends suspension
+    expect($wrestler->isEmployed())->toBeFalse();
 
     $this->assertDatabaseHas('wrestlers_retirements', [
         'wrestler_id' => $wrestler->id,
@@ -196,8 +197,8 @@ test('it can retire injured wrestler', function () {
 
     $wrestler->refresh();
     expect($wrestler->isRetired())->toBeTrue();
-    expect($wrestler->isInjured())->toBeTrue(); // Injury record remains (career-ending injury)
-    expect($wrestler->isEmployed())->toBeFalse(); // Employment should end
+    expect($wrestler->isInjured())->toBeFalse(); // Retirement ends active injury
+    expect($wrestler->isEmployed())->toBeFalse();
 
     $this->assertDatabaseHas('wrestlers_retirements', [
         'wrestler_id' => $wrestler->id,


### PR DESCRIPTION
## Summary

**Pipeline:**
- `StatusTransitionPipeline::createRetirement` also ends active suspension and injury (subsumes #620)
- `StatusTransitionPipeline::createRelease` also ends active suspension and injury (subsumes #626)

**Validation:**
- `ValidatesInjury` accepts suspended entities as valid candidates for injury (orthogonal — subsumes #622)

**Action:**
- Wrestlers `EmployAction` is now idempotent (parallels Referees `EmployAction` in #625)

**Tests:**
- Wrestlers RetireActionTest: align suspended/injured factory preconditions with orthogonal-state design (suspension/injury are cleared by retirement)
- Wrestlers EmployActionTest: convert `it employs suspended/injured wrestler` scenarios to idempotent expectations
- Wrestlers InjureActionTest: align suspended-can-be-injured precondition; drop `currentInjury()` parens in null-checks
- Wrestlers DeleteActionTest: rename pivot table from `wrestler_managers` to `wrestlers_managers` (matches migration)
- TagTeams RetireActionTest / ReleaseActionTest: drop `currentEmployment()` / `currentRetirement()` / `currentSuspension()` parens in null-checks

## Test plan
- [x] `php artisan test tests/Integration/Actions/Wrestlers/{Employ,Injure,Retire,Delete}ActionTest.php tests/Integration/Actions/TagTeams/{Retire,Release}ActionTest.php` — all passing
- [x] Full suite: 162 → 145 (-17) on this branch alone