### PR TITLE
Fix stable lifecycle validation drift

### DIFF
--- a/app/Models/Concerns/ValidatesStableLifecycle.php
+++ b/app/Models/Concerns/ValidatesStableLifecycle.php
@@ -489,8 +489,8 @@ trait ValidatesStableLifecycle
                     ->orWhereHas('suspensions', function ($suspensionQuery) {
                         $suspensionQuery->whereNull('ended_at'); // Currently suspended
                     })
-                    ->orWhereHas('currentStables', function ($stableQuery) {
-                        $stableQuery->where('stable_id', '!=', $this->id); // In another stable
+                    ->orWhereHas('currentStable', function ($stableQuery) {
+                        $stableQuery->whereKeyNot($this->id); // In another stable
                     });
             })
             ->get();
@@ -503,8 +503,8 @@ trait ValidatesStableLifecycle
                     ->orWhereHas('suspensions', function ($suspensionQuery) {
                         $suspensionQuery->whereNull('ended_at'); // Currently suspended
                     })
-                    ->orWhereHas('currentStables', function ($stableQuery) {
-                        $stableQuery->where('stable_id', '!=', $this->id); // In another stable
+                    ->orWhereHas('currentStable', function ($stableQuery) {
+                        $stableQuery->whereKeyNot($this->id); // In another stable
                     });
             })
             ->get();

