### PR TITLE
test: raise Pest PHPStan to level 7

### DIFF
--- a/phpstan-pest.neon
+++ b/phpstan-pest.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 6
+  level: 7
 
   paths:
     - tests

--- a/tests/Helpers/StatusTestExpectations.php
+++ b/tests/Helpers/StatusTestExpectations.php
@@ -221,7 +221,7 @@ function expectCurrentRelationshipsActive(Wrestler $wrestler): void
 
     $currentTagTeam = $wrestler->currentTagTeam;
     if ($currentTagTeam) {
-        expect($currentTagTeam->pivot->left_at)->toBeNull();
+        expect(relatedPivotAttribute($currentTagTeam, 'left_at'))->toBeNull();
     }
 }
 
@@ -237,7 +237,7 @@ function expectPreviousRelationshipsEnded(Wrestler $wrestler): void
 
     $previousTagTeams = $wrestler->previousTagTeams()->get();
     foreach ($previousTagTeams as $tagTeam) {
-        expect($tagTeam->pivot->left_at)->not->toBeNull();
+        expect(relatedPivotAttribute($tagTeam, 'left_at'))->not->toBeNull();
     }
 }
 

--- a/tests/Integration/Actions/Events/LifecycleTest.php
+++ b/tests/Integration/Actions/Events/LifecycleTest.php
@@ -282,7 +282,7 @@ describe('Event Activation Action Integration', function () {
             expect(Event::find($event->id))->toBeNull();
 
             RestoreAction::run($event);
-            $restoredEvent = Event::find($event->id);
+            $restoredEvent = Event::query()->whereKey($event->getKey())->firstOrFail();
             expect($restoredEvent->name)->toBe('Final Event Name');
             expect($restoredEvent->isScheduled())->toBeTrue();
         });
