### PR TITLE
ci: provision Node for Blade formatting

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -28,6 +28,12 @@ jobs:
           echo "$php_bin_dir" >> "$GITHUB_PATH"
           "$php_bin_dir/php" -v
 
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
       - name: Install Composer
         run: |
           mkdir -p "$RUNNER_TEMP/composer-bin"


### PR DESCRIPTION
## Summary

- provision Node.js 22 in the PHP code-style workflow
- enable npm dependency caching through setup-node
- make Blade formatting independent of the self-hosted runner's Homebrew Node installation

## Verification

- workflow YAML parses successfully
- git diff whitespace validation passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated formatting workflow to use Node.js 22.
  * Added npm dependency caching to improve workflow efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->