### PR TITLE
fix: restore referee employment on unretire

### DIFF
--- a/app/Actions/Referees/UnretireAction.php
+++ b/app/Actions/Referees/UnretireAction.php
@@ -51,5 +51,12 @@ class UnretireAction
 
         // Use StatusTransitionPipeline for consistent unretirement handling
         StatusTransitionPipeline::unretire($referee, $unretiredDate)->execute();
+
+        // Restart employment from the unretirement date so the referee is
+        // available for match assignments again.
+        $referee->employments()->create([
+            'started_at' => $unretiredDate,
+            'ended_at' => null,
+        ]);
     }
 }

--- a/tests/Integration/Actions/Referees/UnretireActionTest.php
+++ b/tests/Integration/Actions/Referees/UnretireActionTest.php
@@ -26,11 +26,12 @@ test('it unretires a retired referee', function () {
     $retirement->refresh();
 
     expect($referee->isRetired())->toBeFalse();
-    expect($referee->isEmployed())->toBeFalse();
+    expect($referee->isEmployed())->toBeTrue();
     expect($retirement->ended_at)->not->toBeNull();
 
-    $this->assertDatabaseMissing('referees_employments', [
+    $this->assertDatabaseHas('referees_employments', [
         'referee_id' => $referee->id,
+        'started_at' => now()->toDateTimeString(),
         'ended_at' => null,
     ]);
 });
@@ -46,7 +47,7 @@ test('it unretires referee with specific unretirement date', function () {
     $retirement->refresh();
 
     expect($referee->isRetired())->toBeFalse();
-    expect($referee->isEmployed())->toBeFalse();
+    expect($referee->isEmployed())->toBeTrue();
     expect($retirement->ended_at->toDateTimeString())->toBe($unretiredDate->toDateTimeString());
 
     $this->assertDatabaseHas('referees_retirements', [
@@ -54,8 +55,9 @@ test('it unretires referee with specific unretirement date', function () {
         'ended_at' => $unretiredDate->toDateTimeString(),
     ]);
 
-    $this->assertDatabaseMissing('referees_employments', [
+    $this->assertDatabaseHas('referees_employments', [
         'referee_id' => $referee->id,
+        'started_at' => $unretiredDate->toDateTimeString(),
         'ended_at' => null,
     ]);
 });
@@ -71,7 +73,7 @@ test('it uses StatusTransitionPipeline for consistent unretirement', function ()
     $referee->refresh();
 
     expect($referee->isRetired())->toBeFalse();
-    expect($referee->isEmployed())->toBeFalse();
+    expect($referee->isEmployed())->toBeTrue();
 });
 
 test('it handles DateHelper date resolution', function () {
@@ -88,8 +90,9 @@ test('it handles DateHelper date resolution', function () {
         'ended_at' => $unretiredDate->toDateTimeString(),
     ]);
 
-    $this->assertDatabaseMissing('referees_employments', [
+    $this->assertDatabaseHas('referees_employments', [
         'referee_id' => $referee->id,
+        'started_at' => $unretiredDate->toDateTimeString(),
         'ended_at' => null,
     ]);
 });
@@ -102,7 +105,7 @@ test('it validates referee can be unretired', function () {
 
     $referee->refresh();
     expect($referee->isRetired())->toBeFalse();
-    expect($referee->isEmployed())->toBeFalse();
+    expect($referee->isEmployed())->toBeTrue();
 });
 
 test('it throws exception when referee cannot be unretired', function () {
@@ -132,7 +135,7 @@ test('it preserves retirement history', function () {
     ]);
 });
 
-test('it leaves referee unemployed after unretirement', function () {
+test('it restores referee employment after unretirement', function () {
     $referee = Referee::factory()->retired()->create();
 
     expect($referee->isEmployed())->toBeFalse();
@@ -140,5 +143,10 @@ test('it leaves referee unemployed after unretirement', function () {
     UnretireAction::run($referee);
 
     $referee->refresh();
-    expect($referee->currentEmployment)->toBeNull();
+    $employment = $referee->currentEmployment;
+
+    expect($employment)->not->toBeNull();
+    expect($employment->referee_id)->toBe($referee->id);
+    expect($employment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    expect($employment->ended_at)->toBeNull();
 });

--- a/tests/Integration/Livewire/Referees/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Referees/Components/ActionsTest.php
@@ -333,7 +333,7 @@ describe('RefereesActions Integration Tests', function () {
             // Comeback
             $component->call('unretire');
             expect($referee->fresh()->isRetired())->toBeFalse();
-            expect($referee->fresh()->isEmployed())->toBeFalse();
+            expect($referee->fresh()->isEmployed())->toBeTrue();
             expect(true)->toBeTrue();
         });
 


### PR DESCRIPTION
## Summary

- Restore referee employment when a retired referee is unretired, matching manager unretirement behavior and the Referee UnretireAction docblock.
- Update referee unretirement coverage to assert the new active employment record, unretirement date, and Livewire lifecycle expectation.
- Port the useful behavior from stale PR #621 onto current `development`.

## Notes

- Did not adopt stale PR #625's idempotent EmployAction behavior because it conflicts with the shared employment validator and existing manager/referee double-employment rules.

## Verification

- [x] `php artisan test tests/Integration/Actions/Referees/UnretireActionTest.php tests/Integration/Actions/Managers/UnretireActionTest.php`
- [x] `./vendor/bin/pest tests/Integration/Livewire/Referees/Components/ActionsTest.php tests/Integration/Livewire/Managers/Components/ActionsTest.php`
- [x] `./vendor/bin/pint app/Actions/Referees/UnretireAction.php tests/Integration/Actions/Referees/UnretireActionTest.php`
- [x] `./vendor/bin/pint --dirty`
- [x] `git diff --check`
- [x] GitHub checks: CI, php-code-styling, PHPStan, CodeRabbit

## Merge

- Squash-merged into `development` as `926bd0b1f0985341e6f1019c02788d11c5d4506f`.