### PR TITLE
fix: make referee unretire employment atomic

### DIFF
--- a/app/Actions/Referees/UnretireAction.php
+++ b/app/Actions/Referees/UnretireAction.php
@@ -9,6 +9,7 @@ use App\Exceptions\Roster\CannotBeUnretiredException;
 use App\Models\Referees\Referee;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Lorisleiva\Actions\Concerns\AsAction;
 
 class UnretireAction
@@ -49,14 +50,13 @@ class UnretireAction
 
         $unretiredDate = DateHelper::resolveDate($unretiredDate);
 
-        // Use StatusTransitionPipeline for consistent unretirement handling
-        StatusTransitionPipeline::unretire($referee, $unretiredDate)->execute();
+        DB::transaction(function () use ($referee, $unretiredDate): void {
+            StatusTransitionPipeline::unretire($referee, $unretiredDate)->execute();
 
-        // Restart employment from the unretirement date so the referee is
-        // available for match assignments again.
-        $referee->employments()->create([
-            'started_at' => $unretiredDate,
-            'ended_at' => null,
-        ]);
+            $referee->employments()->create([
+                'started_at' => $unretiredDate,
+                'ended_at' => null,
+            ]);
+        });
     }
 }

--- a/tests/Integration/Actions/Referees/UnretireActionTest.php
+++ b/tests/Integration/Actions/Referees/UnretireActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\Referees\UnretireAction;
 use App\Exceptions\Roster\CannotBeUnretiredException;
 use App\Models\Referees\Referee;
+use App\Models\Referees\RefereeEmployment;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -149,4 +150,27 @@ test('it restores referee employment after unretirement', function () {
     expect($employment->referee_id)->toBe($referee->id);
     expect($employment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
+});
+
+test('it rolls back retirement changes when employment restoration fails', function () {
+    $referee = Referee::factory()->retired()->create();
+    $retirement = $referee->currentRetirement;
+
+    RefereeEmployment::creating(function (): void {
+        throw new RuntimeException('Employment restoration failed.');
+    });
+
+    try {
+        expect(fn () => UnretireAction::run($referee))
+            ->toThrow(RuntimeException::class);
+    } finally {
+        RefereeEmployment::flushEventListeners();
+    }
+
+    $referee->refresh();
+    $retirement->refresh();
+
+    expect($referee->isRetired())->toBeTrue();
+    expect($referee->isEmployed())->toBeFalse();
+    expect($retirement->ended_at)->toBeNull();
 });


### PR DESCRIPTION
## Summary

- Wrap referee unretirement status transition and employment restoration in one database transaction.
- Remove the inline comments CodeRabbit flagged in `UnretireAction`.
- Add regression coverage proving retirement changes roll back if employment restoration fails.

## Context

Follow-up to PR #646's CodeRabbit review. The referee should not end retirement unless the replacement active employment record is also created successfully.

## Verification

- [x] `./vendor/bin/pest tests/Integration/Actions/Referees/UnretireActionTest.php tests/Integration/Livewire/Referees/Components/ActionsTest.php`
- [x] `./vendor/bin/pint --dirty`
- [x] `git diff --check`
