### PR TITLE
test: align Livewire table column expectations

### DIFF
--- a/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
@@ -4,14 +4,14 @@ declare(strict_types=1);
 
 use App\Builders\Events\EventBuilder;
 use App\Livewire\Concerns\ShowTableTrait;
+use App\Livewire\Table\Columns\DateColumn;
+use App\Livewire\Table\Columns\LinkColumn;
+use App\Livewire\Table\DataTableComponent;
 use App\Livewire\Venues\Tables\PreviousEvents;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Users\User;
 use Livewire\Livewire;
-use Rappasoft\LaravelLivewireTables\DataTableComponent;
-use Rappasoft\LaravelLivewireTables\Views\Columns\DateColumn;
-use Rappasoft\LaravelLivewireTables\Views\Columns\LinkColumn;
 
 /**
  * Integration tests for PreviousEventsTable component query building and functionality.

--- a/tests/Unit/Livewire/Concerns/BaseTableTraitTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseTableTraitTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use App\Livewire\Concerns\BaseTableTrait;
 use App\Livewire\Concerns\Columns\HasActionColumn;
-use Rappasoft\LaravelLivewireTables\Views\Column;
+use App\Livewire\Table\Column;
 use Tests\Integration\Livewire\Concerns\BaseTableTraitTest;
 
 /**
@@ -133,7 +133,7 @@ describe('BaseTableTrait Unit Tests', function () {
             $source = file_get_contents($reflection->getFileName());
 
             expect($source)->toContain('use App\\Livewire\\Concerns\\Columns\\HasActionColumn;');
-            expect($source)->toContain('use Rappasoft\\LaravelLivewireTables\\Views\\Column;');
+            expect($source)->toContain('use App\\Livewire\\Table\\Column;');
         });
     });
 
@@ -162,11 +162,11 @@ describe('BaseTableTrait Unit Tests', function () {
     });
 
     describe('laravel livewire tables integration', function () {
-        test('uses Laravel Livewire Tables components', function () {
+        test('uses application Livewire table components', function () {
             $reflection = new ReflectionClass(BaseTableTrait::class);
             $source = file_get_contents($reflection->getFileName());
 
-            expect($source)->toContain('Rappasoft\\LaravelLivewireTables\\Views\\Column');
+            expect($source)->toContain('App\\Livewire\\Table\\Column');
         });
 
         test('follows Laravel Livewire Tables patterns', function () {

--- a/tests/Unit/Livewire/Concerns/Columns/HasActionColumnTest.php
+++ b/tests/Unit/Livewire/Concerns/Columns/HasActionColumnTest.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use App\Livewire\Concerns\Columns\HasActionColumn;
-use Rappasoft\LaravelLivewireTables\Views\Column;
+use App\Livewire\Table\Column;
 use Tests\Integration\Livewire\Concerns\Columns\HasActionColumnTest;
 
 /**
@@ -48,7 +48,7 @@ describe('HasActionColumn Unit Tests', function () {
 
             $method = $reflection->getMethod('getDefaultActionColumn');
             expect($method->isProtected())->toBeTrue();
-            expect($method->getReturnType()->getName())->toBe('Rappasoft\\LaravelLivewireTables\\Views\\Column');
+            expect($method->getReturnType()->getName())->toBe(Column::class);
             expect($method->getNumberOfParameters())->toBe(0);
         });
     });
@@ -70,7 +70,7 @@ describe('HasActionColumn Unit Tests', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
             $source = file_get_contents($reflection->getFileName());
 
-            expect($source)->toContain('use Rappasoft\\LaravelLivewireTables\\Views\\Column;');
+            expect($source)->toContain('use App\\Livewire\\Table\\Column;');
         });
     });
 


### PR DESCRIPTION
## Summary
- Align Livewire table column expectations with the Laravel 13 / Livewire 4 app table wrappers.
- Keep application code unchanged; tests now assert `App\Livewire\Table\*` conventions.

## Testing
- `php -d memory_limit=4G ./vendor/bin/pest tests/Unit/Livewire/Concerns/Columns/HasActionColumnTest.php tests/Unit/Livewire/Concerns/BaseTableTraitTest.php tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php --colors=never`
- `./vendor/bin/pint --test tests/Unit/Livewire/Concerns/Columns/HasActionColumnTest.php tests/Unit/Livewire/Concerns/BaseTableTraitTest.php tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php`

Linear: INF-104