### PR TITLE
test: align tag team retire action expectations

### DIFF
--- a/tests/Integration/Actions/TagTeams/RetireActionTest.php
+++ b/tests/Integration/Actions/TagTeams/RetireActionTest.php
@@ -94,15 +94,15 @@ test('it uses StatusTransitionPipeline for retirement', function () {
     // Get current employment to verify it gets ended
     $currentEmployment = $tagTeam->currentEmployment;
     expect($currentEmployment)->not()->toBeNull();
-    expect($tagTeam->currentRetirement())->toBeNull();
+    expect($tagTeam->currentRetirement)->toBeNull();
 
     RetireAction::run($tagTeam);
 
     $tagTeam->refresh();
 
     // Verify employment ended and retirement created through pipeline
-    expect($tagTeam->currentEmployment())->toBeNull();
-    expect($tagTeam->currentRetirement())->not()->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
+    expect($tagTeam->currentRetirement)->not()->toBeNull();
     expect($tagTeam->isRetired())->toBeTrue();
     expect($tagTeam->isEmployed())->toBeFalse();
 });
@@ -232,6 +232,6 @@ test('it preserves employment and retirement history', function () {
     expect($tagTeam->retirements()->count())->toBe($originalRetirementCount + 1);
 
     // Current employment should be ended, current retirement should be active
-    expect($tagTeam->currentEmployment())->toBeNull();
-    expect($tagTeam->currentRetirement())->not()->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
+    expect($tagTeam->currentRetirement)->not()->toBeNull();
 });


### PR DESCRIPTION
## Summary
- Align tag-team RetireAction tests to assert loaded relationship properties instead of relation builder method calls.
- Keeps the fix scoped to expectation drift; no production code changes.

## Verification
- `git diff --check`
- `./vendor/bin/pest --colors=never --compact tests/Integration/Actions/TagTeams/RetireActionTest.php` blocked locally: `env: php: No such file or directory`

## Ticket
INF-109


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test assertions for retirement functionality to use property access patterns, ensuring test reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeffreyDavidson/Ringside/pull/639?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->