### PR TITLE
test: raise Pest PHPStan to level 4

### DIFF
--- a/phpstan-pest.neon
+++ b/phpstan-pest.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 3
+  level: 4
 
   paths:
     - tests

--- a/tests/Feature/Livewire/Wrestlers/Components/ActionsTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Components/ActionsTest.php
@@ -26,19 +26,6 @@ describe('Actions Basic Functionality', function () {
         expect($component->instance()->wrestler->id)->toBe($this->wrestler->id);
     });
 
-    it('has required action methods', function () {
-        $component = new Actions();
-
-        expect(method_exists($component, 'employ'))->toBeTrue();
-        expect(method_exists($component, 'release'))->toBeTrue();
-        expect(method_exists($component, 'retire'))->toBeTrue();
-        expect(method_exists($component, 'unretire'))->toBeTrue();
-        expect(method_exists($component, 'suspend'))->toBeTrue();
-        expect(method_exists($component, 'reinstate'))->toBeTrue();
-        expect(method_exists($component, 'injure'))->toBeTrue();
-        expect(method_exists($component, 'healFromInjury'))->toBeTrue();
-    });
-
     it('can render successfully', function () {
         $component = testLivewire(Actions::class, ['wrestler' => $this->wrestler]);
 

--- a/tests/Helpers/StatusTestExpectations.php
+++ b/tests/Helpers/StatusTestExpectations.php
@@ -181,9 +181,6 @@ function expectTagTeamMembership($wrestler, $tagTeam, array $expectedPivotData =
         } elseif ($expectedValue instanceof Carbon) {
             // Handle Carbon instance comparison with string format
             expect(Carbon::parse($actualValue)->format('Y-m-d H:i:s'))->toBe($expectedValue->format('Y-m-d H:i:s'));
-        } elseif ($actualValue instanceof Carbon && $expectedValue instanceof Carbon) {
-            // Handle Carbon instance comparison with string format
-            expect($actualValue->format('Y-m-d H:i:s'))->toBe($expectedValue->format('Y-m-d H:i:s'));
         } elseif (is_numeric($actualValue) && is_numeric($expectedValue)) {
             expect((int) $actualValue)->toBe((int) $expectedValue);
         } else {
@@ -202,11 +199,9 @@ function expectCurrentRelationshipsActive(Wrestler $wrestler): void
         expect(relatedPivotAttribute($manager, 'fired_at'))->toBeNull();
     }
 
-    if (method_exists($wrestler, 'currentTagTeam')) {
-        $currentTagTeam = $wrestler->currentTagTeam;
-        if ($currentTagTeam) {
-            expect($currentTagTeam->pivot->left_at)->toBeNull();
-        }
+    $currentTagTeam = $wrestler->currentTagTeam;
+    if ($currentTagTeam) {
+        expect($currentTagTeam->pivot->left_at)->toBeNull();
     }
 }
 
@@ -220,11 +215,9 @@ function expectPreviousRelationshipsEnded(Wrestler $wrestler): void
         expect(relatedPivotAttribute($manager, 'fired_at'))->not->toBeNull();
     }
 
-    if (method_exists($wrestler, 'previousTagTeams')) {
-        $previousTagTeams = $wrestler->previousTagTeams()->get();
-        foreach ($previousTagTeams as $tagTeam) {
-            expect($tagTeam->pivot->left_at)->not->toBeNull();
-        }
+    $previousTagTeams = $wrestler->previousTagTeams()->get();
+    foreach ($previousTagTeams as $tagTeam) {
+        expect($tagTeam->pivot->left_at)->not->toBeNull();
     }
 }
 

--- a/tests/Integration/Builders/UserQueryBuilderTest.php
+++ b/tests/Integration/Builders/UserQueryBuilderTest.php
@@ -324,9 +324,6 @@ describe('UserBuilder Unit Tests', function () {
 
     describe('future extensibility', function () {
         test('builder is prepared for additional scopes', function () {
-            // Verify the builder can be extended with new methods
-            expect(method_exists(UserBuilder::class, '__call'))->toBeTrue();
-
             // Test that we can add scopes dynamically (Laravel's built-in functionality)
             $query = User::query();
             expect($query)->toBeInstanceOf(UserBuilder::class);

--- a/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
+++ b/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
@@ -209,9 +209,7 @@ describe('VenueForm Integration Tests', function () {
     });
 
     describe('extra data loading', function () {
-        test('loadExtraData method exists but has minimal implementation', function () {
-            expect(method_exists($this->form, 'loadExtraData'))->toBeTrue();
-
+        test('loadExtraData has a void return type', function () {
             $reflection = new ReflectionMethod($this->form, 'loadExtraData');
             expect(reflectionReturnTypeName($reflection))->toBe('void');
         });

--- a/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
@@ -310,7 +310,7 @@ describe('PreviousEventsTable Integration Tests', function () {
             // Create many events for the venue
             Event::factory()->count(50)->create([
                 'venue_id' => $this->venue->id,
-                'date' => now()->subDays(rand(1, 365)),
+                'date' => now()->subDays(random_int(1, 365)),
             ]);
 
             $component = Livewire::actingAs($this->admin)

--- a/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
@@ -229,9 +229,6 @@ describe('PreviousEventsTable Integration Tests', function () {
             $table = new PreviousEvents();
             $reflection = new ReflectionClass($table);
 
-            expect(property_exists($table, 'databaseTableName'))->toBeTrue();
-            expect(property_exists($table, 'resourceName'))->toBeTrue();
-
             $databaseTableNameProperty = $reflection->getProperty('databaseTableName');
             $databaseTableNameProperty->setAccessible(true);
             expect($databaseTableNameProperty->getValue($table))->toBe('events');

--- a/tests/Integration/Models/TagTeams/TagTeamWrestlerTest.php
+++ b/tests/Integration/Models/TagTeams/TagTeamWrestlerTest.php
@@ -88,13 +88,11 @@ describe('TagTeamWrestler Pivot Model', function () {
             expect($this->wrestler->currentTagTeam->id)->toBe($this->tagTeam->id);
             expect($this->secondWrestler->currentTagTeam->id)->toBe($this->tagTeam->id);
 
-            // Verify tag team has both wrestlers (if the reverse relationship exists)
-            if (method_exists($this->tagTeam, 'currentWrestlers')) {
-                expect($this->tagTeam->currentWrestlers()->count())->toBe(2);
-                expect($this->tagTeam->currentWrestlers->pluck('id'))
-                    ->toContain($this->wrestler->id)
-                    ->toContain($this->secondWrestler->id);
-            }
+            // Verify tag team has both wrestlers
+            expect($this->tagTeam->currentWrestlers()->count())->toBe(2);
+            expect($this->tagTeam->currentWrestlers->pluck('id'))
+                ->toContain($this->wrestler->id)
+                ->toContain($this->secondWrestler->id);
         });
 
         test('wrestler can be part of multiple tag teams across different time periods', function () {
@@ -431,14 +429,12 @@ describe('TagTeamWrestler Pivot Model', function () {
             expect($this->thirdWrestler->isAMemberOfCurrentTagTeam())->toBeTrue();
 
             // Verify tag team evolution
-            if (method_exists($this->tagTeam, 'currentWrestlers')) {
-                $currentMembers = $this->tagTeam->currentWrestlers()->get();
-                expect($currentMembers)->toHaveCount(2);
-                expect($currentMembers->pluck('id'))
-                    ->toContain($this->secondWrestler->id)
-                    ->toContain($this->thirdWrestler->id)
-                    ->not->toContain($this->wrestler->id);
-            }
+            $currentMembers = $this->tagTeam->currentWrestlers()->get();
+            expect($currentMembers)->toHaveCount(2);
+            expect($currentMembers->pluck('id'))
+                ->toContain($this->secondWrestler->id)
+                ->toContain($this->thirdWrestler->id)
+                ->not->toContain($this->wrestler->id);
         });
     });
 

--- a/tests/Integration/Models/Wrestlers/WrestlerManagerTest.php
+++ b/tests/Integration/Models/Wrestlers/WrestlerManagerTest.php
@@ -71,12 +71,10 @@ describe('WrestlerManager Pivot Model', function () {
             expect($this->secondWrestler->currentManagers()->count())->toBe(1);
 
             // Verify manager has both wrestlers
-            if (method_exists($this->manager, 'currentWrestlers')) {
-                expect($this->manager->currentWrestlers()->count())->toBe(2);
-                expect($this->manager->currentWrestlers->pluck('id'))
-                    ->toContain($this->wrestler->id)
-                    ->toContain($this->secondWrestler->id);
-            }
+            expect($this->manager->currentWrestlers()->count())->toBe(2);
+            expect($this->manager->currentWrestlers->pluck('id'))
+                ->toContain($this->wrestler->id)
+                ->toContain($this->secondWrestler->id);
         });
 
         test('wrestler can have multiple managers during different time periods', function () {

--- a/tests/Unit/Builders/Concerns/BuilderConcernsTest.php
+++ b/tests/Unit/Builders/Concerns/BuilderConcernsTest.php
@@ -187,9 +187,6 @@ describe('Builder Concerns Unit Tests', function () {
             expect(class_uses(TagTeamBuilder::class))->toContain(HasRetirementScopes::class);
             expect(class_uses(TitleBuilder::class))->toContain(HasRetirementScopes::class);
 
-            // Verify that methods are available on concrete builders
-            $builder = Wrestler::query();
-            expect(method_exists($builder, 'retired'))->toBeTrue();
         });
 
         test('retired method generates correct query conditions', function () {

--- a/tests/Unit/Builders/Contracts/BuilderContractsTest.php
+++ b/tests/Unit/Builders/Contracts/BuilderContractsTest.php
@@ -17,7 +17,6 @@ use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
-use Carbon\Carbon;
 
 /**
  * Unit tests for Builder Contract interfaces.
@@ -90,10 +89,6 @@ describe('Builder Contracts Unit Tests', function () {
             // Arrange
             $builder = Wrestler::query();
 
-            // Act & Assert
-            expect(method_exists($builder, 'available'))->toBeTrue();
-            expect(method_exists($builder, 'unavailable'))->toBeTrue();
-
             $availableBuilder = $builder->available();
             $unavailableBuilder = $builder->unavailable();
 
@@ -132,9 +127,6 @@ describe('Builder Contracts Unit Tests', function () {
             // Assert - WrestlerBuilder has booking methods but doesn't implement the interface
             expect($builder)->not->toBeInstanceOf(HasBooking::class);
             expect($builder)->toBeInstanceOf(WrestlerBuilder::class);
-            expect(method_exists($builder, 'bookable'))->toBeTrue();
-            expect(method_exists($builder, 'availableOn'))->toBeTrue();
-            expect(method_exists($builder, 'notBookedOn'))->toBeTrue();
         });
 
         test('tag team builder implements HasBooking contract', function () {
@@ -149,20 +141,8 @@ describe('Builder Contracts Unit Tests', function () {
         test('booking contract methods exist and return builder instance', function () {
             // Arrange
             $builder = Wrestler::query();
-            $testDate = Carbon::parse('2024-12-31');
-
-            // Act & Assert
-            expect(method_exists($builder, 'bookable'))->toBeTrue();
-            expect(method_exists($builder, 'availableOn'))->toBeTrue();
-            expect(method_exists($builder, 'notBookedOn'))->toBeTrue();
-
             $bookableBuilder = $builder->bookable();
             expect($bookableBuilder)->toBeInstanceOf(WrestlerBuilder::class);
-
-            // Note: availableOn and notBookedOn require database tables for match relationships
-            // so we only test method existence for unit test scope
-            expect(method_exists($builder, 'availableOn'))->toBeTrue();
-            expect(method_exists($builder, 'notBookedOn'))->toBeTrue();
         });
 
         test('tag team builder implements HasBooking contract fully', function () {
@@ -232,12 +212,6 @@ describe('Builder Contracts Unit Tests', function () {
         test('employment contract methods exist and return builder instance', function () {
             // Arrange
             $builder = Wrestler::query();
-
-            // Act & Assert
-            expect(method_exists($builder, 'unemployed'))->toBeTrue();
-            expect(method_exists($builder, 'employed'))->toBeTrue();
-            expect(method_exists($builder, 'released'))->toBeTrue();
-            expect(method_exists($builder, 'futureEmployed'))->toBeTrue();
 
             $unemployedBuilder = $builder->unemployed();
             $employedBuilder = $builder->employed();
@@ -315,9 +289,6 @@ describe('Builder Contracts Unit Tests', function () {
             // Arrange
             $builder = Wrestler::query();
 
-            // Act & Assert
-            expect(method_exists($builder, 'retired'))->toBeTrue();
-
             $retiredBuilder = $builder->retired();
             expect($retiredBuilder)->toBeInstanceOf(WrestlerBuilder::class);
         });
@@ -381,9 +352,6 @@ describe('Builder Contracts Unit Tests', function () {
         test('suspension contract methods exist and return builder instance', function () {
             // Arrange
             $builder = Wrestler::query();
-
-            // Act & Assert
-            expect(method_exists($builder, 'suspended'))->toBeTrue();
 
             $suspendedBuilder = $builder->suspended();
             expect($suspendedBuilder)->toBeInstanceOf(WrestlerBuilder::class);

--- a/tests/Unit/Builders/Roster/SingleRosterMemberBuilderTest.php
+++ b/tests/Unit/Builders/Roster/SingleRosterMemberBuilderTest.php
@@ -172,21 +172,6 @@ describe('SingleRosterMemberBuilder Unit Tests', function () {
         });
     });
 
-    describe('date-based availability scopes', function () {
-        test('base class availableOn method signature exists', function () {
-            // Arrange
-            $testDate = now()->addWeek();
-            $builder = Wrestler::query();
-
-            // Act & Assert - Verify the method exists on the base class
-            expect(method_exists($builder, 'availableOn'))->toBeTrue();
-
-            // Note: WrestlerBuilder overrides this method with match-booking logic,
-            // so we test method existence rather than full functionality to avoid
-            // database table dependencies in unit tests.
-        });
-    });
-
     describe('query builder inheritance verification', function () {
         test('query scope methods return correct builder instance', function () {
             // Act

--- a/tests/Unit/Models/Concerns/ProvidesDisplayNameTest.php
+++ b/tests/Unit/Models/Concerns/ProvidesDisplayNameTest.php
@@ -145,7 +145,6 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
 
                 public $name = 'Test';
             };
-            expect(property_exists($model, 'name'))->toBeTrue();
             expect($model->name)->toBe('Test');
         });
 
@@ -156,7 +155,6 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
 
                 public $full_name = 'Test';
             };
-            expect(property_exists($model, 'full_name'))->toBeTrue();
             expect($model->full_name)->toBe('Test');
         });
 
@@ -169,8 +167,7 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
 
                 public $last_name = 'Doe';
             };
-            expect(property_exists($model, 'first_name'))->toBeTrue();
-            expect(property_exists($model, 'last_name'))->toBeTrue();
+            expect([$model->first_name, $model->last_name])->toBe(['John', 'Doe']);
         });
     });
 

--- a/tests/Unit/Models/Events/EventTest.php
+++ b/tests/Unit/Models/Events/EventTest.php
@@ -90,17 +90,4 @@ describe('Event Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has venue relationship method', function () {
-            $event = new Event();
-
-            expect(method_exists($event, 'venue'))->toBeTrue();
-        });
-
-        test('has matches relationship method', function () {
-            $event = new Event();
-
-            expect(method_exists($event, 'matches'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Events/VenueTest.php
+++ b/tests/Unit/Models/Events/VenueTest.php
@@ -92,11 +92,4 @@ describe('Venue Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has events relationship method', function () {
-            $venue = new Venue();
-
-            expect(method_exists($venue, 'events'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Managers/ManagerEmploymentTest.php
+++ b/tests/Unit/Models/Managers/ManagerEmploymentTest.php
@@ -91,11 +91,4 @@ describe('ManagerEmployment Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has manager relationship method', function () {
-            $managerEmployment = new ManagerEmployment();
-
-            expect(method_exists($managerEmployment, 'manager'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Managers/ManagerTest.php
+++ b/tests/Unit/Models/Managers/ManagerTest.php
@@ -105,11 +105,4 @@ describe('Manager Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has display name methods from ProvidesDisplayName trait', function () {
-            $manager = new Manager();
-
-            expect(method_exists($manager, 'getDisplayName'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Matches/EventMatchCompetitorTest.php
+++ b/tests/Unit/Models/Matches/EventMatchCompetitorTest.php
@@ -102,17 +102,4 @@ describe('MatchCompetitor Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has competitor relationship method', function () {
-            $MatchCompetitor = new MatchCompetitor();
-
-            expect(method_exists($MatchCompetitor, 'competitor'))->toBeTrue();
-        });
-
-        test('has getCompetitor business method', function () {
-            $MatchCompetitor = new MatchCompetitor();
-
-            expect(method_exists($MatchCompetitor, 'getCompetitor'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Matches/EventMatchResultTest.php
+++ b/tests/Unit/Models/Matches/EventMatchResultTest.php
@@ -87,23 +87,4 @@ describe('MatchResult Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has winners relationship method', function () {
-            $MatchResult = new MatchResult();
-
-            expect(method_exists($MatchResult, 'winners'))->toBeTrue();
-        });
-
-        test('has losers relationship method', function () {
-            $MatchResult = new MatchResult();
-
-            expect(method_exists($MatchResult, 'losers'))->toBeTrue();
-        });
-
-        test('has winner relationship method', function () {
-            $MatchResult = new MatchResult();
-
-            expect(method_exists($MatchResult, 'winner'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Matches/MatchStipulationTest.php
+++ b/tests/Unit/Models/Matches/MatchStipulationTest.php
@@ -84,25 +84,6 @@ describe('MatchStipulation Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has required relationship methods', function () {
-            $matchStipulation = new MatchStipulation();
-
-            expect(method_exists($matchStipulation, 'eventMatches'))->toBeTrue();
-        });
-
-        test('has business logic helper methods', function () {
-            $matchStipulation = new MatchStipulation();
-
-            expect(method_exists($matchStipulation, 'isStandardMatch'))->toBeTrue();
-            expect(method_exists($matchStipulation, 'requiresSpecialSetup'))->toBeTrue();
-            expect(method_exists($matchStipulation, 'isHardcoreStipulation'))->toBeTrue();
-            expect(method_exists($matchStipulation, 'hasEliminationRules'))->toBeTrue();
-            expect(method_exists($matchStipulation, 'getDisplayName'))->toBeTrue();
-            expect(method_exists($matchStipulation, 'getMatchPreview'))->toBeTrue();
-        });
-    });
-
     describe('model inheritance', function () {
         test('extends eloquent model', function () {
             $matchStipulation = new MatchStipulation();

--- a/tests/Unit/Models/Shared/StateTest.php
+++ b/tests/Unit/Models/Shared/StateTest.php
@@ -58,7 +58,6 @@ describe('State Model Unit Tests', function () {
         test('has state data rows property', function () {
             $state = new State();
 
-            expect(property_exists($state, 'rows'))->toBeTrue();
             expect($state->rows)->toBeArray();
             expect($state->rows)->not->toBeEmpty();
         });

--- a/tests/Unit/Models/Stables/StableActivityPeriodTest.php
+++ b/tests/Unit/Models/Stables/StableActivityPeriodTest.php
@@ -91,11 +91,4 @@ describe('StableActivityPeriod Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has stable relationship method', function () {
-            $stableActivityPeriod = new StableActivityPeriod();
-
-            expect(method_exists($stableActivityPeriod, 'stable'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Stables/StableTest.php
+++ b/tests/Unit/Models/Stables/StableTest.php
@@ -100,21 +100,4 @@ describe('Stable Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has member relationship methods', function () {
-            $stable = new Stable();
-
-            expect(method_exists($stable, 'wrestlers'))->toBeTrue();
-            expect(method_exists($stable, 'tagTeams'))->toBeTrue();
-            expect(method_exists($stable, 'currentWrestlers'))->toBeTrue();
-            expect(method_exists($stable, 'currentTagTeams'))->toBeTrue();
-        });
-
-        test('has activity period methods', function () {
-            $stable = new Stable();
-
-            expect(method_exists($stable, 'activityPeriods'))->toBeTrue();
-            expect(method_exists($stable, 'isCurrentlyActive'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/TagTeams/TagTeamEmploymentTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamEmploymentTest.php
@@ -91,17 +91,4 @@ describe('TagTeamEmployment Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has tagTeam relationship method', function () {
-            $tagTeamEmployment = new TagTeamEmployment();
-
-            expect(method_exists($tagTeamEmployment, 'tagTeam'))->toBeTrue();
-        });
-
-        test('has startedBefore business method', function () {
-            $tagTeamEmployment = new TagTeamEmployment();
-
-            expect(method_exists($tagTeamEmployment, 'startedBefore'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/TagTeams/TagTeamSuspensionTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamSuspensionTest.php
@@ -91,11 +91,4 @@ describe('TagTeamSuspension Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has tagTeam relationship method', function () {
-            $tagTeamSuspension = new TagTeamSuspension();
-
-            expect(method_exists($tagTeamSuspension, 'tagTeam'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/TagTeams/TagTeamTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamTest.php
@@ -119,12 +119,4 @@ describe('TagTeam Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has required relationship methods', function () {
-            $tagTeam = new TagTeam();
-
-            expect(method_exists($tagTeam, 'isBookable'))->toBeTrue();
-            expect(method_exists($tagTeam, 'isUnbookable'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/TagTeams/TagTeamWrestlerTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamWrestlerTest.php
@@ -94,17 +94,4 @@ describe('TagTeamWrestler Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has tagTeam relationship method', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
-
-            expect(method_exists($tagTeamWrestler, 'tagTeam'))->toBeTrue();
-        });
-
-        test('has wrestler relationship method', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
-
-            expect(method_exists($tagTeamWrestler, 'wrestler'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Titles/TitleActivityPeriodTest.php
+++ b/tests/Unit/Models/Titles/TitleActivityPeriodTest.php
@@ -91,11 +91,4 @@ describe('TitleActivityPeriod Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has title relationship method', function () {
-            $titleActivityPeriod = new TitleActivityPeriod();
-
-            expect(method_exists($titleActivityPeriod, 'title'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Titles/TitleStatusChangeTest.php
+++ b/tests/Unit/Models/Titles/TitleStatusChangeTest.php
@@ -92,11 +92,4 @@ describe('TitleStatusChange Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has title relationship method', function () {
-            $titleStatusChange = new TitleStatusChange();
-
-            expect(method_exists($titleStatusChange, 'title'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Users/UserTest.php
+++ b/tests/Unit/Models/Users/UserTest.php
@@ -94,13 +94,4 @@ describe('User Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has required relationship methods', function () {
-            $user = new User();
-
-            expect(method_exists($user, 'isAdministrator'))->toBeTrue();
-            expect(method_exists($user, 'getAvatar'))->toBeTrue();
-            expect(method_exists($user, 'wrestlers'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Wrestlers/WrestlerEmploymentTest.php
+++ b/tests/Unit/Models/Wrestlers/WrestlerEmploymentTest.php
@@ -87,11 +87,4 @@ describe('WrestlerEmployment Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has wrestler relationship method', function () {
-            $wrestlerEmployment = new WrestlerEmployment();
-
-            expect(method_exists($wrestlerEmployment, 'wrestler'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Wrestlers/WrestlerRetirementTest.php
+++ b/tests/Unit/Models/Wrestlers/WrestlerRetirementTest.php
@@ -91,11 +91,4 @@ describe('WrestlerRetirement Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has wrestler relationship method', function () {
-            $wrestlerRetirement = new WrestlerRetirement();
-
-            expect(method_exists($wrestlerRetirement, 'wrestler'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Wrestlers/WrestlerSuspensionTest.php
+++ b/tests/Unit/Models/Wrestlers/WrestlerSuspensionTest.php
@@ -87,11 +87,4 @@ describe('WrestlerSuspension Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has wrestler relationship method', function () {
-            $wrestlerSuspension = new WrestlerSuspension();
-
-            expect(method_exists($wrestlerSuspension, 'wrestler'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Models/Wrestlers/WrestlerTest.php
+++ b/tests/Unit/Models/Wrestlers/WrestlerTest.php
@@ -137,11 +137,4 @@ describe('Wrestler Model Unit Tests', function () {
         });
     });
 
-    describe('business logic methods', function () {
-        test('has isBookable business method', function () {
-            $wrestler = new Wrestler();
-
-            expect(method_exists($wrestler, 'isBookable'))->toBeTrue();
-        });
-    });
 });

--- a/tests/Unit/Policies/PolicyBeforeHookTest.php
+++ b/tests/Unit/Policies/PolicyBeforeHookTest.php
@@ -68,13 +68,6 @@ describe('Policy Before Hook Pattern', function () {
         }
     });
 
-    test('all policies have before hook method', function () {
-        foreach ($this->policies as $policy) {
-            expect(method_exists($policy, 'before'))
-                ->toBeTrue(get_class($policy).' should have before method');
-        }
-    });
-
 });
 
 /**

--- a/tests/Unit/Policies/StablePolicyTest.php
+++ b/tests/Unit/Policies/StablePolicyTest.php
@@ -277,9 +277,6 @@ describe('StablePolicy Unit Tests', function () {
 
             foreach ($methods as [$method, $params]) {
                 $result = $this->policy->$method($this->basicUser, ...$params);
-                expect(is_bool($result))->toBeTrue(
-                    "Method {$method} should return boolean, got ".gettype($result)
-                );
                 expect($result)->toBeFalse(
                     "Basic user should not be authorized for {$method}"
                 );

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -168,17 +168,6 @@ describe('UserPolicy integration with Gate facade', function () {
 });
 
 describe('UserPolicy method signatures', function () {
-    test('policy class exists and has required methods', function () {
-        expect(class_exists(UserPolicy::class))->toBeTrue();
-        expect(method_exists(UserPolicy::class, 'before'))->toBeTrue();
-        expect(method_exists(UserPolicy::class, 'viewList'))->toBeTrue();
-        expect(method_exists(UserPolicy::class, 'view'))->toBeTrue();
-        expect(method_exists(UserPolicy::class, 'create'))->toBeTrue();
-        expect(method_exists(UserPolicy::class, 'update'))->toBeTrue();
-        expect(method_exists(UserPolicy::class, 'delete'))->toBeTrue();
-        expect(method_exists(UserPolicy::class, 'restore'))->toBeTrue();
-    });
-
     test('before method has correct signature', function () {
         $reflection = new ReflectionMethod(UserPolicy::class, 'before');
 


### PR DESCRIPTION
## Summary
- raise Pest PHPStan analysis from level 3 to level 4
- remove redundant method and property existence tests already guaranteed by concrete types
- replace conditional relationship checks with direct behavioral assertions
- remove an unreachable Carbon comparison branch

## Verification
- composer test:types: application and Pest PHPStan pass
- composer test:rector: pass
- Pint with the Blade flag over tests: pass
- full parallel Pest suite: 3,516 tests and 11,197 assertions pass

## Note
The complete composer test:push command reaches the pre-existing Blade formatting backlog outside this change. All checks relevant to this PHP and test-only diff pass independently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Streamlined automated coverage by focusing on observable behavior rather than implementation details.
  - Improved validation of wrestler, tag-team, venue, event, policy, and user workflows.
  - Strengthened date comparisons and relationship checks in integration tests.
  - Added verification for explicit return types where applicable.
  - Removed redundant method and property-existence assertions.

- **Refactor**
  - Increased static analysis strictness to identify more potential issues during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->