### PR TITLE
ci: reduce Ringside Actions usage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,10 +3,16 @@ name: CI Pipeline
 on:
   push:
     branches:
-      - '*'         # matches every branch that doesn't contain a '/'
-      - '*/*'       # matches every branch containing a single '/'
-      - '**'        # matches every branch
-      - '!master'
+      - development
+      - master
+  pull_request:
+    branches:
+      - development
+      - master
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   ci:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,11 +16,11 @@ concurrency:
 
 jobs:
   ci:
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, macOS, ARM64, mac-studio-ringside]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
+        os: [macOS]
         php: [8.4]
         laravel: [13.*]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,42 +25,23 @@ jobs:
         laravel: [13.*]
 
     name: CI - PHP-${{ matrix.php }} - Laravel-${{ matrix.laravel }}
-    env:
-      extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}-L${{ matrix.laravel }}
-      extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo, :psr
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
-          key: ${{ env.extensionKey }}
+      - name: Verify local PHP
+        run: php -v && php -m
 
-      - name: Cache extensions
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ matrix.os }}-${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ matrix.os }}-${{ steps.extcache.outputs.key }}
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
-          tools: phpunit:latest
-          ini-values: memory_limit=512M
-          coverage: none
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Composer
+        run: |
+          mkdir -p "$RUNNER_TEMP/composer-bin"
+          curl -sS https://getcomposer.org/installer -o "$RUNNER_TEMP/composer-setup.php"
+          php "$RUNNER_TEMP/composer-setup.php" --install-dir="$RUNNER_TEMP/composer-bin" --filename=composer
+          echo "$RUNNER_TEMP/composer-bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/composer-bin/composer" --version
 
       - name: Setup problem matchers for PHP
-        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+        run: echo "PHP problem matcher skipped on self-hosted runner"
 
       - name: Get composer cache directory
         id: composer-cache
@@ -89,7 +70,7 @@ jobs:
           php artisan config:cache
 
       - name: Setup problem matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+        run: echo "PHPUnit problem matcher skipped on self-hosted runner"
 
       - name: Run Feature Tests
         run: php ./vendor/bin/pest --ci --testsuite "Feature" --no-coverage --parallel

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -32,6 +32,7 @@ jobs:
           pintVersion: 1.18.3
 
       - name: Commit styling changes
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: 'style: apply Laravel Pint formatting fixes'

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   php-code-styling:
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64, mac-studio-ringside]
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,15 +1,17 @@
 name: Fix PHP code style issues
 
 on:
-  push:
+  pull_request:
     branches:
-      - '*'         # matches every branch that doesn't contain a '/'
-      - '*/*'       # matches every branch containing a single '/'
-      - '**'        # matches every branch
-      - '!master'
-      - '!development'  # exclude protected development branch
+      - development
+      - master
     paths:
       - '**.php'
+  workflow_dispatch:
+
+concurrency:
+  group: pint-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
@@ -22,7 +24,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.head_ref || github.ref_name }}
 
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@latest

--- a/.github/workflows/run-tests-pcov-pull.yml
+++ b/.github/workflows/run-tests-pcov-pull.yml
@@ -1,14 +1,7 @@
 name: run-tests-pcov-pull
 
 on:
-  push:
-    branches:
-      - 'development'
-      - 'master'
-  pull_request:
-    branches:
-      - 'development'
-      - 'master'
+  workflow_dispatch:
 
 concurrency:
   group: pcov-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/run-tests-pcov-pull.yml
+++ b/.github/workflows/run-tests-pcov-pull.yml
@@ -10,6 +10,10 @@ on:
       - 'development'
       - 'master'
 
+concurrency:
+  group: pcov-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/run-tests-pcov-pull.yml
+++ b/.github/workflows/run-tests-pcov-pull.yml
@@ -25,42 +25,23 @@ jobs:
         laravel: [13]
 
     name: PCOV - ${{ matrix.os }} - P${{ matrix.php }} - L${{ matrix.laravel }}
-    env:
-      extensionKey: phpextensions-${{ matrix.os }}-P${{ matrix.php }}-withpcov
-      extensions: dom, curl, libxml, mbstring, zip, pdo, sqlite, pcov,pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, fileinfo
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Setup cache environment
-        id: extcache
-        uses: shivammathur/cache-extensions@v1
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
-          key: ${{ env.extensionKey }}
+      - name: Verify local PHP
+        run: php -v && php -m
 
-      - name: Cache extensions
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.extcache.outputs.dir }}
-          key: ${{ steps.extcache.outputs.key }}
-          restore-keys: ${{ steps.extcache.outputs.key }}
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: ${{ env.extensions }}
-          tools: phpunit:latest
-          ini-values: memory_limit=512M
-          coverage: pcov
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install Composer
+        run: |
+          mkdir -p "$RUNNER_TEMP/composer-bin"
+          curl -sS https://getcomposer.org/installer -o "$RUNNER_TEMP/composer-setup.php"
+          php "$RUNNER_TEMP/composer-setup.php" --install-dir="$RUNNER_TEMP/composer-bin" --filename=composer
+          echo "$RUNNER_TEMP/composer-bin" >> "$GITHUB_PATH"
+          "$RUNNER_TEMP/composer-bin/composer" --version
 
       - name: Setup problem matchers for PHP
-        run: echo "::add-matcher::${{ runner.tool_cache }}/php.json"
+        run: echo "PHP problem matcher skipped on self-hosted runner"
 
       - name: Get composer cache directory
         id: composer-cache
@@ -89,7 +70,7 @@ jobs:
           php artisan config:cache
 
       - name: Setup problem matchers for PHPUnit
-        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+        run: echo "PHPUnit problem matcher skipped on self-hosted runner"
 
       - name: Run All Tests
         run: ./vendor/bin/pest --parallel --cache-directory=".phpunit.cache/code-coverage" --strict-coverage --coverage-clover ./coverage.xml --testsuite "Feature","Integration","Unit"

--- a/.github/workflows/run-tests-pcov-pull.yml
+++ b/.github/workflows/run-tests-pcov-pull.yml
@@ -16,11 +16,11 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ${{ matrix.os }}
+    runs-on: [self-hosted, macOS, ARM64, mac-studio-ringside]
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04]
+        os: [macOS]
         php: [8.4]
         laravel: [13]
 


### PR DESCRIPTION
## Summary

- Stop running the main Ringside CI workflow on every feature-branch push.
- Run normal CI on PRs to development / master and pushes to protected branches only.
- Move the PCOV coverage workflow to manual dispatch only so it does not block the single Mac runner.
- Move the Pint auto-fix workflow from all branch pushes to PRs/manual dispatch.
- Guard the Pint auto-commit step so it only pushes changes for same-repository PRs.
- Add concurrency cancellation so superseded runs do not keep burning minutes.
- Run Ringside checks on the repo-scoped Mac Studio runner label mac-studio-ringside.

## Verification

- git diff --check
- mac-studio-ringside runner registered and online

## Notes

This keeps normal PR coverage while reducing accidental GitHub-hosted minute usage and avoiding long PCOV coverage jobs on the single self-hosted runner.
