### PR TITLE
fix: guard stable retirement future activations

### DIFF
--- a/app/Actions/Stables/RetireAction.php
+++ b/app/Actions/Stables/RetireAction.php
@@ -68,11 +68,12 @@ class RetireAction
         $stable->ensureCanBeRetired();
 
         $retirementDate = $retirementDate ?? now();
+        $operationalDate = $retirementDate->isFuture() ? now() : $retirementDate;
 
-        DB::transaction(function () use ($stable, $retirementDate): void {
+        DB::transaction(function () use ($stable, $retirementDate, $operationalDate): void {
             // End activity if currently active using injected Action
             if ($stable->isCurrentlyActive()) {
-                $this->endActivityPeriodAction->handle($stable, $retirementDate);
+                $this->endActivityPeriodAction->handle($stable, $operationalDate);
             }
 
             // Get current members using enhanced model method
@@ -98,7 +99,7 @@ class RetireAction
             }
 
             // Remove all current members using injected Action
-            $this->removeStableMembersAction->handle($stable, $currentMembers, $retirementDate);
+            $this->removeStableMembersAction->handle($stable, $currentMembers, $operationalDate);
 
             // Create retirement record directly
             $stable->retirements()->create([

--- a/app/Models/Concerns/ValidatesStableLifecycle.php
+++ b/app/Models/Concerns/ValidatesStableLifecycle.php
@@ -534,6 +534,10 @@ trait ValidatesStableLifecycle
             return false;
         }
 
+        if (! $this->isCurrentlyActive() && $this->hasFutureActivation()) {
+            return false;
+        }
+
         // Basic retirement is possible if not already retired and has been active
         return true;
     }
@@ -554,6 +558,10 @@ trait ValidatesStableLifecycle
         }
 
         if (! $this->hasActivityPeriods()) {
+            throw CannotBeRetiredException::notActive($this);
+        }
+
+        if (! $this->isCurrentlyActive() && $this->hasFutureActivation()) {
             throw CannotBeRetiredException::notActive($this);
         }
 

--- a/tests/Integration/Actions/Stables/RetireActionTest.php
+++ b/tests/Integration/Actions/Stables/RetireActionTest.php
@@ -45,6 +45,27 @@ test('it retires an active stable at a specific datetime', function () {
     expect($stable->isCurrentlyActive())->toBeFalse();
 });
 
+test('it records a future retirement date while ending current operations now', function () {
+    $stable = Stable::factory()->active()->create();
+    $datetime = now()->addMonth();
+
+    resolve(RetireAction::class)->handle($stable, $datetime);
+
+    $stable->refresh();
+
+    expect($stable->isRetired())->toBeTrue();
+    expect($stable->currentRetirement->started_at->toDateTimeString())->toBe($datetime->toDateTimeString());
+    expect($stable->activityPeriods()->latest('id')->first()->ended_at->toDateTimeString())->toBe(now()->toDateTimeString());
+
+    foreach ($stable->previousWrestlers as $wrestler) {
+        expect($wrestler->pivot->left_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    }
+
+    foreach ($stable->previousTagTeams as $tagTeam) {
+        expect($tagTeam->pivot->left_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    }
+});
+
 test('it retires an inactive stable at the current datetime by default', function () {
     $stable = Stable::factory()->inactive()->create();
 
@@ -121,5 +142,6 @@ test('it throws exception trying to retire a non retirable stable', function ($f
     resolve(RetireAction::class)->handle($stable);
 })->throws(CannotBeRetiredException::class)->with([
     'unactivated',
+    'withFutureActivation',
     'retired',
 ]);


### PR DESCRIPTION
## Summary

- Reject retirement for stables that only have a future activation scheduled
- Preserve a user-supplied future retirement date on the retirement record while ending current operations at now
- Add regression coverage for future-only activations and future retirement dates

## Verification

- `php artisan test tests/Integration/Actions/Stables/RetireActionTest.php tests/Integration/Actions/Stables/LifecycleTest.php`
- `./vendor/bin/pint app/Actions/Stables/RetireAction.php app/Models/Concerns/ValidatesStableLifecycle.php tests/Integration/Actions/Stables/RetireActionTest.php`
- `git diff --check`

## Notes

Ports the useful behavior from stale PR #624 onto current `development`. Current `development` already covers the stable lifecycle and Livewire/table pieces from #619 and #631.
