### PR TITLE
INF-62: Align verification baseline with Laravel 13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,7 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         php: [8.4]
-        laravel: [12.*]
-        stability: [prefer-dist]
+        laravel: [13.*]
 
     name: CI - PHP-${{ matrix.php }} - Laravel-${{ matrix.laravel }}
     env:
@@ -75,12 +74,7 @@ jobs:
           composer config github-oauth.github.com $GITHUB_TOKEN
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer require "laravel/framework:${{ matrix.laravel }}" --no-interaction --no-update
-
-      - name: Update dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer update --${{ matrix.stability }} --no-interaction
+        run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Setup Laravel application
         run: |

--- a/.github/workflows/run-tests-pcov-pull.yml
+++ b/.github/workflows/run-tests-pcov-pull.yml
@@ -18,10 +18,9 @@ jobs:
       matrix:
         os: [ubuntu-24.04]
         php: [8.4]
-        laravel: [12]
-        stability: [prefer-dist]
+        laravel: [13]
 
-    name: PCOV - ${{ matrix.os }} - P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }}
+    name: PCOV - ${{ matrix.os }} - P${{ matrix.php }} - L${{ matrix.laravel }}
     env:
       extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}-withpcov
       extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pcov,pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo
@@ -77,12 +76,7 @@ jobs:
           composer config github-oauth.github.com $GITHUB_TOKEN
 
       - name: Install dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer require "laravel/framework:${{ matrix.laravel }}.*" --no-interaction --no-update
-
-      - name: Update dependencies
-        if: steps.composer-cache.outputs.cache-hit != 'true'
-        run: composer update --${{ matrix.stability }} --no-interaction
+        run: composer install --prefer-dist --no-interaction --no-progress
 
       - name: Setup Laravel application
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -171,10 +171,10 @@ The Laravel Boost guidelines are specifically curated by Laravel maintainers for
 ## Foundational Context
 This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
 
-- php - 8.4.11
-- laravel/framework (LARAVEL) - v12
+- php - 8.4.20
+- laravel/framework (LARAVEL) - v13
 - laravel/prompts (PROMPTS) - v0
-- livewire/livewire (LIVEWIRE) - v3
+- livewire/livewire (LIVEWIRE) - v4
 - larastan/larastan (LARASTAN) - v3
 - laravel/pint (PINT) - v1
 - pestphp/pest (PEST) - v3
@@ -333,14 +333,14 @@ protected function isAccessible(User $user, ?string $path = null): bool
 - If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
 
 
-=== laravel/v12 rules ===
+=== laravel/v13 rules ===
 
-## Laravel 12
+## Laravel 13
 
 - Use the `search-docs` tool to get version specific documentation.
 - Since Laravel 11, Laravel has a new streamlined file structure which this project uses.
 
-### Laravel 12 Structure
+### Laravel 13 Structure
 - No middleware files in `app/Http/Middleware/`.
 - `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
 - `bootstrap/providers.php` contains application specific service providers.
@@ -402,9 +402,9 @@ protected function isAccessible(User $user, ?string $path = null): bool
     </code-snippet>
 
 
-=== livewire/v3 rules ===
+=== livewire/v4 rules ===
 
-## Livewire 3
+## Livewire 4
 
 ### Key Changes From Livewire 2
 - These things changed in Livewire 2, but may not have been updated in this application. Verify this application's setup to ensure you conform with application conventions.

--- a/docs/README.md
+++ b/docs/README.md
@@ -71,7 +71,7 @@ This Laravel project is configured with Claude Code and MCP servers for enhanced
 - **Laravel DebugBar** (if installed) - Debug information
 
 ### Environment
-- Laravel Framework with Livewire 3
+- Laravel Framework 13 with Livewire 4
 - Alpine.js for frontend interactivity
 - Tailwind CSS for styling
 - Laravel Breeze for authentication

--- a/docs/workflows/ci-cd.md
+++ b/docs/workflows/ci-cd.md
@@ -9,7 +9,7 @@ The project uses a streamlined CI/CD approach with 3 automated workflows:
 **Purpose**: Comprehensive testing and static analysis
 
 **What it does:**
-- Runs on PHP 8.4 with Laravel 12.* on Ubuntu 24.04
+- Runs on PHP 8.4 with Laravel 13.* on Ubuntu 24.04
 - Executes all test suites in parallel (Feature, Integration, Unit)
 - Runs PHPStan static analysis (`composer test:types`)
 - Uses optimized `.env.testing` configuration


### PR DESCRIPTION
## Summary
- Aligns Ringside CI/PCOV workflows with the intended Laravel 13 / Livewire 4 baseline.
- Stops CI from mutating dependency constraints during the run; it now installs the committed dependency set with `composer install`.
- Updates project/agent docs that still referenced Laravel 12 / Livewire 3.

Linear: INF-62

## Verification
```bash
export PATH="$HOME/Library/Application Support/Herd/bin:$PATH"
composer validate --strict --no-check-publish
# PASS: ./composer.json is valid

git diff --check
# PASS: no whitespace errors
```

## Known blockers exposed after preserving Laravel 13
The Laravel 13 stack boots far enough to run tests, but the application suite is not green yet. The replacement run exposed failing assertions that should be handled as follow-up testing/runtime cleanup instead of hiding them by downgrading the framework:

- stale model metadata/fillable expectations
- stale Livewire table `Column` return type/import expectations
- stale TagTeam trait expectation
- likely broader static-analysis/test baseline cleanup after this PR lands

This PR intentionally keeps scope narrow: establish the correct Laravel 13 verification baseline, then split test failures separately.
