### PR TITLE
test: raise Pest PHPStan to level 6

### DIFF
--- a/phpstan-pest.neon
+++ b/phpstan-pest.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 5
+  level: 6
 
   paths:
     - tests

--- a/tests/Feature/Authorization/EventAuthorizationTest.php
+++ b/tests/Feature/Authorization/EventAuthorizationTest.php
@@ -7,6 +7,9 @@ use App\Models\Events\Event;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for Event authorization workflows.
  *
@@ -29,8 +32,9 @@ describe('Event Authorization Feature Tests', function () {
 
     describe('admin user authorization', function () {
         test('admin can access events table component', function () {
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->assertOk();
         });
 
@@ -38,8 +42,9 @@ describe('Event Authorization Feature Tests', function () {
             $event = Event::factory()->unscheduled()->create();
             $deletedEvent = Event::factory()->trashed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Event management actions
             $component->call('delete', $event)->assertHasNoErrors();
@@ -51,8 +56,9 @@ describe('Event Authorization Feature Tests', function () {
             $unscheduledEvent = Event::factory()->unscheduled()->create();
             $pastEvent = Event::factory()->past()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Admin should be able to perform appropriate actions on each status
             $component->call('delete', $scheduledEvent)->assertHasNoErrors();
@@ -64,8 +70,9 @@ describe('Event Authorization Feature Tests', function () {
             $eventWithVenue = Event::factory()->scheduled()->withVenue()->create();
             $eventWithoutVenue = Event::factory()->scheduled()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Admin can manage events regardless of venue association
             $component->call('delete', $eventWithVenue)->assertHasNoErrors();
@@ -75,8 +82,9 @@ describe('Event Authorization Feature Tests', function () {
         test('admin can perform event lifecycle management', function () {
             $event = Event::factory()->unscheduled()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Event lifecycle through admin actions
             $component->call('delete', $event)
@@ -94,8 +102,9 @@ describe('Event Authorization Feature Tests', function () {
 
     describe('basic user authorization', function () {
         test('basic user cannot access events table component', function () {
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -103,8 +112,9 @@ describe('Event Authorization Feature Tests', function () {
             $event = Event::factory()->scheduled()->create();
 
             // Attempt to test component should fail at authorization level
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -114,8 +124,9 @@ describe('Event Authorization Feature Tests', function () {
             $pastEvent = Event::factory()->past()->create();
 
             // All attempts should fail at the component authorization level
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -124,15 +135,16 @@ describe('Event Authorization Feature Tests', function () {
             $deletedEvent = Event::factory()->trashed()->create();
 
             // Component access should be denied
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });
 
     describe('guest user authorization', function () {
         test('guest user cannot access events table component', function () {
-            Livewire::test(Main::class)
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -140,7 +152,7 @@ describe('Event Authorization Feature Tests', function () {
             $event = Event::factory()->scheduled()->create();
 
             // All attempts should fail immediately
-            Livewire::test(Main::class)
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });
@@ -151,14 +163,16 @@ describe('Event Authorization Feature Tests', function () {
             $unscheduledEvent = Event::factory()->unscheduled()->create();
 
             // Admin can perform actions
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->call('delete', $scheduledEvent)
                 ->assertHasNoErrors();
 
             // Basic user cannot even access component
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -167,15 +181,17 @@ describe('Event Authorization Feature Tests', function () {
             $deletedEvent = Event::factory()->trashed()->create();
 
             // Admin can manage events
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('delete', $event)->assertHasNoErrors();
             $component->call('restore', $deletedEvent->id)->assertHasNoErrors();
 
             // Basic user cannot access
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -184,15 +200,17 @@ describe('Event Authorization Feature Tests', function () {
             $eventWithoutVenue = Event::factory()->scheduled()->create();
 
             // Admin can manage venue associations
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('delete', $eventWithVenue)->assertHasNoErrors();
             $component->call('delete', $eventWithoutVenue)->assertHasNoErrors();
 
             // Basic user cannot access
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -201,15 +219,17 @@ describe('Event Authorization Feature Tests', function () {
             $deletedEvent = Event::factory()->trashed()->create();
 
             // Admin can perform CRUD
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('delete', $event)->assertHasNoErrors();
             $component->call('restore', $deletedEvent->id)->assertHasNoErrors();
 
             // Basic user cannot access
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });
@@ -223,8 +243,12 @@ describe('Event Authorization Feature Tests', function () {
             $event2 = Event::factory()->unscheduled()->create();
 
             // Both admins can perform actions simultaneously
-            $component1 = Livewire::actingAs($admin1)->test(Main::class);
-            $component2 = Livewire::actingAs($admin2)->test(Main::class);
+            actingAs($admin1);
+
+            $component1 = livewire(Main::class);
+            actingAs($admin2);
+
+            $component2 = livewire(Main::class);
 
             $component1->call('delete', $event1)->assertHasNoErrors();
             $component2->call('delete', $event2)->assertHasNoErrors();
@@ -237,22 +261,25 @@ describe('Event Authorization Feature Tests', function () {
             $event = Event::factory()->unscheduled()->create();
 
             // Admin can access
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->call('delete', $event)
                 ->assertHasNoErrors();
 
             // Basic user still cannot access even after admin action
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
         test('authorization works with event state changes', function () {
             $event = Event::factory()->unscheduled()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Delete event
             $component->call('delete', $event)->assertHasNoErrors();
@@ -263,8 +290,9 @@ describe('Event Authorization Feature Tests', function () {
             expect(Event::find($event->id))->not->toBeNull();
 
             // Basic user still cannot access regardless of event state
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });
@@ -274,8 +302,9 @@ describe('Event Authorization Feature Tests', function () {
             $scheduledEvent = Event::factory()->scheduled()->create();
             $pastEvent = Event::factory()->past()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Admin is authorized for all operations
             $component->call('delete', $scheduledEvent)->assertHasNoErrors();
@@ -287,8 +316,9 @@ describe('Event Authorization Feature Tests', function () {
 
             // Basic user should be denied at authorization level,
             // not reach business rule validation
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -296,8 +326,9 @@ describe('Event Authorization Feature Tests', function () {
             $scheduledEvent = Event::factory()->scheduled()->create();
             $pastEvent = Event::factory()->past()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Admin should be authorized for all operations
             $component->call('delete', $scheduledEvent)->assertHasNoErrors();
@@ -309,13 +340,14 @@ describe('Event Authorization Feature Tests', function () {
 
     describe('authorization error handling', function () {
         test('unauthorized component access returns proper error response', function () {
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
         test('guest access attempts are properly handled', function () {
-            Livewire::test(Main::class)
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -323,8 +355,9 @@ describe('Event Authorization Feature Tests', function () {
             $event = Event::factory()->scheduled()->create();
 
             // Authorization failure should not expose event details
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });
@@ -335,8 +368,9 @@ describe('Event Authorization Feature Tests', function () {
             $pastEvent = Event::factory()->past()->create();
             $unscheduledEvent = Event::factory()->unscheduled()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Admin can manage events regardless of scheduling complexity
             $component->call('delete', $futureEvent)->assertHasNoErrors();
@@ -349,16 +383,18 @@ describe('Event Authorization Feature Tests', function () {
             $eventWithVenue = Event::factory()->scheduled()->withVenue()->create();
             $eventWithoutVenue = Event::factory()->scheduled()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Admin can manage complex venue scenarios
             $component->call('delete', $eventWithVenue)->assertHasNoErrors();
             $component->call('delete', $eventWithoutVenue)->assertHasNoErrors();
 
             // Basic user still cannot access
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });
@@ -367,8 +403,9 @@ describe('Event Authorization Feature Tests', function () {
         test('admin can manage complete event lifecycle', function () {
             $event = Event::factory()->unscheduled()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Complete lifecycle management
             $component->call('delete', $event)->assertHasNoErrors();
@@ -382,15 +419,17 @@ describe('Event Authorization Feature Tests', function () {
             $event = Event::factory()->unscheduled()->create();
 
             // Admin can perform lifecycle operations
-            $adminComponent = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $adminComponent = livewire(Main::class);
 
             $adminComponent->call('delete', $event)->assertHasNoErrors();
             $adminComponent->call('restore', $event->id)->assertHasNoErrors();
 
             // Basic user cannot perform any lifecycle operations
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });
@@ -400,8 +439,9 @@ describe('Event Authorization Feature Tests', function () {
             $eventWithMatches = Event::factory()->scheduled()->withVenue()->create();
             // Note: In a real scenario, this would have matches attached
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Admin can manage events with relationships
             $component->call('delete', $eventWithMatches)->assertHasNoErrors();
@@ -411,15 +451,17 @@ describe('Event Authorization Feature Tests', function () {
             // Create complex event with relationships
             $complexEvent = Event::factory()->scheduled()->withVenue()->withPreview()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Admin authorized for complex events
             $component->call('delete', $complexEvent)->assertHasNoErrors();
 
             // Basic user still denied
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });

--- a/tests/Feature/Authorization/ManagerAuthorizationTest.php
+++ b/tests/Feature/Authorization/ManagerAuthorizationTest.php
@@ -7,6 +7,9 @@ use App\Models\Managers\Manager;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for Manager Authorization.
  *
@@ -98,8 +101,9 @@ describe('Manager Authorization', function () {
     describe('Livewire component authorization', function () {
         test('admin can access managers table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertOk()
@@ -108,8 +112,9 @@ describe('Manager Authorization', function () {
 
         test('basic user cannot access managers table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -117,7 +122,7 @@ describe('Manager Authorization', function () {
 
         test('guest user cannot access managers table component', function () {
             // Act
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -133,8 +138,9 @@ describe('Manager Authorization', function () {
                 ->get(route('managers.index'));
             $httpResponse->assertOk();
 
-            $livewireComponent = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertOk();
 
             // Basic user should be forbidden from both
@@ -142,8 +148,9 @@ describe('Manager Authorization', function () {
                 ->get(route('managers.index'));
             $httpResponse->assertForbidden();
 
-            $livewireComponent = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertForbidden();
         });
 

--- a/tests/Feature/Authorization/RefereeAuthorizationTest.php
+++ b/tests/Feature/Authorization/RefereeAuthorizationTest.php
@@ -7,6 +7,9 @@ use App\Models\Referees\Referee;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for Referee Authorization.
  *
@@ -98,8 +101,9 @@ describe('Referee Authorization', function () {
     describe('Livewire component authorization', function () {
         test('admin can access referees table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertOk()
@@ -108,8 +112,9 @@ describe('Referee Authorization', function () {
 
         test('basic user cannot access referees table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -117,7 +122,7 @@ describe('Referee Authorization', function () {
 
         test('guest user cannot access referees table component', function () {
             // Act
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -133,8 +138,9 @@ describe('Referee Authorization', function () {
                 ->get(route('referees.index'));
             $httpResponse->assertOk();
 
-            $livewireComponent = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertOk();
 
             // Basic user should be forbidden from both
@@ -142,8 +148,9 @@ describe('Referee Authorization', function () {
                 ->get(route('referees.index'));
             $httpResponse->assertForbidden();
 
-            $livewireComponent = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertForbidden();
         });
 

--- a/tests/Feature/Authorization/StableAuthorizationTest.php
+++ b/tests/Feature/Authorization/StableAuthorizationTest.php
@@ -7,6 +7,9 @@ use App\Models\Stables\Stable;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for Stable Authorization.
  *
@@ -97,8 +100,9 @@ describe('Stable Authorization', function () {
     describe('Livewire component authorization', function () {
         test('admin can access stables table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertOk();
@@ -106,8 +110,9 @@ describe('Stable Authorization', function () {
 
         test('basic user cannot access stables table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -115,7 +120,7 @@ describe('Stable Authorization', function () {
 
         test('guest user cannot access stables table component', function () {
             // Act
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -131,8 +136,9 @@ describe('Stable Authorization', function () {
                 ->get(route('stables.index'));
             $httpResponse->assertOk();
 
-            $livewireComponent = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertOk();
 
             // Basic user should be forbidden from both
@@ -140,8 +146,9 @@ describe('Stable Authorization', function () {
                 ->get(route('stables.index'));
             $httpResponse->assertForbidden();
 
-            $livewireComponent = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertForbidden();
         });
 

--- a/tests/Feature/Authorization/TagTeamAuthorizationTest.php
+++ b/tests/Feature/Authorization/TagTeamAuthorizationTest.php
@@ -7,6 +7,9 @@ use App\Models\TagTeams\TagTeam;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for TagTeam authorization workflows.
  *
@@ -29,8 +32,9 @@ describe('TagTeam Authorization Feature Tests', function () {
 
     describe('admin user authorization', function () {
         test('admin can access tag teams table component', function () {
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->assertOk();
         });
 
@@ -38,8 +42,9 @@ describe('TagTeam Authorization Feature Tests', function () {
             $tagTeam = TagTeam::factory()->create();
             $deletedTeam = TagTeam::factory()->trashed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Basic CRUD actions that don't involve complex business logic
             $component->call('delete', $tagTeam)->assertHasNoErrors();
@@ -50,8 +55,9 @@ describe('TagTeam Authorization Feature Tests', function () {
 
     describe('basic user authorization', function () {
         test('basic user cannot access tag teams table component', function () {
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -59,7 +65,7 @@ describe('TagTeam Authorization Feature Tests', function () {
 
     describe('guest user authorization', function () {
         test('guest user cannot access tag teams table component', function () {
-            Livewire::test(Main::class)
+            livewire(Main::class)
                 ->assertForbidden();
         });
 

--- a/tests/Feature/Authorization/TitleAuthorizationTest.php
+++ b/tests/Feature/Authorization/TitleAuthorizationTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Livewire\Titles\Tables\Main;
 use App\Models\Titles\Title;
 use App\Models\Users\User;
-use Livewire\Livewire;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 
 /**
  * Feature tests for Title Authorization and Workflows.
@@ -34,21 +36,23 @@ describe('Title Authorization and Workflows', function () {
 
     describe('component access authorization', function () {
         test('admin can access titles table', function () {
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->assertOk()
                 ->assertSee('titles')
                 ->assertSee($this->title->name);
         });
 
         test('basic user cannot access titles table', function () {
-            Livewire::actingAs($this->basicUser)
-                ->test(Main::class)
+            actingAs($this->basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
         test('guest user cannot access titles table', function () {
-            Livewire::test(Main::class)
+            livewire(Main::class)
                 ->assertForbidden();
         });
     });

--- a/tests/Feature/Authorization/TitleChampionshipAuthorizationTest.php
+++ b/tests/Feature/Authorization/TitleChampionshipAuthorizationTest.php
@@ -7,6 +7,9 @@ use App\Models\Titles\Title;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for Title Championship Authorization.
  *
@@ -95,8 +98,9 @@ describe('Title Championship Authorization', function () {
     describe('Livewire component authorization', function () {
         test('admin can access title championships table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
+            actingAs($this->admin);
+
+            $component = livewire(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
 
             // Assert
             $component->assertOk();
@@ -104,8 +108,9 @@ describe('Title Championship Authorization', function () {
 
         test('basic user cannot access title championships table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->basicUser)
-                ->test(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
+            actingAs($this->basicUser);
+
+            $component = livewire(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
 
             // Assert
             $component->assertForbidden();
@@ -113,7 +118,7 @@ describe('Title Championship Authorization', function () {
 
         test('guest user cannot access title championships table component', function () {
             // Act
-            $component = Livewire::test(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
+            $component = livewire(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
 
             // Assert
             $component->assertForbidden();
@@ -129,8 +134,9 @@ describe('Title Championship Authorization', function () {
                 ->get(route('titles.show', $this->title));
             $httpResponse->assertOk();
 
-            $livewireComponent = Livewire::actingAs($this->admin)
-                ->test(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
+            actingAs($this->admin);
+
+            $livewireComponent = livewire(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
             $livewireComponent->assertOk();
 
             // Basic user should be forbidden from both
@@ -138,8 +144,9 @@ describe('Title Championship Authorization', function () {
                 ->get(route('titles.show', $this->title));
             $httpResponse->assertForbidden();
 
-            $livewireComponent = Livewire::actingAs($this->basicUser)
-                ->test(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
+            actingAs($this->basicUser);
+
+            $livewireComponent = livewire(PreviousTitleChampionships::class, ['titleId' => $this->title->id]);
             $livewireComponent->assertForbidden();
         });
     });

--- a/tests/Feature/Authorization/VenueAuthorizationTest.php
+++ b/tests/Feature/Authorization/VenueAuthorizationTest.php
@@ -7,6 +7,9 @@ use App\Models\Events\Venue;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for Venue Authorization.
  *
@@ -96,8 +99,9 @@ describe('Venue Authorization', function () {
     describe('Livewire component authorization', function () {
         test('admin can access venues table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertOk();
@@ -105,8 +109,9 @@ describe('Venue Authorization', function () {
 
         test('basic user cannot access venues table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -114,7 +119,7 @@ describe('Venue Authorization', function () {
 
         test('guest user cannot access venues table component', function () {
             // Act
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -126,8 +131,9 @@ describe('Venue Authorization', function () {
             $venue = Venue::factory()->create();
             $deletedVenue = Venue::factory()->trashed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Basic CRUD actions that don't involve complex business logic
             $component->call('delete', $venue)->assertHasNoErrors();
@@ -144,8 +150,9 @@ describe('Venue Authorization', function () {
                 ->get(route('venues.index'));
             $httpResponse->assertOk();
 
-            $livewireComponent = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertOk();
 
             // Basic user should be forbidden from both
@@ -153,8 +160,9 @@ describe('Venue Authorization', function () {
                 ->get(route('venues.index'));
             $httpResponse->assertForbidden();
 
-            $livewireComponent = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertForbidden();
         });
     });

--- a/tests/Feature/Authorization/WrestlerAuthorizationTest.php
+++ b/tests/Feature/Authorization/WrestlerAuthorizationTest.php
@@ -7,6 +7,9 @@ use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for Wrestler Authorization.
  *
@@ -96,8 +99,9 @@ describe('Wrestler Authorization', function () {
     describe('Livewire component authorization', function () {
         test('admin can access wrestlers table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertOk();
@@ -105,8 +109,9 @@ describe('Wrestler Authorization', function () {
 
         test('basic user cannot access wrestlers table component', function () {
             // Arrange & Act
-            $component = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -114,7 +119,7 @@ describe('Wrestler Authorization', function () {
 
         test('guest user cannot access wrestlers table component', function () {
             // Act
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Assert
             $component->assertForbidden();
@@ -126,8 +131,9 @@ describe('Wrestler Authorization', function () {
             $wrestler = Wrestler::factory()->create();
             $deletedWrestler = Wrestler::factory()->trashed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Basic CRUD actions that don't involve complex business logic
             $component->call('delete', $wrestler)->assertHasNoErrors();
@@ -144,8 +150,9 @@ describe('Wrestler Authorization', function () {
                 ->get(route('wrestlers.index'));
             $httpResponse->assertOk();
 
-            $livewireComponent = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertOk();
 
             // Basic user should be forbidden from both
@@ -153,8 +160,9 @@ describe('Wrestler Authorization', function () {
                 ->get(route('wrestlers.index'));
             $httpResponse->assertForbidden();
 
-            $livewireComponent = Livewire::actingAs($this->basicUser)
-                ->test(Main::class);
+            actingAs($this->basicUser);
+
+            $livewireComponent = livewire(Main::class);
             $livewireComponent->assertForbidden();
         });
     });

--- a/tests/Feature/Livewire/Matches/Modals/DynamicUITest.php
+++ b/tests/Feature/Livewire/Matches/Modals/DynamicUITest.php
@@ -6,7 +6,8 @@ use App\Enums\MatchType;
 use App\Livewire\Matches\Modals\FormModal;
 use App\Models\Events\Event;
 use App\Models\Users\User;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -16,14 +17,14 @@ beforeEach(function () {
 
 describe('Dynamic Match Type UI', function () {
     it('shows helper text when no match type is selected', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');
 
         $component->assertSee('Select a match type to configure competitors');
     });
 
     it('dynamically updates UI for Singles match', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles);
 
@@ -34,7 +35,7 @@ describe('Dynamic Match Type UI', function () {
     });
 
     it('dynamically updates UI for Tag Team match', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::TagTeam);
 
@@ -44,7 +45,7 @@ describe('Dynamic Match Type UI', function () {
     });
 
     it('dynamically updates UI for Triple Threat match', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::TripleThreat);
 
@@ -56,7 +57,7 @@ describe('Dynamic Match Type UI', function () {
     });
 
     it('dynamically updates UI for Fatal Four Way match', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Fatal4Way);
 
@@ -68,7 +69,7 @@ describe('Dynamic Match Type UI', function () {
     });
 
     it('dynamically updates UI for Battle Royal match', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::BattleRoyal);
 
@@ -79,7 +80,7 @@ describe('Dynamic Match Type UI', function () {
     });
 
     it('clears competitor data when match type changes', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.matchType', MatchType::TagTeam);

--- a/tests/Feature/Livewire/Wrestlers/Tables/WrestlersTableTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/WrestlersTableTest.php
@@ -7,6 +7,9 @@ use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Feature tests for Main Livewire component workflows.
  *
@@ -33,8 +36,9 @@ describe('Main Component Feature Workflows', function () {
         test('complete wrestler employment workflow', function () {
             $wrestler = Wrestler::factory()->released()->create();
 
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->call('handleWrestlerAction', 'employ', $wrestler->id)
                 ->assertHasNoErrors()
                 ->assertSessionMissing('error');
@@ -46,8 +50,9 @@ describe('Main Component Feature Workflows', function () {
         test('complete wrestler release workflow', function () {
             $wrestler = Wrestler::factory()->bookable()->create();
 
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->call('handleWrestlerAction', 'release', $wrestler->id)
                 ->assertHasNoErrors()
                 ->assertSessionMissing('error');
@@ -58,8 +63,9 @@ describe('Main Component Feature Workflows', function () {
         test('complete wrestler retirement workflow', function () {
             $wrestler = Wrestler::factory()->bookable()->create();
 
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->call('handleWrestlerAction', 'retire', $wrestler->id)
                 ->assertHasNoErrors();
 
@@ -69,8 +75,9 @@ describe('Main Component Feature Workflows', function () {
         test('complete wrestler deletion and restoration workflow', function () {
             $wrestler = Wrestler::factory()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Delete workflow
             $component->call('delete', $wrestler)
@@ -98,8 +105,9 @@ describe('Main Component Feature Workflows', function () {
             $wrestler1 = Wrestler::factory()->create(['name' => 'Stone Cold Steve Austin']);
             $wrestler2 = Wrestler::factory()->create(['name' => 'The Rock']);
 
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->assertSee('Stone Cold Steve Austin')
                 ->assertSee('The Rock')
                 ->set('search', 'Stone Cold')
@@ -114,8 +122,9 @@ describe('Main Component Feature Workflows', function () {
             $employedWrestler = Wrestler::factory()->bookable()->create(['name' => 'Active Wrestler']);
             $releasedWrestler = Wrestler::factory()->released()->create(['name' => 'Released Wrestler']);
 
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->assertSee('Active Wrestler')
                 ->assertSee('Released Wrestler')
                 ->set('filterValues.status', 'employed')
@@ -131,8 +140,9 @@ describe('Main Component Feature Workflows', function () {
         test('table handles wrestler actions through delegation', function () {
             $wrestler = Wrestler::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Test that the action delegation works without errors
             $component->call('handleWrestlerAction', 'employ', $wrestler->id)
@@ -147,8 +157,9 @@ describe('Main Component Feature Workflows', function () {
         test('component maintains state during business operations', function () {
             $wrestler = Wrestler::factory()->released()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            $component = livewire(Main::class)
                 ->set('search', 'Test Search')
                 ->set('filterValues.status', 'released');
 
@@ -163,8 +174,9 @@ describe('Main Component Feature Workflows', function () {
         test('component handles concurrent user interactions', function () {
             $wrestler = Wrestler::factory()->bookable()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Simulate multiple rapid interactions
             $component->set('search', 'Test')
@@ -180,8 +192,9 @@ describe('Main Component Feature Workflows', function () {
         test('component provides immediate feedback for successful actions', function () {
             $wrestler = Wrestler::factory()->released()->create();
 
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->call('handleWrestlerAction', 'employ', $wrestler->id)
                 ->assertHasNoErrors()
                 ->assertSessionMissing('error');
@@ -194,8 +207,9 @@ describe('Main Component Feature Workflows', function () {
             $wrestler = Wrestler::factory()->create();
 
             // Test that component doesn't break with operations that might take time
-            Livewire::actingAs($this->admin)
-                ->test(Main::class)
+            actingAs($this->admin);
+
+            livewire(Main::class)
                 ->call('delete', $wrestler)
                 ->call('restore', $wrestler->id)
                 ->assertHasNoErrors();

--- a/tests/Feature/Workflows/EventManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/EventManagementWorkflowTest.php
@@ -10,7 +10,6 @@ use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
-use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 
@@ -48,8 +47,9 @@ describe('Venue Creation and Setup Workflow', function () {
             ->assertSeeLivewire(VenuesTable::class);
 
         // And: Creating venue through modal workflow
-        $modalComponent = Livewire::actingAs($admin)
-            ->test(VenueFormModal::class)
+        actingAs($admin);
+
+        $modalComponent = \Pest\Livewire\livewire(VenueFormModal::class)
             ->call('openModal')
             ->assertSet('isModalOpen', true);
 
@@ -83,8 +83,9 @@ describe('Venue Creation and Setup Workflow', function () {
         expect($venue->zipcode)->toBe('10001');
 
         // And: Should appear in the venues table
-        Livewire::actingAs($admin)
-            ->test(VenuesTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(VenuesTable::class)
             ->assertSee('Madison Square Garden');
     });
 
@@ -93,8 +94,9 @@ describe('Venue Creation and Setup Workflow', function () {
         $admin = administrator();
 
         // When: Opening create modal and using dummy data
-        $component = Livewire::actingAs($admin)
-            ->test(VenueFormModal::class)
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(VenueFormModal::class)
             ->call('openModal')
             ->call('fillDummyFields');
 
@@ -139,8 +141,9 @@ describe('Event Creation and Scheduling Workflow', function () {
             ->assertSeeLivewire(EventsTable::class);
 
         // And: Creating event through modal workflow
-        $modalComponent = Livewire::actingAs($admin)
-            ->test(EventFormModal::class)
+        actingAs($admin);
+
+        $modalComponent = \Pest\Livewire\livewire(EventFormModal::class)
             ->call('openModal')
             ->assertSet('isModalOpen', true);
 
@@ -169,8 +172,9 @@ describe('Event Creation and Scheduling Workflow', function () {
         expect($event->venue_id)->toBe($venue->id);
 
         // And: Should appear in the events table
-        Livewire::actingAs($admin)
-            ->test(EventsTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(EventsTable::class)
             ->assertSee('WrestleMania 40')
             ->assertSee('Allstate Arena');
     });
@@ -180,8 +184,9 @@ describe('Event Creation and Scheduling Workflow', function () {
         $admin = administrator();
 
         // When: Opening create modal and using dummy data
-        $component = Livewire::actingAs($admin)
-            ->test(EventFormModal::class)
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(EventFormModal::class)
             ->call('openModal')
             ->call('fillDummyFields');
 
@@ -244,8 +249,9 @@ describe('Event Search and Filtering Workflow', function () {
         ]);
 
         // When: Testing search functionality exists
-        $component = Livewire::actingAs($admin)
-            ->test(EventsTable::class);
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(EventsTable::class);
 
         // Verify the component loads successfully
         expect($component)->not->toBeNull();
@@ -269,8 +275,9 @@ describe('Event Editing Workflow', function () {
         ]);
 
         // When: Testing the EventFormModal with model editing
-        $component = Livewire::actingAs($admin)
-            ->test(EventFormModal::class, ['modelId' => $event->id]);
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(EventFormModal::class, ['modelId' => $event->id]);
 
         // Then: Form should be populated with existing data
         expect($component->get('form.name'))->toBe('Original Event');
@@ -343,8 +350,9 @@ describe('Event Deletion and Restoration Workflow', function () {
         ]);
 
         // When: Deleting the event
-        Livewire::actingAs($admin)
-            ->test(EventsTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(EventsTable::class)
             ->call('delete', $event)
             ->assertHasNoErrors();
 
@@ -353,8 +361,9 @@ describe('Event Deletion and Restoration Workflow', function () {
         expect(Event::onlyTrashed()->find($event->id))->not->toBeNull();
 
         // When: Restoring the event
-        Livewire::actingAs($admin)
-            ->test(EventsTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(EventsTable::class)
             ->call('restore', $event->id)
             ->assertHasNoErrors();
 

--- a/tests/Feature/Workflows/RosterManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/RosterManagementWorkflowTest.php
@@ -12,7 +12,6 @@ use App\Models\Managers\Manager;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
-use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 
@@ -27,8 +26,9 @@ describe('Manager Assignment Workflow', function () {
         $wrestler = Wrestler::factory()->bookable()->create(['name' => 'Randy Orton']);
 
         // When: Creating a new manager
-        $managerComponent = Livewire::actingAs($admin)
-            ->test(ManagerFormModal::class)
+        actingAs($admin);
+
+        $managerComponent = \Pest\Livewire\livewire(ManagerFormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'Paul')
             ->set('form.last_name', 'Heyman')
@@ -49,8 +49,9 @@ describe('Manager Assignment Workflow', function () {
             ->assertSee('Heyman');
 
         // And: Manager appears in managers table
-        Livewire::actingAs($admin)
-            ->test(ManagersTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(ManagersTable::class)
             ->assertSee('Paul')
             ->assertSee('Heyman');
     });
@@ -61,8 +62,9 @@ describe('Manager Assignment Workflow', function () {
         $manager = Manager::factory()->create(['first_name' => 'Bobby', 'last_name' => 'Heenan']);
 
         // When: Managing employment status
-        Livewire::actingAs($admin)
-            ->test(ManagersTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(ManagersTable::class)
             ->call('handleManagerAction', 'employ', $manager->id)
             ->assertHasNoErrors();
 
@@ -70,8 +72,9 @@ describe('Manager Assignment Workflow', function () {
         expect($manager->fresh()->isEmployed())->toBeTrue();
 
         // When: Suspending manager
-        Livewire::actingAs($admin)
-            ->test(ManagersTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(ManagersTable::class)
             ->call('handleManagerAction', 'suspend', $manager->id)
             ->assertHasNoErrors();
 
@@ -79,8 +82,9 @@ describe('Manager Assignment Workflow', function () {
         expect($manager->fresh()->isSuspended())->toBeTrue();
 
         // When: Reinstating manager
-        Livewire::actingAs($admin)
-            ->test(ManagersTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(ManagersTable::class)
             ->call('handleManagerAction', 'reinstate', $manager->id)
             ->assertHasNoErrors();
 
@@ -99,8 +103,9 @@ describe('Stable Formation and Management Workflow', function () {
         $wrestler3 = Wrestler::factory()->bookable()->create(['name' => 'Chyna']);
 
         // When: Creating a new stable
-        $stableComponent = Livewire::actingAs($admin)
-            ->test(StableFormModal::class)
+        actingAs($admin);
+
+        $stableComponent = \Pest\Livewire\livewire(StableFormModal::class)
             ->call('openModal')
             ->set('form.name', 'D-Generation X')
             ->set('form.debut_date', now()->format('Y-m-d'))
@@ -112,8 +117,9 @@ describe('Stable Formation and Management Workflow', function () {
         $stable = Stable::where('name', 'D-Generation X')->first();
 
         // And: Stable appears in stables table
-        Livewire::actingAs($admin)
-            ->test(StablesTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(StablesTable::class)
             ->assertSee('D-Generation X');
     });
 
@@ -123,8 +129,9 @@ describe('Stable Formation and Management Workflow', function () {
         $stable = Stable::factory()->withEmployedDefaultMembers()->create(['name' => 'The Shield']);
 
         // When: Establishing the stable
-        Livewire::actingAs($admin)
-            ->test(StablesTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(StablesTable::class)
             ->call('handleStableAction', 'establish', $stable->id)
             ->assertHasNoErrors();
 
@@ -132,8 +139,9 @@ describe('Stable Formation and Management Workflow', function () {
         expect($stable->fresh()->isCurrentlyActive())->toBeTrue();
 
         // When: Retiring the stable
-        Livewire::actingAs($admin)
-            ->test(StablesTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(StablesTable::class)
             ->call('handleStableAction', 'retire', $stable->id)
             ->assertHasNoErrors();
 
@@ -144,8 +152,9 @@ describe('Stable Formation and Management Workflow', function () {
         $retiredStable = Stable::factory()->retired()->create(['name' => 'Evolution']);
 
         // When: Unretiring the stable
-        Livewire::actingAs($admin)
-            ->test(StablesTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(StablesTable::class)
             ->call('handleStableAction', 'unretire', $retiredStable->id)
             ->assertHasNoErrors();
 
@@ -162,8 +171,9 @@ describe('Tag Team Formation and Management Workflow', function () {
         $wrestler2 = Wrestler::factory()->bookable()->create(['name' => 'Jeff Hardy']);
 
         // When: Creating a new tag team
-        $tagTeamComponent = Livewire::actingAs($admin)
-            ->test(TagTeamFormModal::class)
+        actingAs($admin);
+
+        $tagTeamComponent = \Pest\Livewire\livewire(TagTeamFormModal::class)
             ->call('openModal')
             ->set('form.name', 'The Hardy Boyz')
             ->set('form.wrestlerA', $wrestler1->id)
@@ -177,8 +187,9 @@ describe('Tag Team Formation and Management Workflow', function () {
         $tagTeam = TagTeam::where('name', 'The Hardy Boyz')->first();
 
         // And: Tag team appears in tag teams table
-        Livewire::actingAs($admin)
-            ->test(TagTeamsTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(TagTeamsTable::class)
             ->assertSee('The Hardy Boyz');
 
         // When: Viewing tag team details
@@ -197,8 +208,9 @@ describe('Tag Team Formation and Management Workflow', function () {
         $tagTeam->wrestlers()->attach($wrestlers->pluck('id'), ['joined_at' => now()]);
 
         // When: Employing the tag team
-        Livewire::actingAs($admin)
-            ->test(TagTeamsTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(TagTeamsTable::class)
             ->call('handleTagTeamAction', 'employ', $tagTeam->id)
             ->assertHasNoErrors();
 
@@ -206,8 +218,9 @@ describe('Tag Team Formation and Management Workflow', function () {
         expect($tagTeam->fresh()->isEmployed())->toBeTrue();
 
         // When: Suspending tag team
-        Livewire::actingAs($admin)
-            ->test(TagTeamsTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(TagTeamsTable::class)
             ->call('handleTagTeamAction', 'suspend', $tagTeam->id)
             ->assertHasNoErrors();
 
@@ -215,8 +228,9 @@ describe('Tag Team Formation and Management Workflow', function () {
         expect($tagTeam->fresh()->isSuspended())->toBeTrue();
 
         // When: Reinstating tag team
-        Livewire::actingAs($admin)
-            ->test(TagTeamsTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(TagTeamsTable::class)
             ->call('handleTagTeamAction', 'reinstate', $tagTeam->id)
             ->assertHasNoErrors();
 
@@ -225,8 +239,9 @@ describe('Tag Team Formation and Management Workflow', function () {
         expect($tagTeam->fresh()->isSuspended())->toBeFalse();
 
         // When: Retiring tag team
-        Livewire::actingAs($admin)
-            ->test(TagTeamsTable::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(TagTeamsTable::class)
             ->call('handleTagTeamAction', 'retire', $tagTeam->id)
             ->assertHasNoErrors();
 

--- a/tests/Feature/Workflows/TitleManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/TitleManagementWorkflowTest.php
@@ -6,7 +6,6 @@ use App\Livewire\Titles\Modals\FormModal;
 use App\Livewire\Titles\Tables\Main;
 use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
-use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 
@@ -26,8 +25,9 @@ describe('Title Creation and Setup Workflow', function () {
             ->assertSeeLivewire(Main::class);
 
         // And: Creating title through modal workflow
-        $modalComponent = Livewire::actingAs($admin)
-            ->test(FormModal::class)
+        actingAs($admin);
+
+        $modalComponent = \Pest\Livewire\livewire(FormModal::class)
             ->call('openModal')
             ->assertSet('isModalOpen', true);
 
@@ -56,8 +56,9 @@ describe('Title Creation and Setup Workflow', function () {
         expect($title->name)->toBe('WWE Championship Title');
 
         // And: Should appear in the titles table
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->assertSee('WWE Championship Title');
     });
 
@@ -66,8 +67,9 @@ describe('Title Creation and Setup Workflow', function () {
         $admin = administrator();
 
         // When: Opening create modal and using dummy data
-        $component = Livewire::actingAs($admin)
-            ->test(FormModal::class)
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(FormModal::class)
             ->call('openModal')
             ->call('fillDummyFields');
 
@@ -94,8 +96,9 @@ describe('Title Lifecycle Management Workflow', function () {
         $title = Title::factory()->create(['name' => 'Intercontinental Championship Title']);
 
         // When: Debuting the title
-        $component = Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(Main::class)
             ->call('handleTitleAction', 'debut', $title->id)
             ->assertHasNoErrors();
 
@@ -103,8 +106,9 @@ describe('Title Lifecycle Management Workflow', function () {
         expect($title->fresh()->isCurrentlyActive())->toBeTrue();
 
         // When: Pulling (deactivating) the title
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleTitleAction', 'pull', $title->id)
             ->assertHasNoErrors();
 
@@ -112,8 +116,9 @@ describe('Title Lifecycle Management Workflow', function () {
         expect($title->fresh()->isCurrentlyActive())->toBeFalse();
 
         // When: Reinstating the title
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleTitleAction', 'reinstate', $title->id)
             ->assertHasNoErrors();
 
@@ -121,8 +126,9 @@ describe('Title Lifecycle Management Workflow', function () {
         expect($title->fresh()->isCurrentlyActive())->toBeTrue();
 
         // When: Retiring the title
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleTitleAction', 'retire', $title->id)
             ->assertHasNoErrors();
 
@@ -130,8 +136,9 @@ describe('Title Lifecycle Management Workflow', function () {
         expect($title->fresh()->isRetired())->toBeTrue();
 
         // When: Unretiring the title
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleTitleAction', 'unretire', $title->id)
             ->assertHasNoErrors();
 
@@ -169,28 +176,32 @@ describe('Title Search and Filtering Workflow', function () {
         $inactiveTitle = Title::factory()->create(['name' => 'ECW Championship Title']);
 
         // When: Searching for specific title
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->set('search', 'WWE')
             ->assertSee('WWE Championship Title')
             ->assertDontSee('WCW Championship Title')
             ->assertDontSee('ECW Championship Title');
 
         // When: Filtering by active status
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->set('filterValues.status', 'active')
             ->assertSee('WWE Championship Title');
 
         // When: Filtering by retired status
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->set('filterValues.status', 'retired')
             ->assertSee('WCW Championship Title');
 
         // When: Clearing filters
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->set('filterValues.status', '')
             ->set('search', '')
             ->assertSee('WWE Championship Title')
@@ -208,8 +219,9 @@ describe('Title Editing Workflow', function () {
         ]);
 
         // When: Opening edit modal for the title
-        $component = Livewire::actingAs($admin)
-            ->test(FormModal::class)
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(FormModal::class)
             ->call('openModal', $title->id)
             ->assertSet('isModalOpen', true);
 
@@ -228,8 +240,9 @@ describe('Title Editing Workflow', function () {
         expect($title->name)->toBe('Updated Championship Title');
 
         // And: Updated information should appear in table
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->assertSee('Updated Championship Title');
     });
 });
@@ -256,8 +269,9 @@ describe('Championship Reign Workflow', function () {
             ->assertSeeLivewire('titles.tables.previous-title-championships');
 
         // And: Title appears in main titles listing
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->assertSee('United States Championship Title');
     });
 });
@@ -269,8 +283,9 @@ describe('Title Deletion and Restoration Workflow', function () {
         $title = Title::factory()->create(['name' => 'Test Championship Title']);
 
         // When: Deleting the title
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('delete', $title)
             ->assertHasNoErrors();
 
@@ -279,8 +294,9 @@ describe('Title Deletion and Restoration Workflow', function () {
         expect(Title::onlyTrashed()->find($title->id))->not->toBeNull();
 
         // When: Restoring the title
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('restore', $title->id)
             ->assertHasNoErrors();
 
@@ -297,14 +313,16 @@ describe('Title Business Rules Workflow', function () {
         $title = Title::factory()->create(['name' => 'Money in the Bank Title']);
 
         // When: Attempting to pull an inactive title (business rule check)
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleTitleAction', 'pull', $title->id)
             ->assertHasNoErrors();
 
         // When: Properly debuting title first
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleTitleAction', 'debut', $title->id)
             ->assertHasNoErrors();
 
@@ -312,8 +330,9 @@ describe('Title Business Rules Workflow', function () {
         expect($title->fresh()->isCurrentlyActive())->toBeTrue();
 
         // When: Now pulling the active title (should succeed)
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleTitleAction', 'pull', $title->id)
             ->assertHasNoErrors();
 

--- a/tests/Feature/Workflows/WrestlerManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/WrestlerManagementWorkflowTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use App\Livewire\Wrestlers\Modals\FormModal;
 use App\Livewire\Wrestlers\Tables\Main;
 use App\Models\Wrestlers\Wrestler;
-use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 
@@ -25,8 +24,9 @@ describe('Wrestler Creation Journey', function () {
             ->assertSeeLivewire(Main::class);
 
         // And: Creating wrestler through modal workflow
-        $modalComponent = Livewire::actingAs($admin)
-            ->test(FormModal::class)
+        actingAs($admin);
+
+        $modalComponent = \Pest\Livewire\livewire(FormModal::class)
             ->call('openModal') // Open for creation
             ->assertSet('isModalOpen', true);
 
@@ -62,8 +62,9 @@ describe('Wrestler Creation Journey', function () {
         expect($wrestler->signature_move)->toBe('Attitude Adjustment');
 
         // And: Should appear in the wrestlers table
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->assertSee('John Cena')
             ->assertSee('West Newbury, MA');
     });
@@ -73,8 +74,9 @@ describe('Wrestler Creation Journey', function () {
         $admin = administrator();
 
         // When: Opening create modal and using dummy data
-        $component = Livewire::actingAs($admin)
-            ->test(FormModal::class)
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(FormModal::class)
             ->call('openModal')
             ->call('fillDummyFields');
 
@@ -103,8 +105,9 @@ describe('Wrestler Employment Status Management Journey', function () {
         $wrestler = Wrestler::factory()->create(['name' => 'Daniel Bryan']);
 
         // When: Employing the wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleWrestlerAction', 'employ', $wrestler->id)
             ->assertHasNoErrors();
 
@@ -112,8 +115,9 @@ describe('Wrestler Employment Status Management Journey', function () {
         expect($wrestler->fresh()->isEmployed())->toBeTrue();
 
         // When: Suspending the employed wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleWrestlerAction', 'suspend', $wrestler->id)
             ->assertHasNoErrors();
 
@@ -121,8 +125,9 @@ describe('Wrestler Employment Status Management Journey', function () {
         expect($wrestler->fresh()->isSuspended())->toBeTrue();
 
         // When: Reinstating the suspended wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleWrestlerAction', 'reinstate', $wrestler->id)
             ->assertHasNoErrors();
 
@@ -131,8 +136,9 @@ describe('Wrestler Employment Status Management Journey', function () {
         expect($wrestler->fresh()->isSuspended())->toBeFalse();
 
         // When: Retiring the wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleWrestlerAction', 'retire', $wrestler->id)
             ->assertHasNoErrors();
 
@@ -140,8 +146,9 @@ describe('Wrestler Employment Status Management Journey', function () {
         expect($wrestler->fresh()->isRetired())->toBeTrue();
 
         // When: Unretiring the wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleWrestlerAction', 'unretire', $wrestler->id)
             ->assertHasNoErrors();
 
@@ -158,8 +165,9 @@ describe('Wrestler Employment Status Management Journey', function () {
         $wrestler = Wrestler::factory()->bookable()->create(['name' => 'CM Punk']);
 
         // When: Injuring the wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleWrestlerAction', 'injure', $wrestler->id)
             ->assertHasNoErrors();
 
@@ -167,8 +175,9 @@ describe('Wrestler Employment Status Management Journey', function () {
         expect($wrestler->fresh()->isInjured())->toBeTrue();
 
         // When: Healing the wrestler from injury
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('handleWrestlerAction', 'heal', $wrestler->id)
             ->assertHasNoErrors();
 
@@ -188,8 +197,9 @@ describe('Wrestler Profile Management Journey', function () {
         ]);
 
         // When: Opening edit modal for the wrestler
-        $component = Livewire::actingAs($admin)
-            ->test(FormModal::class)
+        actingAs($admin);
+
+        $component = \Pest\Livewire\livewire(FormModal::class)
             ->call('openModal', $wrestler->id)
             ->assertSet('isModalOpen', true);
 
@@ -213,8 +223,9 @@ describe('Wrestler Profile Management Journey', function () {
         expect($wrestler->signature_move)->toBe('New Finisher');
 
         // And: Updated information should appear in table
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->assertSee('Updated Name')
             ->assertSee('Updated City, UT');
     });
@@ -261,30 +272,34 @@ describe('Wrestler Search and Filtering Journey', function () {
         $retiredWrestler = Wrestler::factory()->retired()->create(['name' => 'Mick Foley']);
 
         // When: Searching for specific wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->set('search', 'John')
             ->assertSee($bookableWrestler->name)
             ->assertDontSee($releasedWrestler->name)
             ->assertDontSee($retiredWrestler->name);
 
         // When: Filtering by employment status
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->set('filterValues.status', 'employed')
             ->assertSee($bookableWrestler->name)
             ->assertDontSee($releasedWrestler->name);
 
         // When: Filtering by released status
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->set('filterValues.status', 'released')
             ->assertSee($releasedWrestler->name)
             ->assertDontSee($bookableWrestler->name);
 
         // When: Clearing filters
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->set('filterValues.status', '')
             ->set('search', '')
             ->assertSee($bookableWrestler->name)
@@ -300,8 +315,9 @@ describe('Wrestler Deletion and Restoration Journey', function () {
         $wrestler = Wrestler::factory()->create(['name' => 'Test Wrestler']);
 
         // When: Deleting the wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('delete', $wrestler)
             ->assertHasNoErrors();
 
@@ -310,8 +326,9 @@ describe('Wrestler Deletion and Restoration Journey', function () {
         expect(Wrestler::onlyTrashed()->find($wrestler->id))->not->toBeNull();
 
         // When: Restoring the wrestler
-        Livewire::actingAs($admin)
-            ->test(Main::class)
+        actingAs($admin);
+
+        \Pest\Livewire\livewire(Main::class)
             ->call('restore', $wrestler->id)
             ->assertHasNoErrors();
 

--- a/tests/Helpers/IntegrationTestHelpers.php
+++ b/tests/Helpers/IntegrationTestHelpers.php
@@ -20,6 +20,8 @@ use Illuminate\Support\Carbon;
 
 /**
  * Create a complete employment lifecycle scenario.
+ *
+ * @return array<string, mixed>
  */
 function createEmploymentLifecycleScenario(string $entityType = 'wrestler'): array
 {
@@ -42,6 +44,8 @@ function createEmploymentLifecycleScenario(string $entityType = 'wrestler'): arr
 
 /**
  * Create a championship storyline scenario.
+ *
+ * @return array<string, mixed>
  */
 function createChampionshipStoryline(): array
 {
@@ -67,6 +71,8 @@ function createChampionshipStoryline(): array
 
 /**
  * Create a multi-generational title lineage.
+ *
+ * @return array<string, mixed>
  */
 function createTitleLineage(int $reignCount = 5): array
 {
@@ -97,6 +103,8 @@ function createTitleLineage(int $reignCount = 5): array
 
 /**
  * Create a stable formation and split scenario.
+ *
+ * @return array<string, mixed>
  */
 function createStableLifecycleScenario(): array
 {
@@ -122,6 +130,8 @@ function createStableLifecycleScenario(): array
 
 /**
  * Create an injury storyline with recovery.
+ *
+ * @return array<string, mixed>
  */
 function createInjuryStoryline(): array
 {
@@ -147,6 +157,8 @@ function createInjuryStoryline(): array
 
 /**
  * Create a retirement ceremony scenario.
+ *
+ * @return array<string, mixed>
  */
 function createRetirementCeremonyScenario(): array
 {
@@ -190,6 +202,8 @@ function createRetirementCeremonyScenario(): array
 
 /**
  * Create a tournament bracket scenario.
+ *
+ * @return array<string, mixed>
  */
 function createTournamentScenario(int $participantCount = 8): array
 {
@@ -219,6 +233,8 @@ function createTournamentScenario(int $participantCount = 8): array
 
 /**
  * Create a company merger scenario.
+ *
+ * @return array<string, mixed>
  */
 function createCompanyMergerScenario(): array
 {
@@ -261,6 +277,8 @@ function createCompanyMergerScenario(): array
 
 /**
  * Set up a realistic test database state.
+ *
+ * @return array<string, mixed>
  */
 function setupRealisticTestState(): array
 {
@@ -294,8 +312,10 @@ function setupRealisticTestState(): array
 
 /**
  * Create management relationship with proper pivot data.
+ *
+ * @param  array<string, mixed>  $options
  */
-function createManagementRelationship($wrestler, $manager, array $options = []): void
+function createManagementRelationship(Wrestler $wrestler, Manager $manager, array $options = []): void
 {
     $defaultOptions = [
         'hired_at' => Carbon::now()->subMonths(6),
@@ -310,8 +330,10 @@ function createManagementRelationship($wrestler, $manager, array $options = []):
 
 /**
  * Create tag team membership with proper pivot data.
+ *
+ * @param  array<string, mixed>  $options
  */
-function createTagTeamMembership($wrestler, $tagTeam, array $options = []): void
+function createTagTeamMembership(Wrestler $wrestler, TagTeam $tagTeam, array $options = []): void
 {
     $defaultOptions = [
         'joined_at' => Carbon::now()->subMonths(6),
@@ -327,7 +349,7 @@ function createTagTeamMembership($wrestler, $tagTeam, array $options = []): void
 /**
  * End management relationship by setting fired_at date.
  */
-function endManagementRelationship($wrestler, $manager, ?Carbon $endDate = null): void
+function endManagementRelationship(Wrestler $wrestler, Manager $manager, ?Carbon $endDate = null): void
 {
     $endDate = $endDate ?? Carbon::now();
     $wrestler->managers()->updateExistingPivot($manager->id, [
@@ -339,7 +361,7 @@ function endManagementRelationship($wrestler, $manager, ?Carbon $endDate = null)
 /**
  * End tag team membership by setting left_at date.
  */
-function endTagTeamMembership($wrestler, $tagTeam, ?Carbon $endDate = null): void
+function endTagTeamMembership(Wrestler $wrestler, TagTeam $tagTeam, ?Carbon $endDate = null): void
 {
     $endDate = $endDate ?? Carbon::now();
     $wrestler->tagTeams()->updateExistingPivot($tagTeam->id, [
@@ -350,8 +372,10 @@ function endTagTeamMembership($wrestler, $tagTeam, ?Carbon $endDate = null): voi
 
 /**
  * Create multiple management periods for complex scenarios.
+ *
+ * @param  array<int, array{manager: Manager, hired_at: Carbon, fired_at?: Carbon|null}>  $periods
  */
-function createManagementHistory($wrestler, array $periods): void
+function createManagementHistory(Wrestler $wrestler, array $periods): void
 {
     foreach ($periods as $period) {
         createManagementRelationship($wrestler, $period['manager'], [
@@ -363,8 +387,10 @@ function createManagementHistory($wrestler, array $periods): void
 
 /**
  * Create multiple tag team membership periods for complex scenarios.
+ *
+ * @param  array<int, array{tag_team: TagTeam, joined_at: Carbon, left_at?: Carbon|null}>  $periods
  */
-function createTagTeamHistory($wrestler, array $periods): void
+function createTagTeamHistory(Wrestler $wrestler, array $periods): void
 {
     foreach ($periods as $period) {
         createTagTeamMembership($wrestler, $period['tag_team'], [
@@ -376,8 +402,10 @@ function createTagTeamHistory($wrestler, array $periods): void
 
 /**
  * Create overlapping relationship periods for validation testing.
+ *
+ * @return array<string, Carbon|bool>
  */
-function createOverlappingManagementPeriods($wrestler, $manager1, $manager2): array
+function createOverlappingManagementPeriods(Wrestler $wrestler, Manager $manager1, Manager $manager2): array
 {
     $firstPeriodStart = Carbon::now()->subYear();
     $firstPeriodEnd = Carbon::now()->subMonths(6);
@@ -403,8 +431,10 @@ function createOverlappingManagementPeriods($wrestler, $manager1, $manager2): ar
 
 /**
  * Create complex relationship scenario with multiple periods and partners.
+ *
+ * @return array<string, mixed>
  */
-function createComplexRelationshipScenario($wrestler): array
+function createComplexRelationshipScenario(Wrestler $wrestler): array
 {
     $manager1 = Manager::factory()->employed()->create(['name' => 'First Manager']);
     $manager2 = Manager::factory()->employed()->create(['name' => 'Second Manager']);

--- a/tests/Helpers/StatusTestExpectations.php
+++ b/tests/Helpers/StatusTestExpectations.php
@@ -7,6 +7,8 @@ use App\Models\Contracts\Employable;
 use App\Models\Contracts\Injurable;
 use App\Models\Contracts\Retirable;
 use App\Models\Contracts\Suspendable;
+use App\Models\Referees\Referee;
+use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -21,6 +23,8 @@ use Illuminate\Support\Carbon;
 
 /**
  * Expect an entity to have a specific employment status.
+ *
+ * @param  Model&Employable<Model, Model>  $entity
  */
 function expectEmploymentStatus(Model&Employable $entity, EmploymentStatus $expectedStatus): void
 {
@@ -30,6 +34,8 @@ function expectEmploymentStatus(Model&Employable $entity, EmploymentStatus $expe
 
 /**
  * Expect an entity to transition from one status to another.
+ *
+ * @param  Model&Employable<Model, Model>  $entity
  */
 function expectStatusTransition(Model&Employable $entity, EmploymentStatus $fromStatus, EmploymentStatus $toStatus): void
 {
@@ -41,7 +47,7 @@ function expectStatusTransition(Model&Employable $entity, EmploymentStatus $from
 /**
  * Expect an entity to be in an active, bookable state.
  */
-function expectToBeBookable($entity): void
+function expectToBeBookable(Wrestler|Referee|TagTeam $entity): void
 {
     $entity = $entity->fresh();
     expect($entity->isEmployed())->toBeTrue();
@@ -52,7 +58,7 @@ function expectToBeBookable($entity): void
 /**
  * Expect an entity to be unavailable for booking.
  */
-function expectToBeUnavailable($entity): void
+function expectToBeUnavailable(Wrestler|Referee|TagTeam $entity): void
 {
     $entity = $entity->fresh();
     expect($entity->isBookable())->toBeFalse();
@@ -60,6 +66,8 @@ function expectToBeUnavailable($entity): void
 
 /**
  * Expect employment lifecycle to be valid.
+ *
+ * @param  Model&Employable<Model, Model>  $entity
  */
 function expectValidEmploymentLifecycle(Model&Employable $entity): void
 {
@@ -82,6 +90,8 @@ function expectValidEmploymentLifecycle(Model&Employable $entity): void
 
 /**
  * Expect retirement state to be consistent.
+ *
+ * @param  Model&Retirable<Model, Model>  $entity
  */
 function expectValidRetirementState(Model&Retirable $entity): void
 {
@@ -99,6 +109,8 @@ function expectValidRetirementState(Model&Retirable $entity): void
 
 /**
  * Expect injury state to be consistent.
+ *
+ * @param  Model&Injurable<Model, Model>  $entity
  */
 function expectValidInjuryState(Model&Injurable $entity): void
 {
@@ -116,6 +128,8 @@ function expectValidInjuryState(Model&Injurable $entity): void
 
 /**
  * Expect suspension state to be consistent.
+ *
+ * @param  Model&Suspendable<Model, Model>  $entity
  */
 function expectValidSuspensionState(Model&Suspendable $entity): void
 {
@@ -133,6 +147,8 @@ function expectValidSuspensionState(Model&Suspendable $entity): void
 
 /**
  * Expect a complete entity state to be valid and consistent.
+ *
+ * @param  Model&Employable<Model, Model>  $entity
  */
 function expectValidEntityState(Model&Employable $entity): void
 {
@@ -153,8 +169,10 @@ function expectValidEntityState(Model&Employable $entity): void
 
 /**
  * Expect relationship counts to match expected values.
+ *
+ * @param  array<string, int>  $expectedCounts
  */
-function expectRelationshipCounts($entity, array $expectedCounts): void
+function expectRelationshipCounts(Model $entity, array $expectedCounts): void
 {
     foreach ($expectedCounts as $relationship => $count) {
         expect($entity->{$relationship}()->count())->toBe($count);
@@ -163,8 +181,10 @@ function expectRelationshipCounts($entity, array $expectedCounts): void
 
 /**
  * Expect tag team membership to be correctly configured.
+ *
+ * @param  array<string, mixed>  $expectedPivotData
  */
-function expectTagTeamMembership($wrestler, $tagTeam, array $expectedPivotData = []): void
+function expectTagTeamMembership(Wrestler $wrestler, TagTeam $tagTeam, array $expectedPivotData = []): void
 {
     expect($wrestler->tagTeams()->count())->toBeGreaterThan(0);
 

--- a/tests/Helpers/TestHelpers.php
+++ b/tests/Helpers/TestHelpers.php
@@ -22,6 +22,8 @@ use Illuminate\Support\Collection;
 
 /**
  * Create a wrestler with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createWrestler(array $attributes = []): Wrestler
 {
@@ -30,6 +32,8 @@ function createWrestler(array $attributes = []): Wrestler
 
 /**
  * Create an employed wrestler for testing availability scenarios.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createEmployedWrestler(array $attributes = []): Wrestler
 {
@@ -38,6 +42,8 @@ function createEmployedWrestler(array $attributes = []): Wrestler
 
 /**
  * Create a bookable wrestler for match testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createBookableWrestler(array $attributes = []): Wrestler
 {
@@ -46,6 +52,8 @@ function createBookableWrestler(array $attributes = []): Wrestler
 
 /**
  * Create a manager with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createManager(array $attributes = []): Manager
 {
@@ -54,6 +62,8 @@ function createManager(array $attributes = []): Manager
 
 /**
  * Create a referee with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createReferee(array $attributes = []): Referee
 {
@@ -62,6 +72,8 @@ function createReferee(array $attributes = []): Referee
 
 /**
  * Create a tag team with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createTagTeam(array $attributes = []): TagTeam
 {
@@ -70,6 +82,8 @@ function createTagTeam(array $attributes = []): TagTeam
 
 /**
  * Create a stable with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createStable(array $attributes = []): Stable
 {
@@ -78,6 +92,8 @@ function createStable(array $attributes = []): Stable
 
 /**
  * Create a title with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createTitle(array $attributes = []): Title
 {
@@ -86,6 +102,8 @@ function createTitle(array $attributes = []): Title
 
 /**
  * Create a venue with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createVenue(array $attributes = []): Venue
 {
@@ -94,6 +112,8 @@ function createVenue(array $attributes = []): Venue
 
 /**
  * Create an event with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createEvent(array $attributes = []): Event
 {
@@ -102,6 +122,8 @@ function createEvent(array $attributes = []): Event
 
 /**
  * Create a match with realistic attributes for testing.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createMatch(array $attributes = []): EventMatch
 {
@@ -110,6 +132,9 @@ function createMatch(array $attributes = []): EventMatch
 
 /**
  * Create a collection of wrestlers for testing bulk operations.
+ *
+ * @param  array<string, mixed>  $attributes
+ * @return Collection<int, Wrestler>
  */
 function createWrestlers(int $count = 5, array $attributes = []): Collection
 {
@@ -118,6 +143,9 @@ function createWrestlers(int $count = 5, array $attributes = []): Collection
 
 /**
  * Create a collection of managers for testing bulk operations.
+ *
+ * @param  array<string, mixed>  $attributes
+ * @return Collection<int, Manager>
  */
 function createManagers(int $count = 5, array $attributes = []): Collection
 {
@@ -126,6 +154,9 @@ function createManagers(int $count = 5, array $attributes = []): Collection
 
 /**
  * Create a collection of referees for testing bulk operations.
+ *
+ * @param  array<string, mixed>  $attributes
+ * @return Collection<int, Referee>
  */
 function createReferees(int $count = 5, array $attributes = []): Collection
 {
@@ -134,6 +165,8 @@ function createReferees(int $count = 5, array $attributes = []): Collection
 
 /**
  * Create a complete roster with wrestlers, managers, referees, tag teams, and stables.
+ *
+ * @return array<string, mixed>
  */
 function createFullRoster(int $size = 10): array
 {
@@ -148,6 +181,8 @@ function createFullRoster(int $size = 10): array
 
 /**
  * Create a complete event with matches and participants.
+ *
+ * @return array<string, mixed>
  */
 function createEventWithMatches(int $matchCount = 3): array
 {
@@ -169,6 +204,8 @@ function createEventWithMatches(int $matchCount = 3): array
 
 /**
  * Create a tag team with wrestlers.
+ *
+ * @return array<string, mixed>
  */
 function createTagTeamWithWrestlers(int $wrestlerCount = 2): array
 {
@@ -189,6 +226,8 @@ function createTagTeamWithWrestlers(int $wrestlerCount = 2): array
 
 /**
  * Create a stable with members.
+ *
+ * @return array<string, mixed>
  */
 function createStableWithMembers(int $wrestlerCount = 3, int $tagTeamCount = 1): array
 {
@@ -217,6 +256,8 @@ function createStableWithMembers(int $wrestlerCount = 3, int $tagTeamCount = 1):
 
 /**
  * Create a wrestler with a manager relationship.
+ *
+ * @return array<string, mixed>
  */
 function createWrestlerWithManager(): array
 {
@@ -235,6 +276,8 @@ function createWrestlerWithManager(): array
 
 /**
  * Create a championship scenario with title and champion.
+ *
+ * @return array<string, mixed>
  */
 function createChampionshipScenario(string $championType = 'wrestler'): array
 {
@@ -266,6 +309,8 @@ function createChampionshipScenario(string $championType = 'wrestler'): array
 
 /**
  * Create an injured wrestler for testing injury scenarios.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createInjuredWrestler(array $attributes = []): Wrestler
 {
@@ -274,6 +319,8 @@ function createInjuredWrestler(array $attributes = []): Wrestler
 
 /**
  * Create a suspended wrestler for testing suspension scenarios.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createSuspendedWrestler(array $attributes = []): Wrestler
 {
@@ -282,6 +329,8 @@ function createSuspendedWrestler(array $attributes = []): Wrestler
 
 /**
  * Create a retired wrestler for testing retirement scenarios.
+ *
+ * @param  array<string, mixed>  $attributes
  */
 function createRetiredWrestler(array $attributes = []): Wrestler
 {
@@ -336,6 +385,8 @@ function wrestlingDate(string $period = 'recent'): Carbon\Carbon
 
 /**
  * Create a realistic wrestling time period (start and end dates).
+ *
+ * @return array{started_at: Carbon\Carbon, ended_at: Carbon\Carbon|null}
  */
 function wrestlingTimePeriod(string $type = 'employment'): array
 {

--- a/tests/Helpers/TestHelpers.php
+++ b/tests/Helpers/TestHelpers.php
@@ -375,10 +375,10 @@ function seedBasicLookupData(): void
 function wrestlingDate(string $period = 'recent'): Carbon\Carbon
 {
     return match ($period) {
-        'recent' => now()->subDays(rand(1, 30)),
-        'past' => now()->subMonths(rand(1, 24)),
-        'future' => now()->addDays(rand(1, 90)),
-        'historical' => now()->subYears(rand(1, 10)),
+        'recent' => now()->subDays(random_int(1, 30)),
+        'past' => now()->subMonths(random_int(1, 24)),
+        'future' => now()->addDays(random_int(1, 90)),
+        'historical' => now()->subYears(random_int(1, 10)),
         default => now(),
     };
 }
@@ -391,19 +391,19 @@ function wrestlingDate(string $period = 'recent'): Carbon\Carbon
 function wrestlingTimePeriod(string $type = 'employment'): array
 {
     $start = match ($type) {
-        'employment' => now()->subMonths(rand(1, 24)),
-        'injury' => now()->subWeeks(rand(1, 12)),
-        'suspension' => now()->subMonths(rand(1, 6)),
-        'retirement' => now()->subYears(rand(1, 5)),
-        default => now()->subMonths(rand(1, 12)),
+        'employment' => now()->subMonths(random_int(1, 24)),
+        'injury' => now()->subWeeks(random_int(1, 12)),
+        'suspension' => now()->subMonths(random_int(1, 6)),
+        'retirement' => now()->subYears(random_int(1, 5)),
+        default => now()->subMonths(random_int(1, 12)),
     };
 
     $end = match ($type) {
-        'employment' => rand(0, 1) ? $start->copy()->addMonths(rand(1, 12)) : null,
-        'injury' => rand(0, 1) ? $start->copy()->addWeeks(rand(1, 8)) : null,
-        'suspension' => rand(0, 1) ? $start->copy()->addMonths(rand(1, 3)) : null,
-        'retirement' => rand(0, 1) ? $start->copy()->addYears(rand(1, 3)) : null,
-        default => rand(0, 1) ? $start->copy()->addMonths(rand(1, 6)) : null,
+        'employment' => random_int(0, 1) ? $start->copy()->addMonths(random_int(1, 12)) : null,
+        'injury' => random_int(0, 1) ? $start->copy()->addWeeks(random_int(1, 8)) : null,
+        'suspension' => random_int(0, 1) ? $start->copy()->addMonths(random_int(1, 3)) : null,
+        'retirement' => random_int(0, 1) ? $start->copy()->addYears(random_int(1, 3)) : null,
+        default => random_int(0, 1) ? $start->copy()->addMonths(random_int(1, 6)) : null,
     };
 
     return [

--- a/tests/Integration/Livewire/Events/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Events/Modals/FormModalTest.php
@@ -8,7 +8,8 @@ use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Users\User;
 use Illuminate\Support\Carbon;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -37,7 +38,7 @@ describe('FormModal Configuration', function () {
 
 describe('FormModal Rendering', function () {
     it('can render in create mode', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertOk();
@@ -46,14 +47,14 @@ describe('FormModal Rendering', function () {
     it('can render in edit mode', function () {
         $event = Event::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $event->id);
 
         $component->assertOk();
     });
 
     it('displays correct title in create mode', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Create Event');
@@ -62,7 +63,7 @@ describe('FormModal Rendering', function () {
     it('displays correct title in edit mode', function () {
         $event = Event::factory()->create(['name' => 'Test Event']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $event->id);
 
         $component->assertSee('Edit Event');
@@ -71,7 +72,7 @@ describe('FormModal Rendering', function () {
     it('presents venues list for selection', function () {
         $venue = Venue::factory()->create(['name' => 'Test Arena']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Test Arena');
@@ -82,7 +83,7 @@ describe('FormModal Create Operations', function () {
     it('can create a new event with valid data', function () {
         $venue = Venue::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'WrestleMania 40')
             ->set('form.date', '2024-04-06')
@@ -100,7 +101,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates required fields when creating', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', '')
             ->set('form.date', null)
@@ -118,7 +119,7 @@ describe('FormModal Create Operations', function () {
     it('validates event name uniqueness', function () {
         Event::factory()->create(['name' => 'Existing Event']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Existing Event')
             ->set('form.date', '2024-04-06')
@@ -132,7 +133,7 @@ describe('FormModal Create Operations', function () {
     // InvalidFormatException before validation rules can be applied
     // This test has been temporarily disabled - date validation works in practice
     it('validates date format', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Event')
             ->set('form.date', '2023-13-32')
@@ -142,7 +143,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates venue exists', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Event')
             ->set('form.date', '2024-04-06')
@@ -156,7 +157,7 @@ describe('FormModal Create Operations', function () {
         $yesterday = Carbon::yesterday()->toDateString();
         $venue = Venue::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Historical Event')
             ->set('form.date', $yesterday)
@@ -178,7 +179,7 @@ describe('FormModal Edit Operations', function () {
             'venue_id' => $venue1->id,
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $event->id)
             ->set('form.name', 'Updated Event')
             ->set('form.date', '2024-04-07')
@@ -204,7 +205,7 @@ describe('FormModal Edit Operations', function () {
             'venue_id' => $venue->id,
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $event->id);
 
         $component->assertSet('form.name', 'Test Event');
@@ -216,7 +217,7 @@ describe('FormModal Edit Operations', function () {
         $event1 = Event::factory()->create(['name' => 'Event One']);
         $event2 = Event::factory()->create(['name' => 'Event Two']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $event2->id)
             ->set('form.name', 'Event One')
             ->call('save');
@@ -232,7 +233,7 @@ describe('FormModal Edit Operations', function () {
             'venue_id' => $venue->id,
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $event->id)
             ->set('form.name', 'Test Event')
             ->set('form.date', '2024-04-07')
@@ -246,7 +247,7 @@ describe('FormModal Edit Operations', function () {
         $venue = Venue::factory()->create();
         $event = Event::factory()->past()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $event->id)
             ->set('form.date', '2025-01-01')
             ->set('form.venue_id', $venue->id)
@@ -262,7 +263,7 @@ describe('FormModal Venue Integration', function () {
         $venue1 = Venue::factory()->create(['name' => 'Arena One']);
         $venue2 = Venue::factory()->create(['name' => 'Arena Two']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Arena One');
@@ -273,7 +274,7 @@ describe('FormModal Venue Integration', function () {
         $availableVenue = Venue::factory()->available()->create(['name' => 'Available Arena']);
         $inactiveVenue = Venue::factory()->inactive()->create(['name' => 'Inactive Arena']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         // Both available and inactive venues should be shown for flexibility
@@ -288,7 +289,7 @@ describe('FormModal Venue Integration', function () {
             'state' => 'Test State',
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.venue_id', $venue->id);
 
@@ -304,7 +305,7 @@ describe('FormModal State Management', function () {
         $venue = Venue::factory()->create();
         $event = Event::factory()->create(['name' => 'Test Event']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $event->id)
             ->call('openModal');
 
@@ -316,7 +317,7 @@ describe('FormModal State Management', function () {
     it('closes modal after successful save', function () {
         $venue = Venue::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Event')
             ->set('form.date', '2024-04-06')
@@ -327,7 +328,7 @@ describe('FormModal State Management', function () {
     });
 
     it('keeps modal open when validation fails', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', '')
             ->call('save');
@@ -340,7 +341,7 @@ describe('FormModal Business Logic', function () {
     it('handles event descriptions correctly', function () {
         $venue = Venue::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Event')
             ->set('form.date', '2024-04-06')
@@ -359,7 +360,7 @@ describe('FormModal Business Logic', function () {
     it('handles promotional content fields', function () {
         $venue = Venue::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Event')
             ->set('form.date', '2024-04-06')
@@ -380,7 +381,7 @@ describe('FormModal Authorization', function () {
     it('requires authentication', function () {
         auth()->logout();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertForbidden();
@@ -390,7 +391,7 @@ describe('FormModal Authorization', function () {
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertForbidden();

--- a/tests/Integration/Livewire/Events/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Events/Tables/MainTest.php
@@ -9,6 +9,9 @@ use App\Models\Events\Venue;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for EventsTable Livewire component.
  *
@@ -36,8 +39,9 @@ describe('EventsTable Component Integration', function () {
             $unscheduledEvent = Event::factory()->unscheduled()->create(['name' => 'Draft Event']);
             $pastEvent = Event::factory()->past()->atVenue($this->venue)->create(['name' => 'Royal Rumble']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee($scheduledEvent->name)
@@ -53,8 +57,9 @@ describe('EventsTable Component Integration', function () {
             $unscheduledEvent = Event::factory()->unscheduled()->create(['name' => 'Unscheduled Event']);
             $pastEvent = Event::factory()->past()->create(['name' => 'Past Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Scheduled Event')
@@ -69,8 +74,9 @@ describe('EventsTable Component Integration', function () {
             expect($event->venue)->not()->toBeNull();
             expect($event->venue->name)->toBe('Test Arena');
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Venue Event')
@@ -81,8 +87,9 @@ describe('EventsTable Component Integration', function () {
             $futureEvent = Event::factory()->scheduled()->create(['name' => 'Future Event']);
             $unscheduledEvent = Event::factory()->unscheduled()->create(['name' => 'No Date Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Future Event')
@@ -94,8 +101,9 @@ describe('EventsTable Component Integration', function () {
             $eventWithVenue = Event::factory()->scheduled()->atVenue($this->venue)->create(['name' => 'Venue Event']);
             $eventWithoutVenue = Event::factory()->scheduled()->create(['name' => 'No Venue Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Venue Event')
@@ -111,8 +119,9 @@ describe('EventsTable Component Integration', function () {
             $summerSlam = Event::factory()->scheduled()->create(['name' => 'SummerSlam 2024']);
             $royalRumble = Event::factory()->scheduled()->create(['name' => 'Royal Rumble']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Test search for "WrestleMania"
             $component->set('search', 'WrestleMania')
@@ -132,8 +141,9 @@ describe('EventsTable Component Integration', function () {
             $unscheduledEvent = Event::factory()->unscheduled()->create(['name' => 'Unscheduled Event']);
             $pastEvent = Event::factory()->past()->create(['name' => 'Past Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Initially should see all events
             $component->assertSee('Scheduled Event')
@@ -152,8 +162,9 @@ describe('EventsTable Component Integration', function () {
             $event2 = Event::factory()->scheduled()->atVenue($venue2)->create(['name' => 'Event at Venue Two']);
             $event3 = Event::factory()->scheduled()->create(['name' => 'Event with No Venue']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Event at Venue One')
@@ -165,8 +176,9 @@ describe('EventsTable Component Integration', function () {
             $earlyEvent = Event::factory()->scheduledOn('2024-01-15')->create(['name' => 'Early Event']);
             $lateEvent = Event::factory()->scheduledOn('2024-12-15')->create(['name' => 'Late Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Early Event')
@@ -178,8 +190,9 @@ describe('EventsTable Component Integration', function () {
         test('delete action integration works correctly', function () {
             $event = Event::factory()->unscheduled()->create(['name' => 'Deletable Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('delete', $event)
                 ->assertHasNoErrors();
@@ -192,8 +205,9 @@ describe('EventsTable Component Integration', function () {
         test('restore action integration works correctly', function () {
             $deletedEvent = Event::factory()->trashed()->create(['name' => 'Deleted Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('restore', $deletedEvent->id)
                 ->assertHasNoErrors()
@@ -209,8 +223,9 @@ describe('EventsTable Component Integration', function () {
         test('delete action works for appropriate event status', function () {
             $unscheduledEvent = Event::factory()->unscheduled()->create(['name' => 'Unscheduled Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('delete', $unscheduledEvent)
                 ->assertHasNoErrors();
@@ -222,8 +237,9 @@ describe('EventsTable Component Integration', function () {
         test('restore action works for deleted events', function () {
             $deletedEvent = Event::factory()->trashed()->create(['name' => 'Deleted Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('restore', $deletedEvent->id)
                 ->assertHasNoErrors()
@@ -237,13 +253,14 @@ describe('EventsTable Component Integration', function () {
         test('component requires proper authorization for access', function () {
             $basicUser = User::factory()->create();
 
-            Livewire::actingAs($basicUser)
-                ->test(Main::class)
+            actingAs($basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
         test('guest users cannot access component', function () {
-            Livewire::test(Main::class)
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -251,8 +268,9 @@ describe('EventsTable Component Integration', function () {
             $event = Event::factory()->unscheduled()->create();
             $deletedEvent = Event::factory()->trashed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // All actions should be available to admin
             $component->call('delete', $event)->assertHasNoErrors();
@@ -266,8 +284,9 @@ describe('EventsTable Component Integration', function () {
             Event::factory()->count(10)->unscheduled()->create();
             Event::factory()->count(5)->past()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
         });
@@ -278,8 +297,9 @@ describe('EventsTable Component Integration', function () {
             // Ensure venue relationship exists for eager loading test
             expect($event->venue)->not()->toBeNull();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Test Event')
@@ -292,8 +312,9 @@ describe('EventsTable Component Integration', function () {
             Event::factory()->count(10)->unscheduled()->create();
             Event::factory()->count(5)->past()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
 
@@ -316,8 +337,9 @@ describe('EventsTable Component Integration', function () {
             // Simulate venue change by updating the event
             $event->update(['venue_id' => $venue2->id]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Venue Change Event')
@@ -330,8 +352,9 @@ describe('EventsTable Component Integration', function () {
             // Simulate scheduling the event
             $event->update(['date' => now()->addMonths(2)]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Scheduling Event');
@@ -343,8 +366,9 @@ describe('EventsTable Component Integration', function () {
             // Verify event is originally scheduled
             expect($event->isScheduled())->toBeTrue();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Date Change Event');
@@ -362,8 +386,9 @@ describe('EventsTable Component Integration', function () {
             // Event with neither date nor venue
             $draftEvent = Event::factory()->unscheduled()->create(['name' => 'Draft Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Complete Event')
@@ -378,16 +403,18 @@ describe('EventsTable Component Integration', function () {
         test('component maintains state through action calls', function () {
             $event = Event::factory()->unscheduled()->create(['name' => 'State Test Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Perform action and verify component state updates
             $component->call('delete', $event)
                 ->assertHasNoErrors();
 
             // Component should reflect the change after refresh
-            $refreshComponent = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $refreshComponent = livewire(Main::class);
 
             $refreshComponent->assertOk()
                 ->assertDontSee('State Test Event');
@@ -397,8 +424,9 @@ describe('EventsTable Component Integration', function () {
             $event1 = Event::factory()->unscheduled()->create(['name' => 'Event One']);
             $event2 = Event::factory()->unscheduled()->create(['name' => 'Event Two']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Perform multiple actions
             $component->call('delete', $event1)
@@ -419,8 +447,9 @@ describe('EventsTable Component Integration', function () {
             $unscheduledEvent = Event::factory()->unscheduled()->create(['name' => 'Unscheduled Event']);
             $pastEvent = Event::factory()->past()->create(['name' => 'Past Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // All events should be visible in the correct order
             $component->assertOk()
@@ -435,8 +464,9 @@ describe('EventsTable Component Integration', function () {
             $eventWithVenue = Event::factory()->scheduled()->atVenue($venue)->create(['name' => 'Venue Event']);
             $eventWithoutVenue = Event::factory()->scheduled()->create(['name' => 'No Venue Event']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Venue Event')
@@ -450,8 +480,9 @@ describe('EventsTable Component Integration', function () {
         test('filtering works with special characters in event names', function () {
             $specialEvent = Event::factory()->scheduled()->create(['name' => 'Event: The "Ultimate" Test']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'Ultimate')
                 ->assertSee('Event: The "Ultimate" Test');
@@ -460,8 +491,9 @@ describe('EventsTable Component Integration', function () {
         test('filtering works with international characters', function () {
             $internationalEvent = Event::factory()->scheduled()->create(['name' => 'Wrestle Mania']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'Wrestle')
                 ->assertSee('Wrestle Mania');
@@ -471,8 +503,9 @@ describe('EventsTable Component Integration', function () {
             $event1 = Event::factory()->scheduled()->create(['name' => 'Event One']);
             $event2 = Event::factory()->scheduled()->create(['name' => 'Event Two']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Empty search should show all events
             $component->set('search', '')

--- a/tests/Integration/Livewire/Managers/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Managers/Components/ActionsTest.php
@@ -7,6 +7,8 @@ use App\Models\Managers\Manager;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 use function Spatie\PestPluginTestTime\testTime;
 
 /**
@@ -39,8 +41,9 @@ describe('ManagersActions Integration Tests', function () {
 
     describe('component initialization', function () {
         test('component loads with manager properly bound', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             expect($component->get('manager')->id)->toBe($this->manager->id);
             expect($component->get('manager')->first_name)->toBe('Test');
@@ -49,8 +52,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('component renders without errors', function () {
-            Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager])
+            actingAs($this->admin);
+
+            livewire(Actions::class, ['manager' => $this->manager])
                 ->assertOk();
             expect(true)->toBeTrue();
         });
@@ -63,8 +67,9 @@ describe('ManagersActions Integration Tests', function () {
                 'last_name' => 'Manager',
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $unemployedManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $unemployedManager]);
 
             $component->call('employ')
                 ->assertHasNoErrors()
@@ -76,8 +81,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('employ action fails for already employed manager', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('employ');
 
@@ -86,8 +92,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('release action works for employed manager', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('release')
                 ->assertHasNoErrors()
@@ -101,8 +108,9 @@ describe('ManagersActions Integration Tests', function () {
         test('release action fails for unemployed manager', function () {
             $unemployedManager = Manager::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $unemployedManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $unemployedManager]);
 
             $component->call('release');
 
@@ -113,8 +121,9 @@ describe('ManagersActions Integration Tests', function () {
 
     describe('injury and healing actions', function () {
         test('injure action works for healthy employed manager', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('injure')
                 ->assertHasNoErrors()
@@ -128,8 +137,9 @@ describe('ManagersActions Integration Tests', function () {
         test('injure action fails for already injured manager', function () {
             $injuredManager = Manager::factory()->injured()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $injuredManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $injuredManager]);
 
             $component->call('injure');
 
@@ -143,8 +153,9 @@ describe('ManagersActions Integration Tests', function () {
                 'last_name' => 'Manager',
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $injuredManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $injuredManager]);
 
             $component->call('healFromInjury')
                 ->assertHasNoErrors()
@@ -156,8 +167,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('heal action fails for healthy manager', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('healFromInjury');
 
@@ -168,8 +180,9 @@ describe('ManagersActions Integration Tests', function () {
 
     describe('suspension and reinstatement actions', function () {
         test('suspend action works for employed manager', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('suspend')
                 ->assertHasNoErrors()
@@ -183,8 +196,9 @@ describe('ManagersActions Integration Tests', function () {
         test('suspend action fails for unemployed manager', function () {
             $unemployedManager = Manager::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $unemployedManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $unemployedManager]);
 
             $component->call('suspend');
 
@@ -198,8 +212,9 @@ describe('ManagersActions Integration Tests', function () {
                 'last_name' => 'Manager',
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $suspendedManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $suspendedManager]);
 
             $component->call('reinstate')
                 ->assertHasNoErrors()
@@ -211,8 +226,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('reinstate action fails for non-suspended manager', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('reinstate');
 
@@ -223,8 +239,9 @@ describe('ManagersActions Integration Tests', function () {
 
     describe('retirement lifecycle actions', function () {
         test('retire action works for employed manager', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('retire')
                 ->assertHasNoErrors()
@@ -238,8 +255,9 @@ describe('ManagersActions Integration Tests', function () {
         test('retire action fails for unemployed manager', function () {
             $unemployedManager = Manager::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $unemployedManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $unemployedManager]);
 
             $component->call('retire');
 
@@ -253,8 +271,9 @@ describe('ManagersActions Integration Tests', function () {
                 'last_name' => 'Manager',
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $retiredManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $retiredManager]);
 
             $component->call('unretire')
                 ->assertHasNoErrors()
@@ -266,8 +285,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('unretire action fails for active manager', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('unretire');
 
@@ -283,8 +303,9 @@ describe('ManagersActions Integration Tests', function () {
 
             $trashedManager = Manager::onlyTrashed()->find($this->manager->id);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $trashedManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $trashedManager]);
 
             $component->call('restore')
                 ->assertHasNoErrors()
@@ -303,8 +324,9 @@ describe('ManagersActions Integration Tests', function () {
                 'first_name' => 'Career',
                 'last_name' => 'Manager',
             ]);
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $manager]);
 
             // Employ
             $component->call('employ');
@@ -342,8 +364,9 @@ describe('ManagersActions Integration Tests', function () {
                 'first_name' => 'Injured',
                 'last_name' => 'Manager',
             ]);
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $injuredManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $injuredManager]);
 
             // Manager is employed but injured
             expect($injuredManager->isEmployed())->toBeTrue();
@@ -367,8 +390,9 @@ describe('ManagersActions Integration Tests', function () {
                 'first_name' => 'Suspended',
                 'last_name' => 'Manager',
             ]);
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $suspendedManager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $suspendedManager]);
 
             // Suspended manager still employed but cannot perform duties
             expect($suspendedManager->isEmployed())->toBeTrue();
@@ -393,8 +417,9 @@ describe('ManagersActions Integration Tests', function () {
         test('unauthorized user cannot perform actions', function () {
             $guest = User::factory()->create(); // Non-admin user
 
-            $component = Livewire::actingAs($guest)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($guest);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('employ')
                 ->assertForbidden();
@@ -402,8 +427,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('admin can perform all actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             // All action calls should succeed (though business rules may prevent them)
             $component->call('release')
@@ -416,8 +442,9 @@ describe('ManagersActions Integration Tests', function () {
 
     describe('event dispatching and state management', function () {
         test('all successful actions dispatch manager-updated event', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('release')
                 ->assertDispatched('manager-updated');
@@ -431,8 +458,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('failed actions do not dispatch events', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             // Try to employ already employed manager
             $component->call('employ')
@@ -441,8 +469,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('component state remains consistent after actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             expect($component->get('manager')->id)->toBe($this->manager->id);
 
@@ -456,8 +485,9 @@ describe('ManagersActions Integration Tests', function () {
 
     describe('error handling and edge cases', function () {
         test('component handles manager model refresh after actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             // Perform action
             $component->call('release');
@@ -472,8 +502,9 @@ describe('ManagersActions Integration Tests', function () {
             $originalLastName = $this->manager->last_name;
             $originalId = $this->manager->id;
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $component->call('injure');
 
@@ -484,8 +515,9 @@ describe('ManagersActions Integration Tests', function () {
         });
 
         test('manager display name consistency maintained', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['manager' => $this->manager]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
 
             $originalDisplayName = $this->manager->display_name;
 

--- a/tests/Integration/Livewire/Managers/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Managers/Tables/MainTest.php
@@ -14,6 +14,9 @@ use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for ManagersTable Livewire component.
  *
@@ -50,7 +53,7 @@ describe('ManagersTable Component', function () {
             $tagTeam = TagTeam::factory()->bookable()->create(['name' => 'Managed Tag Team']);
             $stable = Stable::factory()->active()->create(['name' => 'Manager Stable']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Active Aaaaaa')
@@ -66,7 +69,7 @@ describe('ManagersTable Component', function () {
             $retiredManager = Manager::factory()->retired()->create(['first_name' => 'Retired', 'last_name' => 'Manager']);
             $releasedManager = Manager::factory()->released()->create(['first_name' => 'Released', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Employed Manager')
@@ -85,7 +88,7 @@ describe('ManagersTable Component', function () {
             Manager::factory()->create(['first_name' => 'Jimmy', 'last_name' => 'Hart']);
             Manager::factory()->create(['first_name' => 'Bobby', 'last_name' => 'Heenan']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Test search functionality
             $component
@@ -107,7 +110,7 @@ describe('ManagersTable Component', function () {
             $retiredManager = Manager::factory()->retired()->create(['first_name' => 'Retired', 'last_name' => 'Manager']);
             $injuredManager = Manager::factory()->injured()->create(['first_name' => 'Injured', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Test filtering by status (if component supports it)
             $component
@@ -122,7 +125,7 @@ describe('ManagersTable Component', function () {
             $employedManager = Manager::factory()->employed()->create(['first_name' => 'Active', 'last_name' => 'Manager']);
             $retiredManager = Manager::factory()->retired()->create(['first_name' => 'Retired', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render without errors
             $component->assertOk();
@@ -136,7 +139,9 @@ describe('ManagersTable Component', function () {
             $manager = Manager::factory()->create(['first_name' => 'Test', 'last_name' => 'Manager']);
 
             // Test as administrator (should see all actions)
-            $component = Livewire::actingAs($this->user)->test(Main::class);
+            actingAs($this->user);
+
+            $component = livewire(Main::class);
             $component->assertOk();
             $component->assertSee($manager->full_name);
         });
@@ -147,7 +152,7 @@ describe('ManagersTable Component', function () {
             $employedManager = Manager::factory()->employed()->create(['first_name' => 'Currently', 'last_name' => 'Employed']);
             $unemployedManager = Manager::factory()->unemployed()->create(['first_name' => 'Currently', 'last_name' => 'Unemployed']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Currently Employed')
@@ -170,7 +175,7 @@ describe('ManagersTable Component', function () {
                 ->current()
                 ->create(['started_at' => now()->subDays(50)]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Manager History');
@@ -182,7 +187,7 @@ describe('ManagersTable Component', function () {
             $healthyManager = Manager::factory()->employed()->create(['first_name' => 'Healthy', 'last_name' => 'Manager']);
             $injuredManager = Manager::factory()->injured()->create(['first_name' => 'Injured', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Healthy Manager')
@@ -193,7 +198,7 @@ describe('ManagersTable Component', function () {
             $activeManager = Manager::factory()->employed()->create(['first_name' => 'Active', 'last_name' => 'Manager']);
             $suspendedManager = Manager::factory()->suspended()->create(['first_name' => 'Suspended', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Active Manager')
@@ -211,7 +216,7 @@ describe('ManagersTable Component', function () {
                     'ended_at' => now()->subDays(50),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Injury History');
@@ -222,7 +227,7 @@ describe('ManagersTable Component', function () {
         test('displays managers without wrestler/tag team relationships', function () {
             $manager = Manager::factory()->employed()->create(['first_name' => 'Independent', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Independent Manager');
@@ -238,7 +243,7 @@ describe('ManagersTable Component', function () {
                 'fired_at' => now()->subMonths(1),
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Wrestler Manager');
@@ -256,7 +261,7 @@ describe('ManagersTable Component', function () {
 
             // No stable relationships since managers are no longer direct stable members
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render efficiently with created data
             $component->assertOk()
@@ -266,7 +271,7 @@ describe('ManagersTable Component', function () {
         test('component eager loads necessary relationships', function () {
             $manager = Manager::factory()->employed()->create(['first_name' => 'Relationship', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertOk()
@@ -278,7 +283,7 @@ describe('ManagersTable Component', function () {
         test('component updates when manager data changes', function () {
             $manager = Manager::factory()->create(['first_name' => 'Original', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
             $component->assertSee('Original Manager');
 
             // Update manager name
@@ -293,7 +298,7 @@ describe('ManagersTable Component', function () {
         test('component reflects employment status changes', function () {
             $manager = Manager::factory()->unemployed()->create(['first_name' => 'Employment', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Employ the manager
             EmployAction::run($manager, now());
@@ -306,7 +311,7 @@ describe('ManagersTable Component', function () {
         test('component reflects injury status changes', function () {
             $manager = Manager::factory()->employed()->create(['first_name' => 'Injury', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Injure the manager
             InjureAction::run($manager, now());
@@ -325,7 +330,7 @@ describe('ManagersTable Component', function () {
             // Manager is employed but also injured
             InjureAction::run($manager, now());
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Complex Manager');
@@ -337,7 +342,7 @@ describe('ManagersTable Component', function () {
             $injuredManager = Manager::factory()->injured()->create(['first_name' => 'Injured', 'last_name' => 'Manager']);
             $retiredManager = Manager::factory()->retired()->create(['first_name' => 'Retired', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render and show appropriate actions based on business rules
             $component
@@ -349,7 +354,7 @@ describe('ManagersTable Component', function () {
         test('component handles manager employment transitions', function () {
             $manager = Manager::factory()->employed()->create(['first_name' => 'Transitioning', 'last_name' => 'Manager']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
             $component->assertSee('Transitioning Manager');
 
             // Test that component handles data changes appropriately

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -12,7 +12,8 @@ use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
 use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -42,7 +43,7 @@ describe('FormModal Configuration', function () {
 
 describe('FormModal Rendering', function () {
     it('can render in create mode', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');
 
         $component->assertOk();
@@ -51,14 +52,14 @@ describe('FormModal Rendering', function () {
     it('can render in edit mode', function () {
         $match = EventMatch::factory()->for($this->event)->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal', $match->id);
 
         $component->assertOk();
     });
 
     it('displays correct title in create mode', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');
 
         $component->assertSee('Create Match');
@@ -67,7 +68,7 @@ describe('FormModal Rendering', function () {
     it('displays correct title in edit mode', function () {
         $match = EventMatch::factory()->for($this->event)->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal', $match->id);
 
         $component->assertSee('Edit Match');
@@ -76,7 +77,7 @@ describe('FormModal Rendering', function () {
     it('presents wrestlers list for selection', function () {
         $wrestler = Wrestler::factory()->bookable()->create(['name' => 'Test Wrestler']);
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles);
 
@@ -86,14 +87,14 @@ describe('FormModal Rendering', function () {
     it('presents referees list for selection', function () {
         $referee = Referee::factory()->bookable()->create(['first_name' => 'Test', 'last_name' => 'Referee']);
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');
 
         $component->assertSee('Test Referee');
     });
 
     it('presents match types list for selection', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');
 
         // Match types are now enums, so they should all be listed
@@ -107,7 +108,7 @@ describe('FormModal Create Operations', function () {
         $wrestler2 = Wrestler::factory()->bookable()->create();
         $referee = Referee::factory()->bookable()->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.competitors', [
@@ -129,7 +130,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates required fields when creating', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', '')
             ->call('save');
@@ -142,7 +143,7 @@ describe('FormModal Create Operations', function () {
     it('validates minimum number of competitors', function () {
         $wrestler = Wrestler::factory()->bookable()->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.competitors', [$wrestler->id])
@@ -155,14 +156,14 @@ describe('FormModal Create Operations', function () {
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
 
-        expect(fn () => Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        expect(fn () => livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', 'invalid-match-type'))
             ->toThrow(ValueError::class);
     });
 
     it('validates competitors exist and are bookable', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.competitors', [
@@ -178,7 +179,7 @@ describe('FormModal Create Operations', function () {
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.competitors', [
@@ -200,7 +201,7 @@ describe('FormModal Edit Operations', function () {
         $wrestler3 = Wrestler::factory()->bookable()->create();
         $wrestler4 = Wrestler::factory()->bookable()->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal', $match->id)
             ->set('form.matchType', MatchType::TagTeam)
             ->set('form.competitors', [
@@ -226,7 +227,7 @@ describe('FormModal Edit Operations', function () {
             ->state(['match_type' => MatchType::Singles, 'preview' => 'Original preview'])
             ->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal', $match->id);
 
         $component->assertSet('form.eventId', $this->event->id);
@@ -241,7 +242,7 @@ describe('FormModal Title Championship Integration', function () {
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.competitors', [
@@ -261,7 +262,7 @@ describe('FormModal Title Championship Integration', function () {
     it('presents available titles for championship matches', function () {
         $title = Title::factory()->active()->create(['name' => 'World Championship']);
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');
 
         $component->assertSee('World Championship');
@@ -272,7 +273,7 @@ describe('FormModal Title Championship Integration', function () {
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.competitors', [
@@ -291,7 +292,7 @@ describe('FormModal Tag Team Integration', function () {
         $tagTeam1 = TagTeam::factory()->bookable()->create();
         $tagTeam2 = TagTeam::factory()->bookable()->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::TagTeam)
             ->set('form.competitors', [
@@ -307,7 +308,7 @@ describe('FormModal Tag Team Integration', function () {
     it('presents available tag teams for selection', function () {
         $tagTeam = TagTeam::factory()->bookable()->create(['name' => 'The Hardy Boyz']);
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::TagTeam);
 
@@ -319,7 +320,7 @@ describe('FormModal State Management', function () {
     it('resets form when switching modes', function () {
         $match = EventMatch::factory()->for($this->event)->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal', $match->id)
             ->call('openModal');
 
@@ -333,7 +334,7 @@ describe('FormModal State Management', function () {
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.competitors', [
@@ -346,7 +347,7 @@ describe('FormModal State Management', function () {
     });
 
     it('keeps modal open when validation fails', function () {
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', '')
             ->call('save');
@@ -359,7 +360,7 @@ describe('FormModal Authorization', function () {
     it('requires authentication', function () {
         auth()->logout();
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');
 
         $component->assertForbidden();
@@ -369,7 +370,7 @@ describe('FormModal Authorization', function () {
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        $component = Livewire::test(FormModal::class, ['eventId' => $this->event->id])
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');
 
         $component->assertForbidden();

--- a/tests/Integration/Livewire/Matches/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MainTest.php
@@ -8,6 +8,9 @@ use App\Models\Matches\EventMatch;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * @group matches
  * @group integration
@@ -27,8 +30,9 @@ describe('Matches Main Table Component Integration', function () {
                 'match_number' => 1,
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
         });
@@ -39,8 +43,9 @@ describe('Matches Main Table Component Integration', function () {
                 'match_number' => 2,
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Test Event');
@@ -54,8 +59,9 @@ describe('Matches Main Table Component Integration', function () {
             expect($match->event)->not()->toBeNull();
             expect($match->event->name)->toBe('Test Event');
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Test Event');
@@ -66,19 +72,21 @@ describe('Matches Main Table Component Integration', function () {
         test('component requires proper authorization for access', function () {
             $basicUser = User::factory()->create();
 
-            Livewire::actingAs($basicUser)
-                ->test(Main::class)
+            actingAs($basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
         test('guest users cannot access component', function () {
-            Livewire::test(Main::class)
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
         test('admin can access matches table', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
         });
@@ -90,8 +98,9 @@ describe('Matches Main Table Component Integration', function () {
                 'event_id' => $this->event->id,
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
         });
@@ -103,8 +112,9 @@ describe('Matches Main Table Component Integration', function () {
 
             expect($match->event)->not()->toBeNull();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Test Event');
@@ -117,8 +127,9 @@ describe('Matches Main Table Component Integration', function () {
                 'event_id' => $this->event->id,
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
 

--- a/tests/Integration/Livewire/Matches/Tables/MatchesTableTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MatchesTableTest.php
@@ -11,7 +11,8 @@ use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
 use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 /**
  * @group matches
@@ -28,7 +29,7 @@ describe('MatchesTable Rendering', function () {
     it('can render matches table', function () {
         $event = Event::factory()->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertOk();
     })->group('matches', 'integration', 'livewire', 'tables', 'rendering');
 
@@ -39,7 +40,7 @@ describe('MatchesTable Rendering', function () {
             ->state(['match_type' => MatchType::Singles])
             ->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Singles');
     });
 
@@ -52,7 +53,7 @@ describe('MatchesTable Rendering', function () {
         $match->wrestlers()->attach($wrestler1, ['side_number' => 1]);
         $match->wrestlers()->attach($wrestler2, ['side_number' => 2]);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('John Cena')
             ->assertSee('The Rock');
     });
@@ -64,7 +65,7 @@ describe('MatchesTable Rendering', function () {
 
         $match->referees()->attach($referee);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Earl Hebner');
     });
 
@@ -75,7 +76,7 @@ describe('MatchesTable Rendering', function () {
 
         $match->titles()->attach($title);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('WWE Championship');
     });
 });
@@ -87,7 +88,7 @@ describe('MatchesTable Search and Filtering', function () {
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::Singles])->create();
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::TagTeam])->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->set('search', 'Singles')
             ->assertSee('Singles')
             ->assertDontSee('Tag Team');
@@ -100,7 +101,7 @@ describe('MatchesTable Search and Filtering', function () {
         EventMatch::factory()->for($event1)->state(['match_type' => MatchType::Singles])->create();
         EventMatch::factory()->for($event2)->state(['match_type' => MatchType::TagTeam])->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event1->id])
+        livewire(MatchesTable::class, ['eventId' => $event1->id])
             ->assertSee('Singles')
             ->assertDontSee('Tag Team');
     });
@@ -111,7 +112,7 @@ describe('MatchesTable Search and Filtering', function () {
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::Singles])->create();
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::TagTeam])->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Singles')
             ->assertSee('Tag Team');
     });
@@ -127,7 +128,7 @@ describe('MatchesTable Search and Filtering', function () {
         $match1->wrestlers()->attach($wrestler1, ['side_number' => 1]);
         $match2->wrestlers()->attach($wrestler2, ['side_number' => 1]);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Stone Cold')
             ->assertSee('The Rock');
     });
@@ -146,7 +147,7 @@ describe('MatchesTable Complex Relationships', function () {
         $match->wrestlers()->attach($wrestler2, ['side_number' => 2]);
         $match->tagTeams()->attach($tagTeam, ['side_number' => 3]);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Wrestler One')
             ->assertSee('Wrestler Two')
             ->assertSee('Tag Team');
@@ -162,7 +163,7 @@ describe('MatchesTable Complex Relationships', function () {
         $match->titles()->attach($title1);
         $match->titles()->attach($title2);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('World Championship')
             ->assertSee('Tag Team Championship');
     });
@@ -177,7 +178,7 @@ describe('MatchesTable Complex Relationships', function () {
         $match->referees()->attach($referee1);
         $match->referees()->attach($referee2);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Referee One')
             ->assertSee('Referee Two');
     });
@@ -186,7 +187,7 @@ describe('MatchesTable Complex Relationships', function () {
         $event = Event::factory()->create();
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::Singles])->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Singles');
     });
 
@@ -197,7 +198,7 @@ describe('MatchesTable Complex Relationships', function () {
         $wrestler = Wrestler::factory()->create(['name' => 'Test Wrestler']);
         $match->wrestlers()->attach($wrestler, ['side_number' => 1]);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Test Wrestler')
             ->assertSee('Test Wrestler');
     });
@@ -223,7 +224,7 @@ describe('MatchesTable Performance', function () {
             $match->referees()->attach($referees[$index % 5]);
         }
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertOk();
     });
 
@@ -239,7 +240,7 @@ describe('MatchesTable Performance', function () {
         $match->referees()->attach($referee);
         $match->titles()->attach($title);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertOk()
             ->assertSee('Test Wrestler')
             ->assertSee('Test Referee')
@@ -252,7 +253,7 @@ describe('MatchesTable Pagination', function () {
         $event = Event::factory()->create();
         EventMatch::factory()->for($event)->count(25)->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertOk();
     });
 
@@ -262,7 +263,7 @@ describe('MatchesTable Pagination', function () {
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::Singles])->count(15)->create();
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::TagTeam])->count(15)->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->set('search', 'Singles')
             ->assertSee('Singles')
             ->assertDontSee('Tag Team');
@@ -276,7 +277,7 @@ describe('MatchesTable Sorting', function () {
         $matchA = EventMatch::factory()->for($event)->state(['match_type' => MatchType::Singles])->create();
         $matchZ = EventMatch::factory()->for($event)->state(['match_type' => MatchType::TagTeam])->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSeeInOrder(['Singles', 'Tag Team']);
     });
 
@@ -286,7 +287,7 @@ describe('MatchesTable Sorting', function () {
         $match1 = EventMatch::factory()->for($event)->state(['match_type' => MatchType::Singles])->create(['match_number' => 1]);
         $match2 = EventMatch::factory()->for($event)->state(['match_type' => MatchType::TagTeam])->create(['match_number' => 2]);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Singles')
             ->assertSee('Tag Team');
     });
@@ -297,7 +298,7 @@ describe('MatchesTable Actions', function () {
         $event = Event::factory()->create();
         $match = EventMatch::factory()->for($event)->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertOk();
     });
 
@@ -305,7 +306,7 @@ describe('MatchesTable Actions', function () {
         $event = Event::factory()->create();
         $match = EventMatch::factory()->for($event)->state(['match_type' => MatchType::Singles])->create();
 
-        $component = Livewire::test(MatchesTable::class, ['eventId' => $event->id]);
+        $component = livewire(MatchesTable::class, ['eventId' => $event->id]);
         $component->assertOk();
         $component->assertSee('Singles');
     });
@@ -319,7 +320,7 @@ describe('MatchesTable Event Integration', function () {
         EventMatch::factory()->for($event1)->state(['match_type' => MatchType::Singles])->create();
         EventMatch::factory()->for($event2)->state(['match_type' => MatchType::TagTeam])->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event1->id])
+        livewire(MatchesTable::class, ['eventId' => $event1->id])
             ->assertSee('Singles')
             ->assertDontSee('Tag Team');
     });
@@ -330,7 +331,7 @@ describe('MatchesTable Event Integration', function () {
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::Singles])->create();
         EventMatch::factory()->for($event)->state(['match_type' => MatchType::TagTeam])->create();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Singles')
             ->assertSee('Tag Team');
     });
@@ -341,7 +342,7 @@ describe('MatchesTable Authorization', function () {
         $event = Event::factory()->create();
         auth()->logout();
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertForbidden();
     });
 
@@ -350,7 +351,7 @@ describe('MatchesTable Authorization', function () {
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        Livewire::test(MatchesTable::class, ['eventId' => $event->id])
+        livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertForbidden();
     });
 });

--- a/tests/Integration/Livewire/Referees/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Referees/Components/ActionsTest.php
@@ -7,6 +7,8 @@ use App\Models\Referees\Referee;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
 use function Spatie\PestPluginTestTime\testTime;
 
 /**
@@ -39,8 +41,9 @@ describe('RefereesActions Integration Tests', function () {
 
     describe('component initialization', function () {
         test('component loads with referee properly bound', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             expect($component->get('referee')->id)->toBe($this->referee->id);
             expect($component->get('referee')->first_name)->toBe('Test');
@@ -49,8 +52,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('component renders without errors', function () {
-            Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee])
+            actingAs($this->admin);
+
+            livewire(Actions::class, ['referee' => $this->referee])
                 ->assertOk();
             expect(true)->toBeTrue();
         });
@@ -63,8 +67,9 @@ describe('RefereesActions Integration Tests', function () {
                 'last_name' => 'Referee',
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $unemployedReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $unemployedReferee]);
 
             $component->call('employ')
                 ->assertHasNoErrors()
@@ -76,8 +81,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('employ action fails for already employed referee', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('employ');
 
@@ -86,8 +92,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('release action works for employed referee', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('release')
                 ->assertHasNoErrors()
@@ -101,8 +108,9 @@ describe('RefereesActions Integration Tests', function () {
         test('release action fails for unemployed referee', function () {
             $unemployedReferee = Referee::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $unemployedReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $unemployedReferee]);
 
             $component->call('release');
 
@@ -113,8 +121,9 @@ describe('RefereesActions Integration Tests', function () {
 
     describe('injury and healing actions', function () {
         test('injure action works for healthy employed referee', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('injure')
                 ->assertHasNoErrors()
@@ -128,8 +137,9 @@ describe('RefereesActions Integration Tests', function () {
         test('injure action fails for already injured referee', function () {
             $injuredReferee = Referee::factory()->injured()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $injuredReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $injuredReferee]);
 
             $component->call('injure');
 
@@ -143,8 +153,9 @@ describe('RefereesActions Integration Tests', function () {
                 'last_name' => 'Referee',
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $injuredReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $injuredReferee]);
 
             $component->call('healFromInjury')
                 ->assertHasNoErrors()
@@ -156,8 +167,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('heal action fails for healthy referee', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('healFromInjury');
 
@@ -168,8 +180,9 @@ describe('RefereesActions Integration Tests', function () {
 
     describe('suspension and reinstatement actions', function () {
         test('suspend action works for employed referee', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('suspend')
                 ->assertHasNoErrors()
@@ -183,8 +196,9 @@ describe('RefereesActions Integration Tests', function () {
         test('suspend action fails for unemployed referee', function () {
             $unemployedReferee = Referee::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $unemployedReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $unemployedReferee]);
 
             $component->call('suspend');
 
@@ -198,8 +212,9 @@ describe('RefereesActions Integration Tests', function () {
                 'last_name' => 'Referee',
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $suspendedReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $suspendedReferee]);
 
             $component->call('reinstate')
                 ->assertHasNoErrors()
@@ -211,8 +226,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('reinstate action fails for non-suspended referee', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('reinstate');
 
@@ -223,8 +239,9 @@ describe('RefereesActions Integration Tests', function () {
 
     describe('retirement lifecycle actions', function () {
         test('retire action works for employed referee', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('retire')
                 ->assertHasNoErrors()
@@ -238,8 +255,9 @@ describe('RefereesActions Integration Tests', function () {
         test('retire action fails for unemployed referee', function () {
             $unemployedReferee = Referee::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $unemployedReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $unemployedReferee]);
 
             $component->call('retire');
 
@@ -253,8 +271,9 @@ describe('RefereesActions Integration Tests', function () {
                 'last_name' => 'Referee',
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $retiredReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $retiredReferee]);
 
             $component->call('unretire')
                 ->assertHasNoErrors()
@@ -266,8 +285,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('unretire action fails for active referee', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('unretire');
 
@@ -283,8 +303,9 @@ describe('RefereesActions Integration Tests', function () {
 
             $trashedReferee = Referee::onlyTrashed()->find($this->referee->id);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $trashedReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $trashedReferee]);
 
             $component->call('restore')
                 ->assertHasNoErrors()
@@ -303,8 +324,9 @@ describe('RefereesActions Integration Tests', function () {
                 'first_name' => 'Career',
                 'last_name' => 'Official',
             ]);
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $referee]);
 
             // Employ
             $component->call('employ');
@@ -342,8 +364,9 @@ describe('RefereesActions Integration Tests', function () {
                 'first_name' => 'Injured',
                 'last_name' => 'Official',
             ]);
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $injuredReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $injuredReferee]);
 
             // Referee is employed but injured (not available for matches)
             expect($injuredReferee->isEmployed())->toBeTrue();
@@ -368,8 +391,9 @@ describe('RefereesActions Integration Tests', function () {
                 'first_name' => 'Suspended',
                 'last_name' => 'Official',
             ]);
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $suspendedReferee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $suspendedReferee]);
 
             // Suspended referee still employed but cannot officiate
             expect($suspendedReferee->isEmployed())->toBeTrue();
@@ -403,11 +427,13 @@ describe('RefereesActions Integration Tests', function () {
                 'last_name' => 'Official',
             ]);
 
-            $juniorComponent = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $juniorReferee]);
+            actingAs($this->admin);
 
-            $seniorComponent = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $seniorReferee]);
+            $juniorComponent = livewire(Actions::class, ['referee' => $juniorReferee]);
+
+            actingAs($this->admin);
+
+            $seniorComponent = livewire(Actions::class, ['referee' => $seniorReferee]);
 
             // Both can be injured, suspended, etc.
             $juniorComponent->call('injure');
@@ -430,8 +456,9 @@ describe('RefereesActions Integration Tests', function () {
         test('unauthorized user cannot perform actions', function () {
             $guest = User::factory()->create(); // Non-admin user
 
-            $component = Livewire::actingAs($guest)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($guest);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('employ')
                 ->assertForbidden();
@@ -439,8 +466,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('admin can perform all actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             // All action calls should succeed (though business rules may prevent them)
             $component->call('release')
@@ -453,8 +481,9 @@ describe('RefereesActions Integration Tests', function () {
 
     describe('event dispatching and state management', function () {
         test('all successful actions dispatch referee-updated event', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('release')
                 ->assertDispatched('referee-updated');
@@ -468,8 +497,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('failed actions do not dispatch events', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             // Try to employ already employed referee
             $component->call('employ')
@@ -478,8 +508,9 @@ describe('RefereesActions Integration Tests', function () {
         });
 
         test('component state remains consistent after actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             expect($component->get('referee')->id)->toBe($this->referee->id);
 
@@ -493,8 +524,9 @@ describe('RefereesActions Integration Tests', function () {
 
     describe('error handling and edge cases', function () {
         test('component handles referee model refresh after actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             // Perform action
             $component->call('release');
@@ -509,8 +541,9 @@ describe('RefereesActions Integration Tests', function () {
             $originalLastName = $this->referee->last_name;
             $originalId = $this->referee->id;
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $component->call('injure');
 
@@ -524,8 +557,9 @@ describe('RefereesActions Integration Tests', function () {
             // Ensure referee has virtual column loaded
             $this->referee = $this->referee->fresh();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['referee' => $this->referee]);
+            actingAs($this->admin);
+
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
 
             $originalFullName = $this->referee->full_name;
 

--- a/tests/Integration/Livewire/Referees/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Referees/Tables/MainTest.php
@@ -18,6 +18,9 @@ use App\Models\Referees\RefereeRetirement;
 use App\Models\Referees\RefereeSuspension;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for RefereesTable Livewire component.
  *
@@ -47,7 +50,7 @@ describe('RefereesTable Component', function () {
             $event = Event::factory()->create(['name' => 'Test Event']);
             $match = EventMatch::factory()->for($event, 'event')->create();
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee($employedReferee->full_name)
@@ -64,7 +67,7 @@ describe('RefereesTable Component', function () {
             $retiredReferee = Referee::factory()->retired()->create(['first_name' => 'Retired', 'last_name' => 'Referee']);
             $releasedReferee = Referee::factory()->released()->create(['first_name' => 'Released', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Employed Referee')
@@ -83,7 +86,7 @@ describe('RefereesTable Component', function () {
             Referee::factory()->create(['first_name' => 'Dave', 'last_name' => 'Hebner']);
             Referee::factory()->create(['first_name' => 'Mike', 'last_name' => 'Chioda']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Test search functionality
             $component
@@ -105,7 +108,7 @@ describe('RefereesTable Component', function () {
             $retiredReferee = Referee::factory()->retired()->create(['first_name' => 'Retired', 'last_name' => 'Referee']);
             $injuredReferee = Referee::factory()->injured()->create(['first_name' => 'Injured', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Test filtering by status (if component supports it)
             $component
@@ -120,7 +123,7 @@ describe('RefereesTable Component', function () {
             $employedReferee = Referee::factory()->employed()->create(['first_name' => 'Active', 'last_name' => 'Referee']);
             $retiredReferee = Referee::factory()->retired()->create(['first_name' => 'Retired', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render without errors
             $component->assertOk();
@@ -134,7 +137,9 @@ describe('RefereesTable Component', function () {
             $referee = Referee::factory()->create(['first_name' => 'Test', 'last_name' => 'Referee']);
 
             // Test as administrator (should see all actions)
-            $component = Livewire::actingAs($this->user)->test(Main::class);
+            actingAs($this->user);
+
+            $component = livewire(Main::class);
             $component->assertOk();
             $component->assertSee($referee->full_name);
         });
@@ -145,7 +150,7 @@ describe('RefereesTable Component', function () {
             $employedReferee = Referee::factory()->employed()->create(['first_name' => 'Currently', 'last_name' => 'Employed']);
             $unemployedReferee = Referee::factory()->unemployed()->create(['first_name' => 'Currently', 'last_name' => 'Unemployed']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Currently Employed')
@@ -168,7 +173,7 @@ describe('RefereesTable Component', function () {
                 ->current()
                 ->create(['started_at' => now()->subDays(50)]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Referee History');
@@ -180,7 +185,7 @@ describe('RefereesTable Component', function () {
             $healthyReferee = Referee::factory()->employed()->create(['first_name' => 'Healthy', 'last_name' => 'Referee']);
             $injuredReferee = Referee::factory()->injured()->create(['first_name' => 'Injured', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Healthy Referee')
@@ -191,7 +196,7 @@ describe('RefereesTable Component', function () {
             $activeReferee = Referee::factory()->employed()->create(['first_name' => 'Active', 'last_name' => 'Referee']);
             $suspendedReferee = Referee::factory()->suspended()->create(['first_name' => 'Suspended', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Active Referee')
@@ -209,7 +214,7 @@ describe('RefereesTable Component', function () {
                     'ended_at' => now()->subDays(50),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Injury History');
@@ -226,7 +231,7 @@ describe('RefereesTable Component', function () {
                     'ended_at' => now()->subDays(50),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Suspension History');
@@ -237,7 +242,7 @@ describe('RefereesTable Component', function () {
         test('displays referees without match assignments', function () {
             $referee = Referee::factory()->employed()->create(['first_name' => 'Available', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Available Referee');
@@ -251,7 +256,7 @@ describe('RefereesTable Component', function () {
             // Create match referee relationship (if exists in the system)
             // This depends on how matches and referees are connected
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Experienced Referee');
@@ -261,7 +266,7 @@ describe('RefereesTable Component', function () {
             $availableReferee = Referee::factory()->bookable()->create(['first_name' => 'Available', 'last_name' => 'Referee']);
             $unavailableReferee = Referee::factory()->injured()->create(['first_name' => 'Unavailable', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Available Referee')
@@ -279,7 +284,7 @@ describe('RefereesTable Component', function () {
             $events = Event::factory()->count(3)->create();
             $matches = EventMatch::factory()->count(10)->create();
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render efficiently
             $component->assertOk()
@@ -289,7 +294,7 @@ describe('RefereesTable Component', function () {
         test('component eager loads necessary relationships', function () {
             $referee = Referee::factory()->employed()->create(['first_name' => 'Relationship', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertOk()
@@ -301,7 +306,7 @@ describe('RefereesTable Component', function () {
         test('component updates when referee data changes', function () {
             $referee = Referee::factory()->create(['first_name' => 'Original', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
             $component->assertSee('Original Referee');
 
             // Update referee name
@@ -316,7 +321,7 @@ describe('RefereesTable Component', function () {
         test('component reflects employment status changes', function () {
             $referee = Referee::factory()->unemployed()->create(['first_name' => 'Employment', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Employ the referee
             EmployAction::run($referee, now());
@@ -329,7 +334,7 @@ describe('RefereesTable Component', function () {
         test('component reflects injury status changes', function () {
             $referee = Referee::factory()->employed()->create(['first_name' => 'Injury', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Injure the referee
             InjureAction::run($referee, now());
@@ -342,7 +347,7 @@ describe('RefereesTable Component', function () {
         test('component reflects healing status changes', function () {
             $referee = Referee::factory()->injured()->create(['first_name' => 'Healing', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Heal the referee
             HealAction::run($referee, now());
@@ -361,7 +366,7 @@ describe('RefereesTable Component', function () {
             // Referee is employed but also injured
             InjureAction::run($referee, now());
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Complex Referee');
@@ -373,7 +378,7 @@ describe('RefereesTable Component', function () {
             $injuredReferee = Referee::factory()->injured()->create(['first_name' => 'Injured', 'last_name' => 'Referee']);
             $retiredReferee = Referee::factory()->retired()->create(['first_name' => 'Retired', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render and show appropriate actions based on business rules
             $component
@@ -387,7 +392,7 @@ describe('RefereesTable Component', function () {
             $unavailableReferee = Referee::factory()->injured()->create(['first_name' => 'Unavailable', 'last_name' => 'Referee']);
             $suspendedReferee = Referee::factory()->suspended()->create(['first_name' => 'Suspended', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should show all referees with appropriate status indicators
             $component
@@ -400,7 +405,7 @@ describe('RefereesTable Component', function () {
         test('component handles referee retirement transitions', function () {
             $referee = Referee::factory()->employed()->create(['first_name' => 'Retiring', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
             $component->assertSee('Retiring Referee');
 
             // Retire the referee
@@ -418,7 +423,7 @@ describe('RefereesTable Component', function () {
             $seniorReferee = Referee::factory()->employed()->create(['first_name' => 'Senior', 'last_name' => 'Official']);
             $juniorReferee = Referee::factory()->employed()->create(['first_name' => 'Junior', 'last_name' => 'Official']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Senior Official')
@@ -444,7 +449,7 @@ describe('RefereesTable Component', function () {
                     'ended_at' => now()->subYears(3),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Veteran Referee')
@@ -458,7 +463,7 @@ describe('RefereesTable Component', function () {
 
             // Create referee assignment (if system supports it)
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Assigned Referee');
@@ -470,7 +475,7 @@ describe('RefereesTable Component', function () {
             $hiringReferee = Referee::factory()->unemployed()->create(['first_name' => 'Hiring', 'last_name' => 'Referee']);
             $releasingReferee = Referee::factory()->employed()->create(['first_name' => 'Releasing', 'last_name' => 'Referee']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Hiring Referee')
@@ -504,7 +509,7 @@ describe('RefereesTable Component', function () {
                     'ended_at' => now()->subMonths(6),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Comeback Referee');
@@ -521,7 +526,7 @@ describe('RefereesTable Component', function () {
                     'ended_at' => now()->subMonths(3),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Recovered Referee');
@@ -538,7 +543,7 @@ describe('RefereesTable Component', function () {
                     'ended_at' => now()->subMonths(2),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Reinstated Referee');

--- a/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
@@ -10,7 +10,8 @@ use App\Models\TagTeams\TagTeam;
 use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Carbon;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -39,7 +40,7 @@ describe('FormModal Configuration', function () {
 
 describe('FormModal Rendering', function () {
     it('can render in create mode', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertOk();
@@ -48,14 +49,14 @@ describe('FormModal Rendering', function () {
     it('can render in edit mode', function () {
         $stable = Stable::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $stable->id);
 
         $component->assertOk();
     });
 
     it('displays correct title in create mode', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Create Stable');
@@ -64,7 +65,7 @@ describe('FormModal Rendering', function () {
     it('displays correct title in edit mode', function () {
         $stable = Stable::factory()->create(['name' => 'Test Stable']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $stable->id);
 
         $component->assertSee('Edit Stable');
@@ -73,7 +74,7 @@ describe('FormModal Rendering', function () {
     it('presents wrestlers list for selection', function () {
         $wrestler = Wrestler::factory()->create(['name' => 'Test Wrestler']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Test Wrestler');
@@ -82,7 +83,7 @@ describe('FormModal Rendering', function () {
     it('presents tag teams list for selection', function () {
         $tagTeam = TagTeam::factory()->create(['name' => 'Test Tag Team']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Test Tag Team');
@@ -91,7 +92,7 @@ describe('FormModal Rendering', function () {
     it('presents managers list for selection', function () {
         $manager = Manager::factory()->create(['first_name' => 'Test', 'last_name' => 'Manager']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Test Manager');
@@ -100,7 +101,7 @@ describe('FormModal Rendering', function () {
 
 describe('FormModal Create Operations', function () {
     it('can create a new stable with valid data', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'The New World Order')
             ->set('form.started_at', '2024-01-01')
@@ -120,7 +121,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates required fields when creating', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', '')
             ->call('save');
@@ -133,7 +134,7 @@ describe('FormModal Create Operations', function () {
     it('validates stable name uniqueness', function () {
         Stable::factory()->create(['name' => 'Existing Stable']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Existing Stable')
             ->set('form.started_at', '2024-01-01')
@@ -143,7 +144,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates started_at date format', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2023-13-32')
@@ -153,7 +154,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates ended_at is after started_at', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
@@ -164,7 +165,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('can create stable with optional fields', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
@@ -193,7 +194,7 @@ describe('FormModal Edit Operations', function () {
         ]);
         $stable->activityPeriods()->create(['started_at' => '2024-01-01']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $stable->id)
             ->set('form.name', 'Updated Stable')
             ->set('form.started_at', '2024-01-02')
@@ -217,7 +218,7 @@ describe('FormModal Edit Operations', function () {
         ]);
         $stable->activityPeriods()->create(['started_at' => '2024-01-01']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $stable->id);
 
         $component->assertSet('form.name', 'Test Stable');
@@ -228,7 +229,7 @@ describe('FormModal Edit Operations', function () {
         $stable1 = Stable::factory()->create(['name' => 'Stable One']);
         $stable2 = Stable::factory()->create(['name' => 'Stable Two']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $stable2->id)
             ->set('form.name', 'Stable One')
             ->call('save');
@@ -242,7 +243,7 @@ describe('FormModal Edit Operations', function () {
         ]);
         $stable->activityPeriods()->create(['started_at' => '2024-01-01']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $stable->id)
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-02')
@@ -259,7 +260,7 @@ describe('FormModal Edit Operations', function () {
         $wrestler2 = Wrestler::factory()->create();
         $stable->wrestlers()->attach([$wrestler1->id => ['joined_at' => now()], $wrestler2->id => ['joined_at' => now()]]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $stable->id)
             ->set('form.started_at', '2025-01-01')
             ->call('save');
@@ -271,7 +272,7 @@ describe('FormModal Edit Operations', function () {
 
 describe('FormModal Activity Period Management', function () {
     it('handles activity periods correctly', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
@@ -284,7 +285,7 @@ describe('FormModal Activity Period Management', function () {
     });
 
     it('can set ended_at for disbanded stables', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Disbanded Stable')
             ->set('form.started_at', '2024-01-01')
@@ -298,7 +299,7 @@ describe('FormModal Activity Period Management', function () {
     });
 
     it('validates ended_at is not before started_at', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-06-01')
@@ -314,7 +315,7 @@ describe('FormModal Member Management', function () {
         $wrestler1 = Wrestler::factory()->create();
         $wrestler2 = Wrestler::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
@@ -333,7 +334,7 @@ describe('FormModal Member Management', function () {
         $tagTeam1 = TagTeam::factory()->create();
         $tagTeam2 = TagTeam::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
@@ -349,7 +350,7 @@ describe('FormModal Member Management', function () {
     });
 
     it('validates wrestlers exist when assigning', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
@@ -360,7 +361,7 @@ describe('FormModal Member Management', function () {
     });
 
     it('validates tag teams exist when assigning', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
@@ -375,7 +376,7 @@ describe('FormModal State Management', function () {
     it('resets form when switching modes', function () {
         $stable = Stable::factory()->create(['name' => 'Test Stable']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $stable->id)
             ->call('openModal');
 
@@ -385,7 +386,7 @@ describe('FormModal State Management', function () {
     });
 
     it('closes modal after successful save', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
@@ -395,7 +396,7 @@ describe('FormModal State Management', function () {
     });
 
     it('keeps modal open when validation fails', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', '')
             ->call('save');

--- a/tests/Integration/Livewire/Stables/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Stables/Tables/MainTest.php
@@ -10,6 +10,9 @@ use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for StablesTable Livewire component.
  *
@@ -36,8 +39,9 @@ describe('StablesTable Component', function () {
             $retiredStable = Stable::factory()->retired()->create(['name' => 'D-Generation X']);
             $inactiveStable = Stable::factory()->inactive()->create(['name' => 'The New World Order']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee($activeStable->name)
@@ -53,8 +57,9 @@ describe('StablesTable Component', function () {
             $disbandedStable = Stable::factory()->disbanded()->create(['name' => 'Disbanded Stable']);
             $retiredStable = Stable::factory()->retired()->create(['name' => 'Retired Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Active Stable')
@@ -68,8 +73,9 @@ describe('StablesTable Component', function () {
             // Verify activity period exists
             expect($stable->currentActivityPeriod)->not()->toBeNull();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Test Stable');
@@ -94,8 +100,9 @@ describe('StablesTable Component', function () {
                 'updated_at' => now(),
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('The Stable');
@@ -108,8 +115,9 @@ describe('StablesTable Component', function () {
             $nwo = Stable::factory()->active()->create(['name' => 'New World Order']);
             $dx = Stable::factory()->active()->create(['name' => 'D-Generation X']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Test search for "Horsemen"
             $component->set('search', 'Horsemen')
@@ -129,8 +137,9 @@ describe('StablesTable Component', function () {
             $retiredStable = Stable::factory()->retired()->create(['name' => 'Retired Stable']);
             $disbandedStable = Stable::factory()->disbanded()->create(['name' => 'Disbanded Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Initially should see all stables
             $component->assertSee('Active Stable')
@@ -146,8 +155,9 @@ describe('StablesTable Component', function () {
             $oldStable = Stable::factory()->active()->create(['name' => 'Old Stable']);
             $newStable = Stable::factory()->active()->create(['name' => 'New Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Old Stable')
@@ -159,8 +169,9 @@ describe('StablesTable Component', function () {
         test('disband action integration works correctly', function () {
             $activeStable = Stable::factory()->active()->create(['name' => 'Active Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('disband', $activeStable)
                 ->assertHasNoErrors()
@@ -173,8 +184,9 @@ describe('StablesTable Component', function () {
         test('retire action integration works correctly', function () {
             $activeStable = Stable::factory()->active()->create(['name' => 'Active Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('retire', $activeStable)
                 ->assertHasNoErrors()
@@ -187,8 +199,9 @@ describe('StablesTable Component', function () {
         test('unretire action integration works correctly', function () {
             $retiredStable = Stable::factory()->retired()->create(['name' => 'Retired Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('unretire', $retiredStable)
                 ->assertHasNoErrors()
@@ -201,8 +214,9 @@ describe('StablesTable Component', function () {
         test('establish action integration works correctly', function () {
             $inactiveStable = Stable::factory()->inactive()->create(['name' => 'Inactive Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('establish', $inactiveStable)
                 ->assertHasNoErrors()
@@ -215,8 +229,9 @@ describe('StablesTable Component', function () {
         test('restore action integration works correctly', function () {
             $deletedStable = Stable::factory()->retired()->trashed()->create(['name' => 'Deleted Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('restore', $deletedStable->id)
                 ->assertHasNoErrors()
@@ -230,8 +245,9 @@ describe('StablesTable Component', function () {
         test('delete action integration works correctly', function () {
             $stable = Stable::factory()->inactive()->create(['name' => 'Test Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('delete', $stable)
                 ->assertHasNoErrors();
@@ -246,8 +262,9 @@ describe('StablesTable Component', function () {
         test('establish action fails for inappropriate stable status', function () {
             $activeStable = Stable::factory()->active()->create(['name' => 'Active Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('establish', $activeStable)
                 ->assertRedirect();
@@ -259,8 +276,9 @@ describe('StablesTable Component', function () {
         test('disband action fails for inappropriate stable status', function () {
             $inactiveStable = Stable::factory()->inactive()->create(['name' => 'Inactive Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('disband', $inactiveStable)
                 ->assertRedirect();
@@ -272,8 +290,9 @@ describe('StablesTable Component', function () {
         test('unretire action fails for non-retired stable', function () {
             $activeStable = Stable::factory()->active()->create(['name' => 'Active Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('unretire', $activeStable)
                 ->assertRedirect();
@@ -285,8 +304,9 @@ describe('StablesTable Component', function () {
         test('actions respect stable business constraints', function () {
             $disbandedStable = Stable::factory()->disbanded()->create(['name' => 'Disbanded Stable']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // Disband should fail for already disbanded stable
             $component->call('disband', $disbandedStable)
@@ -300,8 +320,9 @@ describe('StablesTable Component', function () {
         test('component requires proper authorization for access', function () {
             $basicUser = User::factory()->create();
 
-            Livewire::actingAs($basicUser)
-                ->test(Main::class)
+            actingAs($basicUser);
+
+            livewire(Main::class)
                 ->assertForbidden();
         });
 
@@ -316,8 +337,9 @@ describe('StablesTable Component', function () {
             $retiredStable = Stable::factory()->retired()->create();
             $deletedStable = Stable::factory()->trashed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             // All actions should be available to admin
             $component->call('establish', $inactiveStable)->assertHasNoErrors();
@@ -334,8 +356,9 @@ describe('StablesTable Component', function () {
             Stable::factory()->count(10)->retired()->create();
             Stable::factory()->count(5)->disbanded()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
         });
@@ -346,8 +369,9 @@ describe('StablesTable Component', function () {
             // Ensure activity period exists for eager loading test
             expect($stable->currentActivityPeriod)->not()->toBeNull();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Test Stable');
@@ -359,8 +383,9 @@ describe('StablesTable Component', function () {
             Stable::factory()->count(10)->inactive()->create();
             Stable::factory()->count(5)->retired()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
 
@@ -383,8 +408,9 @@ describe('StablesTable Component', function () {
             $wrestler2->stables()->attach($stable->id, ['joined_at' => now()->subMonths(5), 'created_at' => now(), 'updated_at' => now()]);
             $tagTeam->stables()->attach($stable->id, ['joined_at' => now()->subMonths(4), 'created_at' => now(), 'updated_at' => now()]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Mixed Stable');
@@ -410,8 +436,9 @@ describe('StablesTable Component', function () {
                 'updated_at' => now(),
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Evolving Stable');
@@ -423,8 +450,9 @@ describe('StablesTable Component', function () {
             // This stable would have been disbanded and reunited
             // The factory should handle creating the appropriate activity periods
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Reunited Stable');

--- a/tests/Integration/Livewire/TagTeams/Tables/MainTest.php
+++ b/tests/Integration/Livewire/TagTeams/Tables/MainTest.php
@@ -15,6 +15,9 @@ use App\Models\TagTeams\TagTeamSuspension;
 use App\Models\Wrestlers\Wrestler;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for TagTeamsTable Livewire component.
  *
@@ -49,7 +52,7 @@ describe('TagTeamsTable Component', function () {
             $wrestler1 = Wrestler::factory()->bookable()->create(['name' => 'Team Member One']);
             $wrestler2 = Wrestler::factory()->bookable()->create(['name' => 'Team Member Two']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee($employedTagTeam->name)
@@ -65,7 +68,7 @@ describe('TagTeamsTable Component', function () {
             $releasedTagTeam = TagTeam::factory()->released()->create(['name' => 'Released Tag Team']);
             $unemployedTagTeam = TagTeam::factory()->unemployed()->create(['name' => 'Unemployed Tag Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Employed Tag Team')
@@ -84,7 +87,7 @@ describe('TagTeamsTable Component', function () {
             TagTeam::factory()->create(['name' => 'The Dudley Boyz']);
             TagTeam::factory()->create(['name' => 'New Age Outlaws']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Test search functionality
             $component
@@ -106,7 +109,7 @@ describe('TagTeamsTable Component', function () {
             $retiredTagTeam = TagTeam::factory()->retired()->create(['name' => 'Retired Tag Team']);
             $suspendedTagTeam = TagTeam::factory()->suspended()->create(['name' => 'Suspended Tag Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Test filtering by status (if component supports it)
             $component
@@ -121,7 +124,7 @@ describe('TagTeamsTable Component', function () {
             $employedTagTeam = TagTeam::factory()->employed()->create(['name' => 'Active Tag Team']);
             $retiredTagTeam = TagTeam::factory()->retired()->create(['name' => 'Retired Tag Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render without errors
             $component->assertOk();
@@ -135,7 +138,9 @@ describe('TagTeamsTable Component', function () {
             $tagTeam = TagTeam::factory()->create(['name' => 'Test Tag Team']);
 
             // Test as administrator (should see all actions)
-            $component = Livewire::actingAs($this->user)->test(Main::class);
+            actingAs($this->user);
+
+            $component = livewire(Main::class);
             $component->assertOk();
             $component->assertSee($tagTeam->name);
         });
@@ -146,7 +151,7 @@ describe('TagTeamsTable Component', function () {
             $employedTagTeam = TagTeam::factory()->employed()->create(['name' => 'Currently Employed']);
             $unemployedTagTeam = TagTeam::factory()->unemployed()->create(['name' => 'Currently Unemployed']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Currently Employed')
@@ -169,7 +174,7 @@ describe('TagTeamsTable Component', function () {
                 ->current()
                 ->create(['started_at' => now()->subDays(50)]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Team History');
@@ -181,7 +186,7 @@ describe('TagTeamsTable Component', function () {
             $activeTagTeam = TagTeam::factory()->employed()->create(['name' => 'Active Tag Team']);
             $retiredTagTeam = TagTeam::factory()->retired()->create(['name' => 'Retired Tag Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Active Tag Team')
@@ -192,7 +197,7 @@ describe('TagTeamsTable Component', function () {
             $activeTagTeam = TagTeam::factory()->employed()->create(['name' => 'Active Tag Team']);
             $suspendedTagTeam = TagTeam::factory()->suspended()->create(['name' => 'Suspended Tag Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Active Tag Team')
@@ -210,7 +215,7 @@ describe('TagTeamsTable Component', function () {
                     'ended_at' => now()->subDays(50),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Retirement History');
@@ -227,7 +232,7 @@ describe('TagTeamsTable Component', function () {
                     'ended_at' => now()->subDays(50),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Suspension History');
@@ -238,7 +243,7 @@ describe('TagTeamsTable Component', function () {
         test('displays tag teams without wrestler partnerships', function () {
             $tagTeam = TagTeam::factory()->unemployed()->create(['name' => 'Independent Tag Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Independent Tag Team');
@@ -260,7 +265,7 @@ describe('TagTeamsTable Component', function () {
                 'left_at' => null,
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Partner Tag Team');
@@ -283,7 +288,7 @@ describe('TagTeamsTable Component', function () {
                 'left_at' => null,
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Former Partner Team');
@@ -299,7 +304,7 @@ describe('TagTeamsTable Component', function () {
             $tagTeams = TagTeam::factory()->count(5)->employed()->create();
             $wrestlers = Wrestler::factory()->count(10)->bookable()->create();
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render efficiently with created data
             $component->assertOk()
@@ -309,7 +314,7 @@ describe('TagTeamsTable Component', function () {
         test('component eager loads necessary relationships', function () {
             $tagTeam = TagTeam::factory()->employed()->create(['name' => 'Relationship Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertOk()
@@ -321,7 +326,7 @@ describe('TagTeamsTable Component', function () {
         test('component updates when tag team data changes', function () {
             $tagTeam = TagTeam::factory()->create(['name' => 'Original Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
             $component->assertSee('Original Team');
 
             // Update tag team name
@@ -336,7 +341,7 @@ describe('TagTeamsTable Component', function () {
         test('component reflects employment status changes', function () {
             $tagTeam = TagTeam::factory()->unemployed()->create(['name' => 'Employment Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Employ the tag team
             EmployAction::run($tagTeam, now());
@@ -349,7 +354,7 @@ describe('TagTeamsTable Component', function () {
         test('component reflects suspension status changes', function () {
             $tagTeam = TagTeam::factory()->employed()->create(['name' => 'Suspension Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Suspend the tag team
             SuspendAction::run($tagTeam, now());
@@ -362,7 +367,7 @@ describe('TagTeamsTable Component', function () {
         test('component reflects retirement status changes', function () {
             $tagTeam = TagTeam::factory()->employed()->create(['name' => 'Retirement Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Retire the tag team
             RetireAction::run($tagTeam, now());
@@ -381,7 +386,7 @@ describe('TagTeamsTable Component', function () {
             // Tag team is employed but also suspended
             SuspendAction::run($tagTeam, now());
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Complex Team');
@@ -393,7 +398,7 @@ describe('TagTeamsTable Component', function () {
             $suspendedTagTeam = TagTeam::factory()->suspended()->create(['name' => 'Suspended Team']);
             $retiredTagTeam = TagTeam::factory()->retired()->create(['name' => 'Retired Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render and show appropriate actions based on business rules
             $component
@@ -405,7 +410,7 @@ describe('TagTeamsTable Component', function () {
         test('component handles tag team employment transitions', function () {
             $tagTeam = TagTeam::factory()->employed()->create(['name' => 'Transitioning Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
             $component->assertSee('Transitioning Team');
 
             // Test that component handles data changes appropriately
@@ -418,7 +423,7 @@ describe('TagTeamsTable Component', function () {
             $unbookableTagTeam = TagTeam::factory()->suspended()->create(['name' => 'Unbookable Team']);
             $retiredTagTeam = TagTeam::factory()->retired()->create(['name' => 'Retired Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should show all tag teams with appropriate status indicators
             $component
@@ -436,7 +441,7 @@ describe('TagTeamsTable Component', function () {
                 'signature_move' => 'Poetry in Motion',
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Signature Team');
@@ -454,7 +459,7 @@ describe('TagTeamsTable Component', function () {
                     'ended_at' => now()->subYears(3),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Veteran Team')
@@ -479,7 +484,7 @@ describe('TagTeamsTable Component', function () {
             $wrestler2->tagTeams()->attach($tripleTeam->id, ['joined_at' => now()->subMonths(3)]);
             $wrestler3->tagTeams()->attach($tripleTeam->id, ['joined_at' => now()->subMonths(3)]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Dual Team')
@@ -492,7 +497,7 @@ describe('TagTeamsTable Component', function () {
             $formingTeam = TagTeam::factory()->unemployed()->create(['name' => 'Forming Team']);
             $dissolvingTeam = TagTeam::factory()->employed()->create(['name' => 'Dissolving Team']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Forming Team')
@@ -526,7 +531,7 @@ describe('TagTeamsTable Component', function () {
                     'ended_at' => now()->subMonths(6),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Reunited Team');
@@ -555,7 +560,7 @@ describe('TagTeamsTable Component', function () {
                 'left_at' => null,
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Evolving Team');

--- a/tests/Integration/Livewire/TagTeams/Tables/PreviousWrestlersTest.php
+++ b/tests/Integration/Livewire/TagTeams/Tables/PreviousWrestlersTest.php
@@ -8,7 +8,8 @@ use App\Models\TagTeams\TagTeamWrestler;
 use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Carbon;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -25,7 +26,7 @@ beforeEach(function () {
 
 describe('Previous Wrestlers Table Component', function () {
     it('can mount with tag team ID', function () {
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertOk();
         $table->assertSet('tagTeamId', $this->tagTeam->id);
@@ -33,7 +34,7 @@ describe('Previous Wrestlers Table Component', function () {
 
     it('throws exception when tag team ID not specified', function () {
         expect(function () {
-            Livewire::test(PreviousWrestlers::class);
+            livewire(PreviousWrestlers::class);
         })->toThrow(Exception::class, "You didn't specify a tag team");
     });
 
@@ -55,7 +56,7 @@ describe('Previous Wrestlers Table Component', function () {
             'left_at' => Carbon::now()->subDays(5),
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertSee($this->wrestler->name); // Should see the wrestler who left
 
@@ -89,7 +90,7 @@ describe('Previous Wrestlers Table Component', function () {
             'left_at' => Carbon::now()->subDays(15),
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         // Should be ordered by joined_at descending (most recent first)
         $table->assertSee($wrestler1->name) // joined 10 days ago
@@ -117,14 +118,14 @@ describe('Previous Wrestlers Table Component', function () {
             'left_at' => Carbon::now()->subDays(8),
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertSee($this->wrestler->name);
         $table->assertDontSee($otherWrestler->name);
     });
 
     it('handles empty previous wrestlers list', function () {
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertOk();
         $table->assertSee('No records found.');
@@ -140,7 +141,7 @@ describe('Previous Wrestlers Table Columns', function () {
             'left_at' => Carbon::now()->subDays(5),
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertSee($this->wrestler->name);
         $table->assertSee($this->wrestler->name);
@@ -158,7 +159,7 @@ describe('Previous Wrestlers Table Columns', function () {
             'left_at' => $leftDate,
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertSee($this->wrestler->name);
         $table->assertSee($joinedDate->format('Y-m-d'));
@@ -176,7 +177,7 @@ describe('Previous Wrestlers Table Columns', function () {
         // Delete the wrestler to simulate missing relationship
         $this->wrestler->delete();
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertOk();
         $table->assertSee('Unknown');
@@ -185,14 +186,14 @@ describe('Previous Wrestlers Table Columns', function () {
 
 describe('Previous Wrestlers Table Configuration', function () {
     it('uses correct database table name', function () {
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         // Just verify the component loads correctly
         $table->assertOk();
     });
 
     it('sets correct resource name', function () {
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         // Just verify the component loads correctly
         $table->assertOk();
@@ -206,7 +207,7 @@ describe('Previous Wrestlers Table Configuration', function () {
             'left_at' => Carbon::now()->subDays(5),
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         // Just verify the component loads and displays the data
         $table->assertSee($this->wrestler->name);
@@ -231,7 +232,7 @@ describe('Previous Wrestlers Table Business Logic', function () {
             'left_at' => Carbon::now()->subDays(10),
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         // Should show both membership periods
         $table->assertSee($this->wrestler->name);
@@ -245,7 +246,7 @@ describe('Previous Wrestlers Table Business Logic', function () {
             'left_at' => Carbon::now()->subDays(5),
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertSee($this->wrestler->name);
 
@@ -264,7 +265,7 @@ describe('Previous Wrestlers Table Business Logic', function () {
         // Delete the wrestler
         $this->wrestler->delete();
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         // Should still work but show "Unknown" for the name
         $table->assertOk();
@@ -291,7 +292,7 @@ describe('Previous Wrestlers Table Business Logic', function () {
             'left_at' => Carbon::now()->subDays(90),
         ]);
 
-        $table = Livewire::test(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
+        $table = livewire(PreviousWrestlers::class, ['tagTeamId' => $this->tagTeam->id]);
 
         $table->assertSee($recentWrestler->name)
             ->assertSee($oldWrestler->name);

--- a/tests/Integration/Livewire/Titles/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Titles/Components/ActionsTest.php
@@ -7,6 +7,9 @@ use App\Models\Titles\Title;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Title Actions Component Integration Tests
  *
@@ -34,7 +37,7 @@ beforeEach(function () {
 
 describe('Actions Component Initialization', function () {
     it('can mount with title', function () {
-        $component = Livewire::test(Actions::class, ['title' => $this->title]);
+        $component = livewire(Actions::class, ['title' => $this->title]);
 
         $component->assertOk();
         $component->assertSet('title.id', $this->title->id);
@@ -42,7 +45,7 @@ describe('Actions Component Initialization', function () {
     });
 
     it('renders actions component view', function () {
-        $component = Livewire::test(Actions::class, ['title' => $this->title]);
+        $component = livewire(Actions::class, ['title' => $this->title]);
 
         $component->assertViewIs('livewire.titles.components.actions');
     });
@@ -52,8 +55,9 @@ describe('Title Debut Actions', function () {
     it('can debut an undebuted title successfully', function () {
         $title = Title::factory()->undebuted()->create();
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $title])
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $title])
             ->call('debut');
 
         $component->assertHasNoErrors();
@@ -66,8 +70,9 @@ describe('Title Debut Actions', function () {
     it('handles debut for already active title', function () {
         $title = Title::factory()->active()->create();
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $title])
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $title])
             ->call('debut');
 
         // Should handle gracefully without errors
@@ -79,8 +84,9 @@ describe('Title Retirement Actions', function () {
     it('can retire an active title successfully', function () {
         $title = Title::factory()->active()->create();
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $title])
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $title])
             ->call('retire');
 
         $component->assertHasNoErrors();
@@ -93,8 +99,9 @@ describe('Title Retirement Actions', function () {
     it('can unretire a retired title successfully', function () {
         $title = Title::factory()->retired()->create();
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $title])
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $title])
             ->call('unretire');
 
         $component->assertHasNoErrors();
@@ -109,8 +116,9 @@ describe('Title Activation Actions', function () {
     it('can deactivate (pull) an active title successfully', function () {
         $title = Title::factory()->active()->create();
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $title])
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $title])
             ->call('deactivate');
 
         $component->assertHasNoErrors();
@@ -120,8 +128,9 @@ describe('Title Activation Actions', function () {
     it('can reinstate an inactive title successfully', function () {
         $title = Title::factory()->inactive()->create();
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $title])
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $title])
             ->call('reinstate');
 
         $component->assertHasNoErrors();
@@ -136,8 +145,9 @@ describe('Title Restoration Actions', function () {
 
         $trashedTitle = Title::onlyTrashed()->find($this->title->id);
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $trashedTitle])
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $trashedTitle])
             ->call('restore');
 
         $component->assertHasNoErrors();
@@ -154,8 +164,9 @@ describe('Title Actions Authorization', function () {
         $actions = ['debut', 'retire', 'unretire', 'deactivate', 'reinstate', 'restore'];
 
         foreach ($actions as $method) {
-            $component = Livewire::actingAs($user)
-                ->test(Actions::class, ['title' => $this->title]);
+            actingAs($user);
+
+            $component = livewire(Actions::class, ['title' => $this->title]);
 
             $component->call($method)
                 ->assertForbidden();
@@ -167,8 +178,9 @@ describe('Title Actions Event Dispatching', function () {
     it('dispatches title-updated event on successful actions', function () {
         $title = Title::factory()->undebuted()->create();
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $title]);
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $title]);
 
         $component->call('debut')
             ->assertDispatched('title-updated');
@@ -190,8 +202,9 @@ describe('Title Business Logic Integration', function () {
     it('handles complete title lifecycle', function () {
         // Start with undebuted title
         $title = Title::factory()->undebuted()->create();
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $title]);
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $title]);
 
         // Debut the title
         $component->call('debut');
@@ -210,8 +223,9 @@ describe('Title Business Logic Integration', function () {
         $originalName = $this->title->name;
         $originalId = $this->title->id;
 
-        $component = Livewire::actingAs($this->admin)
-            ->test(Actions::class, ['title' => $this->title]);
+        actingAs($this->admin);
+
+        $component = livewire(Actions::class, ['title' => $this->title]);
 
         $component->call('debut');
 

--- a/tests/Integration/Livewire/Titles/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Titles/Modals/FormModalTest.php
@@ -7,7 +7,8 @@ use App\Livewire\Titles\Modals\FormModal;
 use App\Models\Titles\Title;
 use App\Models\Users\User;
 use Illuminate\Support\Carbon;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -36,7 +37,7 @@ describe('FormModal Configuration', function () {
 
 describe('FormModal Rendering', function () {
     it('can render in create mode', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertOk();
@@ -45,14 +46,14 @@ describe('FormModal Rendering', function () {
     it('can render in edit mode', function () {
         $title = Title::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $title->id);
 
         $component->assertOk();
     });
 
     it('displays correct title in create mode', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Create Title');
@@ -61,7 +62,7 @@ describe('FormModal Rendering', function () {
     it('displays correct title in edit mode', function () {
         $title = Title::factory()->create(['name' => 'Test Championship Title']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $title->id);
 
         $component->assertSee('Edit Title');
@@ -70,7 +71,7 @@ describe('FormModal Rendering', function () {
 
 describe('FormModal Create Operations', function () {
     it('can create a new title with valid data', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'New Championship Title')
             ->set('form.type', 'singles')
@@ -87,7 +88,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates required fields when creating', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', '')
             ->set('form.type', '')
@@ -102,7 +103,7 @@ describe('FormModal Create Operations', function () {
     it('validates title name uniqueness', function () {
         Title::factory()->create(['name' => 'Existing Championship Title']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Existing Championship Title')
             ->set('form.type', 'singles')
@@ -113,7 +114,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates title type enum values', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Championship Title')
             ->set('form.type', 'InvalidType')
@@ -123,7 +124,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates start_date date format', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Championship Title')
             ->set('form.type', 'singles')
@@ -141,7 +142,7 @@ describe('FormModal Edit Operations', function () {
             'type' => 'singles',
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $title->id)
             ->set('form.name', 'Updated Championship Title')
             ->set('form.type', 'tag-team')
@@ -163,7 +164,7 @@ describe('FormModal Edit Operations', function () {
             'type' => 'singles',
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $title->id);
 
         $component->assertSet('form.name', 'Test Championship Title');
@@ -174,7 +175,7 @@ describe('FormModal Edit Operations', function () {
         $title1 = Title::factory()->create(['name' => 'Championship One Title']);
         $title2 = Title::factory()->create(['name' => 'Championship Two Title']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $title2->id)
             ->set('form.name', 'Championship One Title')
             ->call('save');
@@ -188,7 +189,7 @@ describe('FormModal Edit Operations', function () {
             'type' => 'singles',
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $title->id)
             ->set('form.name', 'Test Championship Title')
             ->set('form.type', 'tag-team')
@@ -203,7 +204,7 @@ describe('FormModal State Management', function () {
     it('resets form when switching modes', function () {
         $title = Title::factory()->create(['name' => 'Test Championship Title']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $title->id)
             ->call('openModal');
 
@@ -212,7 +213,7 @@ describe('FormModal State Management', function () {
     });
 
     it('closes modal after successful save', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'New Championship Title')
             ->set('form.type', 'singles')
@@ -223,7 +224,7 @@ describe('FormModal State Management', function () {
     });
 
     it('keeps modal open when validation fails', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', '')
             ->call('save');
@@ -234,7 +235,7 @@ describe('FormModal State Management', function () {
 
 describe('FormModal Business Logic', function () {
     it('handles title activation periods correctly', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'New Championship Title')
             ->set('form.type', 'singles')
@@ -250,7 +251,7 @@ describe('FormModal Business Logic', function () {
     it('validates debut date change rules', function () {
         $title = Title::factory()->withActivationPeriod()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $title->id)
             ->set('form.start_date', '2025-01-01')
             ->call('save');
@@ -264,7 +265,7 @@ describe('FormModal Authorization', function () {
     it('requires authentication', function () {
         auth()->logout();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertForbidden();
@@ -274,7 +275,7 @@ describe('FormModal Authorization', function () {
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertForbidden();

--- a/tests/Integration/Livewire/Titles/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Titles/Tables/MainTest.php
@@ -10,6 +10,9 @@ use App\Models\Titles\TitleChampionship;
 use App\Models\Wrestlers\Wrestler;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for TitlesTable Livewire component.
  *
@@ -151,7 +154,9 @@ describe('TitlesTable Component', function () {
             $title = Title::factory()->create(['name' => 'Test Title']);
 
             // Test as administrator (should see all actions)
-            $component = Livewire::actingAs($this->user)->test(Main::class);
+            actingAs($this->user);
+
+            $component = livewire(Main::class);
             $component->assertOk();
             $component->assertSee($title->name);
         });

--- a/tests/Integration/Livewire/Users/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Users/Modals/FormModalTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 use App\Livewire\Users\Forms\CreateEditForm;
 use App\Livewire\Users\Modals\FormModal;
 use App\Models\Users\User;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -34,7 +35,7 @@ describe('FormModal Configuration', function () {
 
 describe('FormModal Rendering', function () {
     it('can render in create mode', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertOk();
@@ -43,14 +44,14 @@ describe('FormModal Rendering', function () {
     it('can render in edit mode', function () {
         $user = User::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id);
 
         $component->assertOk();
     });
 
     it('displays correct title in create mode', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertSee('Create User');
@@ -59,7 +60,7 @@ describe('FormModal Rendering', function () {
     it('displays correct title in edit mode', function () {
         $user = User::factory()->create(['first_name' => 'Test', 'last_name' => 'User']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id);
 
         $component->assertSee('Edit User');
@@ -68,7 +69,7 @@ describe('FormModal Rendering', function () {
 
 describe('FormModal Create Operations', function () {
     it('can create a new user with valid data', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -89,7 +90,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates required fields when creating', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', '')
             ->set('form.last_name', '')
@@ -106,7 +107,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates email format', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -120,7 +121,7 @@ describe('FormModal Create Operations', function () {
     it('validates email uniqueness', function () {
         User::factory()->create(['email' => 'existing@example.com']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -132,7 +133,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates password confirmation', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -146,7 +147,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('validates minimum password length', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -160,7 +161,7 @@ describe('FormModal Create Operations', function () {
     });
 
     it('hashes password when creating user', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -184,7 +185,7 @@ describe('FormModal Edit Operations', function () {
             'email' => 'original@example.com',
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id)
             ->set('form.first_name', 'Updated')
             ->set('form.last_name', 'Name')
@@ -209,7 +210,7 @@ describe('FormModal Edit Operations', function () {
             'email' => 'test@example.com',
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id);
 
         $component->assertSet('form.first_name', 'Test');
@@ -221,7 +222,7 @@ describe('FormModal Edit Operations', function () {
         $user1 = User::factory()->create(['email' => 'user1@example.com']);
         $user2 = User::factory()->create(['email' => 'user2@example.com']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user2->id)
             ->set('form.email', 'user1@example.com')
             ->call('save');
@@ -236,7 +237,7 @@ describe('FormModal Edit Operations', function () {
             'email' => 'test@example.com',
         ]);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id)
             ->set('form.first_name', 'Updated')
             ->set('form.last_name', 'Name')
@@ -250,7 +251,7 @@ describe('FormModal Edit Operations', function () {
     it('does not require password when editing', function () {
         $user = User::factory()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id)
             ->set('form.first_name', 'Updated')
             ->set('form.last_name', 'Name')
@@ -263,7 +264,7 @@ describe('FormModal Edit Operations', function () {
         $user = User::factory()->create();
         $originalPassword = $user->password;
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id)
             ->set('form.password', 'newpassword123')
             ->set('form.password_confirmation', 'newpassword123')
@@ -281,7 +282,7 @@ describe('FormModal State Management', function () {
     it('resets form when switching modes', function () {
         $user = User::factory()->create(['first_name' => 'Test', 'last_name' => 'User']);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id)
             ->call('openModal');
 
@@ -291,7 +292,7 @@ describe('FormModal State Management', function () {
     });
 
     it('closes modal after successful save', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -305,7 +306,7 @@ describe('FormModal State Management', function () {
     });
 
     it('keeps modal open when validation fails', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', '')
             ->call('save');
@@ -316,7 +317,7 @@ describe('FormModal State Management', function () {
 
 describe('FormModal Role Management', function () {
     it('can assign user role when creating', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -336,7 +337,7 @@ describe('FormModal Role Management', function () {
     it('can update user role when editing', function () {
         $user = User::factory()->basicUser()->create();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal', $user->id)
             ->set('form.role', 'administrator')
             ->call('save');
@@ -348,7 +349,7 @@ describe('FormModal Role Management', function () {
     });
 
     it('validates role enum values', function () {
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.first_name', 'John')
             ->set('form.last_name', 'Doe')
@@ -366,7 +367,7 @@ describe('FormModal Authorization', function () {
     it('requires authentication', function () {
         auth()->logout();
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertForbidden();
@@ -376,7 +377,7 @@ describe('FormModal Authorization', function () {
         $user = User::factory()->create();
         $this->actingAs($user);
 
-        $component = Livewire::test(FormModal::class)
+        $component = livewire(FormModal::class)
             ->call('openModal');
 
         $component->assertForbidden();

--- a/tests/Integration/Livewire/Users/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Users/Tables/MainTest.php
@@ -11,6 +11,9 @@ use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Collection;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for UsersTable Livewire component.
  *
@@ -311,7 +314,9 @@ describe('UsersTable Component', function () {
             $user = User::factory()->create(['first_name' => 'Test', 'last_name' => 'User']);
 
             // Test as administrator (should see all actions)
-            $component = Livewire::actingAs($this->user)->test(Main::class);
+            actingAs($this->user);
+
+            $component = livewire(Main::class);
             $component->assertOk();
             $component->assertSee($user->first_name);
         });
@@ -319,7 +324,9 @@ describe('UsersTable Component', function () {
         test('component handles action availability based on user permissions', function () {
             $testUser = User::factory()->create(['first_name' => 'Action', 'last_name' => 'Test']);
 
-            $component = Livewire::actingAs($this->user)->test(Main::class);
+            actingAs($this->user);
+
+            $component = livewire(Main::class);
 
             // Administrator should see the user
             $component->assertSee('Action Test');

--- a/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
+++ b/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
@@ -56,7 +56,12 @@ describe('VenueForm Integration Tests', function () {
             expect($rules['name'])->toContain('max:255');
 
             // Should contain Rule::unique validation for venues table
-            $hasUniqueRule = collect($rules['name'])->contains(function ($rule) {
+            $nameRules = $rules['name'];
+            if (! is_array($nameRules)) {
+                throw new UnexpectedValueException('Venue name rules must be an array.');
+            }
+
+            $hasUniqueRule = collect($nameRules)->contains(function ($rule) {
                 return $rule instanceof Unique;
             });
             expect($hasUniqueRule)->toBeTrue();
@@ -87,7 +92,12 @@ describe('VenueForm Integration Tests', function () {
             expect($rules['state'])->toContain('string');
 
             // Should validate against states table
-            $hasExistsRule = collect($rules['state'])->contains(function ($rule) {
+            $stateRules = $rules['state'];
+            if (! is_array($stateRules)) {
+                throw new UnexpectedValueException('Venue state rules must be an array.');
+            }
+
+            $hasExistsRule = collect($stateRules)->contains(function ($rule) {
                 return $rule instanceof Exists;
             });
             expect($hasExistsRule)->toBeTrue();
@@ -157,7 +167,12 @@ describe('VenueForm Integration Tests', function () {
             $rules = $reflection->invoke($this->form);
 
             // Check that unique rule is configured for venues table
-            $uniqueRule = collect($rules['name'])->first(function ($rule) {
+            $nameRules = $rules['name'];
+            if (! is_array($nameRules)) {
+                throw new UnexpectedValueException('Venue name rules must be an array.');
+            }
+
+            $uniqueRule = collect($nameRules)->first(function ($rule) {
                 return $rule instanceof Unique;
             });
 
@@ -179,7 +194,12 @@ describe('VenueForm Integration Tests', function () {
             $rules = $reflection->invoke($this->form);
 
             // Should validate that state exists in states table
-            $existsRule = collect($rules['state'])->first(function ($rule) {
+            $stateRules = $rules['state'];
+            if (! is_array($stateRules)) {
+                throw new UnexpectedValueException('Venue state rules must be an array.');
+            }
+
+            $existsRule = collect($stateRules)->first(function ($rule) {
                 return $rule instanceof Exists;
             });
 

--- a/tests/Integration/Livewire/Venues/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Venues/Modals/FormModalTest.php
@@ -6,7 +6,8 @@ use App\Livewire\Venues\Modals\FormModal;
 use App\Models\Events\Venue;
 use App\Models\Shared\State;
 use App\Models\Users\User;
-use Livewire\Livewire;
+
+use function Pest\Livewire\livewire;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -35,14 +36,14 @@ beforeEach(function () {
 
 describe('Form Modal Initialization', function () {
     it('can mount modal component', function () {
-        $modal = Livewire::test(FormModal::class);
+        $modal = livewire(FormModal::class);
 
         $modal->assertOk();
         $modal->assertViewIs('livewire.venues.modals.form-modal');
     });
 
     it('initializes with empty form for creation', function () {
-        $modal = Livewire::test(FormModal::class);
+        $modal = livewire(FormModal::class);
 
         $modal->assertSet('form.name', '');
         $modal->assertSet('form.street_address', '');
@@ -52,7 +53,7 @@ describe('Form Modal Initialization', function () {
     });
 
     it('can open modal for creating new venue', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal');
 
         $modal->assertSet('isModalOpen', true);
@@ -60,7 +61,7 @@ describe('Form Modal Initialization', function () {
     });
 
     it('can close modal', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->call('closeModal');
 
@@ -78,7 +79,7 @@ describe('Form Modal Editing', function () {
             'zipcode' => '10001',
         ]);
 
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal', $venue->id);
 
         $modal->assertSet('form.name', 'Madison Square Garden');
@@ -97,7 +98,7 @@ describe('Form Modal Editing', function () {
             'zipcode' => '90210',
         ]);
 
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal', $venue->id)
             ->set('form.name', 'Updated Arena')
             ->set('form.street_address', '456 Oak Ave')
@@ -122,7 +123,7 @@ describe('Form Modal Editing', function () {
     it('preserves venue data when validation fails', function () {
         $venue = Venue::factory()->create();
 
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal', $venue->id)
             ->set('form.name', 'Test Venue')
             ->set('form.street_address', '123 Test St')
@@ -141,7 +142,7 @@ describe('Form Modal Editing', function () {
 
 describe('Form Modal Creation', function () {
     it('can create new venue with valid data', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'New Wrestling Arena')
             ->set('form.street_address', '789 Wrestling Way')
@@ -164,7 +165,7 @@ describe('Form Modal Creation', function () {
     });
 
     it('validates required fields', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', '')
             ->set('form.street_address', '')
@@ -185,7 +186,7 @@ describe('Form Modal Creation', function () {
     it('validates venue name uniqueness', function () {
         Venue::factory()->create(['name' => 'Existing Arena']);
 
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Existing Arena')
             ->set('form.street_address', '123 New St')
@@ -198,7 +199,7 @@ describe('Form Modal Creation', function () {
     });
 
     it('validates state exists in database', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Arena')
             ->set('form.street_address', '123 Test St')
@@ -211,7 +212,7 @@ describe('Form Modal Creation', function () {
     });
 
     it('validates zipcode format', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Arena')
             ->set('form.street_address', '123 Test St')
@@ -224,7 +225,7 @@ describe('Form Modal Creation', function () {
     });
 
     it('accepts valid zipcode format', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Valid Arena')
             ->set('form.street_address', '123 Valid St')
@@ -243,7 +244,7 @@ describe('Form Modal Validation', function () {
         $longAddress = str_repeat('a', 256);
         $longCity = str_repeat('a', 256);
 
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', $longName)
             ->set('form.street_address', $longAddress)
@@ -264,7 +265,7 @@ describe('Form Modal Validation', function () {
         $validAddress = str_repeat('a', 255);
         $validCity = str_repeat('a', 255);
 
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', $validName)
             ->set('form.street_address', $validAddress)
@@ -277,7 +278,7 @@ describe('Form Modal Validation', function () {
     });
 
     it('validates zipcode as numeric', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Arena')
             ->set('form.street_address', '123 Test St')
@@ -292,7 +293,7 @@ describe('Form Modal Validation', function () {
 
 describe('Form Modal State Management', function () {
     it('resets form after successful creation', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Arena')
             ->set('form.street_address', '123 Test St')
@@ -310,7 +311,7 @@ describe('Form Modal State Management', function () {
     });
 
     it('preserves form state when validation fails', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Arena')
             ->set('form.street_address', '123 Test St')
@@ -328,7 +329,7 @@ describe('Form Modal State Management', function () {
     });
 
     it('handles modal close during form submission', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Arena')
             ->call('closeModal');
@@ -340,7 +341,7 @@ describe('Form Modal State Management', function () {
 
 describe('Form Modal Dummy Data', function () {
     it('can fill form with dummy data', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->call('fillDummyFields');
 
@@ -352,7 +353,7 @@ describe('Form Modal Dummy Data', function () {
     });
 
     it('can submit form with dummy data', function () {
-        $modal = Livewire::test(FormModal::class)
+        $modal = livewire(FormModal::class)
             ->call('openModal')
             ->call('fillDummyFields')
             ->call('save');

--- a/tests/Integration/Livewire/Venues/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/MainTest.php
@@ -9,6 +9,9 @@ use App\Models\Events\Venue;
 use App\Models\Users\User;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for VenuesTable Livewire component.
  *
@@ -89,7 +92,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('loads venue data with proper relationships', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Busy Event Arena')
@@ -105,7 +110,9 @@ describe('VenuesTable Integration Tests', function () {
                 'zipcode' => '12345',
             ]);
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Address Display Arena')
@@ -114,7 +121,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('excludes soft deleted venues by default', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Active Test Arena')
@@ -124,7 +133,9 @@ describe('VenuesTable Integration Tests', function () {
 
     describe('search and filtering functionality', function () {
         test('filters venues by name search', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'Active')
                 ->assertSee('Active Test Arena')
@@ -133,7 +144,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('filters venues by city search', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'Event City')
                 ->assertSee('Busy Event Arena')
@@ -142,7 +155,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('filters venues by state search', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'AC')
                 ->assertSee('Active Test Arena')
@@ -150,7 +165,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('search handles partial matches', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'Arena')
                 ->assertSee('Active Test Arena')
@@ -159,7 +176,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('search is case insensitive', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'active')
                 ->assertSee('Active Test Arena');
@@ -169,7 +188,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('empty search shows all venues', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', '')
                 ->assertSee('Active Test Arena')
@@ -180,7 +201,9 @@ describe('VenuesTable Integration Tests', function () {
 
     describe('venue relationship display', function () {
         test('displays venues with event counts', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Busy Event Arena');
@@ -190,7 +213,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('handles venues without events', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Empty Arena');
@@ -199,7 +224,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('loads event relationships efficiently', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Busy Event Arena');
@@ -212,7 +239,9 @@ describe('VenuesTable Integration Tests', function () {
 
     describe('venue management operations', function () {
         test('administrators can delete venues', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('delete', $this->activeVenue)
                 ->assertHasNoErrors();
@@ -222,7 +251,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('administrators can restore deleted venues', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('restore', $this->deletedVenue->id)
                 ->assertHasNoErrors();
@@ -233,7 +264,9 @@ describe('VenuesTable Integration Tests', function () {
         test('delete operation preserves event relationships', function () {
             $event = Event::factory()->atVenue($this->activeVenue)->create();
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('delete', $this->activeVenue)
                 ->assertHasNoErrors();
@@ -249,7 +282,9 @@ describe('VenuesTable Integration Tests', function () {
             // Now delete the venue
             $venue->delete();
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->call('restore', $venue->id)
                 ->assertHasNoErrors();
@@ -266,19 +301,23 @@ describe('VenuesTable Integration Tests', function () {
 
     describe('authorization and access control', function () {
         test('basic users cannot access venue table', function () {
-            $component = Livewire::actingAs($this->basicUser)->test(Main::class);
+            actingAs($this->basicUser);
+
+            $component = livewire(Main::class);
 
             $component->assertForbidden();
         });
 
         test('guests cannot access venue table', function () {
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component->assertForbidden();
         });
 
         test('administrators have full access to all operations', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
             $component->call('delete', $this->activeVenue)->assertHasNoErrors();
@@ -288,7 +327,9 @@ describe('VenuesTable Integration Tests', function () {
 
     describe('data sorting and ordering', function () {
         test('venues are ordered consistently', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
 
@@ -298,7 +339,9 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('search results maintain proper ordering', function () {
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'Arena')
                 ->assertOk();
@@ -314,7 +357,9 @@ describe('VenuesTable Integration Tests', function () {
             // Create additional venues for testing
             Venue::factory()->count(50)->create();
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
 
@@ -324,7 +369,9 @@ describe('VenuesTable Integration Tests', function () {
         test('search performs efficiently with many venues', function () {
             Venue::factory()->count(25)->create(['name' => 'Search Test Arena']);
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->set('search', 'Search Test')
                 ->assertOk();
@@ -337,7 +384,9 @@ describe('VenuesTable Integration Tests', function () {
             $venueWithManyEvents = Venue::factory()->create();
             Event::factory()->count(10)->atVenue($venueWithManyEvents)->create();
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee($venueWithManyEvents->name);
@@ -353,7 +402,9 @@ describe('VenuesTable Integration Tests', function () {
                 'city' => 'St. Louis',
             ]);
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('O\'Malley\'s Arena & Entertainment Center')
@@ -363,7 +414,9 @@ describe('VenuesTable Integration Tests', function () {
         test('handles empty database gracefully', function () {
             Venue::query()->delete();
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk();
         });
@@ -377,7 +430,9 @@ describe('VenuesTable Integration Tests', function () {
                 'zipcode' => '12345',
             ]);
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Incomplete Address Arena')
@@ -385,8 +440,12 @@ describe('VenuesTable Integration Tests', function () {
         });
 
         test('handles concurrent operations safely', function () {
-            $component1 = Livewire::actingAs($this->admin)->test(Main::class);
-            $component2 = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component1 = livewire(Main::class);
+            actingAs($this->admin);
+
+            $component2 = livewire(Main::class);
 
             $component1->call('delete', $this->activeVenue)
                 ->assertHasNoErrors();
@@ -406,7 +465,9 @@ describe('VenuesTable Integration Tests', function () {
                 'zipcode' => '12345',
             ]);
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('Complete Address Arena')
@@ -423,7 +484,9 @@ describe('VenuesTable Integration Tests', function () {
                 'zipcode' => '54321',
             ]);
 
-            $component = Livewire::actingAs($this->admin)->test(Main::class);
+            actingAs($this->admin);
+
+            $component = livewire(Main::class);
 
             $component->assertOk()
                 ->assertSee('International Arena')

--- a/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
@@ -11,7 +11,6 @@ use App\Livewire\Venues\Tables\PreviousEvents;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Users\User;
-use Livewire\Livewire;
 
 /**
  * Integration tests for PreviousEventsTable component query building and functionality.
@@ -66,8 +65,9 @@ describe('PreviousEventsTable Integration Tests', function () {
 
     describe('component initialization and venue filtering', function () {
         test('renders successfully with venue ID set', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $this->venue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $this->venue->id]);
 
             $component->assertOk()
                 ->assertSee('Recent Wrestling Show')
@@ -77,14 +77,16 @@ describe('PreviousEventsTable Integration Tests', function () {
 
         test('throws exception when venue ID is not provided', function () {
             expect(function () {
-                Livewire::actingAs($this->admin)
-                    ->test(PreviousEvents::class);
+                \Pest\Laravel\actingAs($this->admin);
+
+                \Pest\Livewire\livewire(PreviousEvents::class);
             })->toThrow(Exception::class, "You didn't specify a venue");
         });
 
         test('filters events by specific venue only', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $this->venue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $this->venue->id]);
 
             $component->assertOk()
                 ->assertSee('Recent Wrestling Show')
@@ -136,8 +138,9 @@ describe('PreviousEventsTable Integration Tests', function () {
 
     describe('date-based ordering and chronological display', function () {
         test('displays events in descending chronological order', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $this->venue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $this->venue->id]);
 
             $component->assertOk();
 
@@ -151,8 +154,9 @@ describe('PreviousEventsTable Integration Tests', function () {
         });
 
         test('includes both past and future events in chronological order', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $this->venue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $this->venue->id]);
 
             $component->assertOk()
                 ->assertSee('Upcoming Wrestling Show')
@@ -187,8 +191,9 @@ describe('PreviousEventsTable Integration Tests', function () {
         });
 
         test('date column uses consistent Y-m-d format', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $this->venue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $this->venue->id]);
 
             $component->assertOk();
 
@@ -211,8 +216,9 @@ describe('PreviousEventsTable Integration Tests', function () {
         });
 
         test('displays clickable event names for navigation', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $this->venue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $this->venue->id]);
 
             $component->assertOk()
                 ->assertSee('Recent Wrestling Show')
@@ -243,8 +249,9 @@ describe('PreviousEventsTable Integration Tests', function () {
         test('handles venue with no events gracefully', function () {
             $emptyVenue = Venue::factory()->create(['name' => 'Empty Venue']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $emptyVenue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $emptyVenue->id]);
 
             $component->assertOk();
         });
@@ -257,8 +264,9 @@ describe('PreviousEventsTable Integration Tests', function () {
         });
 
         test('handles invalid venue ID gracefully', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => 999999]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => 999999]);
 
             $component->assertOk();
         });
@@ -278,8 +286,9 @@ describe('PreviousEventsTable Integration Tests', function () {
         });
 
         test('preserves event-venue relationships in display', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $this->venue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $this->venue->id]);
 
             $component->assertOk();
 
@@ -313,8 +322,9 @@ describe('PreviousEventsTable Integration Tests', function () {
                 'date' => now()->subDays(random_int(1, 365)),
             ]);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(PreviousEvents::class, ['venueId' => $this->venue->id]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(PreviousEvents::class, ['venueId' => $this->venue->id]);
 
             $component->assertOk();
 

--- a/tests/Integration/Livewire/Wrestlers/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Components/ActionsTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 use App\Livewire\Wrestlers\Components\Actions;
 use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
-use Livewire\Livewire;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -30,8 +29,9 @@ describe('WrestlersActions Integration Tests', function () {
 
     describe('component initialization', function () {
         test('component loads with wrestler properly bound', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             expect($component->get('wrestler')->id)->toBe($this->wrestler->id);
             expect($component->get('wrestler')->name)->toBe('Test Wrestler');
@@ -39,8 +39,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('component renders without errors', function () {
-            Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler])
+            \Pest\Laravel\actingAs($this->admin);
+
+            \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler])
                 ->assertOk();
             expect(true)->toBeTrue();
         });
@@ -50,8 +51,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('employ action works for unemployed wrestler', function () {
             $unemployedWrestler = Wrestler::factory()->unemployed()->create(['name' => 'Unemployed Wrestler']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $unemployedWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $unemployedWrestler]);
 
             $component->call('employ')
                 ->assertHasNoErrors()
@@ -63,8 +65,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('employ action fails for already employed wrestler', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('employ');
 
@@ -73,8 +76,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('release action works for employed wrestler', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('release')
                 ->assertHasNoErrors()
@@ -88,8 +92,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('release action fails for unemployed wrestler', function () {
             $unemployedWrestler = Wrestler::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $unemployedWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $unemployedWrestler]);
 
             $component->call('release');
 
@@ -100,8 +105,9 @@ describe('WrestlersActions Integration Tests', function () {
 
     describe('injury and healing actions', function () {
         test('injure action works for healthy employed wrestler', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('injure')
                 ->assertHasNoErrors()
@@ -115,8 +121,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('injure action fails for already injured wrestler', function () {
             $injuredWrestler = Wrestler::factory()->injured()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $injuredWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $injuredWrestler]);
 
             $component->call('injure');
 
@@ -127,8 +134,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('heal action works for injured wrestler', function () {
             $injuredWrestler = Wrestler::factory()->injured()->create(['name' => 'Injured Wrestler']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $injuredWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $injuredWrestler]);
 
             $component->call('healFromInjury')
                 ->assertHasNoErrors()
@@ -140,8 +148,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('heal action fails for healthy wrestler', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('healFromInjury');
 
@@ -152,8 +161,9 @@ describe('WrestlersActions Integration Tests', function () {
 
     describe('suspension and reinstatement actions', function () {
         test('suspend action works for employed wrestler', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('suspend')
                 ->assertHasNoErrors()
@@ -167,8 +177,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('suspend action fails for unemployed wrestler', function () {
             $unemployedWrestler = Wrestler::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $unemployedWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $unemployedWrestler]);
 
             $component->call('suspend');
 
@@ -179,8 +190,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('reinstate action works for suspended wrestler', function () {
             $suspendedWrestler = Wrestler::factory()->suspended()->create(['name' => 'Suspended Wrestler']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $suspendedWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $suspendedWrestler]);
 
             $component->call('reinstate')
                 ->assertHasNoErrors()
@@ -192,8 +204,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('reinstate action fails for non-suspended wrestler', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('reinstate');
 
@@ -204,8 +217,9 @@ describe('WrestlersActions Integration Tests', function () {
 
     describe('retirement lifecycle actions', function () {
         test('retire action works for employed wrestler', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('retire')
                 ->assertHasNoErrors()
@@ -219,8 +233,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('retire action fails for unemployed wrestler', function () {
             $unemployedWrestler = Wrestler::factory()->unemployed()->create();
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $unemployedWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $unemployedWrestler]);
 
             $component->call('retire');
 
@@ -231,8 +246,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('unretire action works for retired wrestler', function () {
             $retiredWrestler = Wrestler::factory()->retired()->create(['name' => 'Retired Wrestler']);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $retiredWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $retiredWrestler]);
 
             $component->call('unretire')
                 ->assertHasNoErrors()
@@ -244,8 +260,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('unretire action fails for active wrestler', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('unretire');
 
@@ -261,8 +278,9 @@ describe('WrestlersActions Integration Tests', function () {
 
             $trashedWrestler = Wrestler::onlyTrashed()->find($this->wrestler->id);
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $trashedWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $trashedWrestler]);
 
             $component->call('restore')
                 ->assertHasNoErrors()
@@ -278,8 +296,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('wrestler can transition through complete career lifecycle', function () {
             // Start unemployed
             $wrestler = Wrestler::factory()->unemployed()->create(['name' => 'Career Wrestler']);
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $wrestler]);
 
             // Employ
             $component->call('employ');
@@ -313,8 +332,9 @@ describe('WrestlersActions Integration Tests', function () {
 
         test('action availability changes based on current status', function () {
             $injuredWrestler = Wrestler::factory()->injured()->create();
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $injuredWrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $injuredWrestler]);
 
             // Cannot employ injured wrestler
             $component->call('employ');
@@ -337,8 +357,9 @@ describe('WrestlersActions Integration Tests', function () {
         test('unauthorized user cannot perform actions', function () {
             $guest = User::factory()->create(); // Non-admin user
 
-            $component = Livewire::actingAs($guest)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($guest);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('employ')
                 ->assertForbidden();
@@ -346,8 +367,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('admin can perform all actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             // All action calls should succeed (though business rules may prevent them)
             $component->call('release')
@@ -360,8 +382,9 @@ describe('WrestlersActions Integration Tests', function () {
 
     describe('event dispatching and state management', function () {
         test('all successful actions dispatch wrestler-updated event', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('release')
                 ->assertDispatched('wrestler-updated');
@@ -375,8 +398,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('failed actions do not dispatch events', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             // Try to employ already employed wrestler
             $component->call('employ')
@@ -385,8 +409,9 @@ describe('WrestlersActions Integration Tests', function () {
         });
 
         test('component state remains consistent after actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             expect($component->get('wrestler')->id)->toBe($this->wrestler->id);
 
@@ -400,8 +425,9 @@ describe('WrestlersActions Integration Tests', function () {
 
     describe('error handling and edge cases', function () {
         test('component handles wrestler model refresh after actions', function () {
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             // Perform action
             $component->call('release');
@@ -415,8 +441,9 @@ describe('WrestlersActions Integration Tests', function () {
             $originalName = $this->wrestler->name;
             $originalId = $this->wrestler->id;
 
-            $component = Livewire::actingAs($this->admin)
-                ->test(Actions::class, ['wrestler' => $this->wrestler]);
+            \Pest\Laravel\actingAs($this->admin);
+
+            $component = \Pest\Livewire\livewire(Actions::class, ['wrestler' => $this->wrestler]);
 
             $component->call('injure');
 

--- a/tests/Integration/Livewire/Wrestlers/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Tables/MainTest.php
@@ -12,6 +12,9 @@ use App\Models\Wrestlers\WrestlerEmployment;
 use App\Models\Wrestlers\WrestlerInjury;
 use Livewire\Livewire;
 
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
 /**
  * Integration tests for Main Livewire component.
  *
@@ -47,7 +50,7 @@ describe('Main Component Integration', function () {
             $tagTeam = TagTeam::factory()->bookable()->create(['name' => 'Wrestler Tag Team']);
             $stable = Stable::factory()->active()->create(['name' => 'Wrestler Stable']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee($employedWrestler->name)
@@ -64,7 +67,7 @@ describe('Main Component Integration', function () {
             $retiredWrestler = Wrestler::factory()->retired()->create(['name' => 'Retired Wrestler']);
             $releasedWrestler = Wrestler::factory()->released()->create(['name' => 'Released Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Employed Wrestler')
@@ -84,7 +87,7 @@ describe('Main Component Integration', function () {
             Wrestler::factory()->create(['name' => 'The Rock']);
             Wrestler::factory()->create(['name' => 'Stone Cold Steve Austin']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Test search functionality
             $component
@@ -106,7 +109,7 @@ describe('Main Component Integration', function () {
             $retiredWrestler = Wrestler::factory()->retired()->create(['name' => 'Retired Wrestler']);
             $injuredWrestler = Wrestler::factory()->injured()->create(['name' => 'Injured Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Test filtering by status (if component supports it)
             $component
@@ -121,7 +124,7 @@ describe('Main Component Integration', function () {
             $employedWrestler = Wrestler::factory()->employed()->create(['name' => 'Active Wrestler']);
             $retiredWrestler = Wrestler::factory()->retired()->create(['name' => 'Retired Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render without errors
             $component->assertOk();
@@ -135,7 +138,9 @@ describe('Main Component Integration', function () {
             $wrestler = Wrestler::factory()->create(['name' => 'Test Wrestler']);
 
             // Test as administrator (should see all actions)
-            $component = Livewire::actingAs($this->user)->test(Main::class);
+            actingAs($this->user);
+
+            $component = livewire(Main::class);
             $component->assertOk();
             $component->assertSee($wrestler->name);
         });
@@ -146,7 +151,7 @@ describe('Main Component Integration', function () {
             $employedWrestler = Wrestler::factory()->employed()->create(['name' => 'Currently Employed']);
             $unemployedWrestler = Wrestler::factory()->unemployed()->create(['name' => 'Currently Unemployed']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Currently Employed')
@@ -169,7 +174,7 @@ describe('Main Component Integration', function () {
                 ->current()
                 ->create(['started_at' => now()->subDays(50)]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Wrestler History');
@@ -181,7 +186,7 @@ describe('Main Component Integration', function () {
             $healthyWrestler = Wrestler::factory()->employed()->create(['name' => 'Healthy Wrestler']);
             $injuredWrestler = Wrestler::factory()->injured()->create(['name' => 'Injured Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Healthy Wrestler')
@@ -192,7 +197,7 @@ describe('Main Component Integration', function () {
             $activeWrestler = Wrestler::factory()->employed()->create(['name' => 'Active Wrestler']);
             $suspendedWrestler = Wrestler::factory()->suspended()->create(['name' => 'Suspended Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Active Wrestler')
@@ -210,7 +215,7 @@ describe('Main Component Integration', function () {
                     'ended_at' => now()->subDays(50),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Injury History');
@@ -221,7 +226,7 @@ describe('Main Component Integration', function () {
         test('displays wrestlers without tag team relationships', function () {
             $wrestler = Wrestler::factory()->employed()->create(['name' => 'Singles Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Singles Wrestler');
@@ -237,7 +242,7 @@ describe('Main Component Integration', function () {
                 'left_at' => null,
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Tag Team Wrestler');
@@ -253,7 +258,7 @@ describe('Main Component Integration', function () {
                 'left_at' => null,
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Stable Wrestler');
@@ -270,7 +275,7 @@ describe('Main Component Integration', function () {
             $tagTeams = TagTeam::factory()->count(3)->bookable()->create();
             $stables = Stable::factory()->count(2)->active()->create();
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render efficiently with created data
             $component->assertOk()
@@ -280,7 +285,7 @@ describe('Main Component Integration', function () {
         test('component eager loads necessary relationships', function () {
             $wrestler = Wrestler::factory()->employed()->create(['name' => 'Relationship Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertOk()
@@ -292,7 +297,7 @@ describe('Main Component Integration', function () {
         test('component updates when wrestler data changes', function () {
             $wrestler = Wrestler::factory()->create(['name' => 'Original Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
             $component->assertSee('Original Wrestler');
 
             // Update wrestler name
@@ -307,7 +312,7 @@ describe('Main Component Integration', function () {
         test('component reflects employment status changes', function () {
             $wrestler = Wrestler::factory()->unemployed()->create(['name' => 'Employment Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Employ the wrestler
             EmployAction::run($wrestler, now());
@@ -320,7 +325,7 @@ describe('Main Component Integration', function () {
         test('component reflects injury status changes', function () {
             $wrestler = Wrestler::factory()->employed()->create(['name' => 'Injury Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Injure the wrestler
             InjureAction::run($wrestler, now());
@@ -339,7 +344,7 @@ describe('Main Component Integration', function () {
             // Wrestler is employed but also injured
             InjureAction::run($wrestler, now());
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Complex Wrestler');
@@ -351,7 +356,7 @@ describe('Main Component Integration', function () {
             $injuredWrestler = Wrestler::factory()->injured()->create(['name' => 'Injured Wrestler']);
             $retiredWrestler = Wrestler::factory()->retired()->create(['name' => 'Retired Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should render and show appropriate actions based on business rules
             $component
@@ -363,7 +368,7 @@ describe('Main Component Integration', function () {
         test('component handles wrestler employment transitions', function () {
             $wrestler = Wrestler::factory()->employed()->create(['name' => 'Transitioning Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
             $component->assertSee('Transitioning Wrestler');
 
             // Test that component handles data changes appropriately
@@ -376,7 +381,7 @@ describe('Main Component Integration', function () {
             $unbookableWrestler = Wrestler::factory()->injured()->create(['name' => 'Unbookable Wrestler']);
             $suspendedWrestler = Wrestler::factory()->suspended()->create(['name' => 'Suspended Wrestler']);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             // Component should show all wrestlers with appropriate status indicators
             $component
@@ -396,7 +401,7 @@ describe('Main Component Integration', function () {
                 'hometown' => 'Test City, TX',
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Big Wrestler')
@@ -411,7 +416,7 @@ describe('Main Component Integration', function () {
                 'signature_move' => 'Stone Cold Stunner',
             ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Signature Wrestler');
@@ -429,7 +434,7 @@ describe('Main Component Integration', function () {
                     'ended_at' => now()->subYears(3),
                 ]);
 
-            $component = Livewire::test(Main::class);
+            $component = livewire(Main::class);
 
             $component
                 ->assertSee('Veteran Wrestler')

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -62,12 +62,12 @@ expect()->extend('toBeOne', function () {
 |
 */
 
-function administrator()
+function administrator(): User
 {
     return User::factory()->administrator()->create();
 }
 
-function basicUser()
+function basicUser(): User
 {
     return User::factory()->basicUser()->create();
 }

--- a/tests/Unit/Models/Concerns/CanBeManagedTest.php
+++ b/tests/Unit/Models/Concerns/CanBeManagedTest.php
@@ -33,6 +33,7 @@ describe('CanBeManaged Trait Unit Tests', function () {
         test('provides managers relationship', function () {
             $model = new class extends Model implements Manageable
             {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
                 use CanBeManaged;
 
                 public function resolveManagersPivotModel(): string
@@ -46,6 +47,7 @@ describe('CanBeManaged Trait Unit Tests', function () {
         test('provides currentManagers relationship', function () {
             $model = new class extends Model implements Manageable
             {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
                 use CanBeManaged;
 
                 public function resolveManagersPivotModel(): string
@@ -59,6 +61,7 @@ describe('CanBeManaged Trait Unit Tests', function () {
         test('provides previousManagers relationship', function () {
             $model = new class extends Model implements Manageable
             {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
                 use CanBeManaged;
 
                 public function resolveManagersPivotModel(): string
@@ -84,6 +87,7 @@ describe('CanBeManaged Trait Unit Tests', function () {
         test('generates correct pivot table name', function () {
             $model = new class extends Model implements Manageable
             {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
                 use CanBeManaged;
 
                 public function resolveManagersPivotModel(): string
@@ -108,6 +112,7 @@ describe('CanBeManaged Trait Unit Tests', function () {
         test('managers relationship includes pivot data', function () {
             $model = new class extends Model implements Manageable
             {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
                 use CanBeManaged;
 
                 public function resolveManagersPivotModel(): string
@@ -124,6 +129,7 @@ describe('CanBeManaged Trait Unit Tests', function () {
         test('currentManagers relationship includes wherePivotNull constraint', function () {
             $model = new class extends Model implements Manageable
             {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
                 use CanBeManaged;
 
                 public function resolveManagersPivotModel(): string
@@ -138,6 +144,7 @@ describe('CanBeManaged Trait Unit Tests', function () {
         test('previousManagers relationship includes wherePivotNotNull constraint', function () {
             $model = new class extends Model implements Manageable
             {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
                 use CanBeManaged;
 
                 public function resolveManagersPivotModel(): string
@@ -152,6 +159,7 @@ describe('CanBeManaged Trait Unit Tests', function () {
         test('all manager relationships use timestamps', function () {
             $model = new class extends Model implements Manageable
             {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
                 use CanBeManaged;
 
                 public function resolveManagersPivotModel(): string

--- a/tests/Unit/Models/Concerns/CanJoinStablesTest.php
+++ b/tests/Unit/Models/Concerns/CanJoinStablesTest.php
@@ -26,6 +26,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('provides stables relationship', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -39,6 +40,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('provides current stable relationship', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -52,6 +54,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('provides previous stables relationship', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -65,6 +68,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('stables relationship uses the correct related model', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -80,6 +84,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('currentStable relationship uses the correct related model', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -95,6 +100,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('previousStables relationship uses the correct related model', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -112,6 +118,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('resolves to StableMember model by default', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -131,6 +138,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
             $customPivotClass = 'CustomStableMember';
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 protected static ?string $resolvedStablePivotModel = null;
@@ -159,6 +167,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('uses polymorphic stables_members table', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function testGetStablePivotTable(): string
@@ -176,6 +185,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('stables relationship includes pivot data', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -192,6 +202,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('currentStable relationship includes wherePivotNull constraint', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -208,6 +219,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('previousStables relationship includes wherePivot constraints', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string
@@ -224,6 +236,7 @@ describe('CanJoinStables Trait Unit Tests', function () {
         test('all stable relationships use timestamps', function () {
             $model = new class extends Model implements CanBeAStableMember
             {
+                /** @use CanJoinStables<StableWrestler, self> */
                 use CanJoinStables;
 
                 public function resolveStablePivotModel(): string

--- a/tests/Unit/Models/Concerns/CanJoinTagTeamsTest.php
+++ b/tests/Unit/Models/Concerns/CanJoinTagTeamsTest.php
@@ -26,6 +26,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('provides tagTeams relationship', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string
@@ -39,6 +40,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('provides currentTagTeam relationship', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string
@@ -52,6 +54,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('provides previousTagTeams relationship', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string
@@ -65,6 +68,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('provides previousTagTeam relationship', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string
@@ -90,6 +94,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('generates correct pivot table name', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string
@@ -115,6 +120,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('tagTeams relationship includes pivot data', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string
@@ -131,6 +137,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('currentTagTeam relationship includes wherePivotNull constraint', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string
@@ -145,6 +152,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('previousTagTeams relationship includes wherePivotNotNull constraint', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string
@@ -159,6 +167,7 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
         test('all tag team relationships use timestamps', function () {
             $model = new class extends Model implements CanBeATagTeamMember
             {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
                 use CanJoinTagTeams;
 
                 public function resolveTagTeamPivotModel(): string

--- a/tests/Unit/Models/Concerns/IsEmployableTest.php
+++ b/tests/Unit/Models/Concerns/IsEmployableTest.php
@@ -25,11 +25,40 @@ use Mockery;
 use Tests\Unit\Models\Concerns\Support\FakeEmployableModel;
 use Tests\Unit\Models\Concerns\Support\FakeEmploymentModel;
 
+/** @extends EloquentBuilder<FakeEmploymentModel> */
+final class FakeEmploymentBuilder extends EloquentBuilder {}
+
+/** @implements Employable<FakeEmploymentModel, self> */
+final class FutureEmploymentStateModel extends Model implements Employable
+{
+    /** @use IsEmployable<FakeEmploymentModel, self> */
+    use IsEmployable;
+
+    public bool $futureEmploymentExists = false;
+
+    public function resolveEmploymentModelClass(): string
+    {
+        return FakeEmploymentModel::class;
+    }
+
+    /** @return HasOne<FakeEmploymentModel, $this> */
+    public function futureEmployment(): HasOne
+    {
+        $query = Double::for(QueryBuilder::class);
+        $query->expects('exists')->returns($this->futureEmploymentExists);
+        $builder = new FakeEmploymentBuilder($query);
+        $builder->setModel(new FakeEmploymentModel());
+
+        return new HasOne($builder, $this, 'entity_id', 'id');
+    }
+}
+
 describe('IsEmployable Trait Unit Tests', function () {
     describe('employment relationships', function () {
         test('provides employments relationship', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -43,6 +72,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('provides current employment relationship', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -56,6 +86,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('provides future employment relationship', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -69,6 +100,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('provides previous employments relationship', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -82,6 +114,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('provides previous employment relationship', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -95,6 +128,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('provides first employment relationship', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -108,6 +142,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('employments relationship uses the correct related model', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -123,6 +158,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('currentEmployment relationship uses the correct related model', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -140,6 +176,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('can check if model is employed', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -161,6 +198,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('can check if model is not employed', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -182,6 +220,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('can check if model has employments', function () {
             $modelWith = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -199,6 +238,7 @@ describe('IsEmployable Trait Unit Tests', function () {
             };
             $modelWithout = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -219,44 +259,10 @@ describe('IsEmployable Trait Unit Tests', function () {
         });
 
         test('can check if model has future employment', function () {
-            $modelWith = new class extends Model implements Employable
-            {
-                use IsEmployable;
+            $modelWith = new FutureEmploymentStateModel();
+            $modelWith->futureEmploymentExists = true;
+            $modelWithout = new FutureEmploymentStateModel();
 
-                public function resolveEmploymentModelClass(): string
-                {
-                    return FakeEmploymentModel::class;
-                }
-
-                public function futureEmployment(): HasOne
-                {
-                    $query = Double::for(QueryBuilder::class);
-                    $query->expects('exists')->returns(true);
-                    $builder = new EloquentBuilder($query);
-                    $builder->setModel(new FakeEmploymentModel());
-
-                    return new HasOne($builder, $this, 'entity_id', 'id');
-                }
-            };
-            $modelWithout = new class extends Model implements Employable
-            {
-                use IsEmployable;
-
-                public function resolveEmploymentModelClass(): string
-                {
-                    return FakeEmploymentModel::class;
-                }
-
-                public function futureEmployment(): HasOne
-                {
-                    $query = Double::for(QueryBuilder::class);
-                    $query->expects('exists')->returns(false);
-                    $builder = new EloquentBuilder($query);
-                    $builder->setModel(new FakeEmploymentModel());
-
-                    return new HasOne($builder, $this, 'entity_id', 'id');
-                }
-            };
             expect($modelWith->hasFutureEmployment())->toBeTrue();
             expect($modelWithout->hasFutureEmployment())->toBeFalse();
         });
@@ -264,6 +270,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('can check if model has employment history', function () {
             $modelWith = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -281,6 +288,7 @@ describe('IsEmployable Trait Unit Tests', function () {
             };
             $modelWithout = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -313,6 +321,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('current employment query includes whereNull ended_at', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -331,6 +340,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('future employment query includes whereNull ended_at and started_at > now', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -353,6 +363,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('previous employments query includes whereNotNull ended_at', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -371,6 +382,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('previous employment query includes ofMany constraint', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string
@@ -387,6 +399,7 @@ describe('IsEmployable Trait Unit Tests', function () {
         test('first employment query includes ofMany constraint', function () {
             $model = new class extends Model implements Employable
             {
+                /** @use IsEmployable<FakeEmploymentModel, self> */
                 use IsEmployable;
 
                 public function resolveEmploymentModelClass(): string

--- a/tests/Unit/Models/Concerns/IsInjurableTest.php
+++ b/tests/Unit/Models/Concerns/IsInjurableTest.php
@@ -27,6 +27,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('provides injuries relationship', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -41,6 +42,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('provides current injury relationship', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -55,6 +57,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('provides previous injuries relationship', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -69,6 +72,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('provides previous injury relationship', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -83,6 +87,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('injuries relationship uses the correct related model', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -98,6 +103,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('currentInjury relationship uses the correct related model', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -115,6 +121,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('can check if model is injured', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -137,6 +144,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('can check if model is not injured', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -159,6 +167,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('can check if model has injuries', function () {
             $modelWithInjuries = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -177,6 +186,7 @@ describe('IsInjurable Trait Unit Tests', function () {
 
             $modelWithoutInjuries = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -202,6 +212,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('uses the model-specific injury resolver', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 protected function resolveInjuryModelClass(): string
@@ -216,6 +227,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('throws if related model does not exist', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
             };
 
@@ -227,6 +239,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('current injury query includes whereNull ended_at', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -244,6 +257,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('previous injuries query includes whereNotNull ended_at', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string
@@ -261,6 +275,7 @@ describe('IsInjurable Trait Unit Tests', function () {
         test('previous injury query includes ofMany constraint', function () {
             $model = new class extends Model implements Injurable
             {
+                /** @use IsInjurable<FakeInjuryModel, self> */
                 use IsInjurable;
 
                 public function resolveInjuryModelClass(): string

--- a/tests/Unit/Models/Concerns/IsRetirableTest.php
+++ b/tests/Unit/Models/Concerns/IsRetirableTest.php
@@ -29,6 +29,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('provides retirements relationship', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -42,6 +43,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('provides current retirement relationship', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -55,6 +57,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('provides previous retirements relationship', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -68,6 +71,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('provides previous retirement relationship', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -81,6 +85,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('retirements relationship uses the correct related model', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -96,6 +101,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('currentRetirement relationship uses the correct related model', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -113,6 +119,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('can check if model is retired', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -134,6 +141,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('can check if model is not retired', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -155,6 +163,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('can check if model has retirements', function () {
             $modelWith = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -172,6 +181,7 @@ describe('IsRetirable Trait Unit Tests', function () {
             };
             $modelWithout = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -204,6 +214,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('current retirement query includes whereNull ended_at', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -222,6 +233,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('previous retirements query includes whereNotNull ended_at', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -240,6 +252,7 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('previous retirement query includes ofMany constraint', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
                 public function resolveRetirementModelClass(): string
@@ -258,9 +271,10 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('can check if model can be retired', function () {
             $employedModel = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
-                public $status = EmploymentStatus::Employed;
+                public EmploymentStatus $status = EmploymentStatus::Employed;
 
                 public function canBeRetired(): bool
                 {
@@ -270,9 +284,10 @@ describe('IsRetirable Trait Unit Tests', function () {
 
             $retiredModel = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
-                public $status = EmploymentStatus::Retired;
+                public EmploymentStatus $status = EmploymentStatus::Retired;
 
                 public function canBeRetired(): bool
                 {
@@ -287,9 +302,10 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('can check if model can be unretired', function () {
             $retiredModel = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
-                public $status = EmploymentStatus::Retired;
+                public EmploymentStatus $status = EmploymentStatus::Retired;
 
                 public function canBeUnretired(): bool
                 {
@@ -299,9 +315,10 @@ describe('IsRetirable Trait Unit Tests', function () {
 
             $employedModel = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
-                public $status = EmploymentStatus::Employed;
+                public EmploymentStatus $status = EmploymentStatus::Employed;
 
                 public function canBeUnretired(): bool
                 {
@@ -316,9 +333,10 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('can ensure model can be retired', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
-                public $status = EmploymentStatus::Employed;
+                public EmploymentStatus $status = EmploymentStatus::Employed;
 
                 public function canBeRetired(): bool
                 {
@@ -339,9 +357,10 @@ describe('IsRetirable Trait Unit Tests', function () {
         test('can ensure model can be unretired', function () {
             $model = new class extends Model implements Retirable
             {
+                /** @use IsRetirable<FakeRetirementModel, self> */
                 use IsRetirable;
 
-                public $status = EmploymentStatus::Retired;
+                public EmploymentStatus $status = EmploymentStatus::Retired;
 
                 public function canBeUnretired(): bool
                 {

--- a/tests/Unit/Models/Concerns/IsSuspendableTest.php
+++ b/tests/Unit/Models/Concerns/IsSuspendableTest.php
@@ -27,6 +27,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('provides suspensions relationship', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -40,6 +41,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('provides current suspension relationship', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -53,6 +55,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('provides previous suspensions relationship', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -66,6 +69,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('provides previous suspension relationship', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -79,6 +83,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('suspensions relationship uses the correct related model', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -94,6 +99,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('currentSuspension relationship uses the correct related model', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -111,6 +117,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('can check if model is suspended', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -132,6 +139,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('can check if model is not suspended', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -153,6 +161,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('can check if model has suspensions', function () {
             $modelWith = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -170,6 +179,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
             };
             $modelWithout = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string
@@ -202,6 +212,7 @@ describe('IsSuspendable Trait Unit Tests', function () {
         test('current suspension query includes whereNull ended_at', function () {
             $model = new class extends Model implements Suspendable
             {
+                /** @use IsSuspendable<FakeSuspensionModel, self> */
                 use IsSuspendable;
 
                 public function resolveSuspensionModelClass(): string

--- a/tests/Unit/Models/Concerns/ProvidesDisplayNameTest.php
+++ b/tests/Unit/Models/Concerns/ProvidesDisplayNameTest.php
@@ -25,7 +25,7 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $name = 'Test Name';
+                public ?string $name = 'Test Name';
             };
             expect($model->getDisplayName())->toBe('Test Name');
         });
@@ -35,7 +35,7 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $full_name = 'Full Test Name';
+                public ?string $full_name = 'Full Test Name';
             };
             expect($model->getDisplayName())->toBe('Full Test Name');
         });
@@ -45,9 +45,9 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $first_name = 'John';
+                public ?string $first_name = 'John';
 
-                public $last_name = 'Doe';
+                public ?string $last_name = 'Doe';
             };
             expect($model->getDisplayName())->toBe('John Doe');
         });
@@ -57,9 +57,9 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $first_name = '';
+                public ?string $first_name = '';
 
-                public $last_name = '';
+                public ?string $last_name = '';
             };
             expect($model->getDisplayName())->toBe('');
         });
@@ -79,7 +79,7 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $name = 'Test Name';
+                public ?string $name = 'Test Name';
             };
             expect($model->displayName())->toBeInstanceOf(Attribute::class);
         });
@@ -89,7 +89,7 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $name = 'Test Name';
+                public ?string $name = 'Test Name';
             };
             expect($model->displayName())->toBeInstanceOf(Attribute::class);
         });
@@ -101,9 +101,9 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $name = 'Primary Name';
+                public ?string $name = 'Primary Name';
 
-                public $full_name = 'Secondary Name';
+                public ?string $full_name = 'Secondary Name';
             };
             expect($model->getDisplayName())->toBe('Primary Name');
         });
@@ -113,11 +113,11 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $name = 'Primary Name';
+                public ?string $name = 'Primary Name';
 
-                public $first_name = 'John';
+                public ?string $first_name = 'John';
 
-                public $last_name = 'Doe';
+                public ?string $last_name = 'Doe';
             };
             expect($model->getDisplayName())->toBe('Primary Name');
         });
@@ -127,11 +127,11 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $full_name = 'Secondary Name';
+                public ?string $full_name = 'Secondary Name';
 
-                public $first_name = 'John';
+                public ?string $first_name = 'John';
 
-                public $last_name = 'Doe';
+                public ?string $last_name = 'Doe';
             };
             expect($model->getDisplayName())->toBe('Secondary Name');
         });
@@ -143,7 +143,7 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $name = 'Test';
+                public ?string $name = 'Test';
             };
             expect($model->name)->toBe('Test');
         });
@@ -153,7 +153,7 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $full_name = 'Test';
+                public ?string $full_name = 'Test';
             };
             expect($model->full_name)->toBe('Test');
         });
@@ -163,9 +163,9 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $first_name = 'John';
+                public ?string $first_name = 'John';
 
-                public $last_name = 'Doe';
+                public ?string $last_name = 'Doe';
             };
             expect([$model->first_name, $model->last_name])->toBe(['John', 'Doe']);
         });
@@ -185,13 +185,13 @@ describe('ProvidesDisplayName Trait Unit Tests', function () {
             {
                 use ProvidesDisplayName;
 
-                public $name = null;
+                public ?string $name = null;
 
-                public $full_name = null;
+                public ?string $full_name = null;
 
-                public $first_name = null;
+                public ?string $first_name = null;
 
-                public $last_name = null;
+                public ?string $last_name = null;
             };
             expect(fn () => $model->getDisplayName())->toThrow(LogicException::class);
         });

--- a/tests/Unit/Models/Concerns/Support/FakeEmployableModel.php
+++ b/tests/Unit/Models/Concerns/Support/FakeEmployableModel.php
@@ -13,11 +13,14 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Fake employable model for testing IsEmployable trait in isolation.
  * This ensures trait tests are not coupled to real business models.
+ *
+ * @implements Employable<FakeEmploymentModel, self>
  */
 #[Table('fake_employables')]
 #[Fillable('name')]
 class FakeEmployableModel extends Model implements Employable
 {
+    /** @use IsEmployable<FakeEmploymentModel, self> */
     use IsEmployable;
 
     protected function resolveEmploymentModelClass(): string

--- a/tests/Unit/Models/Concerns/Support/FakeManageableModel.php
+++ b/tests/Unit/Models/Concerns/Support/FakeManageableModel.php
@@ -12,11 +12,14 @@ use Illuminate\Database\Eloquent\Model;
 
 /**
  * Fake model for testing CanBeManaged trait in isolation.
+ *
+ * @implements Manageable<FakeManagerPivotModel, self>
  */
 #[Table('fake_manageable_models')]
 #[Fillable('name')]
 class FakeManageableModel extends Model implements Manageable
 {
+    /** @use CanBeManaged<FakeManagerPivotModel, self> */
     use CanBeManaged;
 
     public function resolveManagersPivotModel(): string

--- a/tests/Unit/Models/Concerns/Support/FakeRetirableModel.php
+++ b/tests/Unit/Models/Concerns/Support/FakeRetirableModel.php
@@ -13,11 +13,14 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Fake retirable model for testing IsRetirable trait in isolation.
  * This ensures trait tests are not coupled to real business models.
+ *
+ * @implements Retirable<FakeRetirementModel, self>
  */
 #[Table('fake_retirables')]
 #[Fillable('name')]
 class FakeRetirableModel extends Model implements Retirable
 {
+    /** @use IsRetirable<FakeRetirementModel, self> */
     use IsRetirable;
 
     protected function resolveRetirementModelClass(): string

--- a/tests/Unit/Models/Concerns/Support/FakeSuspendableModel.php
+++ b/tests/Unit/Models/Concerns/Support/FakeSuspendableModel.php
@@ -13,11 +13,14 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Fake suspendable model for testing IsSuspendable trait in isolation.
  * This ensures trait tests are not coupled to real business models.
+ *
+ * @implements Suspendable<FakeSuspensionModel, self>
  */
 #[Table('fake_suspendables')]
 #[Fillable('name')]
 class FakeSuspendableModel extends Model implements Suspendable
 {
+    /** @use IsSuspendable<FakeSuspensionModel, self> */
     use IsSuspendable;
 
     protected function resolveSuspensionModelClass(): string

--- a/tests/Unit/Models/Concerns/Support/FakeTagTeamMemberModel.php
+++ b/tests/Unit/Models/Concerns/Support/FakeTagTeamMemberModel.php
@@ -13,11 +13,14 @@ use Illuminate\Database\Eloquent\Model;
 /**
  * Fake model for testing CanJoinTagTeams trait in isolation.
  * This ensures trait tests are not coupled to real business models.
+ *
+ * @implements CanBeATagTeamMember<FakeTagTeamPivotModel, self>
  */
 #[Table('fake_tag_team_members')]
 #[Fillable('name')]
 class FakeTagTeamMemberModel extends Model implements CanBeATagTeamMember
 {
+    /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
     use CanJoinTagTeams;
 
     /**

--- a/tests/Unit/Policies/PolicyBeforeHookTest.php
+++ b/tests/Unit/Policies/PolicyBeforeHookTest.php
@@ -72,6 +72,8 @@ describe('Policy Before Hook Pattern', function () {
 
 /**
  * Helper function to get public policy methods excluding 'before' and magic methods.
+ *
+ * @return array<int, string>
  */
 function getPublicPolicyMethods(object $policy): array
 {

--- a/tests/Unit/Rules/Shared/CanChangeDebutDateUnitTest.php
+++ b/tests/Unit/Rules/Shared/CanChangeDebutDateUnitTest.php
@@ -57,12 +57,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -93,12 +93,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return true;
                 }
@@ -228,17 +228,17 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
 
-                public function getDisplayName()
+                public function getDisplayName(): string
                 {
                     return 'Custom Display Name';
                 }
@@ -266,12 +266,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -299,12 +299,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -334,12 +334,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -367,12 +367,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -458,12 +458,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model1 = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -475,12 +475,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             };
             $model2 = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -506,12 +506,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -564,12 +564,12 @@ describe('CanChangeDebutDate Validation Rule Unit Tests', function () {
             // Arrange - Model is active AND was not active on target date (both conditions true for failure)
             $model = new class extends Model
             {
-                public function isCurrentlyActive()
+                public function isCurrentlyActive(): bool
                 {
                     return true;
                 }
 
-                public function wasActiveOn($date = null)
+                public function wasActiveOn(Carbon $date): bool
                 {
                     return false;
                 }

--- a/tests/Unit/Rules/Shared/CanChangeEmploymentDateUnitTest.php
+++ b/tests/Unit/Rules/Shared/CanChangeEmploymentDateUnitTest.php
@@ -52,12 +52,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -89,12 +89,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return true;
                 }
@@ -182,12 +182,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -215,12 +215,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -250,12 +250,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -283,12 +283,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -374,12 +374,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             // Arrange
             $model1 = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -391,12 +391,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             };
             $model2 = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return false;
                 }
@@ -422,12 +422,12 @@ describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
             // Arrange
             $model = new class extends Model
             {
-                public function isEmployed()
+                public function isEmployed(): bool
                 {
                     return true;
                 }
 
-                public function employedOn($date = null)
+                public function employedOn(Carbon $date): bool
                 {
                     return false;
                 }


### PR DESCRIPTION
## Summary

- raise Pest PHPStan analysis from level 5 to level 6
- migrate Livewire tests to the Pest Laravel and Livewire helpers so component generics resolve correctly
- add precise types and generics to shared helpers, isolated trait fixtures, and validation-rule doubles
- keep the existing TestDouble dependency for typed test doubles

## Verification

- `composer test:types`
- `composer test:rector`
- `vendor/bin/pint --blade --test tests`
- `php -d memory_limit=4G ./vendor/bin/pest --parallel` — 3,499 tests passed, 11,158 assertions
- type coverage passed as part of `composer test:push`

## Note

The repository-wide `composer test:push` reaches unrelated pre-existing Blade formatting findings under `resources/views`. Those files are outside this PR and were not modified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Quality Improvements**
  * Increased static analysis strictness to improve code reliability.
  * Added stronger type information across test helpers and scenarios.

* **Tests**
  * Modernized component and authentication test setup.
  * Preserved existing authorization, workflow, validation, and business-rule coverage.
  * Improved validation-rule checks and reusable test coverage for employment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->