### PR TITLE
test: align tag team suspension relation assertions

### DIFF
--- a/tests/Integration/Actions/TagTeams/SuspendActionTest.php
+++ b/tests/Integration/Actions/TagTeams/SuspendActionTest.php
@@ -51,14 +51,14 @@ test('it suspends tag team with specific suspension date', function () {
 test('it uses StatusTransitionPipeline for suspension', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
 
-    expect($tagTeam->currentSuspension())->toBeNull();
+    expect($tagTeam->currentSuspension)->toBeNull();
 
     SuspendAction::run($tagTeam);
 
     $tagTeam->refresh();
 
     // Verify suspension created through pipeline
-    expect($tagTeam->currentSuspension())->not()->toBeNull();
+    expect($tagTeam->currentSuspension)->not()->toBeNull();
     expect($tagTeam->isSuspended())->toBeTrue();
     expect($tagTeam->isEmployed())->toBeTrue();
 
@@ -212,7 +212,7 @@ test('it preserves suspension history during new suspension', function () {
     expect($tagTeam->suspensions()->where('ended_at', '!=', null)->count())->toBe(1);
 
     // Current suspension should be active
-    expect($tagTeam->currentSuspension())->not()->toBeNull();
+    expect($tagTeam->currentSuspension)->not()->toBeNull();
 });
 
 test('it handles tag team with complex employment history', function () {


### PR DESCRIPTION
## Summary

- Align TagTeams SuspendAction integration assertions with the current `currentSuspension` relationship contract.
- Keep the fix test-only for the reproduced PR #640 baseline failure.

## Classification

Test expectation drift: `currentSuspension()` returns a `HasOne` relation builder; the loaded relation value is available via `currentSuspension`.

## Verification

- ./vendor/bin/pest --colors=never --compact tests/Integration/Actions/TagTeams/SuspendActionTest.php
- git diff --check


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated internal test assertions to improve verification accuracy for suspension status validation in team management workflows.

**Note:** This release contains no user-facing changes. Updates are limited to testing infrastructure improvements.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeffreyDavidson/Ringside/pull/641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->