### PR TITLE
test: update EventMatch metadata assertions

### DIFF
--- a/tests/Unit/Models/Matches/EventMatchTest.php
+++ b/tests/Unit/Models/Matches/EventMatchTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\MatchType;
 use App\Models\Matches\EventMatch;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 
@@ -30,7 +31,7 @@ describe('EventMatch Model Unit Tests', function () {
             expect($eventMatch->getFillable())->toEqual([
                 'event_id',
                 'match_number',
-                'match_type_id',
+                'match_type',
                 'match_stipulation_id',
                 'preview',
             ]);
@@ -40,8 +41,9 @@ describe('EventMatch Model Unit Tests', function () {
             $eventMatch = new EventMatch();
             $casts = $eventMatch->getCasts();
 
-            // EventMatch model has no custom casts
             expect($casts)->toBeArray();
+            expect($casts['id'])->toBe('int');
+            expect($casts['match_type'])->toBe(MatchType::class);
         });
 
         test('has custom eloquent builder', function () {


### PR DESCRIPTION
## Summary
- Updates the EventMatch model metadata unit test for Laravel 13 attribute-driven runtime metadata.
- Keeps app behavior unchanged: EventMatch remains fillable on `match_type` and casts it to `App\Enums\MatchType`.
- Adds an explicit cast assertion so the test documents the enum-backed runtime behavior.

## Verification
- PASS: `php84 artisan test tests/Unit/Models/Matches/EventMatchTest.php` — 9 passed.
- PASS: `php84 vendor/bin/pint --dirty --test` — changed file passes style.
- FAIL (pre-existing/out of scope): `php84 artisan test tests/Unit/Models --compact` — 5 remaining failures in trait/model drift outside INF-103 scope: CanBeManaged support class, HasChampionships currentChampion relationship, MatchResult decision method, Stable trait expectation, TagTeam trait expectation.

## Notes
- Preserves Laravel 13 / Livewire 4; no dependency changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for model validation and type casting configurations to improve code reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeffreyDavidson/Ringside/pull/635?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->