### PR TITLE
fix: align Livewire table + matches modal tests with the custom DataTableComponent

### DIFF
--- a/app/Actions/Stables/UnretireAction.php
+++ b/app/Actions/Stables/UnretireAction.php
@@ -73,7 +73,7 @@ class UnretireAction
         Stable $stable,
         ?Carbon $unretiredDate = null,
         bool $unretireMembers = true,
-        bool $establishImmediately = true,
+        bool $establishImmediately = false,
         bool $requireFormerMembers = true
     ): void {
         $stable->ensureCanBeUnretired($requireFormerMembers);

--- a/app/Models/Concerns/ValidatesStableLifecycle.php
+++ b/app/Models/Concerns/ValidatesStableLifecycle.php
@@ -385,6 +385,15 @@ trait ValidatesStableLifecycle
         }
 
         if ($requireFormerMembers) {
+            // Skip member checks if the stable never had members — restoring an
+            // empty soft-deleted stable is valid; user can attach members later.
+            $hasMemberHistory = $this->previousWrestlers()->exists()
+                || $this->previousTagTeams()->exists();
+
+            if (! $hasMemberHistory) {
+                return;
+            }
+
             // Check if former members are available for restoration
             $availableFormerMembers = $this->getAvailableFormerMembers();
 
@@ -489,8 +498,8 @@ trait ValidatesStableLifecycle
                     ->orWhereHas('suspensions', function ($suspensionQuery) {
                         $suspensionQuery->whereNull('ended_at'); // Currently suspended
                     })
-                    ->orWhereHas('currentStables', function ($stableQuery) {
-                        $stableQuery->where('stable_id', '!=', $this->id); // In another stable
+                    ->orWhereHas('currentStable', function ($stableQuery) {
+                        $stableQuery->where('stables.id', '!=', $this->id); // In another stable
                     });
             })
             ->get();
@@ -503,8 +512,8 @@ trait ValidatesStableLifecycle
                     ->orWhereHas('suspensions', function ($suspensionQuery) {
                         $suspensionQuery->whereNull('ended_at'); // Currently suspended
                     })
-                    ->orWhereHas('currentStables', function ($stableQuery) {
-                        $stableQuery->where('stable_id', '!=', $this->id); // In another stable
+                    ->orWhereHas('currentStable', function ($stableQuery) {
+                        $stableQuery->where('stables.id', '!=', $this->id); // In another stable
                     });
             })
             ->get();

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -152,19 +152,13 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates match type exists', function () {
-        $wrestler1 = Wrestler::factory()->bookable()->create();
-        $wrestler2 = Wrestler::factory()->bookable()->create();
-
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        // Livewire's EnumSynth rejects invalid backing values directly (ValueError),
+        // which is itself the validation barrier — invalid enum strings can't reach
+        // the form property in the first place.
+        expect(fn () => Livewire::test(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
-            ->set('form.matchType', 'invalid-match-type')
-            ->set('form.competitors', [
-                0 => ['wrestlers' => [$wrestler1->id]],
-                1 => ['wrestlers' => [$wrestler2->id]],
-            ])
-            ->call('save');
-
-        $component->assertHasErrors(['form.matchType']);
+            ->set('form.matchType', 'invalid-match-type'))
+            ->toThrow(ValueError::class);
     });
 
     it('validates competitors exist and are bookable', function () {
@@ -203,13 +197,15 @@ describe('FormModal Edit Operations', function () {
         $match = EventMatch::factory()->for($this->event)->create();
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
+        $wrestler3 = Wrestler::factory()->bookable()->create();
+        $wrestler4 = Wrestler::factory()->bookable()->create();
 
         $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal', $match->id)
             ->set('form.matchType', MatchType::TagTeam)
             ->set('form.competitors', [
-                0 => ['wrestlers' => [$wrestler1->id]],
-                1 => ['wrestlers' => [$wrestler2->id]],
+                0 => ['wrestlers' => [$wrestler1->id, $wrestler2->id]],
+                1 => ['wrestlers' => [$wrestler3->id, $wrestler4->id]],
             ])
             ->set('form.preview', 'Updated match preview')
             ->call('save');

--- a/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 use App\Builders\Events\EventBuilder;
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Livewire\Venues\Tables\PreviousEvents;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Users\User;
 use Livewire\Livewire;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 /**
  * Integration tests for PreviousEventsTable component query building and functionality.

--- a/tests/Integration/Livewire/Wrestlers/Tables/PreviousManagersTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Tables/PreviousManagersTest.php
@@ -132,7 +132,7 @@ describe('Previous Managers Table Component', function () {
         $table = Livewire::test(PreviousManagers::class, ['wrestlerId' => $this->wrestler->id]);
 
         $table->assertOk();
-        $table->assertSee('No items found, try to broaden your search');
+        $table->assertSee('No records found.');
         expect(true)->toBeTrue();
     })->group('wrestlers', 'integration', 'livewire', 'tables', 'rendering');
 });
@@ -261,7 +261,7 @@ describe('Previous Managers Table Business Logic', function () {
 
         // Should still work but not show the deleted manager
         $table->assertOk();
-        $table->assertSee('No items found, try to broaden your search');
+        $table->assertSee('No records found.');
         expect(true)->toBeTrue();
     })->group('wrestlers', 'integration', 'livewire', 'tables', 'business', 'deletion');
 });

--- a/tests/Unit/Livewire/Concerns/BaseTableTraitTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseTableTraitTest.php
@@ -133,7 +133,7 @@ describe('BaseTableTrait Unit Tests', function () {
             $source = file_get_contents($reflection->getFileName());
 
             expect($source)->toContain('use App\\Livewire\\Concerns\\Columns\\HasActionColumn;');
-            expect($source)->toContain('use Rappasoft\\LaravelLivewireTables\\Views\\Column;');
+            expect($source)->toContain('use App\\Livewire\\Table\\Column;');
         });
     });
 
@@ -161,15 +161,15 @@ describe('BaseTableTrait Unit Tests', function () {
         });
     });
 
-    describe('laravel livewire tables integration', function () {
-        test('uses Laravel Livewire Tables components', function () {
+    describe('custom table component integration', function () {
+        test('uses the custom App\\Livewire\\Table components', function () {
             $reflection = new ReflectionClass(BaseTableTrait::class);
             $source = file_get_contents($reflection->getFileName());
 
-            expect($source)->toContain('Rappasoft\\LaravelLivewireTables\\Views\\Column');
+            expect($source)->toContain('App\\Livewire\\Table\\Column');
         });
 
-        test('follows Laravel Livewire Tables patterns', function () {
+        test('follows custom table-component patterns', function () {
             $reflection = new ReflectionClass(BaseTableTrait::class);
             $source = file_get_contents($reflection->getFileName());
 

--- a/tests/Unit/Livewire/Concerns/Columns/HasActionColumnTest.php
+++ b/tests/Unit/Livewire/Concerns/Columns/HasActionColumnTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use App\Livewire\Concerns\Columns\HasActionColumn;
-use Rappasoft\LaravelLivewireTables\Views\Column;
+use App\Livewire\Table\Column;
 use Tests\Integration\Livewire\Concerns\Columns\HasActionColumnTest;
 
 /**
@@ -48,7 +48,7 @@ describe('HasActionColumn Unit Tests', function () {
 
             $method = $reflection->getMethod('getDefaultActionColumn');
             expect($method->isProtected())->toBeTrue();
-            expect($method->getReturnType()->getName())->toBe('Rappasoft\\LaravelLivewireTables\\Views\\Column');
+            expect($method->getReturnType()->getName())->toBe('App\\Livewire\\Table\\Column');
             expect($method->getNumberOfParameters())->toBe(0);
         });
     });
@@ -70,7 +70,7 @@ describe('HasActionColumn Unit Tests', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
             $source = file_get_contents($reflection->getFileName());
 
-            expect($source)->toContain('use Rappasoft\\LaravelLivewireTables\\Views\\Column;');
+            expect($source)->toContain('use App\\Livewire\\Table\\Column;');
         });
     });
 


### PR DESCRIPTION
## Summary

Validation/Action (subsumes parts of #619):
- ValidatesStableLifecycle: currentStables (plural, undefined) replaced with currentStable (singular) in former-member queries; disambiguate stables.id
- ValidatesStableLifecycle::ensureCanBeRestored: skip member-availability checks when the stable never had members; restoring an empty soft-deleted stable is valid
- Stables UnretireAction: default establishImmediately = false so unretirement leaves the stable inactive

Tests:
- PreviousEventsTest: switch from Rappasoft Views Columns to App Livewire Table Columns (DateColumn / LinkColumn / DataTableComponent)
- PreviousManagersTest: empty-state copy is now No records found.
- Matches FormModalTest: invalid match-type now throws ValueError at hydration (Livewire EnumSynth); tag-team match needs >= 2 wrestlers per side
- Unit BaseTableTraitTest / HasActionColumnTest: import the custom Column instead of the removed Rappasoft one

## Test plan
- All targeted tests pass
- Full suite: 162 -> 145 (-17)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed stable restoration process to support empty stables
  * Enhanced member availability detection during stable restoration
  * Improved stable unretirement behavior handling

* **Tests**
  * Strengthened validation test coverage for match configuration
  * Updated table component integration tests with improved assertions
  * Refined empty-state message expectations across table views

<!-- end of auto-generated comment: release notes by coderabbit.ai -->