### PR TITLE
fix: workflow + seeder tests + wrestler unretire default

### DIFF
--- a/app/Actions/Wrestlers/UnretireAction.php
+++ b/app/Actions/Wrestlers/UnretireAction.php
@@ -49,7 +49,7 @@ class UnretireAction
      * UnretireAction::run($wrestler, employImmediately: false);
      * ```
      */
-    public function handle(Wrestler $wrestler, ?Carbon $unretirementDate = null, bool $employImmediately = true): void
+    public function handle(Wrestler $wrestler, ?Carbon $unretirementDate = null, bool $employImmediately = false): void
     {
         $wrestler->ensureCanBeUnretired();
 

--- a/tests/Integration/Database/Seeders/MatchesTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/MatchesTableSeederTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\MatchType;
 use App\Models\Matches\EventMatch;
 use Database\Seeders\MatchesTableSeeder;
 use Illuminate\Support\Facades\Artisan;
@@ -51,7 +52,7 @@ describe('MatchesTableSeeder Integration Tests', function () {
             // Assert
             foreach ($eventMatches as $eventMatch) {
                 expect($eventMatch->event_id)->toBeInt();
-                expect($eventMatch->match_type_id)->toBeInt();
+                expect($eventMatch->match_type)->toBeInstanceOf(MatchType::class);
                 expect($eventMatch->match_number)->toBeInt();
                 expect($eventMatch->match_number)->toBeGreaterThan(0);
             }
@@ -105,23 +106,22 @@ describe('MatchesTableSeeder Integration Tests', function () {
             // Arrange
             $eventMatches = EventMatch::take(10)->get();
 
-            // Assert
+            // Assert — match_type is now a backed PHP enum, not an FK to a table
             foreach ($eventMatches as $eventMatch) {
-                expect($eventMatch->match_type_id)->toBeInt();
-                expect($eventMatch->match_type_id)->toBeGreaterThan(0);
+                expect($eventMatch->match_type)->toBeInstanceOf(MatchType::class);
             }
             expect(true)->toBeTrue();
         });
 
         test('event matches can load relationships', function () {
             // Arrange
-            $eventMatch = EventMatch::with(['event', 'matchType'])->first();
+            $eventMatch = EventMatch::with(['event'])->first();
 
             // Assert
             expect($eventMatch->event)->not()->toBeNull();
-            expect($eventMatch->matchType)->not()->toBeNull();
             expect($eventMatch->event->name)->toBeString();
-            expect($eventMatch->matchType->name)->toBeString();
+            expect($eventMatch->match_type)->toBeInstanceOf(MatchType::class);
+            expect($eventMatch->match_type->label())->toBeString();
             expect(true)->toBeTrue();
         });
 

--- a/tests/Integration/Workflows/TagTeams/EmploymentTest.php
+++ b/tests/Integration/Workflows/TagTeams/EmploymentTest.php
@@ -6,6 +6,7 @@ use App\Actions\TagTeams\EmployAction;
 use App\Actions\TagTeams\ReleaseAction;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Carbon;
 
 /**
@@ -35,14 +36,19 @@ describe('TagTeam Employment Workflows', function () {
             $employed = $tagTeam->fresh();
             expect($employed->isEmployed())->toBeTrue();
 
-            // Release
+            // Release ends employment AND ends wrestler partnerships (wrestlers become free agents)
             ReleaseAction::run($employed, Carbon::now());
             $released = $tagTeam->fresh();
             expect($released->isReleased())->toBeTrue();
             expect($released->isEmployed())->toBeFalse();
 
+            // Re-attaching wrestlers is the user's job before re-employing —
+            // the released team has no current partners after the cascade.
+            $wrestlers = Wrestler::factory()->count(2)->create();
+            $released->wrestlers()->attach($wrestlers, ['joined_at' => now(), 'left_at' => null]);
+
             // Re-employ
-            EmployAction::run($released, Carbon::now());
+            EmployAction::run($released->fresh(), Carbon::now());
             $reEmployed = $tagTeam->fresh();
             expect($reEmployed->isEmployed())->toBeTrue();
             expect($reEmployed->isReleased())->toBeFalse();
@@ -156,13 +162,18 @@ describe('TagTeam Employment Workflows', function () {
             expect($employed->isEmployed())->toBeTrue();
             expect($employed->canBeEmployed())->toBeFalse(); // Already employed
 
-            // Release tag team
+            // Release tag team — cascade ends wrestler partnerships, leaving
+            // the team without current partners
             ReleaseAction::run($employed, Carbon::now());
             $released = $tagTeam->fresh();
 
             // Released tag team capabilities
             expect($released->isEmployed())->toBeFalse();
-            expect($released->canBeEmployed())->toBeTrue(); // Can be re-employed
+
+            // Re-attach wrestlers (user's responsibility) to make the team employable again
+            $wrestlers = Wrestler::factory()->count(2)->create();
+            $released->wrestlers()->attach($wrestlers, ['joined_at' => now(), 'left_at' => null]);
+            expect($released->fresh()->canBeEmployed())->toBeTrue();
         });
     });
 


### PR DESCRIPTION
## Summary

**Action:**
- Wrestler `UnretireAction` defaults `employImmediately = false`. Unretirement just ends retirement, leaving the wrestler unemployed; re-employment is a separate user action (matches Stable `UnretireAction` in #619 and the workflow test expectation that `isEmployed` stays false after unretire)

**Tests:**
- TagTeams workflow: re-attach wrestlers between release and re-employ since the release cascade strategy intentionally ends partnerships (wrestlers become free agents)
- Database/Seeders/MatchesTableSeederTest: switch from `match_type_id` integer FK to `match_type` backed enum (`App\Enums\MatchType`, post-enum-migration); drop `matchType` relation expectations

## Test plan
- [x] `php artisan test tests/Integration/Workflows/{Wrestlers,TagTeams}/EmploymentTest.php tests/Integration/Database/Seeders/MatchesTableSeederTest.php` — all passing