--- a/database/factories/Stables/StableFactory.php
+++ b/database/factories/Stables/StableFactory.php
@@ -57,7 +57,7 @@ class StableFactory extends Factory
 
         return $this->has(StableActivation::factory()->started($activationDate), 'activations')
             ->hasAttached(
-                Wrestler::factory()->has(WrestlerEmployment::factory()->started($activationDate), 'employments'),
+                Wrestler::factory()->count(2)->has(WrestlerEmployment::factory()->started($activationDate), 'employments'),
                 ['joined_at' => $activationDate]
             )
             ->hasAttached(
@@ -91,7 +91,7 @@ class StableFactory extends Factory
 
         return $this->has(StableActivation::factory()->started($start)->ended($end), 'activations')
             ->hasAttached(
-                Wrestler::factory()->has(WrestlerEmployment::factory()->started($start), 'employments'),
+                Wrestler::factory()->count(2)->has(WrestlerEmployment::factory()->started($start), 'employments'),
                 ['joined_at' => $start, 'left_at' => $end]
             )
             ->hasAttached(
@@ -160,7 +160,7 @@ class StableFactory extends Factory
     {
         return $this
             ->hasAttached(
-                Wrestler::factory()
+                Wrestler::factory()->count(2)
                     ->has(WrestlerEmployment::factory()->started(Carbon::yesterday()), 'employments'),
                 ['joined_at' => now()]
             )

--- a/tests/Feature/Workflows/RosterManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/RosterManagementWorkflowTest.php
@@ -120,7 +120,7 @@ describe('Stable Formation and Management Workflow', function () {
     test('stable lifecycle management workflow', function () {
         // Given: A stable and administrator
         $admin = administrator();
-        $stable = Stable::factory()->create(['name' => 'The Shield']);
+        $stable = Stable::factory()->withEmployedDefaultMembers()->create(['name' => 'The Shield']);
 
         // When: Establishing the stable
         Livewire::actingAs($admin)
@@ -140,14 +140,17 @@ describe('Stable Formation and Management Workflow', function () {
         // Then: Stable should be retired
         expect($stable->fresh()->isRetired())->toBeTrue();
 
+        // Given: A retired stable with viable former members
+        $retiredStable = Stable::factory()->retired()->create(['name' => 'Evolution']);
+
         // When: Unretiring the stable
         Livewire::actingAs($admin)
             ->test(StablesTable::class)
-            ->call('handleStableAction', 'unretire', $stable->id)
+            ->call('handleStableAction', 'unretire', $retiredStable->id)
             ->assertHasNoErrors();
 
         // Then: Stable should no longer be retired
-        expect($stable->fresh()->isRetired())->toBeFalse();
+        expect($retiredStable->fresh()->isRetired())->toBeFalse();
     });
 });
 

--- a/tests/Integration/Actions/Stables/LifecycleTest.php
+++ b/tests/Integration/Actions/Stables/LifecycleTest.php
@@ -8,10 +8,9 @@ use App\Actions\Stables\RetireAction;
 use App\Actions\Stables\ReuniteAction;
 use App\Actions\Stables\UnretireAction;
 use App\Enums\Stables\StableStatus;
+use App\Exceptions\Roster\Stables\CannotBeDisbandedException;
 use App\Exceptions\Roster\Stables\CannotBeEstablishedException;
 use App\Exceptions\Roster\Stables\CannotBeUnretiredException;
-use App\Exceptions\Status\CannotBeActivatedException;
-use App\Exceptions\Status\CannotBeDisbandedException;
 use App\Models\Stables\Stable;
 use Illuminate\Support\Carbon;
 
@@ -184,18 +183,18 @@ describe('Stable Activation Action Integration', function () {
             UnretireAction::run($this->retiredStable, $unretireDate);
 
             $refreshedStable = $this->retiredStable->fresh();
-            expect($refreshedStable->isInactive())->toBeTrue();
-            expect($refreshedStable->status)->toBe(StableStatus::Inactive);
+            expect($refreshedStable->isCurrentlyActive())->toBeTrue();
+            expect($refreshedStable->status)->toBe(StableStatus::Active);
 
             // Verify retirement is ended
             $retirement = $refreshedStable->retirements()->latest()->first();
             expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($unretireDate->format('Y-m-d H:i:s'));
         });
 
-        test('unretire action does not create new activity period', function () {
+        test('unretire action can leave the stable inactive when immediate establishment is disabled', function () {
             $originalPeriodCount = $this->retiredStable->activityPeriods()->count();
 
-            UnretireAction::run($this->retiredStable, Carbon::now());
+            UnretireAction::run($this->retiredStable, Carbon::now(), establishImmediately: false);
 
             $refreshedStable = $this->retiredStable->fresh();
             expect($refreshedStable->activityPeriods()->count())->toBe($originalPeriodCount);
@@ -205,7 +204,7 @@ describe('Stable Activation Action Integration', function () {
 
     describe('complex lifecycle scenarios', function () {
         test('stable can go through full lifecycle with proper status tracking', function () {
-            $stable = Stable::factory()->create();
+            $stable = Stable::factory()->withEmployedDefaultMembers()->create();
 
             // Debut
             $debutDate = Carbon::now()->subYear();
@@ -229,7 +228,7 @@ describe('Stable Activation Action Integration', function () {
 
             // Unretire
             $unretireDate = Carbon::now();
-            UnretireAction::run($stable, $unretireDate);
+            UnretireAction::run($stable, $unretireDate, establishImmediately: false, requireFormerMembers: false);
 
             $finalStable = $stable->fresh();
             expect($finalStable->isInactive())->toBeTrue();
@@ -250,7 +249,7 @@ describe('Stable Activation Action Integration', function () {
         });
 
         test('action date validation maintains data integrity', function () {
-            $stable = Stable::factory()->create();
+            $stable = Stable::factory()->withEmployedDefaultMembers()->create();
 
             $debutDate = Carbon::now()->subMonths(6);
             $disbandDate = Carbon::now()->subMonths(3);
@@ -291,7 +290,7 @@ describe('Stable Activation Action Integration', function () {
             $activeStable = Stable::factory()->active()->create();
 
             expect(fn () => ReuniteAction::run($activeStable, Carbon::now()))
-                ->toThrow(CannotBeActivatedException::class);
+                ->toThrow(CannotBeEstablishedException::class);
         });
 
         test('retire action works from active or disbanded status', function () {

--- a/tests/Integration/Livewire/Stables/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Stables/Tables/MainTest.php
@@ -195,7 +195,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable is unretired
-            expect($retiredStable->fresh()->isInactive())->toBeTrue();
+            expect($retiredStable->fresh()->isCurrentlyActive())->toBeTrue();
         });
 
         test('establish action integration works correctly', function () {
@@ -213,7 +213,7 @@ describe('StablesTable Component', function () {
         });
 
         test('restore action integration works correctly', function () {
-            $deletedStable = Stable::factory()->trashed()->create(['name' => 'Deleted Stable']);
+            $deletedStable = Stable::factory()->retired()->trashed()->create(['name' => 'Deleted Stable']);
 
             $component = Livewire::actingAs($this->admin)
                 ->test(Main::class);


### PR DESCRIPTION
## Summary

- Updated stable lifecycle validation to use the existing singular currentStable relationship when checking whether a former member belongs to another stable.
- Updated stable factories and lifecycle/workflow/table tests to provide viable former-member fixtures for the three-member stable rule.
- Aligned unretire and restore expectations with the current action contract: default unretire establishes the stable immediately; inactive unretire remains available through establishImmediately: false.

## Domain note

A wrestler or tag team can only belong to one stable at a time. This PR keeps that model intact and does not add a plural current stable API.

## Verification

PASS: ./vendor/bin/pest --colors=never --compact tests/Unit/Models/Concerns/CanJoinStablesTest.php tests/Integration/Actions/Stables/LifecycleTest.php tests/Feature/Workflows/RosterManagementWorkflowTest.php tests/Integration/Livewire/Stables/Tables/MainTest.php
Result: 65 passed, 201 assertions.

PASS: composer test:lint -- --dirty
Result: Pint passed.

PARTIAL: php -d memory_limit=4G ./vendor/bin/pest --colors=never --compact --testsuite=Feature,Integration,Unit --stop-on-failure
Result before the singular-relationship correction: stable lifecycle bucket cleared; the broader run then stopped later in a separate tag-team RetireAction unit-test bucket.