### PR TITLE
test: align tag team lifecycle trait expectation

### DIFF
--- a/tests/Unit/Models/TagTeams/TagTeamTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamTest.php
@@ -12,9 +12,7 @@ use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsRetirable;
 use App\Models\Concerns\IsSuspendable;
 use App\Models\Concerns\ProvidesTagTeamWrestlers;
-use App\Models\Concerns\ValidatesEmployment;
-use App\Models\Concerns\ValidatesRetirement;
-use App\Models\Concerns\ValidatesSuspension;
+use App\Models\Concerns\ValidatesTagTeamLifecycle;
 use App\Models\Contracts\Bookable;
 use App\Models\Contracts\CanBeAStableMember;
 use App\Models\Contracts\CanBeChampion;
@@ -87,9 +85,7 @@ describe('TagTeam Model Unit Tests', function () {
             expect(TagTeam::class)->usesTrait(IsSuspendable::class);
             expect(TagTeam::class)->usesTrait(ProvidesTagTeamWrestlers::class);
             expect(TagTeam::class)->usesTrait(SoftDeletes::class);
-            expect(TagTeam::class)->usesTrait(ValidatesEmployment::class);
-            expect(TagTeam::class)->usesTrait(ValidatesRetirement::class);
-            expect(TagTeam::class)->usesTrait(ValidatesSuspension::class);
+            expect(TagTeam::class)->usesTrait(ValidatesTagTeamLifecycle::class);
         });
     });
 


### PR DESCRIPTION
## Summary

- Update the `TagTeam` trait integration test to expect `ValidatesTagTeamLifecycle`.
- Preserve current model behavior: `TagTeam` already uses the tag-team-specific lifecycle validation trait instead of the generic employment, retirement, and suspension validators.

## Verification

- `php artisan test tests/Unit/Models/TagTeams/TagTeamTest.php --compact`
- `php artisan test tests/Unit/Models/TagTeams tests/Unit/Models/Concerns/ProvidesTagTeamWrestlersTest.php --compact`
- `composer test:lint -- --dirty`

## Notes

The targeted PHPStan file run reported `No files found to analyse` for the test path, so the meaningful gates are the targeted Pest runs plus the dirty Pint/lint check.
