### PR TITLE
ci: add advisory Ward security scan

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -25,10 +25,6 @@ jobs:
     continue-on-error: true
     timeout-minutes: 15
 
-    env:
-      GOPATH: ${{ runner.temp }}/ward-go
-      WARD_HOME: ${{ runner.temp }}/ward-home
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -40,22 +36,22 @@ jobs:
         with:
           go-version: '1.24.x'
 
+      - name: Configure Ward environment
+        run: |
+          echo "GOPATH=$RUNNER_TEMP/ward-go" >> "$GITHUB_ENV"
+          echo "HOME=$RUNNER_TEMP/ward-home" >> "$GITHUB_ENV"
+          mkdir -p "$RUNNER_TEMP/ward-home"
+
       - name: Install Ward
         run: |
           go install github.com/eljakani/ward@v0.4.2
           echo "$GOPATH/bin" >> "$GITHUB_PATH"
 
       - name: Initialize Ward
-        env:
-          HOME: ${{ env.WARD_HOME }}
-        run: |
-          mkdir -p "$HOME"
-          ward init
+        run: ward init
 
       - name: Generate pull request baseline
         if: github.event_name == 'pull_request'
-        env:
-          HOME: ${{ env.WARD_HOME }}
         run: |
           git checkout "${{ github.event.pull_request.base.sha }}"
           ward scan . --output json --update-baseline "$RUNNER_TEMP/ward-baseline.json" || true
@@ -63,8 +59,6 @@ jobs:
 
       - name: Scan pull request changes
         if: github.event_name == 'pull_request'
-        env:
-          HOME: ${{ env.WARD_HOME }}
         run: |
           if [ -f "$RUNNER_TEMP/ward-baseline.json" ]; then
             ward scan . --output json,sarif --baseline "$RUNNER_TEMP/ward-baseline.json" --fail-on high
@@ -74,8 +68,6 @@ jobs:
 
       - name: Run scheduled security scan
         if: github.event_name != 'pull_request'
-        env:
-          HOME: ${{ env.WARD_HOME }}
         run: ward scan . --output json,sarif --fail-on high
 
       - name: Upload Ward reports

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,0 +1,97 @@
+name: Security Scan
+
+on:
+  pull_request:
+    branches:
+      - development
+      - master
+  schedule:
+    - cron: '0 9 * * 1'
+  workflow_dispatch:
+
+concurrency:
+  group: security-scan-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+jobs:
+  ward:
+    name: Ward Security Scan
+    runs-on: [self-hosted, macOS, ARM64, mac-studio-ringside]
+    continue-on-error: true
+    timeout-minutes: 15
+
+    env:
+      GOPATH: ${{ runner.temp }}/ward-go
+      WARD_HOME: ${{ runner.temp }}/ward-home
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.24.x'
+
+      - name: Install Ward
+        run: |
+          go install github.com/eljakani/ward@v0.4.2
+          echo "$GOPATH/bin" >> "$GITHUB_PATH"
+
+      - name: Initialize Ward
+        env:
+          HOME: ${{ env.WARD_HOME }}
+        run: |
+          mkdir -p "$HOME"
+          ward init
+
+      - name: Generate pull request baseline
+        if: github.event_name == 'pull_request'
+        env:
+          HOME: ${{ env.WARD_HOME }}
+        run: |
+          git checkout "${{ github.event.pull_request.base.sha }}"
+          ward scan . --output json --update-baseline "$RUNNER_TEMP/ward-baseline.json" || true
+          git checkout "${{ github.sha }}"
+
+      - name: Scan pull request changes
+        if: github.event_name == 'pull_request'
+        env:
+          HOME: ${{ env.WARD_HOME }}
+        run: |
+          if [ -f "$RUNNER_TEMP/ward-baseline.json" ]; then
+            ward scan . --output json,sarif --baseline "$RUNNER_TEMP/ward-baseline.json" --fail-on high
+          else
+            ward scan . --output json,sarif --fail-on high
+          fi
+
+      - name: Run scheduled security scan
+        if: github.event_name != 'pull_request'
+        env:
+          HOME: ${{ env.WARD_HOME }}
+        run: ward scan . --output json,sarif --fail-on high
+
+      - name: Upload Ward reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ward-security-reports
+          path: |
+            ward-report.json
+            ward-report.sarif
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload Ward SARIF
+        if: always() && hashFiles('ward-report.sarif') != ''
+        continue-on-error: true
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: ward-report.sarif

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -70,6 +70,12 @@ jobs:
         if: github.event_name != 'pull_request'
         run: ward scan . --output json,sarif --fail-on high
 
+      - name: Normalize empty SARIF collections
+        if: always() && hashFiles('ward-report.sarif') != ''
+        run: |
+          jq '(.runs[].tool.driver.rules //= []) | (.runs[].results //= [])' ward-report.sarif > "$RUNNER_TEMP/ward-report.sarif"
+          mv "$RUNNER_TEMP/ward-report.sarif" ward-report.sarif
+
       - name: Upload Ward reports
         if: always()
         uses: actions/upload-artifact@v4
@@ -84,6 +90,6 @@ jobs:
       - name: Upload Ward SARIF
         if: always() && hashFiles('ward-report.sarif') != ''
         continue-on-error: true
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ward-report.sarif


### PR DESCRIPTION
## Summary
- add a dedicated Laravel security scan for pull requests, weekly schedules, and manual runs
- pin Ward to `v0.4.2` instead of tracking an unreviewed latest release
- isolate Go and Ward state under the self-hosted runner temporary directory
- baseline pull requests against their actual base commit so reports emphasize new findings
- upload JSON and SARIF reports with 14-day retention
- keep the scan advisory while findings and false positives are evaluated

## Safety and rollout
- the Ward job uses `continue-on-error: true`, so it is not a required merge gate yet
- the job has a 15-minute timeout
- SARIF upload is non-blocking in case GitHub code scanning is unavailable
- no local Go installation or application dependency is introduced

## Verification
- workflow YAML parsed successfully
- workflow uses flags documented by Ward v0.4.2
- diff and whitespace validation passed