### PR TITLE
fix: allow orthogonal injury suspension states

### DIFF
--- a/app/Models/Concerns/ValidatesInjury.php
+++ b/app/Models/Concerns/ValidatesInjury.php
@@ -39,7 +39,6 @@ trait ValidatesInjury
      * - Must not be retired
      * - Must not have future employment scheduled
      * - Must not already be injured
-     * - Must not be suspended
      *
      * @return bool True if the model can be injured, false otherwise
      *
@@ -57,8 +56,7 @@ trait ValidatesInjury
         return ! $this->isNotInEmployment()
             && ! $this->isRetired()
             && ! $this->hasFutureEmployment()
-            && ! $this->isInjured()
-            && ! $this->isSuspended();
+            && ! $this->isInjured();
     }
 
     /**
@@ -97,9 +95,6 @@ trait ValidatesInjury
             throw CannotBeInjuredException::injured($this);
         }
 
-        if ($this->isSuspended()) {
-            throw CannotBeInjuredException::suspended($this);
-        }
     }
 
     /**

--- a/app/Models/Concerns/ValidatesSuspension.php
+++ b/app/Models/Concerns/ValidatesSuspension.php
@@ -95,9 +95,8 @@ trait ValidatesSuspension
      * - Must not be unemployed
      * - Must not be released
      * - Must not have future employment
-     * - Must not be injured
      * - Must not be retired
-     * - Must not be bookable (already reinstated)
+     * - Must be suspended or injured
      *
      * @return bool True if the model can be reinstated, false otherwise
      *
@@ -113,13 +112,14 @@ trait ValidatesSuspension
     public function canBeReinstated(): bool
     {
         $type = RosterMemberType::fromModel($this);
+        $isSuspended = $this instanceof Suspendable && $this->isSuspended();
+        $isInjured = $type->canBeInjured() && $this instanceof Injurable && $this->isInjured();
 
         return ! $this->isNotInEmployment()
             && ! $this->isReleased()
             && ! $this->hasFutureEmployment()
-            && (! $type->canBeInjured() || ! ($this instanceof Injurable) || ! $this->isInjured())
             && ! $this->isRetired()
-            && (! ($this instanceof Bookable) || ! $this->isBookable());
+            && ($isSuspended || $isInjured);
     }
 
     /**
@@ -139,7 +139,11 @@ trait ValidatesSuspension
      */
     public function ensureCanBeReinstated(): void
     {
-        if ($this instanceof Suspendable && ! $this->isSuspended()) {
+        $type = RosterMemberType::fromModel($this);
+        $isSuspended = $this instanceof Suspendable && $this->isSuspended();
+        $isInjured = $type->canBeInjured() && $this instanceof Injurable && $this->isInjured();
+
+        if (! $isSuspended && ! $isInjured) {
             throw CannotBeReinstatedException::available($this);
         }
 
@@ -149,11 +153,6 @@ trait ValidatesSuspension
 
         if ($this->hasFutureEmployment()) {
             throw CannotBeReinstatedException::hasFutureEmployment($this);
-        }
-
-        $type = RosterMemberType::fromModel($this);
-        if ($type->canBeInjured() && ($this instanceof Injurable) && $this->isInjured()) {
-            throw CannotBeReinstatedException::injured($this);
         }
 
         if ($this->isRetired()) {

--- a/app/Models/Concerns/ValidatesSuspension.php
+++ b/app/Models/Concerns/ValidatesSuspension.php
@@ -96,6 +96,7 @@ trait ValidatesSuspension
      * - Must not be released
      * - Must not have future employment
      * - Must not be retired
+     * - Must not be bookable
      * - Must be suspended or injured
      *
      * @return bool True if the model can be reinstated, false otherwise
@@ -114,11 +115,13 @@ trait ValidatesSuspension
         $type = RosterMemberType::fromModel($this);
         $isSuspended = $this instanceof Suspendable && $this->isSuspended();
         $isInjured = $type->canBeInjured() && $this instanceof Injurable && $this->isInjured();
+        $isBookable = $this instanceof Bookable && $this->isBookable();
 
         return ! $this->isNotInEmployment()
             && ! $this->isReleased()
             && ! $this->hasFutureEmployment()
             && ! $this->isRetired()
+            && ! $isBookable
             && ($isSuspended || $isInjured);
     }
 

--- a/app/Models/Validation/Strategies/IndividualSuspensionValidation.php
+++ b/app/Models/Validation/Strategies/IndividualSuspensionValidation.php
@@ -45,9 +45,6 @@ class IndividualSuspensionValidation implements SuspensionValidationStrategy
             throw CannotBeSuspendedException::suspended($entity);
         }
 
-        if (method_exists($entity, 'isInjured') && $entity->isInjured()) {
-            throw CannotBeSuspendedException::injured($entity);
-        }
     }
 
     /**

--- a/tests/Integration/Actions/Managers/InjureActionTest.php
+++ b/tests/Integration/Actions/Managers/InjureActionTest.php
@@ -124,14 +124,19 @@ test('it maintains employment status during injury', function () {
     expect($employment->ended_at)->toBeNull();
 });
 
-test('it prevents injuring suspended manager', function () {
+test('it injures suspended manager', function () {
     $manager = Manager::factory()->employed()->suspended()->create();
 
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isInjured())->toBeFalse();
 
-    expect(fn () => InjureAction::run($manager))
-        ->toThrow(Exception::class);
+    InjureAction::run($manager);
+
+    $manager->refresh();
+
+    expect($manager->isSuspended())->toBeTrue();
+    expect($manager->isInjured())->toBeTrue();
+    expect($manager->isEmployed())->toBeTrue();
 });
 
 test('it uses DateHelper for consistent date handling', function () {

--- a/tests/Integration/Actions/Managers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Managers/ReinstateActionTest.php
@@ -157,7 +157,7 @@ test('it handles multiple suspensions correctly', function () {
     expect($manager->suspensions()->whereNull('ended_at')->count())->toBe(0);
 });
 
-test('it prevents reinstating injured suspended manager', function () {
+test('it reinstates injured suspended manager', function () {
     // This would be an invalid state, but test the business rule
     $manager = Manager::factory()->employed()->suspended()->create();
 
@@ -168,7 +168,11 @@ test('it prevents reinstating injured suspended manager', function () {
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isInjured())->toBeTrue();
 
-    // Should prevent reinstatement if injured (business rule)
-    expect(fn () => ReinstateAction::run($manager))
-        ->toThrow(Exception::class);
+    ReinstateAction::run($manager);
+
+    $manager->refresh();
+
+    expect($manager->isSuspended())->toBeFalse();
+    expect($manager->isInjured())->toBeFalse();
+    expect($manager->isEmployed())->toBeTrue();
 });

--- a/tests/Integration/Actions/Managers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Managers/ReinstateActionTest.php
@@ -167,6 +167,8 @@ test('it reinstates injured suspended manager', function () {
 
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isInjured())->toBeTrue();
+    $suspensionId = $manager->currentSuspension->id;
+    $injuryId = $manager->currentInjury->id;
 
     ReinstateAction::run($manager);
 
@@ -175,4 +177,12 @@ test('it reinstates injured suspended manager', function () {
     expect($manager->isSuspended())->toBeFalse();
     expect($manager->isInjured())->toBeFalse();
     expect($manager->isEmployed())->toBeTrue();
+    $this->assertDatabaseMissing('managers_suspensions', [
+        'id' => $suspensionId,
+        'ended_at' => null,
+    ]);
+    $this->assertDatabaseMissing('managers_injuries', [
+        'id' => $injuryId,
+        'ended_at' => null,
+    ]);
 });

--- a/tests/Integration/Actions/Managers/SuspendActionTest.php
+++ b/tests/Integration/Actions/Managers/SuspendActionTest.php
@@ -124,14 +124,19 @@ test('it maintains employment status during suspension', function () {
     expect($employment->ended_at)->toBeNull();
 });
 
-test('it prevents suspending injured manager', function () {
+test('it suspends injured manager', function () {
     $manager = Manager::factory()->employed()->injured()->create();
 
     expect($manager->isInjured())->toBeTrue();
     expect($manager->isSuspended())->toBeFalse();
 
-    expect(fn () => SuspendAction::run($manager))
-        ->toThrow(Exception::class);
+    SuspendAction::run($manager);
+
+    $manager->refresh();
+
+    expect($manager->isInjured())->toBeTrue();
+    expect($manager->isSuspended())->toBeTrue();
+    expect($manager->isEmployed())->toBeTrue();
 });
 
 test('it uses DateHelper for consistent date handling', function () {

--- a/tests/Integration/Actions/Wrestlers/InjureActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/InjureActionTest.php
@@ -140,14 +140,19 @@ test('it prevents injuring unemployed wrestler', function () {
         ->toThrow(Exception::class);
 });
 
-test('it prevents injuring suspended wrestler', function () {
+test('it injures suspended wrestler', function () {
     $wrestler = Wrestler::factory()->suspended()->create();
 
     expect($wrestler->isSuspended())->toBeTrue();
     expect($wrestler->isEmployed())->toBeTrue();
 
-    expect(fn () => InjureAction::run($wrestler))
-        ->toThrow(Exception::class);
+    InjureAction::run($wrestler);
+
+    $wrestler->refresh();
+
+    expect($wrestler->isSuspended())->toBeTrue();
+    expect($wrestler->isInjured())->toBeTrue();
+    expect($wrestler->isEmployed())->toBeTrue();
 });
 
 test('it maintains injury history integrity', function () {

--- a/tests/Integration/Actions/Wrestlers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/ReinstateActionTest.php
@@ -30,14 +30,23 @@ test('it reinstates a suspended wrestler', function () {
     ]);
 });
 
-test('it prevents reinstating an injured wrestler', function () {
+test('it reinstates an injured wrestler', function () {
     $wrestler = Wrestler::factory()->injured()->create();
 
     expect($wrestler->isInjured())->toBeTrue();
     expect($wrestler->isEmployed())->toBeTrue();
 
-    expect(fn () => ReinstateAction::run($wrestler))
-        ->toThrow(Exception::class);
+    ReinstateAction::run($wrestler);
+
+    $wrestler->refresh();
+
+    expect($wrestler->isInjured())->toBeFalse();
+    expect($wrestler->isEmployed())->toBeTrue();
+
+    $this->assertDatabaseHas('wrestlers_injuries', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => now()->toDateTimeString(),
+    ]);
 });
 
 test('it reinstates wrestler with specific reinstatement date', function () {
@@ -95,7 +104,7 @@ test('it handles DateHelper date resolution', function () {
     ]);
 });
 
-test('it prevents reinstating wrestler with both suspension and injury', function () {
+test('it reinstates wrestler with both suspension and injury', function () {
     // Create employed wrestler, then suspend and injure them
     $wrestler = Wrestler::factory()->employed()->create();
 
@@ -114,8 +123,13 @@ test('it prevents reinstating wrestler with both suspension and injury', functio
     expect($wrestler->isInjured())->toBeTrue();
     expect($wrestler->isEmployed())->toBeTrue(); // Still employed despite suspension/injury
 
-    expect(fn () => ReinstateAction::run($wrestler))
-        ->toThrow(Exception::class);
+    ReinstateAction::run($wrestler);
+
+    $wrestler->refresh();
+
+    expect($wrestler->isSuspended())->toBeFalse();
+    expect($wrestler->isInjured())->toBeFalse();
+    expect($wrestler->isEmployed())->toBeTrue();
 });
 
 test('it handles multiple suspension records correctly', function () {

--- a/tests/Integration/Actions/Wrestlers/SuspendActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/SuspendActionTest.php
@@ -162,7 +162,7 @@ test('it prevents suspending unemployed wrestler', function () {
         ->toThrow(Exception::class);
 });
 
-test('it prevents suspending injured employed wrestler', function () {
+test('it suspends injured employed wrestler', function () {
     // Create employed wrestler who then gets injured
     $wrestler = Wrestler::factory()->employed()->create();
     $wrestler->injuries()->create([
@@ -173,6 +173,11 @@ test('it prevents suspending injured employed wrestler', function () {
     expect($wrestler->isEmployed())->toBeTrue();
     expect($wrestler->isInjured())->toBeTrue();
 
-    expect(fn () => SuspendAction::run($wrestler))
-        ->toThrow(Exception::class);
+    SuspendAction::run($wrestler);
+
+    $wrestler->refresh();
+
+    expect($wrestler->isInjured())->toBeTrue();
+    expect($wrestler->isSuspended())->toBeTrue();
+    expect($wrestler->isEmployed())->toBeTrue();
 });

--- a/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
+++ b/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
@@ -251,7 +251,12 @@ describe('Wrestler Employment Workflows', function () {
 
             // Reinstate, then test retired wrestler cannot be employed
             ReinstateAction::run($injuredAndSuspended, Carbon::now());
-            RetireAction::run($wrestler->fresh(), Carbon::now());
+            $reinstated = $wrestler->fresh();
+            expect($reinstated->isSuspended())->toBeFalse();
+            expect($reinstated->isInjured())->toBeFalse();
+            expect($reinstated->isEmployed())->toBeTrue();
+
+            RetireAction::run($reinstated, Carbon::now());
             $retired = $wrestler->fresh();
             expect($retired->canBeEmployed())->toBeFalse();
             expect($retired->isRetired())->toBeTrue();

--- a/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
+++ b/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
@@ -235,23 +235,22 @@ describe('Wrestler Employment Workflows', function () {
             EmployAction::run($wrestler, Carbon::now());
             $employed = $wrestler->fresh();
 
-            // Test mutually exclusive statuses - injured wrestler cannot be suspended
+            // Injury and suspension are orthogonal states.
             InjureAction::run($employed, Carbon::now());
             $injured = $wrestler->fresh();
-            expect($injured->canBeSuspended())->toBeFalse();
+            expect($injured->canBeSuspended())->toBeTrue();
             expect($injured->isEmployed())->toBeTrue();
             expect($injured->isInjured())->toBeTrue();
 
-            // Heal wrestler, then test suspended wrestler cannot be injured
-            HealAction::run($injured, Carbon::now());
-            SuspendAction::run($wrestler->fresh(), Carbon::now());
-            $suspended = $wrestler->fresh();
-            expect($suspended->canBeInjured())->toBeFalse();
-            expect($suspended->isEmployed())->toBeTrue();
-            expect($suspended->isSuspended())->toBeTrue();
+            SuspendAction::run($injured, Carbon::now());
+            $injuredAndSuspended = $wrestler->fresh();
+            expect($injuredAndSuspended->canBeInjured())->toBeFalse();
+            expect($injuredAndSuspended->isEmployed())->toBeTrue();
+            expect($injuredAndSuspended->isInjured())->toBeTrue();
+            expect($injuredAndSuspended->isSuspended())->toBeTrue();
 
             // Reinstate, then test retired wrestler cannot be employed
-            ReinstateAction::run($suspended, Carbon::now());
+            ReinstateAction::run($injuredAndSuspended, Carbon::now());
             RetireAction::run($wrestler->fresh(), Carbon::now());
             $retired = $wrestler->fresh();
             expect($retired->canBeEmployed())->toBeFalse();


### PR DESCRIPTION
## Summary

- Treat injury and suspension as orthogonal states for individual roster members
- Allow injured wrestlers/managers to be suspended, and suspended wrestlers/managers to be injured
- Allow reinstatement when an entity is suspended or injured, clearing active suspension and injury records together
- Update workflow coverage to reflect the orthogonal state model

## Verification

- `php artisan test tests/Integration/Actions/Wrestlers/SuspendActionTest.php tests/Integration/Actions/Managers/SuspendActionTest.php tests/Integration/Actions/Referees/SuspendActionTest.php tests/Integration/Actions/TagTeams/SuspendActionTest.php tests/Integration/Actions/Wrestlers/InjureActionTest.php tests/Integration/Actions/Managers/InjureActionTest.php tests/Integration/Actions/Wrestlers/ReinstateActionTest.php tests/Integration/Actions/Managers/ReinstateActionTest.php tests/Integration/Actions/Referees/ReinstateActionTest.php tests/Integration/Actions/TagTeams/ReinstateActionTest.php tests/Integration/Workflows/Wrestlers/EmploymentTest.php` — 114 passed, 447 assertions
- `./vendor/bin/pint app/Models/Concerns/ValidatesInjury.php app/Models/Concerns/ValidatesSuspension.php app/Models/Validation/Strategies/IndividualSuspensionValidation.php tests/Integration/Actions/Managers/InjureActionTest.php tests/Integration/Actions/Managers/ReinstateActionTest.php tests/Integration/Actions/Managers/SuspendActionTest.php tests/Integration/Actions/Wrestlers/InjureActionTest.php tests/Integration/Actions/Wrestlers/ReinstateActionTest.php tests/Integration/Actions/Wrestlers/SuspendActionTest.php tests/Integration/Workflows/Wrestlers/EmploymentTest.php`
- `git diff --check`

## Notes

Ports the useful behavior from stale PRs #622 and #623 onto current `development`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Individuals can now be injured while suspended and suspended while injured simultaneously.
  * Suspension and injury statuses are now treated as independent conditions.
  * Reinstatement functionality now supports both suspended and injured states.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/JeffreyDavidson/Ringside/pull/645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->