@@ -497,7 +497,7 @@ describe('Event Activation Action Integration', function () {
             DeleteAction::run($event);
             RestoreAction::run($event);
 
-            $restoredEvent = Event::find($event->id);
+            $restoredEvent = Event::query()->whereKey($event->getKey())->firstOrFail();
             expect($restoredEvent->name)->toBe($originalState['name']);
             expect($restoredEvent->date->format('Y-m-d H:i:s'))->toBe($originalState['date']->format('Y-m-d H:i:s'));
             expect($restoredEvent->venue_id)->toBe($originalState['venue_id']);

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -63,8 +63,7 @@ describe('Venue Action Integration Tests', function () {
 
             $venue = CreateAction::run($venueData);
 
-            $retrievedVenue = Venue::find($venue->id);
-            expect($retrievedVenue)->not()->toBeNull();
+            $retrievedVenue = Venue::query()->whereKey($venue->getKey())->firstOrFail();
             expect($retrievedVenue->name)->toBe('Database Test Arena');
             expect($retrievedVenue->street_address)->toBe('456 Database Lane');
             expect($retrievedVenue->city)->toBe('Database City');

--- a/tests/Integration/Livewire/Users/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Users/Tables/MainTest.php
@@ -242,6 +242,14 @@ describe('UsersTable Component', function () {
             $bakerPos = mb_strpos($html, 'Baker');
             $cooperPos = mb_strpos($html, 'Cooper');
 
+            expect($andersonPos)->not->toBeFalse();
+            expect($bakerPos)->not->toBeFalse();
+            expect($cooperPos)->not->toBeFalse();
+
+            if ($andersonPos === false || $bakerPos === false || $cooperPos === false) {
+                return;
+            }
+
             expect($andersonPos)->toBeLessThan($bakerPos);
             expect($bakerPos)->toBeLessThan($cooperPos);
         });

--- a/tests/Integration/Models/TagTeams/TagTeamWrestlerTest.php
+++ b/tests/Integration/Models/TagTeams/TagTeamWrestlerTest.php
@@ -118,7 +118,7 @@ describe('TagTeamWrestler Pivot Model', function () {
             // Verify current tag team is correct
             $currentTagTeam = $this->wrestler->currentTagTeam;
             expect($currentTagTeam->id)->toBe($this->secondTagTeam->id);
-            expect($currentTagTeam->pivot->left_at)->toBeNull();
+            expect(relatedPivotAttribute($currentTagTeam, 'left_at'))->toBeNull();
 
             // Verify previous tag team is correct
             $previousTagTeam = $this->wrestler->previousTagTeams()->first();
@@ -186,7 +186,7 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             expect($currentTagTeam)->not()->toBeNull();
             expect($currentTagTeam->id)->toBe($this->secondTagTeam->id);
-            expect($currentTagTeam->pivot->left_at)->toBeNull();
+            expect(relatedPivotAttribute($currentTagTeam, 'left_at'))->toBeNull();
         });
 
         test('previous tag teams query returns only completed relationships', function () {
@@ -194,7 +194,7 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             expect($previousTagTeams)->toHaveCount(1);
             expect($previousTagTeams->first()->id)->toBe($this->tagTeam->id);
-            expect($previousTagTeams->first()->pivot->left_at)->not()->toBeNull();
+            expect(relatedPivotAttribute($previousTagTeams->first(), 'left_at'))->not()->toBeNull();
         });
 
         test('all tag teams query returns complete relationship history', function () {
@@ -397,12 +397,15 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             // Calculate duration of completed period
             $completedPeriod = $this->wrestler->previousTagTeams()->first();
-            $duration = $completedPeriod->pivot->joined_at->diffInDays($completedPeriod->pivot->left_at);
+            $joinedAt = Carbon::parse(relatedPivotAttribute($completedPeriod, 'joined_at'));
+            $leftAt = Carbon::parse(relatedPivotAttribute($completedPeriod, 'left_at'));
+            $duration = $joinedAt->diffInDays($leftAt);
             expect($duration)->toBeGreaterThan(150); // Approximately 6 months
 
             // Calculate duration of current period
             $currentPeriod = $this->wrestler->currentTagTeam;
-            $currentDuration = $currentPeriod->pivot->joined_at->diffInDays(Carbon::now());
+            $currentJoinedAt = Carbon::parse(relatedPivotAttribute($currentPeriod, 'joined_at'));
+            $currentDuration = $currentJoinedAt->diffInDays(Carbon::now());
             expect($currentDuration)->toBeGreaterThan(80); // Approximately 3 months
         });
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -84,6 +84,28 @@ function validationFailureCallback(Closure $observer): Closure
     };
 }
 
+/**
+ * Read the source file represented by a reflection class.
+ *
+ * @template T of object
+ *
+ * @param  ReflectionClass<T>  $reflection
+ */
+function reflectionSource(ReflectionClass $reflection): string
+{
+    $filename = $reflection->getFileName();
+    if ($filename === false) {
+        throw new RuntimeException("Unable to resolve the source file for {$reflection->getName()}.");
+    }
+
+    $source = file_get_contents($filename);
+    if ($source === false) {
+        throw new RuntimeException("Unable to read source file {$filename}.");
+    }
+
+    return $source;
+}
+
 /*
 |--------------------------------------------------------------------------
 | Custom Test Helpers

--- a/tests/Unit/Livewire/Concerns/BaseModalTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseModalTest.php
@@ -180,7 +180,7 @@ describe('BaseModal Unit Tests', function () {
     describe('dependency imports', function () {
         test('imports required dependencies', function () {
             $reflection = new ReflectionClass(BaseModal::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for actual imports in BaseModal
             expect($source)->toContain('use Exception;');

--- a/tests/Unit/Livewire/Concerns/BaseTableTraitTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseTableTraitTest.php
@@ -130,7 +130,7 @@ describe('BaseTableTrait Unit Tests', function () {
     describe('dependency imports', function () {
         test('imports required dependencies', function () {
             $reflection = new ReflectionClass(BaseTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('use App\\Livewire\\Concerns\\Columns\\HasActionColumn;');
             expect($source)->toContain('use App\\Livewire\\Table\\Column;');
@@ -140,7 +140,7 @@ describe('BaseTableTrait Unit Tests', function () {
     describe('method implementation structure', function () {
         test('configuringBaseTableTrait contains expected method calls', function () {
             $reflection = new ReflectionClass(BaseTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for expected configuration calls
             expect($source)->toContain('->setPrimaryKey(\'id\')');
@@ -153,7 +153,7 @@ describe('BaseTableTrait Unit Tests', function () {
 
         test('appendColumns method structure', function () {
             $reflection = new ReflectionClass(BaseTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for conditional action column logic
             expect($source)->toContain('$this->showActionColumn');
@@ -164,14 +164,14 @@ describe('BaseTableTrait Unit Tests', function () {
     describe('laravel livewire tables integration', function () {
         test('uses application Livewire table components', function () {
             $reflection = new ReflectionClass(BaseTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('App\\Livewire\\Table\\Column');
         });
 
         test('follows Laravel Livewire Tables patterns', function () {
             $reflection = new ReflectionClass(BaseTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for standard table configuration patterns
             expect($source)->toContain('configuringBaseTableTrait');

--- a/tests/Unit/Livewire/Concerns/Columns/HasActionColumnTest.php
+++ b/tests/Unit/Livewire/Concerns/Columns/HasActionColumnTest.php
@@ -68,7 +68,7 @@ describe('HasActionColumn Unit Tests', function () {
     describe('dependency imports', function () {
         test('imports Column class', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('use App\\Livewire\\Table\\Column;');
         });
@@ -77,7 +77,7 @@ describe('HasActionColumn Unit Tests', function () {
     describe('method implementation structure', function () {
         test('getDefaultActionColumn creates proper column', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for expected implementation details
             expect($source)->toContain('Column::make(__');
@@ -88,7 +88,7 @@ describe('HasActionColumn Unit Tests', function () {
 
         test('uses view component for action column', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for view component usage
             expect($source)->toContain('view(\'components.tables.columns.action-column\'');
@@ -100,7 +100,7 @@ describe('HasActionColumn Unit Tests', function () {
     describe('trait dependencies', function () {
         test('expects routeBasePath property', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for property references
             expect($source)->toContain('$this->routeBasePath');
@@ -108,7 +108,7 @@ describe('HasActionColumn Unit Tests', function () {
 
         test('expects row object with id property', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for row id reference
             expect($source)->toContain('$row->id');
@@ -176,7 +176,7 @@ describe('HasActionColumn Unit Tests', function () {
     describe('laravel livewire tables integration', function () {
         test('uses Column factory method', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for Column::make usage
             expect($source)->toContain('Column::make(');
@@ -184,7 +184,7 @@ describe('HasActionColumn Unit Tests', function () {
 
         test('uses internationalization for actions', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for translation key
             expect($source)->toContain('__');
@@ -193,7 +193,7 @@ describe('HasActionColumn Unit Tests', function () {
 
         test('configures column properly', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for proper column configuration
             expect($source)->toContain('->label(');
@@ -205,7 +205,7 @@ describe('HasActionColumn Unit Tests', function () {
     describe('column configuration pattern', function () {
         test('uses closure for label generation', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for closure pattern
             expect($source)->toContain('fn ($row, Column $column)');
@@ -213,7 +213,7 @@ describe('HasActionColumn Unit Tests', function () {
 
         test('excludes from column selection', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for exclusion from selection
             expect($source)->toContain('excludeFromColumnSelect()');
@@ -221,7 +221,7 @@ describe('HasActionColumn Unit Tests', function () {
 
         test('enables HTML rendering', function () {
             $reflection = new ReflectionClass(HasActionColumn::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for HTML enabled
             expect($source)->toContain('->html()');

--- a/tests/Unit/Livewire/Concerns/Data/PresentsManagersListTest.php
+++ b/tests/Unit/Livewire/Concerns/Data/PresentsManagersListTest.php
@@ -67,7 +67,7 @@ describe('PresentsManagersList Unit Tests', function () {
     describe('computed attribute configuration', function () {
         test('Computed attribute has correct parameters', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for Computed attribute configuration
             expect($source)->toContain('#[Computed(cache: true, key: \'managers-list\', seconds: 180)]');
@@ -89,14 +89,14 @@ describe('PresentsManagersList Unit Tests', function () {
     describe('dependency imports', function () {
         test('imports Manager model', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('use App\\Models\\Managers\\Manager;');
         });
 
         test('imports Computed attribute', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('use Livewire\\Attributes\\Computed;');
         });
@@ -105,7 +105,7 @@ describe('PresentsManagersList Unit Tests', function () {
     describe('method implementation structure', function () {
         test('getManagers uses correct query structure', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for expected query implementation
             expect($source)->toContain('Manager::select(\'id\', \'full_name\')');
@@ -183,7 +183,7 @@ describe('PresentsManagersList Unit Tests', function () {
 
         test('enables caching for performance', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for cache enabled
             expect($source)->toContain('cache: true');
@@ -191,7 +191,7 @@ describe('PresentsManagersList Unit Tests', function () {
 
         test('uses descriptive cache key', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for meaningful cache key
             expect($source)->toContain('key: \'managers-list\'');
@@ -201,7 +201,7 @@ describe('PresentsManagersList Unit Tests', function () {
     describe('query optimization', function () {
         test('selects only required fields', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for field selection optimization
             expect($source)->toContain('select(\'id\', \'full_name\')');
@@ -209,7 +209,7 @@ describe('PresentsManagersList Unit Tests', function () {
 
         test('uses efficient pluck method', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for pluck usage
             expect($source)->toContain('pluck(\'full_name\', \'id\')');

--- a/tests/Unit/Livewire/Concerns/Data/PresentsTitlesListTest.php
+++ b/tests/Unit/Livewire/Concerns/Data/PresentsTitlesListTest.php
@@ -71,14 +71,14 @@ describe('PresentsTitlesList Unit Tests', function () {
     describe('dependency imports', function () {
         test('imports Title model', function () {
             $reflection = new ReflectionClass(PresentsTitlesList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('use App\\Models\\Titles\\Title;');
         });
 
         test('imports Computed attribute', function () {
             $reflection = new ReflectionClass(PresentsTitlesList::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('use Livewire\\Attributes\\Computed;');
         });

--- a/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
+++ b/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
@@ -181,7 +181,7 @@ describe('GeneratesDummyData Unit Tests', function () {
     describe('dependency imports', function () {
         test('imports Throwable', function () {
             $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('use Throwable;');
         });
@@ -263,7 +263,7 @@ describe('GeneratesDummyData Unit Tests', function () {
     describe('population strategy pattern', function () {
         test('implements multiple population strategies', function () {
             $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for strategy pattern implementation
             expect($source)->toContain('tryPopulateModelForm');
@@ -273,7 +273,7 @@ describe('GeneratesDummyData Unit Tests', function () {
 
         test('uses graceful degradation', function () {
             $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for graceful failure handling
             expect($source)->toContain('// If none work, silently skip');

--- a/tests/Unit/Livewire/Concerns/ManagesActivityPeriodsTest.php
+++ b/tests/Unit/Livewire/Concerns/ManagesActivityPeriodsTest.php
@@ -83,7 +83,7 @@ describe('ManagesActivityPeriods Unit Tests', function () {
     describe('dependency imports', function () {
         test('imports QueryException', function () {
             $reflection = new ReflectionClass(ManagesActivityPeriods::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             expect($source)->toContain('use Illuminate\\Database\\QueryException;');
         });
@@ -92,7 +92,7 @@ describe('ManagesActivityPeriods Unit Tests', function () {
     describe('method implementation structure', function () {
         test('handleActivityPeriodCreation contains expected logic', function () {
             $reflection = new ReflectionClass(ManagesActivityPeriods::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for expected implementation details
             expect($source)->toContain('if (! empty($this->start_date))');
@@ -104,7 +104,7 @@ describe('ManagesActivityPeriods Unit Tests', function () {
     describe('trait dependencies', function () {
         test('expects start_date property', function () {
             $reflection = new ReflectionClass(ManagesActivityPeriods::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for property references
             expect($source)->toContain('$this->start_date');
@@ -112,7 +112,7 @@ describe('ManagesActivityPeriods Unit Tests', function () {
 
         test('expects formModel property', function () {
             $reflection = new ReflectionClass(ManagesActivityPeriods::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for formModel reference
             expect($source)->toContain('$this->formModel');
@@ -180,7 +180,7 @@ describe('ManagesActivityPeriods Unit Tests', function () {
     describe('activity period creation pattern', function () {
         test('uses conditional activity period creation', function () {
             $reflection = new ReflectionClass(ManagesActivityPeriods::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for conditional creation pattern
             expect($source)->toContain('if (! empty($this->start_date))');
@@ -188,7 +188,7 @@ describe('ManagesActivityPeriods Unit Tests', function () {
 
         test('creates activity period with started_at field', function () {
             $reflection = new ReflectionClass(ManagesActivityPeriods::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for correct field mapping
             expect($source)->toContain('\'started_at\' => $this->start_date');
@@ -196,7 +196,7 @@ describe('ManagesActivityPeriods Unit Tests', function () {
 
         test('uses activityPeriods relationship', function () {
             $reflection = new ReflectionClass(ManagesActivityPeriods::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for correct relationship usage
             expect($source)->toContain('$this->formModel->activityPeriods()');

--- a/tests/Unit/Livewire/Concerns/ManagesEmploymentTest.php
+++ b/tests/Unit/Livewire/Concerns/ManagesEmploymentTest.php
@@ -58,7 +58,7 @@ describe('ManagesEmployment Unit Tests', function () {
     describe('method implementation structure', function () {
         test('handleEmploymentCreation contains expected logic', function () {
             $reflection = new ReflectionClass(ManagesEmployment::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for expected implementation details
             expect($source)->toContain('if (! empty($this->employment_date))');
@@ -70,7 +70,7 @@ describe('ManagesEmployment Unit Tests', function () {
     describe('trait dependencies', function () {
         test('expects employment_date property', function () {
             $reflection = new ReflectionClass(ManagesEmployment::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for property references
             expect($source)->toContain('$this->employment_date');
@@ -78,7 +78,7 @@ describe('ManagesEmployment Unit Tests', function () {
 
         test('expects formModel property', function () {
             $reflection = new ReflectionClass(ManagesEmployment::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for formModel reference
             expect($source)->toContain('$this->formModel');
@@ -146,7 +146,7 @@ describe('ManagesEmployment Unit Tests', function () {
     describe('employment creation pattern', function () {
         test('uses conditional employment creation', function () {
             $reflection = new ReflectionClass(ManagesEmployment::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for conditional creation pattern
             expect($source)->toContain('if (! empty($this->employment_date))');
@@ -154,7 +154,7 @@ describe('ManagesEmployment Unit Tests', function () {
 
         test('creates employment with started_at field', function () {
             $reflection = new ReflectionClass(ManagesEmployment::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for correct field mapping
             expect($source)->toContain('\'started_at\' => $this->employment_date');

--- a/tests/Unit/Livewire/Concerns/ShowTableTraitTest.php
+++ b/tests/Unit/Livewire/Concerns/ShowTableTraitTest.php
@@ -58,7 +58,7 @@ describe('ShowTableTrait Unit Tests', function () {
     describe('method implementation structure', function () {
         test('configuringShowTableTrait contains expected method calls', function () {
             $reflection = new ReflectionClass(ShowTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for expected configuration calls
             expect($source)->toContain('->setPrimaryKey(\'id\')');
@@ -75,7 +75,7 @@ describe('ShowTableTrait Unit Tests', function () {
     describe('configuration pattern', function () {
         test('uses fluent interface pattern', function () {
             $reflection = new ReflectionClass(ShowTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for method chaining pattern
             expect($source)->toContain('$this->setPrimaryKey(\'id\')');
@@ -86,7 +86,7 @@ describe('ShowTableTrait Unit Tests', function () {
 
         test('references expected properties', function () {
             $reflection = new ReflectionClass(ShowTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for property references
             expect($source)->toContain('$this->resourceName');
@@ -97,7 +97,7 @@ describe('ShowTableTrait Unit Tests', function () {
     describe('laravel livewire tables integration', function () {
         test('follows Laravel Livewire Tables configuration pattern', function () {
             $reflection = new ReflectionClass(ShowTableTrait::class);
-            $source = file_get_contents($reflection->getFileName());
+            $source = reflectionSource($reflection);
 
             // Check for standard table configuration methods
             expect($source)->toContain('setPrimaryKey');

--- a/tests/Unit/Models/Concerns/IsEmployableTest.php
+++ b/tests/Unit/Models/Concerns/IsEmployableTest.php
@@ -21,7 +21,6 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use JMac\Testing\Double;
-use Mockery;
 use Tests\Unit\Models\Concerns\Support\FakeEmployableModel;
 use Tests\Unit\Models\Concerns\Support\FakeEmploymentModel;
 
@@ -29,27 +28,58 @@ use Tests\Unit\Models\Concerns\Support\FakeEmploymentModel;
 final class FakeEmploymentBuilder extends EloquentBuilder {}
 
 /** @implements Employable<FakeEmploymentModel, self> */
-final class FutureEmploymentStateModel extends Model implements Employable
+final class EmploymentStateModel extends Model implements Employable
 {
     /** @use IsEmployable<FakeEmploymentModel, self> */
     use IsEmployable;
 
     public bool $futureEmploymentExists = false;
 
+    public bool $currentEmploymentExists = false;
+
+    public bool $employmentExists = false;
+
     public function resolveEmploymentModelClass(): string
     {
         return FakeEmploymentModel::class;
     }
 
-    /** @return HasOne<FakeEmploymentModel, $this> */
+    /** @return HasOne<FakeEmploymentModel, self> */
     public function futureEmployment(): HasOne
     {
+        return $this->employmentHasOne($this->futureEmploymentExists);
+    }
+
+    /** @return HasOne<FakeEmploymentModel, self> */
+    public function currentEmployment(): HasOne
+    {
+        return $this->employmentHasOne($this->currentEmploymentExists);
+    }
+
+    /** @return HasMany<FakeEmploymentModel, self> */
+    public function employments(): HasMany
+    {
+        $builder = $this->employmentBuilder($this->employmentExists);
+
+        return new HasMany($builder, new self(), 'entity_id', 'id');
+    }
+
+    /** @return HasOne<FakeEmploymentModel, self> */
+    private function employmentHasOne(bool $exists): HasOne
+    {
+        $builder = $this->employmentBuilder($exists);
+
+        return new HasOne($builder, new self(), 'entity_id', 'id');
+    }
+
+    private function employmentBuilder(bool $exists): FakeEmploymentBuilder
+    {
         $query = Double::for(QueryBuilder::class);
-        $query->expects('exists')->returns($this->futureEmploymentExists);
+        $query->expects('exists')->returns($exists);
         $builder = new FakeEmploymentBuilder($query);
         $builder->setModel(new FakeEmploymentModel());
 
-        return new HasOne($builder, $this, 'entity_id', 'id');
+        return $builder;
     }
 }
 
@@ -174,136 +204,41 @@ describe('IsEmployable Trait Unit Tests', function () {
 
     describe('employment status checks', function () {
         test('can check if model is employed', function () {
-            $model = new class extends Model implements Employable
-            {
-                /** @use IsEmployable<FakeEmploymentModel, self> */
-                use IsEmployable;
+            $model = new EmploymentStateModel();
+            $model->currentEmploymentExists = true;
 
-                public function resolveEmploymentModelClass(): string
-                {
-                    return FakeEmploymentModel::class;
-                }
-
-                public function currentEmployment(): HasOne
-                {
-                    $relation = Mockery::mock(HasOne::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
             expect($model->isEmployed())->toBeTrue();
         });
 
         test('can check if model is not employed', function () {
-            $model = new class extends Model implements Employable
-            {
-                /** @use IsEmployable<FakeEmploymentModel, self> */
-                use IsEmployable;
+            $model = new EmploymentStateModel();
 
-                public function resolveEmploymentModelClass(): string
-                {
-                    return FakeEmploymentModel::class;
-                }
-
-                public function currentEmployment(): HasOne
-                {
-                    $relation = Mockery::mock(HasOne::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
             expect($model->isEmployed())->toBeFalse();
         });
 
         test('can check if model has employments', function () {
-            $modelWith = new class extends Model implements Employable
-            {
-                /** @use IsEmployable<FakeEmploymentModel, self> */
-                use IsEmployable;
+            $modelWith = new EmploymentStateModel();
+            $modelWith->employmentExists = true;
+            $modelWithout = new EmploymentStateModel();
 
-                public function resolveEmploymentModelClass(): string
-                {
-                    return FakeEmploymentModel::class;
-                }
-
-                public function employments(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
-            $modelWithout = new class extends Model implements Employable
-            {
-                /** @use IsEmployable<FakeEmploymentModel, self> */
-                use IsEmployable;
-
-                public function resolveEmploymentModelClass(): string
-                {
-                    return FakeEmploymentModel::class;
-                }
-
-                public function employments(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
             expect($modelWith->hasEmployments())->toBeTrue();
             expect($modelWithout->hasEmployments())->toBeFalse();
         });
 
         test('can check if model has future employment', function () {
-            $modelWith = new FutureEmploymentStateModel();
+            $modelWith = new EmploymentStateModel();
             $modelWith->futureEmploymentExists = true;
-            $modelWithout = new FutureEmploymentStateModel();
+            $modelWithout = new EmploymentStateModel();
 
             expect($modelWith->hasFutureEmployment())->toBeTrue();
             expect($modelWithout->hasFutureEmployment())->toBeFalse();
         });
 
         test('can check if model has employment history', function () {
-            $modelWith = new class extends Model implements Employable
-            {
-                /** @use IsEmployable<FakeEmploymentModel, self> */
-                use IsEmployable;
+            $modelWith = new EmploymentStateModel();
+            $modelWith->employmentExists = true;
+            $modelWithout = new EmploymentStateModel();
 
-                public function resolveEmploymentModelClass(): string
-                {
-                    return FakeEmploymentModel::class;
-                }
-
-                public function employments(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
-            $modelWithout = new class extends Model implements Employable
-            {
-                /** @use IsEmployable<FakeEmploymentModel, self> */
-                use IsEmployable;
-
-                public function resolveEmploymentModelClass(): string
-                {
-                    return FakeEmploymentModel::class;
-                }
-
-                public function employments(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
             expect($modelWith->hasEmploymentHistory())->toBeTrue();
             expect($modelWithout->hasEmploymentHistory())->toBeFalse();
         });

--- a/tests/Unit/Models/Concerns/IsInjurableTest.php
+++ b/tests/Unit/Models/Concerns/IsInjurableTest.php
@@ -15,12 +15,59 @@ namespace Tests\Unit\Models\Concerns;
 
 use App\Models\Concerns\IsInjurable;
 use App\Models\Contracts\Injurable;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Mockery;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use JMac\Testing\Double;
 use RuntimeException;
 use Tests\Unit\Models\Concerns\Support\FakeInjuryModel;
+
+/** @extends EloquentBuilder<FakeInjuryModel> */
+final class FakeInjuryBuilder extends EloquentBuilder {}
+
+/** @implements Injurable<FakeInjuryModel, self> */
+final class InjuryStateModel extends Model implements Injurable
+{
+    /** @use IsInjurable<FakeInjuryModel, self> */
+    use IsInjurable;
+
+    public bool $currentInjuryExists = false;
+
+    public bool $injuryExists = false;
+
+    public function resolveInjuryModelClass(): string
+    {
+        return FakeInjuryModel::class;
+    }
+
+    /** @return HasOne<FakeInjuryModel, self> */
+    public function currentInjury(): HasOne
+    {
+        $builder = $this->injuryBuilder($this->currentInjuryExists);
+
+        return new HasOne($builder, new self(), 'entity_id', 'id');
+    }
+
+    /** @return HasMany<FakeInjuryModel, self> */
+    public function injuries(): HasMany
+    {
+        $builder = $this->injuryBuilder($this->injuryExists);
+
+        return new HasMany($builder, new self(), 'entity_id', 'id');
+    }
+
+    private function injuryBuilder(bool $exists): FakeInjuryBuilder
+    {
+        $query = Double::for(QueryBuilder::class);
+        $query->expects('exists')->returns($exists);
+        $builder = new FakeInjuryBuilder($query);
+        $builder->setModel(new FakeInjuryModel());
+
+        return $builder;
+    }
+}
 
 describe('IsInjurable Trait Unit Tests', function () {
     describe('injury relationships', function () {
@@ -119,89 +166,22 @@ describe('IsInjurable Trait Unit Tests', function () {
 
     describe('injury status checks', function () {
         test('can check if model is injured', function () {
-            $model = new class extends Model implements Injurable
-            {
-                /** @use IsInjurable<FakeInjuryModel, self> */
-                use IsInjurable;
-
-                public function resolveInjuryModelClass(): string
-                {
-                    return FakeInjuryModel::class;
-                }
-
-                public function currentInjury(): HasOne
-                {
-                    $relation = Mockery::mock(HasOne::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
+            $model = new InjuryStateModel();
+            $model->currentInjuryExists = true;
 
             expect($model->isInjured())->toBeTrue();
         });
 
         test('can check if model is not injured', function () {
-            $model = new class extends Model implements Injurable
-            {
-                /** @use IsInjurable<FakeInjuryModel, self> */
-                use IsInjurable;
-
-                public function resolveInjuryModelClass(): string
-                {
-                    return FakeInjuryModel::class;
-                }
-
-                public function currentInjury(): HasOne
-                {
-                    $relation = Mockery::mock(HasOne::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
+            $model = new InjuryStateModel();
 
             expect($model->isInjured())->toBeFalse();
         });
 
         test('can check if model has injuries', function () {
-            $modelWithInjuries = new class extends Model implements Injurable
-            {
-                /** @use IsInjurable<FakeInjuryModel, self> */
-                use IsInjurable;
-
-                public function resolveInjuryModelClass(): string
-                {
-                    return FakeInjuryModel::class;
-                }
-
-                public function injuries(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
-
-            $modelWithoutInjuries = new class extends Model implements Injurable
-            {
-                /** @use IsInjurable<FakeInjuryModel, self> */
-                use IsInjurable;
-
-                public function resolveInjuryModelClass(): string
-                {
-                    return FakeInjuryModel::class;
-                }
-
-                public function injuries(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
+            $modelWithInjuries = new InjuryStateModel();
+            $modelWithInjuries->injuryExists = true;
+            $modelWithoutInjuries = new InjuryStateModel();
 
             expect($modelWithInjuries->hasInjuries())->toBeTrue();
             expect($modelWithoutInjuries->hasInjuries())->toBeFalse();

--- a/tests/Unit/Models/Concerns/IsRetirableTest.php
+++ b/tests/Unit/Models/Concerns/IsRetirableTest.php
@@ -17,12 +17,59 @@ use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\IsRetirable;
 use App\Models\Contracts\Retirable;
 use Exception;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Mockery;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use JMac\Testing\Double;
 use Tests\Unit\Models\Concerns\Support\FakeRetirableModel;
 use Tests\Unit\Models\Concerns\Support\FakeRetirementModel;
+
+/** @extends EloquentBuilder<FakeRetirementModel> */
+final class FakeRetirementBuilder extends EloquentBuilder {}
+
+/** @implements Retirable<FakeRetirementModel, self> */
+final class RetirementStateModel extends Model implements Retirable
+{
+    /** @use IsRetirable<FakeRetirementModel, self> */
+    use IsRetirable;
+
+    public bool $currentRetirementExists = false;
+
+    public bool $retirementExists = false;
+
+    public function resolveRetirementModelClass(): string
+    {
+        return FakeRetirementModel::class;
+    }
+
+    /** @return HasOne<FakeRetirementModel, self> */
+    public function currentRetirement(): HasOne
+    {
+        $builder = $this->retirementBuilder($this->currentRetirementExists);
+
+        return new HasOne($builder, new self(), 'entity_id', 'id');
+    }
+
+    /** @return HasMany<FakeRetirementModel, self> */
+    public function retirements(): HasMany
+    {
+        $builder = $this->retirementBuilder($this->retirementExists);
+
+        return new HasMany($builder, new self(), 'entity_id', 'id');
+    }
+
+    private function retirementBuilder(bool $exists): FakeRetirementBuilder
+    {
+        $query = Double::for(QueryBuilder::class);
+        $query->expects('exists')->returns($exists);
+        $builder = new FakeRetirementBuilder($query);
+        $builder->setModel(new FakeRetirementModel());
+
+        return $builder;
+    }
+}
 
 describe('IsRetirable Trait Unit Tests', function () {
     describe('retirement relationships', function () {
@@ -117,86 +164,23 @@ describe('IsRetirable Trait Unit Tests', function () {
 
     describe('retirement status checks', function () {
         test('can check if model is retired', function () {
-            $model = new class extends Model implements Retirable
-            {
-                /** @use IsRetirable<FakeRetirementModel, self> */
-                use IsRetirable;
+            $model = new RetirementStateModel();
+            $model->currentRetirementExists = true;
 
-                public function resolveRetirementModelClass(): string
-                {
-                    return FakeRetirementModel::class;
-                }
-
-                public function currentRetirement(): HasOne
-                {
-                    $relation = Mockery::mock(HasOne::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
             expect($model->isRetired())->toBeTrue();
         });
 
         test('can check if model is not retired', function () {
-            $model = new class extends Model implements Retirable
-            {
-                /** @use IsRetirable<FakeRetirementModel, self> */
-                use IsRetirable;
+            $model = new RetirementStateModel();
 
-                public function resolveRetirementModelClass(): string
-                {
-                    return FakeRetirementModel::class;
-                }
-
-                public function currentRetirement(): HasOne
-                {
-                    $relation = Mockery::mock(HasOne::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
             expect($model->isRetired())->toBeFalse();
         });
 
         test('can check if model has retirements', function () {
-            $modelWith = new class extends Model implements Retirable
-            {
-                /** @use IsRetirable<FakeRetirementModel, self> */
-                use IsRetirable;
+            $modelWith = new RetirementStateModel();
+            $modelWith->retirementExists = true;
+            $modelWithout = new RetirementStateModel();
 
-                public function resolveRetirementModelClass(): string
-                {
-                    return FakeRetirementModel::class;
-                }
-
-                public function retirements(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
-            $modelWithout = new class extends Model implements Retirable
-            {
-                /** @use IsRetirable<FakeRetirementModel, self> */
-                use IsRetirable;
-
-                public function resolveRetirementModelClass(): string
-                {
-                    return FakeRetirementModel::class;
-                }
-
-                public function retirements(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
             expect($modelWith->hasRetirements())->toBeTrue();
             expect($modelWithout->hasRetirements())->toBeFalse();
         });

--- a/tests/Unit/Models/Concerns/IsSuspendableTest.php
+++ b/tests/Unit/Models/Concerns/IsSuspendableTest.php
@@ -15,12 +15,59 @@ namespace Tests\Unit\Models\Concerns;
 
 use App\Models\Concerns\IsSuspendable;
 use App\Models\Contracts\Suspendable;
+use Illuminate\Database\Eloquent\Builder as EloquentBuilder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use Mockery;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use JMac\Testing\Double;
 use Tests\Unit\Models\Concerns\Support\FakeSuspendableModel;
 use Tests\Unit\Models\Concerns\Support\FakeSuspensionModel;
+
+/** @extends EloquentBuilder<FakeSuspensionModel> */
+final class FakeSuspensionBuilder extends EloquentBuilder {}
+
+/** @implements Suspendable<FakeSuspensionModel, self> */
+final class SuspensionStateModel extends Model implements Suspendable
+{
+    /** @use IsSuspendable<FakeSuspensionModel, self> */
+    use IsSuspendable;
+
+    public bool $currentSuspensionExists = false;
+
+    public bool $suspensionExists = false;
+
+    public function resolveSuspensionModelClass(): string
+    {
+        return FakeSuspensionModel::class;
+    }
+
+    /** @return HasOne<FakeSuspensionModel, self> */
+    public function currentSuspension(): HasOne
+    {
+        $builder = $this->suspensionBuilder($this->currentSuspensionExists);
+
+        return new HasOne($builder, new self(), 'entity_id', 'id');
+    }
+
+    /** @return HasMany<FakeSuspensionModel, self> */
+    public function suspensions(): HasMany
+    {
+        $builder = $this->suspensionBuilder($this->suspensionExists);
+
+        return new HasMany($builder, new self(), 'entity_id', 'id');
+    }
+
+    private function suspensionBuilder(bool $exists): FakeSuspensionBuilder
+    {
+        $query = Double::for(QueryBuilder::class);
+        $query->expects('exists')->returns($exists);
+        $builder = new FakeSuspensionBuilder($query);
+        $builder->setModel(new FakeSuspensionModel());
+
+        return $builder;
+    }
+}
 
 describe('IsSuspendable Trait Unit Tests', function () {
     describe('suspension relationships', function () {
@@ -115,86 +162,23 @@ describe('IsSuspendable Trait Unit Tests', function () {
 
     describe('suspension status checks', function () {
         test('can check if model is suspended', function () {
-            $model = new class extends Model implements Suspendable
-            {
-                /** @use IsSuspendable<FakeSuspensionModel, self> */
-                use IsSuspendable;
+            $model = new SuspensionStateModel();
+            $model->currentSuspensionExists = true;
 
-                public function resolveSuspensionModelClass(): string
-                {
-                    return FakeSuspensionModel::class;
-                }
-
-                public function currentSuspension(): HasOne
-                {
-                    $relation = Mockery::mock(HasOne::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
             expect($model->isSuspended())->toBeTrue();
         });
 
         test('can check if model is not suspended', function () {
-            $model = new class extends Model implements Suspendable
-            {
-                /** @use IsSuspendable<FakeSuspensionModel, self> */
-                use IsSuspendable;
+            $model = new SuspensionStateModel();
 
-                public function resolveSuspensionModelClass(): string
-                {
-                    return FakeSuspensionModel::class;
-                }
-
-                public function currentSuspension(): HasOne
-                {
-                    $relation = Mockery::mock(HasOne::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
             expect($model->isSuspended())->toBeFalse();
         });
 
         test('can check if model has suspensions', function () {
-            $modelWith = new class extends Model implements Suspendable
-            {
-                /** @use IsSuspendable<FakeSuspensionModel, self> */
-                use IsSuspendable;
+            $modelWith = new SuspensionStateModel();
+            $modelWith->suspensionExists = true;
+            $modelWithout = new SuspensionStateModel();
 
-                public function resolveSuspensionModelClass(): string
-                {
-                    return FakeSuspensionModel::class;
-                }
-
-                public function suspensions(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(true);
-
-                    return $relation;
-                }
-            };
-            $modelWithout = new class extends Model implements Suspendable
-            {
-                /** @use IsSuspendable<FakeSuspensionModel, self> */
-                use IsSuspendable;
-
-                public function resolveSuspensionModelClass(): string
-                {
-                    return FakeSuspensionModel::class;
-                }
-
-                public function suspensions(): HasMany
-                {
-                    $relation = Mockery::mock(HasMany::class);
-                    $relation->expects('exists')->andReturn(false);
-
-                    return $relation;
-                }
-            };
             expect($modelWith->hasSuspensions())->toBeTrue();
             expect($modelWithout->hasSuspensions())->toBeFalse();
         });


### PR DESCRIPTION
## Summary

- raise Pest PHPStan analysis from level 6 to level 7
- add safe reflected-source handling for structural tests
- resolve ambiguous Eloquent model and polymorphic pivot types
- replace remaining relation mocks with typed query-backed TestDouble state models

## Verification

- `composer test:types`
- `composer test:rector`
- `vendor/bin/pint --blade --test tests`
- `php -d memory_limit=4G ./vendor/bin/pest --parallel` — 3,499 tests passed, 11,148 assertions