### PR TITLE
fix: skip tag team auto-employ without partners

### DIFF
--- a/app/Actions/Concerns/UnretirementCascadeStrategy.php
+++ b/app/Actions/Concerns/UnretirementCascadeStrategy.php
@@ -188,6 +188,10 @@ class UnretirementCascadeStrategy
                 return;
             }
 
+            if (method_exists($entity, 'currentWrestlers') && $entity->currentWrestlers->isEmpty()) {
+                return;
+            }
+
             // Employ the entity using StatusTransitionPipeline
             StatusTransitionPipeline::employ($entity, $date)
                 ->withCascade(EmploymentCascadeStrategy::wrestlers())

--- a/tests/Integration/Actions/TagTeams/UnretireActionTest.php
+++ b/tests/Integration/Actions/TagTeams/UnretireActionTest.php
@@ -80,6 +80,28 @@ test('it uses StatusTransitionPipeline for unretirement', function () {
     expect($tagTeam->isEmployed())->toBeTrue();
 });
 
+test('it unretires without auto-employing when no current wrestlers are available', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $tagTeam->retirements()->create([
+        'started_at' => now()->subDays(2),
+        'ended_at' => null,
+    ]);
+
+    $tagTeam->refresh();
+    expect($tagTeam->isRetired())->toBeTrue();
+    expect($tagTeam->currentWrestlers)->toBeEmpty();
+
+    UnretireAction::run($tagTeam, requireAvailablePartners: false);
+
+    $tagTeam->refresh();
+
+    expect($tagTeam->isRetired())->toBeFalse();
+    expect($tagTeam->isEmployed())->toBeFalse();
+    expect($tagTeam->currentRetirement)->toBeNull();
+    expect($tagTeam->currentEmployment)->toBeNull();
+    expect($tagTeam->employments()->count())->toBe(0);
+});
+
 test('it prevents unretiring non-retired tag team', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
 

--- a/tests/Integration/Builders/VenueQueryBuilderTest.php
+++ b/tests/Integration/Builders/VenueQueryBuilderTest.php
@@ -30,7 +30,7 @@ describe('VenueBuilder Query Scopes', function () {
         $this->venueWithBothEvents = Venue::factory()->create(['name' => 'Mixed Events Venue']);
 
         // Create events for different venues
-        Event::factory()->atVenue($this->venueWithEvents)->create(['date' => Carbon::now()->subHour()]);  // Past event (1 hour ago)
+        Event::factory()->atVenue($this->venueWithEvents)->create(['date' => null]);
 
         Event::factory()->atVenue($this->venueWithPastEvents)->create([
             'date' => Carbon::yesterday(),


### PR DESCRIPTION
## Summary

- Skip immediate auto-employment when a tag team has no current wrestlers after unretirement
- Add regression coverage for unretiring a partner-less tag team with `requireAvailablePartners: false`
- Stabilize the venue query-builder fixture that was failing in CI near UTC midnight

## Verification

- `php artisan test tests/Integration/Actions/TagTeams/UnretireActionTest.php`
- `php artisan test tests/Integration/Actions/TagTeams/EmployActionTest.php tests/Integration/Actions/TagTeams/RetireActionTest.php tests/Integration/Actions/TagTeams/UnretireActionTest.php tests/Unit/Actions/TagTeams/RetireActionTest.php`
- `php artisan test tests/Integration/Builders/VenueQueryBuilderTest.php tests/Integration/Actions/TagTeams/UnretireActionTest.php tests/Integration/Actions/TagTeams/EmployActionTest.php tests/Integration/Actions/TagTeams/RetireActionTest.php tests/Unit/Actions/TagTeams/RetireActionTest.php`
- `./vendor/bin/pint app/Actions/Concerns/UnretirementCascadeStrategy.php tests/Integration/Actions/TagTeams/UnretireActionTest.php tests/Integration/Builders/VenueQueryBuilderTest.php`
- `git diff --check`

## Notes

Ports the useful behavior from stale PR #627 onto current `development` without adopting unrelated lifecycle changes from #618 or #620.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tag team unretirement logic to prevent unnecessary processing when no available partners exist.

* **Tests**
  * Expanded test coverage for unretirement scenarios and venue query builder fixtures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeffreyDavidson/Ringside/pull/643?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->