### PR TITLE
test: raise Pest PHPStan to level 8

### DIFF
--- a/phpstan-pest.neon
+++ b/phpstan-pest.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 7
+  level: 8
 
   paths:
     - tests

--- a/tests/Feature/Livewire/Wrestlers/Tables/PreviousManagersTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/PreviousManagersTest.php
@@ -81,7 +81,7 @@ describe('PreviousManagers Query Building', function () {
         $results = $component->instance()->builder()->get();
 
         expect($results)->toHaveCount(1);
-        expect($results->first()->wrestler_id)->toBe($this->wrestler->id);
+        expect($results->firstOrFail()->wrestler_id)->toBe($this->wrestler->id);
     });
 
     it('only shows relationships that have ended', function () {
@@ -107,8 +107,8 @@ describe('PreviousManagers Query Building', function () {
         $results = $component->instance()->builder()->get();
 
         expect($results)->toHaveCount(1);
-        expect($results->first()->manager_id)->toBe($previousManager->id);
-        expect($results->first()->fired_at)->not->toBeNull();
+        expect($results->firstOrFail()->manager_id)->toBe($previousManager->id);
+        expect($results->firstOrFail()->fired_at)->not->toBeNull();
     });
 
     it('orders by hired_at descending', function () {
@@ -143,9 +143,9 @@ describe('PreviousManagers Query Building', function () {
 
         expect($results)->toHaveCount(3);
         // Should be ordered by hired_at desc (most recent first)
-        expect($results->first()->manager_id)->toBe($manager2->id);
-        expect($results->get(1)->manager_id)->toBe($this->manager->id);
-        expect($results->last()->manager_id)->toBe($manager3->id);
+        expect($results->firstOrFail()->manager_id)->toBe($manager2->id);
+        expect($results->slice(1)->firstOrFail()->manager_id)->toBe($this->manager->id);
+        expect($results->reverse()->firstOrFail()->manager_id)->toBe($manager3->id);
     });
 });
 

--- a/tests/Feature/Livewire/Wrestlers/Tables/WrestlersTableTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/WrestlersTableTest.php
@@ -44,7 +44,7 @@ describe('Main Component Feature Workflows', function () {
                 ->assertSessionMissing('error');
 
             // Verify workflow completed successfully
-            expect($wrestler->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($wrestler)->isEmployed())->toBeTrue();
         });
 
         test('complete wrestler release workflow', function () {
@@ -57,7 +57,7 @@ describe('Main Component Feature Workflows', function () {
                 ->assertHasNoErrors()
                 ->assertSessionMissing('error');
 
-            expect($wrestler->fresh()->isReleased())->toBeTrue();
+            expect(freshModel($wrestler)->isReleased())->toBeTrue();
         });
 
         test('complete wrestler retirement workflow', function () {
@@ -69,7 +69,7 @@ describe('Main Component Feature Workflows', function () {
                 ->call('handleWrestlerAction', 'retire', $wrestler->id)
                 ->assertHasNoErrors();
 
-            expect($wrestler->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($wrestler)->isRetired())->toBeTrue();
         });
 
         test('complete wrestler deletion and restoration workflow', function () {
@@ -84,7 +84,7 @@ describe('Main Component Feature Workflows', function () {
                 ->assertHasNoErrors();
 
             // Verify wrestler is soft deleted
-            $freshWrestler = Wrestler::withTrashed()->find($wrestler->id);
+            $freshWrestler = Wrestler::withTrashed()->findOrFail($wrestler->id);
             expect($freshWrestler)->not->toBeNull();
             expect($freshWrestler->trashed())->toBeTrue();
             expect(Wrestler::find($wrestler->id))->toBeNull(); // Should not be found without withTrashed()
@@ -95,7 +95,7 @@ describe('Main Component Feature Workflows', function () {
                 ->assertHasNoErrors();
 
             // Verify wrestler is restored
-            expect(Wrestler::withTrashed()->find($wrestler->id)->deleted_at)->toBeNull();
+            expect(Wrestler::withTrashed()->findOrFail($wrestler->id)->deleted_at)->toBeNull();
             expect($wrestler->fresh())->not->toBeNull();
         });
     });

--- a/tests/Feature/Workflows/EventManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/EventManagementWorkflowTest.php
@@ -76,7 +76,7 @@ describe('Venue Creation and Setup Workflow', function () {
         // Then: Venue should be created in database
         expect(Venue::where('name', 'Madison Square Garden')->exists())->toBeTrue();
 
-        $venue = Venue::where('name', 'Madison Square Garden')->first();
+        $venue = Venue::where('name', 'Madison Square Garden')->firstOrFail();
         expect($venue->city)->toBe('New York');
         expect($venue->state)->toBe('NY');
         expect($venue->street_address)->toBe('4 Pennsylvania Plaza');
@@ -168,7 +168,7 @@ describe('Event Creation and Scheduling Workflow', function () {
         // Then: Event should be created in database
         expect(Event::where('name', 'WrestleMania 40')->exists())->toBeTrue();
 
-        $event = Event::where('name', 'WrestleMania 40')->first();
+        $event = Event::where('name', 'WrestleMania 40')->firstOrFail();
         expect($event->venue_id)->toBe($venue->id);
 
         // And: Should appear in the events table
@@ -357,7 +357,7 @@ describe('Event Deletion and Restoration Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Event should be soft deleted
-        expect($event->fresh()->trashed())->toBeTrue();
+        expect(freshModel($event)->trashed())->toBeTrue();
         expect(Event::onlyTrashed()->find($event->id))->not->toBeNull();
 
         // When: Restoring the event
@@ -369,7 +369,7 @@ describe('Event Deletion and Restoration Workflow', function () {
 
         // Then: Event should be restored
         expect($event->fresh())->not->toBeNull();
-        expect($event->fresh()->name)->toBe('Test Event');
+        expect(freshModel($event)->name)->toBe('Test Event');
     });
 });
 

--- a/tests/Feature/Workflows/RosterManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/RosterManagementWorkflowTest.php
@@ -38,7 +38,7 @@ describe('Manager Assignment Workflow', function () {
 
         // Then: Manager should be created
         expect(Manager::where('first_name', 'Paul')->where('last_name', 'Heyman')->exists())->toBeTrue();
-        $manager = Manager::where('first_name', 'Paul')->where('last_name', 'Heyman')->first();
+        $manager = Manager::where('first_name', 'Paul')->where('last_name', 'Heyman')->firstOrFail();
 
         // When: Assigning manager to wrestler (assuming this functionality exists)
         // Note: This would depend on the actual implementation of manager assignment
@@ -69,7 +69,7 @@ describe('Manager Assignment Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Manager should be employed
-        expect($manager->fresh()->isEmployed())->toBeTrue();
+        expect(freshModel($manager)->isEmployed())->toBeTrue();
 
         // When: Suspending manager
         actingAs($admin);
@@ -79,7 +79,7 @@ describe('Manager Assignment Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Manager should be suspended
-        expect($manager->fresh()->isSuspended())->toBeTrue();
+        expect(freshModel($manager)->isSuspended())->toBeTrue();
 
         // When: Reinstating manager
         actingAs($admin);
@@ -89,8 +89,8 @@ describe('Manager Assignment Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Manager should be employed again
-        expect($manager->fresh()->isEmployed())->toBeTrue();
-        expect($manager->fresh()->isSuspended())->toBeFalse();
+        expect(freshModel($manager)->isEmployed())->toBeTrue();
+        expect(freshModel($manager)->isSuspended())->toBeFalse();
     });
 });
 
@@ -114,7 +114,7 @@ describe('Stable Formation and Management Workflow', function () {
 
         // Then: Stable should be created
         expect(Stable::where('name', 'D-Generation X')->exists())->toBeTrue();
-        $stable = Stable::where('name', 'D-Generation X')->first();
+        $stable = Stable::where('name', 'D-Generation X')->firstOrFail();
 
         // And: Stable appears in stables table
         actingAs($admin);
@@ -136,7 +136,7 @@ describe('Stable Formation and Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Stable should be active
-        expect($stable->fresh()->isCurrentlyActive())->toBeTrue();
+        expect(freshModel($stable)->isCurrentlyActive())->toBeTrue();
 
         // When: Retiring the stable
         actingAs($admin);
@@ -146,7 +146,7 @@ describe('Stable Formation and Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Stable should be retired
-        expect($stable->fresh()->isRetired())->toBeTrue();
+        expect(freshModel($stable)->isRetired())->toBeTrue();
 
         // Given: A retired stable with viable former members
         $retiredStable = Stable::factory()->retired()->create(['name' => 'Evolution']);
@@ -159,7 +159,7 @@ describe('Stable Formation and Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Stable should no longer be retired
-        expect($retiredStable->fresh()->isRetired())->toBeFalse();
+        expect(freshModel($retiredStable)->isRetired())->toBeFalse();
     });
 });
 
@@ -184,7 +184,7 @@ describe('Tag Team Formation and Management Workflow', function () {
 
         // Then: Tag team should be created
         expect(TagTeam::where('name', 'The Hardy Boyz')->exists())->toBeTrue();
-        $tagTeam = TagTeam::where('name', 'The Hardy Boyz')->first();
+        $tagTeam = TagTeam::where('name', 'The Hardy Boyz')->firstOrFail();
 
         // And: Tag team appears in tag teams table
         actingAs($admin);
@@ -215,7 +215,7 @@ describe('Tag Team Formation and Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Tag team should be employed
-        expect($tagTeam->fresh()->isEmployed())->toBeTrue();
+        expect(freshModel($tagTeam)->isEmployed())->toBeTrue();
 
         // When: Suspending tag team
         actingAs($admin);
@@ -225,7 +225,7 @@ describe('Tag Team Formation and Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Tag team should be suspended
-        expect($tagTeam->fresh()->isSuspended())->toBeTrue();
+        expect(freshModel($tagTeam)->isSuspended())->toBeTrue();
 
         // When: Reinstating tag team
         actingAs($admin);
@@ -235,8 +235,8 @@ describe('Tag Team Formation and Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Tag team should be employed again
-        expect($tagTeam->fresh()->isEmployed())->toBeTrue();
-        expect($tagTeam->fresh()->isSuspended())->toBeFalse();
+        expect(freshModel($tagTeam)->isEmployed())->toBeTrue();
+        expect(freshModel($tagTeam)->isSuspended())->toBeFalse();
 
         // When: Retiring tag team
         actingAs($admin);
@@ -246,7 +246,7 @@ describe('Tag Team Formation and Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Tag team should be retired
-        expect($tagTeam->fresh()->isRetired())->toBeTrue();
+        expect(freshModel($tagTeam)->isRetired())->toBeTrue();
     });
 });
 

--- a/tests/Feature/Workflows/TitleManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/TitleManagementWorkflowTest.php
@@ -52,7 +52,7 @@ describe('Title Creation and Setup Workflow', function () {
         // Then: Title should be created in database
         expect(Title::where('name', 'WWE Championship Title')->exists())->toBeTrue();
 
-        $title = Title::where('name', 'WWE Championship Title')->first();
+        $title = Title::where('name', 'WWE Championship Title')->firstOrFail();
         expect($title->name)->toBe('WWE Championship Title');
 
         // And: Should appear in the titles table
@@ -103,7 +103,7 @@ describe('Title Lifecycle Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Title should be active (check after component execution)
-        expect($title->fresh()->isCurrentlyActive())->toBeTrue();
+        expect(freshModel($title)->isCurrentlyActive())->toBeTrue();
 
         // When: Pulling (deactivating) the title
         actingAs($admin);
@@ -113,7 +113,7 @@ describe('Title Lifecycle Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Title should be inactive
-        expect($title->fresh()->isCurrentlyActive())->toBeFalse();
+        expect(freshModel($title)->isCurrentlyActive())->toBeFalse();
 
         // When: Reinstating the title
         actingAs($admin);
@@ -123,7 +123,7 @@ describe('Title Lifecycle Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Title should be active again
-        expect($title->fresh()->isCurrentlyActive())->toBeTrue();
+        expect(freshModel($title)->isCurrentlyActive())->toBeTrue();
 
         // When: Retiring the title
         actingAs($admin);
@@ -133,7 +133,7 @@ describe('Title Lifecycle Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Title should be retired
-        expect($title->fresh()->isRetired())->toBeTrue();
+        expect(freshModel($title)->isRetired())->toBeTrue();
 
         // When: Unretiring the title
         actingAs($admin);
@@ -143,7 +143,7 @@ describe('Title Lifecycle Management Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Title should no longer be retired
-        expect($title->fresh()->isRetired())->toBeFalse();
+        expect(freshModel($title)->isRetired())->toBeFalse();
     });
 });
 
@@ -290,7 +290,7 @@ describe('Title Deletion and Restoration Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Title should be soft deleted
-        expect($title->fresh()->trashed())->toBeTrue();
+        expect(freshModel($title)->trashed())->toBeTrue();
         expect(Title::onlyTrashed()->find($title->id))->not->toBeNull();
 
         // When: Restoring the title
@@ -302,7 +302,7 @@ describe('Title Deletion and Restoration Workflow', function () {
 
         // Then: Title should be restored
         expect($title->fresh())->not->toBeNull();
-        expect($title->fresh()->name)->toBe('Test Championship Title');
+        expect(freshModel($title)->name)->toBe('Test Championship Title');
     });
 });
 
@@ -327,7 +327,7 @@ describe('Title Business Rules Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Title should be active
-        expect($title->fresh()->isCurrentlyActive())->toBeTrue();
+        expect(freshModel($title)->isCurrentlyActive())->toBeTrue();
 
         // When: Now pulling the active title (should succeed)
         actingAs($admin);
@@ -337,6 +337,6 @@ describe('Title Business Rules Workflow', function () {
             ->assertHasNoErrors();
 
         // Then: Title should be inactive
-        expect($title->fresh()->isCurrentlyActive())->toBeFalse();
+        expect(freshModel($title)->isCurrentlyActive())->toBeFalse();
     });
 });

--- a/tests/Feature/Workflows/WrestlerManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/WrestlerManagementWorkflowTest.php
@@ -55,7 +55,7 @@ describe('Wrestler Creation Journey', function () {
         // Then: Wrestler should be created in database
         expect(Wrestler::where('name', 'John Cena')->exists())->toBeTrue();
 
-        $wrestler = Wrestler::where('name', 'John Cena')->first();
+        $wrestler = Wrestler::where('name', 'John Cena')->firstOrFail();
         expect($wrestler->hometown)->toBe('West Newbury, MA');
         expect($wrestler->height->toInches())->toBe(73); // 6'1" = 73 inches
         expect($wrestler->weight)->toBe(251);
@@ -112,7 +112,7 @@ describe('Wrestler Employment Status Management Journey', function () {
             ->assertHasNoErrors();
 
         // Then: Wrestler should be employed
-        expect($wrestler->fresh()->isEmployed())->toBeTrue();
+        expect(freshModel($wrestler)->isEmployed())->toBeTrue();
 
         // When: Suspending the employed wrestler
         actingAs($admin);
@@ -122,7 +122,7 @@ describe('Wrestler Employment Status Management Journey', function () {
             ->assertHasNoErrors();
 
         // Then: Wrestler should be suspended
-        expect($wrestler->fresh()->isSuspended())->toBeTrue();
+        expect(freshModel($wrestler)->isSuspended())->toBeTrue();
 
         // When: Reinstating the suspended wrestler
         actingAs($admin);
@@ -132,8 +132,8 @@ describe('Wrestler Employment Status Management Journey', function () {
             ->assertHasNoErrors();
 
         // Then: Wrestler should be employed again
-        expect($wrestler->fresh()->isEmployed())->toBeTrue();
-        expect($wrestler->fresh()->isSuspended())->toBeFalse();
+        expect(freshModel($wrestler)->isEmployed())->toBeTrue();
+        expect(freshModel($wrestler)->isSuspended())->toBeFalse();
 
         // When: Retiring the wrestler
         actingAs($admin);
@@ -143,7 +143,7 @@ describe('Wrestler Employment Status Management Journey', function () {
             ->assertHasNoErrors();
 
         // Then: Wrestler should be retired
-        expect($wrestler->fresh()->isRetired())->toBeTrue();
+        expect(freshModel($wrestler)->isRetired())->toBeTrue();
 
         // When: Unretiring the wrestler
         actingAs($admin);
@@ -153,10 +153,10 @@ describe('Wrestler Employment Status Management Journey', function () {
             ->assertHasNoErrors();
 
         // Then: Wrestler should no longer be retired
-        expect($wrestler->fresh()->isRetired())->toBeFalse();
+        expect(freshModel($wrestler)->isRetired())->toBeFalse();
 
         // And: Should have employment history tracking
-        expect($wrestler->fresh()->hasEmploymentHistory())->toBeTrue();
+        expect(freshModel($wrestler)->hasEmploymentHistory())->toBeTrue();
     });
 
     test('wrestler injury management workflow', function () {
@@ -172,7 +172,7 @@ describe('Wrestler Employment Status Management Journey', function () {
             ->assertHasNoErrors();
 
         // Then: Wrestler should be injured
-        expect($wrestler->fresh()->isInjured())->toBeTrue();
+        expect(freshModel($wrestler)->isInjured())->toBeTrue();
 
         // When: Healing the wrestler from injury
         actingAs($admin);
@@ -182,8 +182,8 @@ describe('Wrestler Employment Status Management Journey', function () {
             ->assertHasNoErrors();
 
         // Then: Wrestler should no longer be injured
-        expect($wrestler->fresh()->isInjured())->toBeFalse();
-        expect($wrestler->fresh()->isEmployed())->toBeTrue();
+        expect(freshModel($wrestler)->isInjured())->toBeFalse();
+        expect(freshModel($wrestler)->isEmployed())->toBeTrue();
     });
 });
 
@@ -322,7 +322,7 @@ describe('Wrestler Deletion and Restoration Journey', function () {
             ->assertHasNoErrors();
 
         // Then: Wrestler should be soft deleted
-        expect($wrestler->fresh()->trashed())->toBeTrue();
+        expect(freshModel($wrestler)->trashed())->toBeTrue();
         expect(Wrestler::onlyTrashed()->find($wrestler->id))->not->toBeNull();
 
         // When: Restoring the wrestler
@@ -334,6 +334,6 @@ describe('Wrestler Deletion and Restoration Journey', function () {
 
         // Then: Wrestler should be restored
         expect($wrestler->fresh())->not->toBeNull();
-        expect($wrestler->fresh()->name)->toBe('Test Wrestler');
+        expect(freshModel($wrestler)->name)->toBe('Test Wrestler');
     });
 });

--- a/tests/Helpers/IntegrationTestHelpers.php
+++ b/tests/Helpers/IntegrationTestHelpers.php
@@ -97,7 +97,7 @@ function createTitleLineage(int $reignCount = 5): array
         'title' => $title,
         'champions' => $champions,
         'championships' => collect($championships),
-        'current_champion' => $champions->last(),
+        'current_champion' => $champions->reverse()->firstOrFail(),
     ];
 }
 
@@ -212,7 +212,7 @@ function createTournamentScenario(int $participantCount = 8): array
 
     // Create tournament matches (simplified)
     $rounds = ceil(log($participantCount, 2));
-    $winner = $participants->first();
+    $winner = $participants->firstOrFail();
 
     // Winner becomes champion
     $championship = TitleChampionship::factory()
@@ -241,12 +241,12 @@ function createCompanyMergerScenario(): array
     // Company A roster
     $companyAWrestlers = Wrestler::factory()->count(5)->bookable()->create();
     $companyATitle = Title::factory()->active()->create(['name' => 'Company A Championship']);
-    $companyAChampion = $companyAWrestlers->first();
+    $companyAChampion = $companyAWrestlers->firstOrFail();
 
     // Company B roster
     $companyBWrestlers = Wrestler::factory()->count(5)->bookable()->create();
     $companyBTitle = Title::factory()->active()->create(['name' => 'Company B Championship']);
-    $companyBChampion = $companyBWrestlers->first();
+    $companyBChampion = $companyBWrestlers->firstOrFail();
 
     // Create championships
     $championshipA = TitleChampionship::factory()

--- a/tests/Helpers/StatusTestExpectations.php
+++ b/tests/Helpers/StatusTestExpectations.php
@@ -49,7 +49,7 @@ function expectStatusTransition(Model&Employable $entity, EmploymentStatus $from
  */
 function expectToBeBookable(Wrestler|Referee|TagTeam $entity): void
 {
-    $entity = $entity->fresh();
+    $entity = freshModel($entity);
     expect($entity->isEmployed())->toBeTrue();
     expect($entity->isBookable())->toBeTrue();
     expect($entity->isNotInEmployment())->toBeFalse();
@@ -60,7 +60,7 @@ function expectToBeBookable(Wrestler|Referee|TagTeam $entity): void
  */
 function expectToBeUnavailable(Wrestler|Referee|TagTeam $entity): void
 {
-    $entity = $entity->fresh();
+    $entity = freshModel($entity);
     expect($entity->isBookable())->toBeFalse();
 }
 
@@ -98,10 +98,9 @@ function expectValidRetirementState(Model&Retirable $entity): void
     $entity->refresh();
 
     if ($entity->isRetired()) {
-        $currentRetirement = $entity->currentRetirement()->first();
-        expect($currentRetirement)->not->toBeNull();
-        expect($currentRetirement?->getAttribute('started_at'))->not->toBeNull();
-        expect($currentRetirement?->getAttribute('ended_at'))->toBeNull();
+        $currentRetirement = $entity->currentRetirement()->firstOrFail();
+        expect($currentRetirement->getAttribute('started_at'))->not->toBeNull();
+        expect($currentRetirement->getAttribute('ended_at'))->toBeNull();
     } else {
         expect($entity->currentRetirement()->first())->toBeNull();
     }
@@ -117,10 +116,9 @@ function expectValidInjuryState(Model&Injurable $entity): void
     $entity->refresh();
 
     if ($entity->isInjured()) {
-        $currentInjury = $entity->currentInjury()->first();
-        expect($currentInjury)->not->toBeNull();
-        expect($currentInjury?->getAttribute('started_at'))->not->toBeNull();
-        expect($currentInjury?->getAttribute('ended_at'))->toBeNull();
+        $currentInjury = $entity->currentInjury()->firstOrFail();
+        expect($currentInjury->getAttribute('started_at'))->not->toBeNull();
+        expect($currentInjury->getAttribute('ended_at'))->toBeNull();
     } else {
         expect($entity->currentInjury()->first())->toBeNull();
     }
@@ -136,10 +134,9 @@ function expectValidSuspensionState(Model&Suspendable $entity): void
     $entity->refresh();
 
     if ($entity->isSuspended()) {
-        $currentSuspension = $entity->currentSuspension()->first();
-        expect($currentSuspension)->not->toBeNull();
-        expect($currentSuspension?->getAttribute('started_at'))->not->toBeNull();
-        expect($currentSuspension?->getAttribute('ended_at'))->toBeNull();
+        $currentSuspension = $entity->currentSuspension()->firstOrFail();
+        expect($currentSuspension->getAttribute('started_at'))->not->toBeNull();
+        expect($currentSuspension->getAttribute('ended_at'))->toBeNull();
     } else {
         expect($entity->currentSuspension()->first())->toBeNull();
     }
@@ -188,7 +185,7 @@ function expectTagTeamMembership(Wrestler $wrestler, TagTeam $tagTeam, array $ex
 {
     expect($wrestler->tagTeams()->count())->toBeGreaterThan(0);
 
-    $relationship = $wrestler->tagTeams()->where('tag_team_id', $tagTeam->id)->first();
+    $relationship = $wrestler->tagTeams()->where('tag_team_id', $tagTeam->id)->firstOrFail();
     expect($relationship)->not->toBeNull();
     expect($relationship->pivot->wrestler_id)->toBe($wrestler->id);
     expect($relationship->pivot->tag_team_id)->toBe($tagTeam->id);

--- a/tests/Integration/Actions/Events/LifecycleTest.php
+++ b/tests/Integration/Actions/Events/LifecycleTest.php
@@ -59,9 +59,9 @@ describe('Event Activation Action Integration', function () {
             expect($event->name)->toBe('Scheduled Event');
             expect($event->isScheduled())->toBeTrue();
             expect($event->hasFutureDate())->toBeTrue();
-            expect($event->date->format('Y-m-d H:i:s'))->toBe($scheduledDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($event->date)->format('Y-m-d H:i:s'))->toBe($scheduledDate->format('Y-m-d H:i:s'));
             expect($event->venue_id)->toBe($this->venue->id);
-            expect($event->venue->name)->toBe($this->venue->name);
+            expect($event->venue()->firstOrFail()->name)->toBe($this->venue->name);
         });
 
         test('create action handles past date events correctly', function () {
@@ -116,7 +116,7 @@ describe('Event Activation Action Integration', function () {
 
             UpdateAction::run($this->event, $eventData);
 
-            $refreshedEvent = $this->event->fresh();
+            $refreshedEvent = freshModel($this->event);
             expect($refreshedEvent->name)->toBe('Scheduled Event');
             expect($refreshedEvent->isScheduled())->toBeTrue();
             expect($refreshedEvent->hasFutureDate())->toBeTrue();
@@ -139,8 +139,8 @@ describe('Event Activation Action Integration', function () {
 
             UpdateAction::run($this->event, $eventData);
 
-            $refreshedEvent = $this->event->fresh();
-            expect($refreshedEvent->date->format('Y-m-d H:i:s'))->toBe($newDate->format('Y-m-d H:i:s'));
+            $refreshedEvent = freshModel($this->event);
+            expect(requiredDate($refreshedEvent->date)->format('Y-m-d H:i:s'))->toBe($newDate->format('Y-m-d H:i:s'));
             expect($refreshedEvent->hasFutureDate())->toBeTrue();
         });
 
@@ -157,9 +157,9 @@ describe('Event Activation Action Integration', function () {
 
             UpdateAction::run($this->event, $eventData);
 
-            $refreshedEvent = $this->event->fresh();
+            $refreshedEvent = freshModel($this->event);
             expect($refreshedEvent->venue_id)->toBe($newVenue->id);
-            expect($refreshedEvent->venue->name)->toBe($newVenue->name);
+            expect($refreshedEvent->venue()->firstOrFail()->name)->toBe($newVenue->name);
         });
 
         test('update action can remove venue from event', function () {
@@ -174,7 +174,7 @@ describe('Event Activation Action Integration', function () {
 
             UpdateAction::run($this->event, $eventData);
 
-            $refreshedEvent = $this->event->fresh();
+            $refreshedEvent = freshModel($this->event);
             expect($refreshedEvent->venue_id)->toBeNull();
             expect($refreshedEvent->venue)->toBeNull();
         });
@@ -191,7 +191,7 @@ describe('Event Activation Action Integration', function () {
 
             UpdateAction::run($this->event, $eventData);
 
-            $refreshedEvent = $this->event->fresh();
+            $refreshedEvent = freshModel($this->event);
             expect($refreshedEvent->isUnscheduled())->toBeTrue();
             expect($refreshedEvent->date)->toBeNull();
             expect($refreshedEvent->preview)->toBe('Unscheduled again');
@@ -208,7 +208,7 @@ describe('Event Activation Action Integration', function () {
 
             expect(Event::find($this->event->id))->toBeNull();
             expect(Event::onlyTrashed()->find($this->event->id))->not()->toBeNull();
-            expect($this->event->fresh()->deleted_at)->not()->toBeNull();
+            expect(freshModel($this->event)->deleted_at)->not()->toBeNull();
         });
 
         test('restore action recovers deleted event', function () {
@@ -217,8 +217,7 @@ describe('Event Activation Action Integration', function () {
 
             RestoreAction::run($this->event);
 
-            $restoredEvent = Event::find($this->event->id);
-            expect($restoredEvent)->not()->toBeNull();
+            $restoredEvent = Event::findOrFail($this->event->id);
             expect($restoredEvent->name)->toBe('Deletable Event');
             expect($restoredEvent->deleted_at)->toBeNull();
         });
@@ -230,8 +229,8 @@ describe('Event Activation Action Integration', function () {
             DeleteAction::run($this->event);
             RestoreAction::run($this->event);
 
-            $restoredEvent = Event::find($this->event->id);
-            expect($restoredEvent->date->format('Y-m-d H:i:s'))->toBe($originalDate->format('Y-m-d H:i:s'));
+            $restoredEvent = Event::findOrFail($this->event->id);
+            expect(requiredDate($restoredEvent->date)->format('Y-m-d H:i:s'))->toBe(requiredDate($originalDate)->format('Y-m-d H:i:s'));
             expect($restoredEvent->venue_id)->toBe($originalVenueId);
             expect($restoredEvent->isScheduled())->toBeTrue();
         });
@@ -259,7 +258,7 @@ describe('Event Activation Action Integration', function () {
             );
             UpdateAction::run($event, $updateData);
 
-            $refreshedEvent = $event->fresh();
+            $refreshedEvent = $event->refresh();
             expect($refreshedEvent->isScheduled())->toBeTrue();
             expect($refreshedEvent->hasFutureDate())->toBeTrue();
 
@@ -272,7 +271,7 @@ describe('Event Activation Action Integration', function () {
             );
             UpdateAction::run($event, $finalUpdateData);
 
-            $finalEvent = $event->fresh();
+            $finalEvent = $event->refresh();
             expect($finalEvent->name)->toBe('Final Event Name');
             expect($finalEvent->preview)->toBe('Updated preview');
             expect($finalEvent->venue_id)->toBe($this->venue->id);
@@ -339,9 +338,9 @@ describe('Event Activation Action Integration', function () {
             );
             UpdateAction::run($event, $updateData);
 
-            $refreshedEvent = $event->fresh();
+            $refreshedEvent = $event->refresh();
             expect($refreshedEvent->venue_id)->toBe($venue2->id);
-            expect($refreshedEvent->venue->name)->toBe('Venue Two');
+            expect($refreshedEvent->venue()->firstOrFail()->name)->toBe('Venue Two');
             expect($refreshedEvent->preview)->toBe('Changed venue');
 
             // Remove venue entirely
@@ -353,7 +352,7 @@ describe('Event Activation Action Integration', function () {
             );
             UpdateAction::run($event, $finalUpdateData);
 
-            $finalEvent = $event->fresh();
+            $finalEvent = $event->refresh();
             expect($finalEvent->venue_id)->toBeNull();
             expect($finalEvent->venue)->toBeNull();
             expect($finalEvent->isScheduled())->toBeTrue(); // Still scheduled, just no venue
@@ -383,7 +382,7 @@ describe('Event Activation Action Integration', function () {
             );
             UpdateAction::run($event, $updateData);
 
-            $refreshedEvent = $event->fresh();
+            $refreshedEvent = $event->refresh();
             expect($refreshedEvent->hasPastDate())->toBeTrue();
             expect($refreshedEvent->hasFutureDate())->toBeFalse();
             expect($refreshedEvent->isScheduled())->toBeTrue(); // Still scheduled, just in past
@@ -403,12 +402,12 @@ describe('Event Activation Action Integration', function () {
 
             UpdateAction::run($event, $updateData);
 
-            $refreshedEvent = $event->fresh();
+            $refreshedEvent = freshModel($event);
             $refreshedEvent->load('venue');
 
             expect($refreshedEvent->venue)->not()->toBeNull();
-            expect($refreshedEvent->venue->id)->toBe($this->venue->id);
-            expect($refreshedEvent->venue->name)->toBe($this->venue->name);
+            expect($refreshedEvent->venue()->firstOrFail()->id)->toBe($this->venue->id);
+            expect($refreshedEvent->venue()->firstOrFail()->name)->toBe($this->venue->name);
         });
 
         test('multiple venue changes maintain referential integrity', function () {
@@ -426,7 +425,7 @@ describe('Event Activation Action Integration', function () {
                 preview: $event->preview
             );
             UpdateAction::run($event, $updateData1);
-            expect($event->fresh()->venue_id)->toBe($venue2->id);
+            expect(freshModel($event)->venue_id)->toBe($venue2->id);
 
             // Change to venue3
             $updateData2 = new EventData(
@@ -436,12 +435,12 @@ describe('Event Activation Action Integration', function () {
                 preview: $event->preview
             );
             UpdateAction::run($event, $updateData2);
-            expect($event->fresh()->venue_id)->toBe($venue3->id);
+            expect(freshModel($event)->venue_id)->toBe($venue3->id);
 
             // Verify venue relationships work
-            $finalEvent = $event->fresh();
+            $finalEvent = freshModel($event);
             $finalEvent->load('venue');
-            expect($finalEvent->venue->id)->toBe($venue3->id);
+            expect($finalEvent->venue()->firstOrFail()->id)->toBe($venue3->id);
         });
     });
 
@@ -499,7 +498,7 @@ describe('Event Activation Action Integration', function () {
 
             $restoredEvent = Event::query()->whereKey($event->getKey())->firstOrFail();
             expect($restoredEvent->name)->toBe($originalState['name']);
-            expect($restoredEvent->date->format('Y-m-d H:i:s'))->toBe($originalState['date']->format('Y-m-d H:i:s'));
+            expect(requiredDate($restoredEvent->date)->format('Y-m-d H:i:s'))->toBe($originalState['date']->format('Y-m-d H:i:s'));
             expect($restoredEvent->venue_id)->toBe($originalState['venue_id']);
             expect($restoredEvent->preview)->toBe($originalState['preview']);
         });
@@ -546,7 +545,7 @@ describe('Event Activation Action Integration', function () {
             );
             UpdateAction::run($event, $updateData);
 
-            $updatedEvent = $event->fresh();
+            $updatedEvent = $event->refresh();
             expect($updatedEvent->hasPastDate())->toBeTrue();
             expect($updatedEvent->hasFutureDate())->toBeFalse();
         });

--- a/tests/Integration/Actions/Managers/CreateActionTest.php
+++ b/tests/Integration/Actions/Managers/CreateActionTest.php
@@ -55,7 +55,7 @@ test('it creates a manager with employment when employment date is provided', fu
     ]);
 
     // Manager should be marked as employed
-    expect($result->fresh()->isEmployed())->toBeTrue();
+    expect($result->refresh()->isEmployed())->toBeTrue();
 });
 
 test('it creates manager with all optional fields', function () {

--- a/tests/Integration/Actions/Managers/DeleteActionTest.php
+++ b/tests/Integration/Actions/Managers/DeleteActionTest.php
@@ -27,7 +27,7 @@ test('it soft deletes an unemployed manager', function () {
     expect(Manager::find($manager->id))->toBeNull();
 
     // Can still find with trashed
-    $trashedManager = Manager::withTrashed()->find($manager->id);
+    $trashedManager = Manager::withTrashed()->findOrFail($manager->id);
     expect($trashedManager)->not->toBeNull();
     expect($trashedManager->deleted_at)->not->toBeNull();
 });
@@ -122,7 +122,7 @@ test('it handles deletion with specific date', function () {
 
     DeleteAction::run($manager, $customDeletionDate);
 
-    $trashedManager = Manager::withTrashed()->find($manager->id);
+    $trashedManager = Manager::withTrashed()->findOrFail($manager->id);
     expect($trashedManager->deleted_at)->not->toBeNull();
 
     // Employment should end on the custom date

--- a/tests/Integration/Actions/Managers/EmployActionTest.php
+++ b/tests/Integration/Actions/Managers/EmployActionTest.php
@@ -112,9 +112,8 @@ test('it handles database transactions correctly', function () {
     expect($manager->status->value)->toBe('employed');
 
     // Verify employment record integrity
-    $employment = $manager->currentEmployment;
-    expect($employment)->not()->toBeNull();
-    expect($employment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $employment = $manager->currentEmployment()->firstOrFail();
+    expect(requiredDate($employment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });
 

--- a/tests/Integration/Actions/Managers/HealActionTest.php
+++ b/tests/Integration/Actions/Managers/HealActionTest.php
@@ -48,8 +48,7 @@ test('it uses StatusTransitionPipeline for healing', function () {
     $manager = Manager::factory()->injured()->create();
 
     // Get current injury to verify it gets ended
-    $currentInjury = $manager->currentInjury;
-    expect($currentInjury)->not()->toBeNull();
+    $currentInjury = $manager->currentInjury()->firstOrFail();
 
     HealAction::run($manager);
 
@@ -77,7 +76,7 @@ test('it prevents healing non-injured manager', function () {
 
 test('it handles database transactions correctly', function () {
     $manager = Manager::factory()->injured()->create();
-    $originalInjuryId = $manager->currentInjury->id;
+    $originalInjuryId = $manager->currentInjury()->firstOrFail()->id;
 
     HealAction::run($manager);
 
@@ -112,8 +111,7 @@ test('it maintains employment status during healing', function () {
     expect($manager->isInjured())->toBeFalse();
 
     // Employment record should remain unchanged
-    $employment = $manager->currentEmployment;
-    expect($employment)->not()->toBeNull();
+    $employment = $manager->currentEmployment()->firstOrFail();
     expect($employment->ended_at)->toBeNull();
 });
 

--- a/tests/Integration/Actions/Managers/InjureActionTest.php
+++ b/tests/Integration/Actions/Managers/InjureActionTest.php
@@ -96,15 +96,14 @@ test('it handles database transactions correctly', function () {
     expect($manager->isInjured())->toBeTrue();
 
     // Verify injury record integrity
-    $injury = $manager->currentInjury;
-    expect($injury)->not()->toBeNull();
-    expect($injury->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $injury = $manager->currentInjury()->firstOrFail();
+    expect(requiredDate($injury->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($injury->ended_at)->toBeNull();
 });
 
 test('it maintains employment status during injury', function () {
     $manager = Manager::factory()->employed()->create();
-    $employmentId = $manager->currentEmployment->id;
+    $employmentId = $manager->currentEmployment()->firstOrFail()->id;
 
     expect($manager->isEmployed())->toBeTrue();
     expect($manager->isInjured())->toBeFalse();
@@ -118,8 +117,7 @@ test('it maintains employment status during injury', function () {
     expect($manager->isInjured())->toBeTrue();
 
     // Employment record should remain unchanged
-    $employment = $manager->currentEmployment;
-    expect($employment)->not()->toBeNull();
+    $employment = $manager->currentEmployment()->firstOrFail();
     expect($employment->id)->toBe($employmentId);
     expect($employment->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/Managers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Managers/ReinstateActionTest.php
@@ -50,8 +50,7 @@ test('it uses StatusTransitionPipeline for reinstatement', function () {
     $manager = Manager::factory()->employed()->suspended()->create();
 
     // Get current suspension to verify it gets ended
-    $currentSuspension = $manager->currentSuspension;
-    expect($currentSuspension)->not()->toBeNull();
+    $currentSuspension = $manager->currentSuspension()->firstOrFail();
 
     ReinstateAction::run($manager);
 
@@ -79,7 +78,7 @@ test('it prevents reinstating non-suspended manager', function () {
 
 test('it handles database transactions correctly', function () {
     $manager = Manager::factory()->employed()->suspended()->create();
-    $originalSuspensionId = $manager->currentSuspension->id;
+    $originalSuspensionId = $manager->currentSuspension()->firstOrFail()->id;
 
     ReinstateAction::run($manager);
 
@@ -101,7 +100,7 @@ test('it handles database transactions correctly', function () {
 
 test('it maintains employment status during reinstatement', function () {
     $manager = Manager::factory()->employed()->suspended()->create();
-    $employmentId = $manager->currentEmployment->id;
+    $employmentId = $manager->currentEmployment()->firstOrFail()->id;
 
     expect($manager->isEmployed())->toBeTrue();
     expect($manager->isSuspended())->toBeTrue();
@@ -115,8 +114,7 @@ test('it maintains employment status during reinstatement', function () {
     expect($manager->isSuspended())->toBeFalse();
 
     // Employment record should remain unchanged
-    $employment = $manager->currentEmployment;
-    expect($employment)->not()->toBeNull();
+    $employment = $manager->currentEmployment()->firstOrFail();
     expect($employment->id)->toBe($employmentId);
     expect($employment->ended_at)->toBeNull();
 });
@@ -167,8 +165,8 @@ test('it reinstates injured suspended manager', function () {
 
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isInjured())->toBeTrue();
-    $suspensionId = $manager->currentSuspension->id;
-    $injuryId = $manager->currentInjury->id;
+    $suspensionId = $manager->currentSuspension()->firstOrFail()->id;
+    $injuryId = $manager->currentInjury()->firstOrFail()->id;
 
     ReinstateAction::run($manager);
 

--- a/tests/Integration/Actions/Managers/ReleaseActionTest.php
+++ b/tests/Integration/Actions/Managers/ReleaseActionTest.php
@@ -248,7 +248,7 @@ test('it preserves management history during release', function () {
     // Verify the current relationship was ended with release date
     $currentRelationship = $manager->wrestlers()
         ->wherePivot('hired_at', now()->subDays(10)->toDateTimeString())
-        ->first();
+        ->firstOrFail();
 
     expect(relatedPivotAttribute($currentRelationship, 'fired_at'))->toBe(now()->toDateTimeString());
 });

--- a/tests/Integration/Actions/Managers/RestoreActionTest.php
+++ b/tests/Integration/Actions/Managers/RestoreActionTest.php
@@ -25,12 +25,11 @@ test('it restores a soft-deleted manager', function () {
     expect(Manager::withTrashed()->find($managerId))->not()->toBeNull();
 
     // Restore the manager
-    $deletedManager = Manager::onlyTrashed()->find($managerId);
+    $deletedManager = Manager::onlyTrashed()->findOrFail($managerId);
     RestoreAction::run($deletedManager);
 
     // Verify manager is restored
-    $restoredManager = Manager::find($managerId);
-    expect($restoredManager)->not()->toBeNull();
+    $restoredManager = Manager::findOrFail($managerId);
     expect($restoredManager->deleted_at)->toBeNull();
 });
 
@@ -43,12 +42,11 @@ test('it handles database transactions correctly', function () {
     $manager->delete();
 
     // Restore the manager
-    $deletedManager = Manager::onlyTrashed()->find($managerId);
+    $deletedManager = Manager::onlyTrashed()->findOrFail($managerId);
     RestoreAction::run($deletedManager);
 
     // Verify transaction was successful
-    $restoredManager = Manager::find($managerId);
-    expect($restoredManager)->not()->toBeNull();
+    $restoredManager = Manager::findOrFail($managerId);
     expect($restoredManager->deleted_at)->toBeNull();
 
     // Verify historical records are preserved
@@ -71,11 +69,11 @@ test('it preserves all historical records during restoration', function () {
     $manager->delete();
 
     // Restore the manager
-    $deletedManager = Manager::onlyTrashed()->find($managerId);
+    $deletedManager = Manager::onlyTrashed()->findOrFail($managerId);
     RestoreAction::run($deletedManager);
 
     // Verify all historical records are preserved
-    $restoredManager = Manager::find($managerId);
+    $restoredManager = Manager::findOrFail($managerId);
     expect($restoredManager->employments()->count())->toBe($originalEmploymentCount);
     expect($restoredManager->suspensions()->count())->toBe($originalSuspensionCount);
     expect($restoredManager->injuries()->count())->toBe($originalInjuryCount);
@@ -92,12 +90,11 @@ test('it does not automatically restore employment relationships', function () {
     $manager->delete();
 
     // Restore the manager
-    $deletedManager = Manager::onlyTrashed()->find($managerId);
+    $deletedManager = Manager::onlyTrashed()->findOrFail($managerId);
     RestoreAction::run($deletedManager);
 
     // Verify manager is restored but not automatically employed
-    $restoredManager = Manager::find($managerId);
-    expect($restoredManager)->not()->toBeNull();
+    $restoredManager = Manager::findOrFail($managerId);
 
     // Manager should not be automatically employed - requires separate action
     // This tests the business rule that restoration doesn't auto-employ
@@ -122,12 +119,11 @@ test('it does not automatically restore management relationships', function () {
     $manager->delete();
 
     // Restore the manager
-    $deletedManager = Manager::onlyTrashed()->find($managerId);
+    $deletedManager = Manager::onlyTrashed()->findOrFail($managerId);
     RestoreAction::run($deletedManager);
 
     // Verify manager is restored
-    $restoredManager = Manager::find($managerId);
-    expect($restoredManager)->not()->toBeNull();
+    $restoredManager = Manager::findOrFail($managerId);
 
     // Management relationships should be preserved but not automatically reactivated
     expect($restoredManager->wrestlers()->count())->toBe(1); // Historical preserved
@@ -155,11 +151,11 @@ test('it handles managers with complex deletion history', function () {
     $manager->delete();
 
     // Restore the manager
-    $deletedManager = Manager::onlyTrashed()->find($managerId);
+    $deletedManager = Manager::onlyTrashed()->findOrFail($managerId);
     RestoreAction::run($deletedManager);
 
     // Verify all complex history is preserved
-    $restoredManager = Manager::find($managerId);
+    $restoredManager = Manager::findOrFail($managerId);
     expect($restoredManager->employments()->count())->toBe($originalRecordCounts['employments']);
     expect($restoredManager->retirements()->count())->toBe($originalRecordCounts['retirements']);
 });
@@ -190,22 +186,22 @@ test('it maintains referential integrity during restoration', function () {
     $manager->delete();
 
     // Restore the manager
-    $deletedManager = Manager::onlyTrashed()->find($managerId);
+    $deletedManager = Manager::onlyTrashed()->findOrFail($managerId);
     RestoreAction::run($deletedManager);
 
     // Verify referential integrity is maintained
-    $restoredManager = Manager::find($managerId);
+    $restoredManager = Manager::findOrFail($managerId);
 
     // All pivot relationships should be preserved
     expect($restoredManager->wrestlers()->count())->toBe(1);
     expect($restoredManager->tagTeams()->count())->toBe(1);
 
     // Verify pivot data integrity
-    $wrestlerPivot = $restoredManager->wrestlers()->first()->pivot;
+    $wrestlerPivot = $restoredManager->wrestlers()->firstOrFail()->pivot;
     expect($wrestlerPivot->getAttribute('hired_at'))->not()->toBeNull();
     expect($wrestlerPivot->getAttribute('fired_at'))->not()->toBeNull();
 
-    $tagTeamPivot = $restoredManager->tagTeams()->first()->pivot;
+    $tagTeamPivot = $restoredManager->tagTeams()->firstOrFail()->pivot;
     expect($tagTeamPivot->getAttribute('hired_at'))->not()->toBeNull();
     expect($tagTeamPivot->getAttribute('fired_at'))->not()->toBeNull();
 });
@@ -218,11 +214,11 @@ test('it allows separate employment after restoration', function () {
     $manager->delete();
 
     // Restore the manager
-    $deletedManager = Manager::onlyTrashed()->find($managerId);
+    $deletedManager = Manager::onlyTrashed()->findOrFail($managerId);
     RestoreAction::run($deletedManager);
 
     // Verify manager can be employed separately after restoration
-    $restoredManager = Manager::find($managerId);
+    $restoredManager = Manager::findOrFail($managerId);
     expect($restoredManager->isEmployed())->toBeFalse();
 
     // This would require a separate EmployAction call

--- a/tests/Integration/Actions/Managers/RetireActionTest.php
+++ b/tests/Integration/Actions/Managers/RetireActionTest.php
@@ -204,9 +204,8 @@ test('it handles database transactions correctly', function () {
     expect($manager->currentWrestlers)->toHaveCount(0);
 
     // Verify all database changes are consistent
-    $retirement = $manager->currentRetirement;
-    expect($retirement)->not()->toBeNull();
-    expect($retirement->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $retirement = $manager->currentRetirement()->firstOrFail();
+    expect(requiredDate($retirement->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($retirement->ended_at)->toBeNull();
 });
 
@@ -258,7 +257,7 @@ test('it preserves management history during retirement', function () {
     // Verify the current relationship was ended with retirement date
     $currentRelationship = $manager->wrestlers()
         ->wherePivot('hired_at', now()->subDays(10)->toDateTimeString())
-        ->first();
+        ->firstOrFail();
 
     expect(relatedPivotAttribute($currentRelationship, 'fired_at'))->toBe(now()->toDateTimeString());
 });

--- a/tests/Integration/Actions/Managers/SuspendActionTest.php
+++ b/tests/Integration/Actions/Managers/SuspendActionTest.php
@@ -96,15 +96,14 @@ test('it handles database transactions correctly', function () {
     expect($manager->isSuspended())->toBeTrue();
 
     // Verify suspension record integrity
-    $suspension = $manager->currentSuspension;
-    expect($suspension)->not()->toBeNull();
-    expect($suspension->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $suspension = $manager->currentSuspension()->firstOrFail();
+    expect(requiredDate($suspension->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($suspension->ended_at)->toBeNull();
 });
 
 test('it maintains employment status during suspension', function () {
     $manager = Manager::factory()->employed()->create();
-    $employmentId = $manager->currentEmployment->id;
+    $employmentId = $manager->currentEmployment()->firstOrFail()->id;
 
     expect($manager->isEmployed())->toBeTrue();
     expect($manager->isSuspended())->toBeFalse();
@@ -118,8 +117,7 @@ test('it maintains employment status during suspension', function () {
     expect($manager->isSuspended())->toBeTrue();
 
     // Employment record should remain unchanged
-    $employment = $manager->currentEmployment;
-    expect($employment)->not()->toBeNull();
+    $employment = $manager->currentEmployment()->firstOrFail();
     expect($employment->id)->toBe($employmentId);
     expect($employment->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/Managers/UnretireActionTest.php
+++ b/tests/Integration/Actions/Managers/UnretireActionTest.php
@@ -64,8 +64,7 @@ test('it uses StatusTransitionPipeline for unretirement', function () {
     $manager = Manager::factory()->retired()->create();
 
     // Get current retirement to verify it gets ended
-    $currentRetirement = $manager->currentRetirement;
-    expect($currentRetirement)->not()->toBeNull();
+    $currentRetirement = $manager->currentRetirement()->firstOrFail();
     expect($manager->currentEmployment)->toBeNull();
 
     UnretireAction::run($manager);
@@ -102,7 +101,7 @@ test('it prevents unretiring non-retired manager', function () {
 
 test('it handles database transactions correctly', function () {
     $manager = Manager::factory()->retired()->create();
-    $originalRetirementId = $manager->currentRetirement->id;
+    $originalRetirementId = $manager->currentRetirement()->firstOrFail()->id;
 
     UnretireAction::run($manager);
 
@@ -120,9 +119,8 @@ test('it handles database transactions correctly', function () {
     ]);
 
     // Verify new employment record was created
-    $employment = $manager->currentEmployment;
-    expect($employment)->not()->toBeNull();
-    expect($employment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $employment = $manager->currentEmployment()->firstOrFail();
+    expect(requiredDate($employment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });
 
@@ -139,9 +137,8 @@ test('it creates new employment period during unretirement', function () {
     expect($manager->isEmployed())->toBeTrue();
 
     // New employment should be current and active
-    $currentEmployment = $manager->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
-    expect($currentEmployment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentEmployment = $manager->currentEmployment()->firstOrFail();
+    expect(requiredDate($currentEmployment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($currentEmployment->ended_at)->toBeNull();
 });
 
@@ -234,7 +231,6 @@ test('it handles manager with complex status history', function () {
     expect($manager->retirements()->count())->toBe(2); // Both historical now
 
     // New employment should be current
-    $currentEmployment = $manager->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
-    expect($currentEmployment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentEmployment = $manager->currentEmployment()->firstOrFail();
+    expect(requiredDate($currentEmployment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });

--- a/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
@@ -27,8 +27,8 @@ test('it adds a single title to a match', function () {
     ]);
 
     // Match should have the title
-    expect($match->fresh()->titles)->toHaveCount(1);
-    expect($match->fresh()->titles->first()->id)->toBe($title->id);
+    expect($match->refresh()->titles)->toHaveCount(1);
+    expect($match->refresh()->titles->firstOrFail()->id)->toBe($title->id);
 });
 
 test('it adds multiple titles to a match', function () {
@@ -52,8 +52,8 @@ test('it adds multiple titles to a match', function () {
     ]);
 
     // Match should have both titles
-    expect($match->fresh()->titles)->toHaveCount(2);
-    expect($match->fresh()->titles->pluck('id'))->toContain($title1->id, $title2->id);
+    expect($match->refresh()->titles)->toHaveCount(2);
+    expect($match->refresh()->titles->pluck('id'))->toContain($title1->id, $title2->id);
 });
 
 test('it filters out inactive titles', function () {
@@ -76,8 +76,8 @@ test('it filters out inactive titles', function () {
         'title_id' => $inactiveTitle->id,
     ]);
 
-    expect($match->fresh()->titles)->toHaveCount(1);
-    expect($match->fresh()->titles->first()->id)->toBe($activeTitle->id);
+    expect($match->refresh()->titles)->toHaveCount(1);
+    expect($match->refresh()->titles->firstOrFail()->id)->toBe($activeTitle->id);
 });
 
 test('it throws exception when no eligible titles provided', function () {
@@ -112,7 +112,7 @@ test('it creates championship match correctly', function () {
     AddTitlesToMatchAction::run($match, $titles);
 
     // Match should be associated with both titles
-    $matchTitles = $match->fresh()->titles;
+    $matchTitles = $match->refresh()->titles;
     expect($matchTitles)->toHaveCount(2);
 
     $titleNames = $matchTitles->pluck('name')->toArray();
@@ -130,7 +130,7 @@ test('it handles transaction consistency', function () {
     AddTitlesToMatchAction::run($match, $titles);
 
     // Both titles should be added atomically
-    expect($match->fresh()->titles)->toHaveCount(2);
+    expect($match->refresh()->titles)->toHaveCount(2);
 
     // Verify both database records exist
     $this->assertDatabaseCount('events_matches_titles', 2);

--- a/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
@@ -30,8 +30,8 @@ test('it adds a single wrestler to a match', function () {
     ]);
 
     // Match should have the wrestler as competitor
-    expect($match->fresh()->competitors()->count())->toBe(1);
-    expect($match->fresh()->competitors()->first()->competitor_id)->toBe($wrestler->id);
+    expect($match->refresh()->competitors()->count())->toBe(1);
+    expect($match->refresh()->competitors()->firstOrFail()->competitor_id)->toBe($wrestler->id);
 });
 
 test('it adds multiple wrestlers to the same side', function () {
@@ -60,7 +60,7 @@ test('it adds multiple wrestlers to the same side', function () {
     ]);
 
     // Match should have both wrestlers
-    expect($match->fresh()->competitors()->count())->toBe(2);
+    expect($match->refresh()->competitors()->count())->toBe(2);
 });
 
 test('it adds wrestlers to different sides', function () {
@@ -89,7 +89,7 @@ test('it adds wrestlers to different sides', function () {
         'side_number' => 2,
     ]);
 
-    expect($match->fresh()->competitors()->count())->toBe(2);
+    expect($match->refresh()->competitors()->count())->toBe(2);
 });
 
 test('it filters out ineligible wrestlers', function () {
@@ -116,7 +116,7 @@ test('it filters out ineligible wrestlers', function () {
         'competitor_type' => Wrestler::class,
     ]);
 
-    expect($match->fresh()->competitors()->count())->toBe(1);
+    expect($match->refresh()->competitors()->count())->toBe(1);
 });
 
 test('it throws exception when no eligible wrestlers provided', function () {
@@ -153,5 +153,5 @@ test('it handles transaction rollback on failure', function () {
         ->toThrow(InvalidArgumentException::class);
 
     // No competitors should be added due to transaction rollback
-    expect($match->fresh()->competitors()->count())->toBe(0);
+    expect($match->refresh()->competitors()->count())->toBe(0);
 });

--- a/tests/Integration/Actions/Referees/CreateActionTest.php
+++ b/tests/Integration/Actions/Referees/CreateActionTest.php
@@ -108,7 +108,7 @@ test('it handles employment creation through EmployAction dependency injection',
     expect($result->isEmployed())->toBeTrue();
     expect($result->currentEmployment()->exists())->toBeTrue();
 
-    $employment = $result->currentEmployment()->first();
-    expect($employment->started_at->toDateTimeString())->toBe($employmentDate->toDateTimeString());
+    $employment = $result->currentEmployment()->firstOrFail();
+    expect(requiredDate($employment->started_at)->toDateTimeString())->toBe($employmentDate->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/Referees/DeleteActionTest.php
+++ b/tests/Integration/Actions/Referees/DeleteActionTest.php
@@ -48,7 +48,7 @@ test('it soft deletes referee with specific deletion date', function () {
 
 test('it ends employment before deletion using StatusTransitionPipeline', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
     expect($employment->ended_at)->toBeNull();
@@ -71,7 +71,7 @@ test('it ends employment before deletion using StatusTransitionPipeline', functi
 
 test('it ends suspension before deletion', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $suspension = $referee->currentSuspension;
+    $suspension = $referee->currentSuspension()->firstOrFail();
 
     expect($referee->isSuspended())->toBeTrue();
     expect($suspension->ended_at)->toBeNull();
@@ -94,7 +94,7 @@ test('it ends suspension before deletion', function () {
 
 test('it ends injury before deletion', function () {
     $referee = Referee::factory()->employed()->injured()->create();
-    $injury = $referee->currentInjury;
+    $injury = $referee->currentInjury()->firstOrFail();
 
     expect($referee->isInjured())->toBeTrue();
     expect($injury->ended_at)->toBeNull();
@@ -117,7 +117,7 @@ test('it ends injury before deletion', function () {
 
 test('it ends retirement before deletion', function () {
     $referee = Referee::factory()->retired()->create();
-    $retirement = $referee->currentRetirement;
+    $retirement = $referee->currentRetirement()->firstOrFail();
 
     expect($referee->isRetired())->toBeTrue();
     expect($retirement->ended_at)->toBeNull();
@@ -156,8 +156,8 @@ test('it handles DateHelper date resolution for deletion', function () {
 
 test('it maintains transaction boundaries', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $employment = $referee->currentEmployment;
-    $suspension = $referee->currentSuspension;
+    $employment = $referee->currentEmployment()->firstOrFail();
+    $suspension = $referee->currentSuspension()->firstOrFail();
 
     DeleteAction::run($referee);
 
@@ -183,7 +183,7 @@ test('it validates referee can be deleted', function () {
 
 test('it preserves historical data after deletion', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     DeleteAction::run($referee);
 
@@ -194,7 +194,7 @@ test('it preserves historical data after deletion', function () {
     $this->assertDatabaseHas('referees_employments', [
         'id' => $employment->id,
         'referee_id' => $referee->id,
-        'started_at' => $employment->started_at->toDateTimeString(),
+        'started_at' => requiredDate($employment->started_at)->toDateTimeString(),
         'ended_at' => now()->toDateTimeString(),
     ]);
 

--- a/tests/Integration/Actions/Referees/EmployActionTest.php
+++ b/tests/Integration/Actions/Referees/EmployActionTest.php
@@ -68,7 +68,7 @@ test('it prevents re-employing injured referee', function () {
 
 test('it employs retired referee and ends retirement', function () {
     $referee = Referee::factory()->retired()->create();
-    $retirement = $referee->currentRetirement;
+    $retirement = $referee->currentRetirement()->firstOrFail();
 
     expect($referee->isRetired())->toBeTrue();
     expect($referee->isEmployed())->toBeFalse();
@@ -113,7 +113,7 @@ test('it handles DateHelper date resolution', function () {
 
 test('it prevents re-employing suspended referee without changing records', function () {
     $referee = Referee::factory()->suspended()->create();
-    $suspension = $referee->currentSuspension;
+    $suspension = $referee->currentSuspension()->firstOrFail();
 
     expect(fn () => EmployAction::run($referee))
         ->toThrow(CannotBeEmployedException::class);
@@ -138,7 +138,7 @@ test('it validates referee can be employed', function () {
 
 test('it prevents double employment', function () {
     $referee = Referee::factory()->employed()->create();
-    $originalEmployment = $referee->currentEmployment;
+    $originalEmployment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
 
@@ -148,7 +148,7 @@ test('it prevents double employment', function () {
     $referee->refresh();
     expect($referee->isEmployed())->toBeTrue();
     expect($referee->employments()->count())->toBe(1);
-    expect($referee->currentEmployment->id)->toBe($originalEmployment->id);
+    expect($referee->currentEmployment()->firstOrFail()->id)->toBe($originalEmployment->id);
 });
 
 test('it updates referee status to employed', function () {
@@ -168,10 +168,10 @@ test('it creates employment record with correct structure', function () {
 
     EmployAction::run($referee, $employmentDate);
 
-    $employment = $referee->fresh()->currentEmployment;
+    $employment = freshModel($referee)->currentEmployment()->firstOrFail();
 
     expect($employment)->not->toBeNull();
     expect($employment->referee_id)->toBe($referee->id);
-    expect($employment->started_at->toDateTimeString())->toBe($employmentDate->toDateTimeString());
+    expect(requiredDate($employment->started_at)->toDateTimeString())->toBe($employmentDate->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/Referees/HealActionTest.php
+++ b/tests/Integration/Actions/Referees/HealActionTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
 
 test('it heals an injured referee', function () {
     $referee = Referee::factory()->employed()->injured()->create();
-    $injury = $referee->currentInjury;
+    $injury = $referee->currentInjury()->firstOrFail();
 
     expect($referee->isInjured())->toBeTrue();
     expect($injury->ended_at)->toBeNull();
@@ -35,7 +35,7 @@ test('it heals an injured referee', function () {
 
 test('it heals referee with specific recovery date', function () {
     $referee = Referee::factory()->employed()->injured()->create();
-    $injury = $referee->currentInjury;
+    $injury = $referee->currentInjury()->firstOrFail();
     $recoveryDate = now()->subDays(2);
 
     HealAction::run($referee, $recoveryDate);
@@ -44,7 +44,7 @@ test('it heals referee with specific recovery date', function () {
     $injury->refresh();
 
     expect($referee->isInjured())->toBeFalse();
-    expect($injury->ended_at->toDateTimeString())->toBe($recoveryDate->toDateTimeString());
+    expect(requiredDate($injury->ended_at)->toDateTimeString())->toBe($recoveryDate->toDateTimeString());
 
     $this->assertDatabaseHas('referees_injuries', [
         'id' => $injury->id,
@@ -102,7 +102,7 @@ test('it throws exception when referee cannot be healed', function () {
 
 test('it maintains referee employment status after healing', function () {
     $referee = Referee::factory()->employed()->injured()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
     expect($referee->isInjured())->toBeTrue();
@@ -120,7 +120,7 @@ test('it maintains referee employment status after healing', function () {
 
 test('it preserves injury history', function () {
     $referee = Referee::factory()->employed()->injured()->create();
-    $injury = $referee->currentInjury;
+    $injury = $referee->currentInjury()->firstOrFail();
     $originalStartedAt = $injury->started_at;
 
     HealAction::run($referee);

--- a/tests/Integration/Actions/Referees/InjureActionTest.php
+++ b/tests/Integration/Actions/Referees/InjureActionTest.php
@@ -100,7 +100,7 @@ test('it maintains transaction boundaries', function () {
 
 test('it maintains referee employment after injury', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
 
@@ -121,10 +121,10 @@ test('it creates injury record with correct structure', function () {
 
     InjureAction::run($referee, $injuryDate);
 
-    $injury = $referee->fresh()->currentInjury;
+    $injury = freshModel($referee)->currentInjury()->firstOrFail();
 
     expect($injury)->not->toBeNull();
     expect($injury->referee_id)->toBe($referee->id);
-    expect($injury->started_at->toDateTimeString())->toBe($injuryDate->toDateTimeString());
+    expect(requiredDate($injury->started_at)->toDateTimeString())->toBe($injuryDate->toDateTimeString());
     expect($injury->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/Referees/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Referees/ReinstateActionTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
 
 test('it reinstates a suspended referee', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $suspension = $referee->currentSuspension;
+    $suspension = $referee->currentSuspension()->firstOrFail();
 
     expect($referee->isSuspended())->toBeTrue();
     expect($suspension->ended_at)->toBeNull();
@@ -35,7 +35,7 @@ test('it reinstates a suspended referee', function () {
 
 test('it reinstates referee with specific reinstatement date', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $suspension = $referee->currentSuspension;
+    $suspension = $referee->currentSuspension()->firstOrFail();
     $reinstatementDate = now()->subDays(1);
 
     ReinstateAction::run($referee, $reinstatementDate);
@@ -44,7 +44,7 @@ test('it reinstates referee with specific reinstatement date', function () {
     $suspension->refresh();
 
     expect($referee->isSuspended())->toBeFalse();
-    expect($suspension->ended_at->toDateTimeString())->toBe($reinstatementDate->toDateTimeString());
+    expect(requiredDate($suspension->ended_at)->toDateTimeString())->toBe($reinstatementDate->toDateTimeString());
 
     $this->assertDatabaseHas('referees_suspensions', [
         'id' => $suspension->id,
@@ -88,7 +88,7 @@ test('it throws exception when referee cannot be reinstated', function () {
 
 test('it maintains referee employment after reinstatement', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
     expect($referee->isSuspended())->toBeTrue();
@@ -106,7 +106,7 @@ test('it maintains referee employment after reinstatement', function () {
 
 test('it preserves suspension history', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $suspension = $referee->currentSuspension;
+    $suspension = $referee->currentSuspension()->firstOrFail();
     $originalStartedAt = $suspension->started_at;
 
     ReinstateAction::run($referee);

--- a/tests/Integration/Actions/Referees/ReleaseActionTest.php
+++ b/tests/Integration/Actions/Referees/ReleaseActionTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
 
 test('it releases an employed referee', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
     expect($employment->ended_at)->toBeNull();
@@ -35,7 +35,7 @@ test('it releases an employed referee', function () {
 
 test('it releases referee with specific release date', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
     $releaseDate = now()->subDays(4);
 
     ReleaseAction::run($referee, $releaseDate);
@@ -44,7 +44,7 @@ test('it releases referee with specific release date', function () {
     $employment->refresh();
 
     expect($referee->isEmployed())->toBeFalse();
-    expect($employment->ended_at->toDateTimeString())->toBe($releaseDate->toDateTimeString());
+    expect(requiredDate($employment->ended_at)->toDateTimeString())->toBe($releaseDate->toDateTimeString());
 
     $this->assertDatabaseHas('referees_employments', [
         'id' => $employment->id,
@@ -88,7 +88,7 @@ test('it throws exception when referee cannot be released', function () {
 
 test('it ends suspension before releasing', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $suspension = $referee->currentSuspension;
+    $suspension = $referee->currentSuspension()->firstOrFail();
 
     expect($referee->isSuspended())->toBeTrue();
     expect($suspension->ended_at)->toBeNull();
@@ -105,7 +105,7 @@ test('it ends suspension before releasing', function () {
 
 test('it ends injury before releasing', function () {
     $referee = Referee::factory()->employed()->injured()->create();
-    $injury = $referee->currentInjury;
+    $injury = $referee->currentInjury()->firstOrFail();
 
     expect($referee->isInjured())->toBeTrue();
     expect($injury->ended_at)->toBeNull();
@@ -122,8 +122,8 @@ test('it ends injury before releasing', function () {
 
 test('it maintains transaction boundaries', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $employment = $referee->currentEmployment;
-    $suspension = $referee->currentSuspension;
+    $employment = $referee->currentEmployment()->firstOrFail();
+    $suspension = $referee->currentSuspension()->firstOrFail();
 
     ReleaseAction::run($referee);
 
@@ -139,7 +139,7 @@ test('it maintains transaction boundaries', function () {
 
 test('it preserves employment history', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
     $originalStartedAt = $employment->started_at;
 
     ReleaseAction::run($referee);

--- a/tests/Integration/Actions/Referees/RestoreActionTest.php
+++ b/tests/Integration/Actions/Referees/RestoreActionTest.php
@@ -86,20 +86,20 @@ test('it preserves referee data after restoration', function () {
     expect($referee->id)->toBe($originalId);
     expect($referee->first_name)->toBe('Earl');
     expect($referee->last_name)->toBe('Hebner');
-    expect($referee->created_at->timestamp)->toBe($originalCreatedAt->timestamp);
+    expect(requiredDate($referee->created_at)->timestamp)->toBe(requiredDate($originalCreatedAt)->timestamp);
     expect($referee->deleted_at)->toBeNull();
 });
 
 test('it does not automatically restore employment relationships', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     // End employment and soft delete referee
     $employment->update(['ended_at' => now()]);
     $referee->delete();
 
     expect($referee->trashed())->toBeTrue();
-    expect($employment->fresh()->ended_at)->not->toBeNull();
+    expect(freshModel($employment)->ended_at)->not->toBeNull();
 
     RestoreAction::run($referee);
 
@@ -147,7 +147,7 @@ test('it preserves historical relationships', function () {
 
 test('it allows referee to be re-employed after restoration', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     // End employment and delete referee
     $employment->update(['ended_at' => now()]);

--- a/tests/Integration/Actions/Referees/RetireActionTest.php
+++ b/tests/Integration/Actions/Referees/RetireActionTest.php
@@ -14,7 +14,7 @@ beforeEach(function () {
 
 test('it retires an employed referee', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
     expect($referee->isRetired())->toBeFalse();
@@ -94,7 +94,7 @@ test('it throws exception when referee cannot be retired', function () {
 
 test('it ends employment when retiring', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($employment->ended_at)->toBeNull();
 
@@ -111,7 +111,7 @@ test('it ends employment when retiring', function () {
 
 test('it ends suspension before retiring', function () {
     $referee = Referee::factory()->employed()->suspended()->create();
-    $suspension = $referee->currentSuspension;
+    $suspension = $referee->currentSuspension()->firstOrFail();
 
     expect($referee->isSuspended())->toBeTrue();
     expect($suspension->ended_at)->toBeNull();
@@ -128,7 +128,7 @@ test('it ends suspension before retiring', function () {
 
 test('it ends injury before retiring', function () {
     $referee = Referee::factory()->employed()->injured()->create();
-    $injury = $referee->currentInjury;
+    $injury = $referee->currentInjury()->firstOrFail();
 
     expect($referee->isInjured())->toBeTrue();
     expect($injury->ended_at)->toBeNull();
@@ -149,10 +149,10 @@ test('it creates retirement record with correct structure', function () {
 
     RetireAction::run($referee, $retirementDate);
 
-    $retirement = $referee->fresh()->currentRetirement;
+    $retirement = freshModel($referee)->currentRetirement()->firstOrFail();
 
     expect($retirement)->not->toBeNull();
     expect($retirement->referee_id)->toBe($referee->id);
-    expect($retirement->started_at->toDateTimeString())->toBe($retirementDate->toDateTimeString());
+    expect(requiredDate($retirement->started_at)->toDateTimeString())->toBe($retirementDate->toDateTimeString());
     expect($retirement->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/Referees/SuspendActionTest.php
+++ b/tests/Integration/Actions/Referees/SuspendActionTest.php
@@ -83,7 +83,7 @@ test('it throws exception when referee cannot be suspended', function () {
 
 test('it maintains referee employment after suspension', function () {
     $referee = Referee::factory()->employed()->create();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
 
@@ -104,10 +104,10 @@ test('it creates suspension record with correct structure', function () {
 
     SuspendAction::run($referee, $suspensionDate);
 
-    $suspension = $referee->fresh()->currentSuspension;
+    $suspension = freshModel($referee)->currentSuspension()->firstOrFail();
 
     expect($suspension)->not->toBeNull();
     expect($suspension->referee_id)->toBe($referee->id);
-    expect($suspension->started_at->toDateTimeString())->toBe($suspensionDate->toDateTimeString());
+    expect(requiredDate($suspension->started_at)->toDateTimeString())->toBe($suspensionDate->toDateTimeString());
     expect($suspension->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/Referees/UnretireActionTest.php
+++ b/tests/Integration/Actions/Referees/UnretireActionTest.php
@@ -15,7 +15,7 @@ beforeEach(function () {
 
 test('it unretires a retired referee', function () {
     $referee = Referee::factory()->retired()->create();
-    $retirement = $referee->currentRetirement;
+    $retirement = $referee->currentRetirement()->firstOrFail();
 
     expect($referee->isRetired())->toBeTrue();
     expect($referee->isEmployed())->toBeFalse();
@@ -39,7 +39,7 @@ test('it unretires a retired referee', function () {
 
 test('it unretires referee with specific unretirement date', function () {
     $referee = Referee::factory()->retired()->create();
-    $retirement = $referee->currentRetirement;
+    $retirement = $referee->currentRetirement()->firstOrFail();
     $unretiredDate = now()->subDays(3);
 
     UnretireAction::run($referee, $unretiredDate);
@@ -49,7 +49,7 @@ test('it unretires referee with specific unretirement date', function () {
 
     expect($referee->isRetired())->toBeFalse();
     expect($referee->isEmployed())->toBeTrue();
-    expect($retirement->ended_at->toDateTimeString())->toBe($unretiredDate->toDateTimeString());
+    expect(requiredDate($retirement->ended_at)->toDateTimeString())->toBe($unretiredDate->toDateTimeString());
 
     $this->assertDatabaseHas('referees_retirements', [
         'id' => $retirement->id,
@@ -120,7 +120,7 @@ test('it throws exception when referee cannot be unretired', function () {
 
 test('it preserves retirement history', function () {
     $referee = Referee::factory()->retired()->create();
-    $retirement = $referee->currentRetirement;
+    $retirement = $referee->currentRetirement()->firstOrFail();
     $originalStartedAt = $retirement->started_at;
 
     UnretireAction::run($referee);
@@ -144,17 +144,17 @@ test('it restores referee employment after unretirement', function () {
     UnretireAction::run($referee);
 
     $referee->refresh();
-    $employment = $referee->currentEmployment;
+    $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($employment)->not->toBeNull();
     expect($employment->referee_id)->toBe($referee->id);
-    expect($employment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    expect(requiredDate($employment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });
 
 test('it rolls back retirement changes when employment restoration fails', function () {
     $referee = Referee::factory()->retired()->create();
-    $retirement = $referee->currentRetirement;
+    $retirement = $referee->currentRetirement()->firstOrFail();
 
     RefereeEmployment::creating(function (): void {
         throw new RuntimeException('Employment restoration failed.');

--- a/tests/Integration/Actions/Referees/UpdateActionTest.php
+++ b/tests/Integration/Actions/Referees/UpdateActionTest.php
@@ -90,7 +90,7 @@ test('it updates referee without employing when no employment date', function ()
 
 test('it does not re-employ already employed referee', function () {
     $referee = Referee::factory()->employed()->create();
-    $originalEmployment = $referee->currentEmployment;
+    $originalEmployment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
 
@@ -109,7 +109,7 @@ test('it does not re-employ already employed referee', function () {
 
     // Should still have only the original employment record
     expect($result->employments()->count())->toBe(1);
-    expect($result->currentEmployment->id)->toBe($originalEmployment->id);
+    expect($result->currentEmployment()->firstOrFail()->id)->toBe($originalEmployment->id);
 });
 
 test('it handles DateHelper date resolution for employment', function () {
@@ -192,7 +192,7 @@ test('it preserves referee id and timestamps', function () {
     $result = UpdateAction::run($referee, $updateData);
 
     expect($result->id)->toBe($originalId);
-    expect($result->created_at->timestamp)->toBe($originalCreatedAt->timestamp);
+    expect(requiredDate($result->created_at)->timestamp)->toBe(requiredDate($originalCreatedAt)->timestamp);
     expect($result->updated_at)->not()->toBeNull();
 });
 
@@ -229,7 +229,7 @@ test('it uses EmployAction for consistent employment handling', function () {
     expect($result->isEmployed())->toBeTrue();
     expect($result->currentEmployment()->exists())->toBeTrue();
 
-    $employment = $result->currentEmployment()->first();
-    expect($employment->started_at->toDateTimeString())->toBe($employmentDate->toDateTimeString());
+    $employment = $result->currentEmployment()->firstOrFail();
+    expect(requiredDate($employment->started_at)->toDateTimeString())->toBe($employmentDate->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });

--- a/tests/Integration/Actions/Stables/LifecycleTest.php
+++ b/tests/Integration/Actions/Stables/LifecycleTest.php
@@ -33,14 +33,13 @@ describe('Stable Activation Action Integration', function () {
 
             EstablishAction::run($this->stable, $debutDate);
 
-            $refreshedStable = $this->stable->fresh();
+            $refreshedStable = freshModel($this->stable);
             expect($refreshedStable->isCurrentlyActive())->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Active);
 
             // Verify activity period is created
-            $activityPeriod = $refreshedStable->activityPeriods()->latest()->first();
-            expect($activityPeriod)->not()->toBeNull();
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($debutDate->format('Y-m-d H:i:s'));
+            $activityPeriod = $refreshedStable->activityPeriods()->latest()->firstOrFail();
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($debutDate->format('Y-m-d H:i:s'));
             expect($activityPeriod->ended_at)->toBeNull();
         });
 
@@ -49,9 +48,9 @@ describe('Stable Activation Action Integration', function () {
 
             EstablishAction::run($this->stable, $pastDate);
 
-            $refreshedStable = $this->stable->fresh();
-            $activityPeriod = $refreshedStable->activityPeriods()->latest()->first();
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($pastDate->format('Y-m-d H:i:s'));
+            $refreshedStable = freshModel($this->stable);
+            $activityPeriod = $refreshedStable->activityPeriods()->latest()->firstOrFail();
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($pastDate->format('Y-m-d H:i:s'));
         });
 
         test('debut action from unformed status creates proper status change', function () {
@@ -59,7 +58,7 @@ describe('Stable Activation Action Integration', function () {
 
             EstablishAction::run($this->stable, Carbon::now());
 
-            $refreshedStable = $this->stable->fresh();
+            $refreshedStable = freshModel($this->stable);
             expect($refreshedStable->isCurrentlyActive())->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Active);
         });
@@ -76,20 +75,20 @@ describe('Stable Activation Action Integration', function () {
 
             DisbandAction::run($this->activeStable, $disbandDate);
 
-            $refreshedStable = $this->activeStable->fresh();
+            $refreshedStable = freshModel($this->activeStable);
             expect($refreshedStable->isDisbanded())->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Inactive);
 
             // Verify activity period is ended
-            $activityPeriod = $refreshedStable->activityPeriods()->latest()->first();
+            $activityPeriod = $refreshedStable->activityPeriods()->latest()->firstOrFail();
             expect($activityPeriod->ended_at)->not()->toBeNull();
-            expect($activityPeriod->ended_at->format('Y-m-d H:i:s'))->toBe($disbandDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->ended_at)->format('Y-m-d H:i:s'))->toBe($disbandDate->format('Y-m-d H:i:s'));
         });
 
         test('disband action creates proper status change record', function () {
             DisbandAction::run($this->activeStable, Carbon::now());
 
-            $refreshedStable = $this->activeStable->fresh();
+            $refreshedStable = freshModel($this->activeStable);
             expect($refreshedStable->status)->toBe(StableStatus::Inactive);
             expect($refreshedStable->isDisbanded())->toBeTrue();
         });
@@ -106,7 +105,7 @@ describe('Stable Activation Action Integration', function () {
 
             ReuniteAction::run($this->disbandedStable, $reuniteDate);
 
-            $refreshedStable = $this->disbandedStable->fresh();
+            $refreshedStable = freshModel($this->disbandedStable);
             expect($refreshedStable->isCurrentlyActive())->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Active);
 
@@ -114,25 +113,23 @@ describe('Stable Activation Action Integration', function () {
             $activityPeriods = $refreshedStable->activityPeriods()->orderBy('started_at')->get();
             expect($activityPeriods)->toHaveCount(2); // Original + reunite
 
-            $latestPeriod = $activityPeriods->last();
-            expect($latestPeriod->started_at->format('Y-m-d H:i:s'))->toBe($reuniteDate->format('Y-m-d H:i:s'));
+            $latestPeriod = $activityPeriods->reverse()->firstOrFail();
+            expect(requiredDate($latestPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($reuniteDate->format('Y-m-d H:i:s'));
             expect($latestPeriod->ended_at)->toBeNull();
         });
 
         test('reunite action maintains historical activity periods', function () {
             ReuniteAction::run($this->disbandedStable, Carbon::now());
 
-            $refreshedStable = $this->disbandedStable->fresh();
+            $refreshedStable = freshModel($this->disbandedStable);
             $activityPeriods = $refreshedStable->activityPeriods()->get();
 
             // Should have both original period (ended) and new period (active)
             expect($activityPeriods)->toHaveCount(2);
 
-            $endedPeriod = $activityPeriods->where('ended_at', '!=', null)->first();
-            $activePeriod = $activityPeriods->where('ended_at', null)->first();
+            $endedPeriod = $activityPeriods->where('ended_at', '!=', null)->firstOrFail();
+            $activePeriod = $activityPeriods->where('ended_at', null)->firstOrFail();
 
-            expect($endedPeriod)->not()->toBeNull();
-            expect($activePeriod)->not()->toBeNull();
         });
     });
 
@@ -146,19 +143,18 @@ describe('Stable Activation Action Integration', function () {
 
             RetireAction::run($this->activeStable, $retireDate);
 
-            $refreshedStable = $this->activeStable->fresh();
+            $refreshedStable = freshModel($this->activeStable);
             expect($refreshedStable->isRetired())->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Retired);
 
             // Verify retirement record
-            $retirement = $refreshedStable->retirements()->latest()->first();
-            expect($retirement)->not()->toBeNull();
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retireDate->format('Y-m-d H:i:s'));
+            $retirement = $refreshedStable->retirements()->latest()->firstOrFail();
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retireDate->format('Y-m-d H:i:s'));
             expect($retirement->ended_at)->toBeNull();
 
             // Verify activity period is ended
-            $activityPeriod = $refreshedStable->activityPeriods()->latest()->first();
-            expect($activityPeriod->ended_at->format('Y-m-d H:i:s'))->toBe($retireDate->format('Y-m-d H:i:s'));
+            $activityPeriod = $refreshedStable->activityPeriods()->latest()->firstOrFail();
+            expect(requiredDate($activityPeriod->ended_at)->format('Y-m-d H:i:s'))->toBe($retireDate->format('Y-m-d H:i:s'));
         });
 
         test('retire action from disbanded status works correctly', function () {
@@ -166,7 +162,7 @@ describe('Stable Activation Action Integration', function () {
 
             RetireAction::run($disbandedStable, Carbon::now());
 
-            $refreshedStable = $disbandedStable->fresh();
+            $refreshedStable = freshModel($disbandedStable);
             expect($refreshedStable->isRetired())->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Retired);
         });
@@ -182,13 +178,13 @@ describe('Stable Activation Action Integration', function () {
 
             UnretireAction::run($this->retiredStable, $unretireDate);
 
-            $refreshedStable = $this->retiredStable->fresh();
+            $refreshedStable = freshModel($this->retiredStable);
             expect($refreshedStable->isCurrentlyActive())->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Active);
 
             // Verify retirement is ended
-            $retirement = $refreshedStable->retirements()->latest()->first();
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($unretireDate->format('Y-m-d H:i:s'));
+            $retirement = $refreshedStable->retirements()->latest()->firstOrFail();
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($unretireDate->format('Y-m-d H:i:s'));
         });
 
         test('unretire action can leave the stable inactive when immediate establishment is disabled', function () {
@@ -196,7 +192,7 @@ describe('Stable Activation Action Integration', function () {
 
             UnretireAction::run($this->retiredStable, Carbon::now(), establishImmediately: false);
 
-            $refreshedStable = $this->retiredStable->fresh();
+            $refreshedStable = freshModel($this->retiredStable);
             expect($refreshedStable->activityPeriods()->count())->toBe($originalPeriodCount);
             expect($refreshedStable->isInactive())->toBeTrue();
         });
@@ -209,28 +205,28 @@ describe('Stable Activation Action Integration', function () {
             // Debut
             $debutDate = Carbon::now()->subYear();
             EstablishAction::run($stable, $debutDate);
-            expect($stable->fresh()->isCurrentlyActive())->toBeTrue();
+            expect(freshModel($stable)->isCurrentlyActive())->toBeTrue();
 
             // Disband
             $disbandDate = Carbon::now()->subMonths(6);
             DisbandAction::run($stable, $disbandDate);
-            expect($stable->fresh()->isDisbanded())->toBeTrue();
+            expect(freshModel($stable)->isDisbanded())->toBeTrue();
 
             // Reunite
             $reuniteDate = Carbon::now()->subMonths(3);
             ReuniteAction::run($stable, $reuniteDate);
-            expect($stable->fresh()->isCurrentlyActive())->toBeTrue();
+            expect(freshModel($stable)->isCurrentlyActive())->toBeTrue();
 
             // Retire
             $retireDate = Carbon::now()->subMonths(1);
             RetireAction::run($stable, $retireDate);
-            expect($stable->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($stable)->isRetired())->toBeTrue();
 
             // Unretire
             $unretireDate = Carbon::now();
             UnretireAction::run($stable, $unretireDate, establishImmediately: false, requireFormerMembers: false);
 
-            $finalStable = $stable->fresh();
+            $finalStable = freshModel($stable);
             expect($finalStable->isInactive())->toBeTrue();
 
             // Verify all status changes are recorded
@@ -243,7 +239,7 @@ describe('Stable Activation Action Integration', function () {
             expect($activityPeriods)->toHaveCount(2); // Original debut + reunite
 
             // Verify retirement record
-            $retirement = $finalStable->retirements()->first();
+            $retirement = $finalStable->retirements()->firstOrFail();
             expect($retirement->started_at)->toBeInstanceOf(Carbon::class);
             expect($retirement->ended_at)->toBeInstanceOf(Carbon::class);
         });
@@ -260,14 +256,14 @@ describe('Stable Activation Action Integration', function () {
             DisbandAction::run($stable, $disbandDate);
             ReuniteAction::run($stable, $reuniteDate);
 
-            $refreshedStable = $stable->fresh();
+            $refreshedStable = freshModel($stable);
             $activityPeriods = $refreshedStable->activityPeriods()->orderBy('started_at')->get();
 
             // Verify chronological order is maintained
-            expect($activityPeriods->first()->started_at->format('Y-m-d H:i:s'))->toBe($debutDate->format('Y-m-d H:i:s'));
-            expect($activityPeriods->first()->ended_at->format('Y-m-d H:i:s'))->toBe($disbandDate->format('Y-m-d H:i:s'));
-            expect($activityPeriods->last()->started_at->format('Y-m-d H:i:s'))->toBe($reuniteDate->format('Y-m-d H:i:s'));
-            expect($activityPeriods->last()->ended_at)->toBeNull();
+            expect(requiredDate($activityPeriods->firstOrFail()->started_at)->format('Y-m-d H:i:s'))->toBe($debutDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriods->firstOrFail()->ended_at)->format('Y-m-d H:i:s'))->toBe($disbandDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriods->reverse()->firstOrFail()->started_at)->format('Y-m-d H:i:s'))->toBe($reuniteDate->format('Y-m-d H:i:s'));
+            expect($activityPeriods->reverse()->firstOrFail()->ended_at)->toBeNull();
         });
     });
 

--- a/tests/Integration/Actions/Stables/RetireActionTest.php
+++ b/tests/Integration/Actions/Stables/RetireActionTest.php
@@ -55,8 +55,8 @@ test('it records a future retirement date while ending current operations now', 
     $stable->refresh();
 
     expect($stable->isRetired())->toBeTrue();
-    expect($stable->currentRetirement->started_at->toDateTimeString())->toBe($datetime->toDateTimeString());
-    expect($stable->activityPeriods()->latest('id')->first()->ended_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    expect(requiredDate($stable->currentRetirement()->firstOrFail()->started_at)->toDateTimeString())->toBe($datetime->toDateTimeString());
+    expect(requiredDate($stable->activityPeriods()->latest('id')->firstOrFail()->ended_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 
     foreach ($stable->previousWrestlers as $wrestler) {
         expect(Carbon::parse(relatedPivotAttribute($wrestler, 'left_at'))->toDateTimeString())

--- a/tests/Integration/Actions/Stables/SplitStableActionTest.php
+++ b/tests/Integration/Actions/Stables/SplitStableActionTest.php
@@ -81,7 +81,7 @@ describe('SplitStableAction Integration Tests', function () {
             expect($newStable->currentTagTeams()->count())->toBe($this->transferTagTeams->count());
 
             // Verify original stable has remaining members
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             expect($refreshedOriginal->currentWrestlers()->count())->toBe($initialWrestlerCount - $this->transferWrestlers->count());
             expect($refreshedOriginal->currentTagTeams()->count())->toBe($initialTagTeamCount - $this->transferTagTeams->count());
         });
@@ -109,7 +109,7 @@ describe('SplitStableAction Integration Tests', function () {
             expect($newStableTagTeamIds->sort()->values())->toEqual($transferTagTeamIds->sort()->values());
 
             // Verify members are no longer in original stable
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             foreach ($transferWrestlerIds as $wrestlerId) {
                 expect($refreshedOriginal->currentWrestlers()->where('wrestlers.id', $wrestlerId)->exists())->toBeFalse();
             }
@@ -146,7 +146,7 @@ describe('SplitStableAction Integration Tests', function () {
 
             // Verify original stable memberships were ended properly
             // Check that transferred wrestlers are no longer current members
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             foreach ($this->transferWrestlers as $wrestler) {
                 expect($refreshedOriginal->currentWrestlers()->where('wrestlers.id', $wrestler->id)->exists())->toBeFalse();
             }
@@ -168,7 +168,7 @@ describe('SplitStableAction Integration Tests', function () {
             );
 
             // Verify all members are preserved across both stables
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             $totalWrestlers = $newStable->currentWrestlers()->count() + $refreshedOriginal->currentWrestlers()->count();
             $totalTagTeams = $newStable->currentTagTeams()->count() + $refreshedOriginal->currentTagTeams()->count();
 
@@ -198,7 +198,7 @@ describe('SplitStableAction Integration Tests', function () {
             expect($newStable->currentTagTeams()->count())->toBe(0);
 
             // Verify original stable retains all tag teams
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             expect($refreshedOriginal->currentTagTeams()->count())->toBe($this->tagTeams->count());
         });
 
@@ -222,7 +222,7 @@ describe('SplitStableAction Integration Tests', function () {
             expect($newStable->currentTagTeams()->count())->toBe($this->transferTagTeams->count());
 
             // Verify original stable retains all wrestlers
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             expect($refreshedOriginal->currentWrestlers()->count())->toBe($this->wrestlers->count());
         });
 
@@ -242,7 +242,7 @@ describe('SplitStableAction Integration Tests', function () {
             expect($newStable->currentTagTeams()->count())->toBe($this->transferTagTeams->count());
 
             // Verify original stable has remaining members
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             expect($refreshedOriginal->currentWrestlers()->count())->toBe($this->wrestlers->count() - $this->transferWrestlers->count());
             expect($refreshedOriginal->currentTagTeams()->count())->toBe($this->tagTeams->count() - $this->transferTagTeams->count());
         });
@@ -262,7 +262,7 @@ describe('SplitStableAction Integration Tests', function () {
             ))->toThrow(CannotBeSplitException::class);
 
             // Verify original stable unchanged
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             expect($refreshedOriginal->currentWrestlers()->count())->toBe($this->wrestlers->count());
             expect($refreshedOriginal->currentTagTeams()->count())->toBe($this->tagTeams->count());
         });
@@ -283,7 +283,7 @@ describe('SplitStableAction Integration Tests', function () {
             ))->toThrow(CannotBeSplitException::class);
 
             // Verify original stable still has all members (transaction rolled back)
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             expect($refreshedOriginal->currentWrestlers()->count())->toBe($this->wrestlers->count());
             expect($refreshedOriginal->currentTagTeams()->count())->toBe($this->tagTeams->count());
         });
@@ -349,8 +349,8 @@ describe('SplitStableAction Integration Tests', function () {
             expect($newStable->activityPeriods()->count())->toBe(1);
 
             // Verify activity period has correct start date
-            $activityPeriod = $newStable->currentActivityPeriod;
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($splitDate->format('Y-m-d H:i:s'));
+            $activityPeriod = $newStable->currentActivityPeriod()->firstOrFail();
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($splitDate->format('Y-m-d H:i:s'));
             expect($activityPeriod->ended_at)->toBeNull();
         });
 
@@ -390,7 +390,7 @@ describe('SplitStableAction Integration Tests', function () {
 
             // Verify both stables exist and have members
             expect($newStable->currentWrestlers()->count())->toBeGreaterThan(0);
-            expect($this->originalStable->fresh()->currentWrestlers()->count())->toBeGreaterThanOrEqual(0);
+            expect(freshModel($this->originalStable)->currentWrestlers()->count())->toBeGreaterThanOrEqual(0);
         });
 
         test('split handles transaction rollback on constraint violation', function () {
@@ -433,7 +433,7 @@ describe('SplitStableAction Integration Tests', function () {
             // Verify both stables meet minimum requirements
             $newStableMemberCount = $newStable->currentWrestlers()->count() + $newStable->currentTagTeams()->count();
 
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
             $originalMemberCount = $refreshedOriginal->currentWrestlers()->count() + $refreshedOriginal->currentTagTeams()->count();
 
             // Assume minimum of 1 member required (adjust based on business rules)
@@ -507,7 +507,7 @@ describe('SplitStableAction Integration Tests', function () {
             expect($newStable->isCurrentlyActive())->toBeTrue();
 
             // Verify original stable status is appropriate
-            $refreshedOriginal = $this->originalStable->fresh();
+            $refreshedOriginal = freshModel($this->originalStable);
 
             // If original has members, should remain active; if empty, may become inactive
             $totalRemainingMembers = $refreshedOriginal->currentWrestlers()->count() + $refreshedOriginal->currentTagTeams()->count();

--- a/tests/Integration/Actions/TagTeams/EmployActionTest.php
+++ b/tests/Integration/Actions/TagTeams/EmployActionTest.php
@@ -97,9 +97,8 @@ test('it handles database transactions correctly', function () {
     expect($tagTeam->isEmployed())->toBeTrue();
 
     // Verify employment record was created
-    $employment = $tagTeam->currentEmployment;
-    expect($employment)->not()->toBeNull();
-    expect($employment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $employment = $tagTeam->currentEmployment()->firstOrFail();
+    expect(requiredDate($employment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });
 
@@ -116,9 +115,8 @@ test('it creates new employment period', function () {
     expect($tagTeam->isEmployed())->toBeTrue();
 
     // New employment should be current and active
-    $currentEmployment = $tagTeam->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
-    expect($currentEmployment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentEmployment = $tagTeam->currentEmployment()->firstOrFail();
+    expect(requiredDate($currentEmployment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($currentEmployment->ended_at)->toBeNull();
 });
 
@@ -158,9 +156,8 @@ test('it handles multiple employment history correctly', function () {
     expect($tagTeam->employments()->count())->toBe(3);
 
     // New employment should be current
-    $currentEmployment = $tagTeam->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
-    expect($currentEmployment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentEmployment = $tagTeam->currentEmployment()->firstOrFail();
+    expect(requiredDate($currentEmployment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });
 
 test('it preserves employment history during new employment', function () {
@@ -209,7 +206,6 @@ test('it handles tag team with complex status history', function () {
     expect($tagTeam->retirements()->count())->toBe(1); // 1 historical
 
     // New employment should be current
-    $currentEmployment = $tagTeam->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
-    expect($currentEmployment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentEmployment = $tagTeam->currentEmployment()->firstOrFail();
+    expect(requiredDate($currentEmployment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });

--- a/tests/Integration/Actions/TagTeams/ReinstateActionTest.php
+++ b/tests/Integration/Actions/TagTeams/ReinstateActionTest.php
@@ -50,8 +50,7 @@ test('it uses StatusTransitionPipeline for reinstatement', function () {
     $tagTeam = TagTeam::factory()->suspended()->create();
 
     // Get current suspension to verify it gets ended
-    $currentSuspension = $tagTeam->currentSuspension;
-    expect($currentSuspension)->not()->toBeNull();
+    $currentSuspension = $tagTeam->currentSuspension()->firstOrFail();
 
     ReinstateAction::run($tagTeam);
 
@@ -84,7 +83,7 @@ test('it prevents reinstating unemployed tag team', function () {
 
 test('it handles database transactions correctly', function () {
     $tagTeam = TagTeam::factory()->suspended()->create();
-    $originalSuspensionId = $tagTeam->currentSuspension->id;
+    $originalSuspensionId = $tagTeam->currentSuspension()->firstOrFail()->id;
 
     ReinstateAction::run($tagTeam);
 
@@ -203,7 +202,7 @@ test('it maintains employment status during reinstatement', function () {
 
     // Employment record should remain active
     expect($tagTeam->currentEmployment)->not()->toBeNull();
-    expect($tagTeam->currentEmployment->ended_at)->toBeNull();
+    expect($tagTeam->currentEmployment()->firstOrFail()->ended_at)->toBeNull();
 });
 
 test('it handles reinstatement with cascade effects', function () {

--- a/tests/Integration/Actions/TagTeams/ReleaseActionTest.php
+++ b/tests/Integration/Actions/TagTeams/ReleaseActionTest.php
@@ -73,8 +73,7 @@ test('it uses StatusTransitionPipeline for release', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
 
     // Get current employment to verify it gets ended
-    $currentEmployment = $tagTeam->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
+    $currentEmployment = $tagTeam->currentEmployment()->firstOrFail();
 
     ReleaseAction::run($tagTeam);
 
@@ -102,7 +101,7 @@ test('it prevents releasing unemployed tag team', function () {
 
 test('it handles database transactions correctly', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
-    $originalEmploymentId = $tagTeam->currentEmployment->id;
+    $originalEmploymentId = $tagTeam->currentEmployment()->firstOrFail()->id;
 
     ReleaseAction::run($tagTeam);
 

--- a/tests/Integration/Actions/TagTeams/RestoreActionTest.php
+++ b/tests/Integration/Actions/TagTeams/RestoreActionTest.php
@@ -225,6 +225,6 @@ test('it maintains data integrity during restoration', function () {
     expect($tagTeam->trashed())->toBeFalse();
 
     // Timestamps should be preserved (creation) but updated (modification)
-    expect($tagTeam->created_at->toDateTimeString())->toBe($originalCreatedAt->toDateTimeString());
+    expect(requiredDate($tagTeam->created_at)->toDateTimeString())->toBe(requiredDate($originalCreatedAt)->toDateTimeString());
     expect($tagTeam->deleted_at)->toBeNull();
 });

--- a/tests/Integration/Actions/TagTeams/RetireActionTest.php
+++ b/tests/Integration/Actions/TagTeams/RetireActionTest.php
@@ -92,8 +92,7 @@ test('it uses StatusTransitionPipeline for retirement', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
 
     // Get current employment to verify it gets ended
-    $currentEmployment = $tagTeam->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
+    $currentEmployment = $tagTeam->currentEmployment()->firstOrFail();
     expect($tagTeam->currentRetirement)->toBeNull();
 
     RetireAction::run($tagTeam);
@@ -127,7 +126,7 @@ test('it prevents retiring already retired tag team', function () {
 
 test('it handles database transactions correctly', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
-    $originalEmploymentId = $tagTeam->currentEmployment->id;
+    $originalEmploymentId = $tagTeam->currentEmployment()->firstOrFail()->id;
 
     RetireAction::run($tagTeam);
 
@@ -145,9 +144,8 @@ test('it handles database transactions correctly', function () {
     ]);
 
     // Verify new retirement record was created
-    $retirement = $tagTeam->currentRetirement;
-    expect($retirement)->not()->toBeNull();
-    expect($retirement->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $retirement = $tagTeam->currentRetirement()->firstOrFail();
+    expect(requiredDate($retirement->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($retirement->ended_at)->toBeNull();
 });
 
@@ -164,9 +162,8 @@ test('it creates new retirement period', function () {
     expect($tagTeam->isRetired())->toBeTrue();
 
     // New retirement should be current and active
-    $currentRetirement = $tagTeam->currentRetirement;
-    expect($currentRetirement)->not()->toBeNull();
-    expect($currentRetirement->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentRetirement = $tagTeam->currentRetirement()->firstOrFail();
+    expect(requiredDate($currentRetirement->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($currentRetirement->ended_at)->toBeNull();
 });
 
@@ -210,9 +207,8 @@ test('it handles multiple retirement history correctly', function () {
     expect($tagTeam->retirements()->count())->toBe(2);
 
     // New retirement should be current
-    $currentRetirement = $tagTeam->currentRetirement;
-    expect($currentRetirement)->not()->toBeNull();
-    expect($currentRetirement->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentRetirement = $tagTeam->currentRetirement()->firstOrFail();
+    expect(requiredDate($currentRetirement->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });
 
 test('it preserves employment and retirement history', function () {

--- a/tests/Integration/Actions/TagTeams/SuspendActionTest.php
+++ b/tests/Integration/Actions/TagTeams/SuspendActionTest.php
@@ -109,9 +109,8 @@ test('it handles database transactions correctly', function () {
     expect($tagTeam->isEmployed())->toBeTrue();
 
     // Verify suspension record was created
-    $suspension = $tagTeam->currentSuspension;
-    expect($suspension)->not()->toBeNull();
-    expect($suspension->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $suspension = $tagTeam->currentSuspension()->firstOrFail();
+    expect(requiredDate($suspension->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($suspension->ended_at)->toBeNull();
 });
 
@@ -128,9 +127,8 @@ test('it creates new suspension period', function () {
     expect($tagTeam->isSuspended())->toBeTrue();
 
     // New suspension should be current and active
-    $currentSuspension = $tagTeam->currentSuspension;
-    expect($currentSuspension)->not()->toBeNull();
-    expect($currentSuspension->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentSuspension = $tagTeam->currentSuspension()->firstOrFail();
+    expect(requiredDate($currentSuspension->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($currentSuspension->ended_at)->toBeNull();
 });
 
@@ -170,14 +168,13 @@ test('it handles multiple suspension history correctly', function () {
     expect($tagTeam->suspensions()->count())->toBe(3);
 
     // New suspension should be current
-    $currentSuspension = $tagTeam->currentSuspension;
-    expect($currentSuspension)->not()->toBeNull();
-    expect($currentSuspension->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentSuspension = $tagTeam->currentSuspension()->firstOrFail();
+    expect(requiredDate($currentSuspension->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });
 
 test('it preserves employment status during suspension', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
-    $originalEmployment = $tagTeam->currentEmployment;
+    $originalEmployment = $tagTeam->currentEmployment()->firstOrFail();
 
     expect($tagTeam->isEmployed())->toBeTrue();
 
@@ -190,8 +187,8 @@ test('it preserves employment status during suspension', function () {
     expect($tagTeam->isSuspended())->toBeTrue();
 
     // Employment record should remain unchanged
-    expect($tagTeam->currentEmployment->id)->toBe($originalEmployment->id);
-    expect($tagTeam->currentEmployment->ended_at)->toBeNull();
+    expect($tagTeam->currentEmployment()->firstOrFail()->id)->toBe($originalEmployment->id);
+    expect($tagTeam->currentEmployment()->firstOrFail()->ended_at)->toBeNull();
 });
 
 test('it preserves suspension history during new suspension', function () {
@@ -240,9 +237,8 @@ test('it handles tag team with complex employment history', function () {
     expect($tagTeam->suspensions()->count())->toBe(2); // 1 historical + 1 new
 
     // New suspension should be current
-    $currentSuspension = $tagTeam->currentSuspension;
-    expect($currentSuspension)->not()->toBeNull();
-    expect($currentSuspension->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentSuspension = $tagTeam->currentSuspension()->firstOrFail();
+    expect(requiredDate($currentSuspension->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });
 
 test('it handles suspension with cascade effects', function () {

--- a/tests/Integration/Actions/TagTeams/UnretireActionTest.php
+++ b/tests/Integration/Actions/TagTeams/UnretireActionTest.php
@@ -65,8 +65,7 @@ test('it uses StatusTransitionPipeline for unretirement', function () {
     $tagTeam = TagTeam::factory()->retired()->create();
 
     // Get current retirement to verify it gets ended
-    $currentRetirement = $tagTeam->currentRetirement;
-    expect($currentRetirement)->not()->toBeNull();
+    $currentRetirement = $tagTeam->currentRetirement()->firstOrFail();
     expect($tagTeam->currentEmployment)->toBeNull();
 
     UnretireAction::run($tagTeam);
@@ -123,7 +122,7 @@ test('it prevents unretiring unemployed tag team', function () {
 
 test('it handles database transactions correctly', function () {
     $tagTeam = TagTeam::factory()->retired()->create();
-    $originalRetirementId = $tagTeam->currentRetirement->id;
+    $originalRetirementId = $tagTeam->currentRetirement()->firstOrFail()->id;
 
     UnretireAction::run($tagTeam);
 
@@ -141,9 +140,8 @@ test('it handles database transactions correctly', function () {
     ]);
 
     // Verify new employment record was created
-    $employment = $tagTeam->currentEmployment;
-    expect($employment)->not()->toBeNull();
-    expect($employment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $employment = $tagTeam->currentEmployment()->firstOrFail();
+    expect(requiredDate($employment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($employment->ended_at)->toBeNull();
 });
 
@@ -176,9 +174,8 @@ test('it creates new employment period', function () {
     expect($tagTeam->isEmployed())->toBeTrue();
 
     // New employment should be current and active
-    $currentEmployment = $tagTeam->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
-    expect($currentEmployment->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    $currentEmployment = $tagTeam->currentEmployment()->firstOrFail();
+    expect(requiredDate($currentEmployment->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
     expect($currentEmployment->ended_at)->toBeNull();
 });
 

--- a/tests/Integration/Actions/TagTeams/UpdateActionTest.php
+++ b/tests/Integration/Actions/TagTeams/UpdateActionTest.php
@@ -13,8 +13,8 @@ beforeEach(function () {
     ]);
 
     $wrestlers = $this->tagTeam->wrestlers;
-    $this->wrestlerA = $wrestlers->first();
-    $this->wrestlerB = $wrestlers->last();
+    $this->wrestlerA = $wrestlers->firstOrFail();
+    $this->wrestlerB = $wrestlers->reverse()->firstOrFail();
 });
 
 test('it updates tag team basic information', function () {
@@ -170,7 +170,7 @@ test('it updates timestamps correctly', function () {
     UpdateAction::run($this->tagTeam, $updateData);
 
     $this->tagTeam->refresh();
-    expect($this->tagTeam->updated_at->toDateTimeString())->not()->toBe($originalUpdatedAt->toDateTimeString());
+    expect(requiredDate($this->tagTeam->updated_at)->toDateTimeString())->not()->toBe(requiredDate($originalUpdatedAt)->toDateTimeString());
 });
 
 test('it preserves unmodified attributes', function () {
@@ -191,7 +191,7 @@ test('it preserves unmodified attributes', function () {
 
     expect($this->tagTeam->name)->toBe('Updated Preservation Team');
     expect($this->tagTeam->signature_move)->toBe('Original Move');
-    expect($this->tagTeam->created_at->toDateTimeString())->toBe($originalCreatedAt->toDateTimeString());
+    expect(requiredDate($this->tagTeam->created_at)->toDateTimeString())->toBe(requiredDate($originalCreatedAt)->toDateTimeString());
     expect($this->tagTeam->id)->toBe($originalId);
 });
 

--- a/tests/Integration/Actions/Titles/ActivateActionTest.php
+++ b/tests/Integration/Actions/Titles/ActivateActionTest.php
@@ -25,14 +25,13 @@ test('it activates an unactivated title at the current datetime by default', fun
     resolve(ActivateAction::class)->handle($title);
 
     // Verify the title is now active and has activity periods
-    $refreshedTitle = $title->fresh();
+    $refreshedTitle = freshModel($title);
     expect($refreshedTitle->isCurrentlyActive())->toBeTrue();
     expect($refreshedTitle->hasActivityPeriods())->toBeTrue();
 
     // Verify the debut was created with correct datetime
-    $activityPeriod = $refreshedTitle->currentActivityPeriod;
-    expect($activityPeriod)->not()->toBeNull();
-    expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    $activityPeriod = $refreshedTitle->currentActivityPeriod()->firstOrFail();
+    expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 });
 
 test('it activates an inactive title at the current datetime by default', function () {
@@ -48,14 +47,13 @@ test('it activates an inactive title at the current datetime by default', functi
     resolve(ActivateAction::class)->handle($title);
 
     // Verify the title is now active
-    $refreshedTitle = $title->fresh();
+    $refreshedTitle = freshModel($title);
     expect($refreshedTitle->isCurrentlyActive())->toBeTrue();
     expect($refreshedTitle->isInactive())->toBeFalse();
 
     // Verify the reinstatement was created with correct datetime
-    $activityPeriod = $refreshedTitle->currentActivityPeriod;
-    expect($activityPeriod)->not()->toBeNull();
-    expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    $activityPeriod = $refreshedTitle->currentActivityPeriod()->firstOrFail();
+    expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 });
 
 test('it activates an unactivated title at a specific datetime', function () {
@@ -70,15 +68,14 @@ test('it activates an unactivated title at a specific datetime', function () {
     resolve(ActivateAction::class)->handle($title, $datetime);
 
     // Verify the title has activity periods but is not currently active (future activation)
-    $refreshedTitle = $title->fresh();
+    $refreshedTitle = freshModel($title);
     expect($refreshedTitle->hasActivityPeriods())->toBeTrue();
     expect($refreshedTitle->hasFutureActivity())->toBeTrue();
     expect($refreshedTitle->isCurrentlyActive())->toBeFalse(); // Future date, so not currently active
 
     // Verify the debut was created with the specific datetime
-    $activityPeriod = $refreshedTitle->futureActivityPeriod;
-    expect($activityPeriod)->not()->toBeNull();
-    expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    $activityPeriod = $refreshedTitle->futureActivityPeriod()->firstOrFail();
+    expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 });
 
 test('it activates an inactive title at a specific datetime', function () {
@@ -94,16 +91,15 @@ test('it activates an inactive title at a specific datetime', function () {
     resolve(ActivateAction::class)->handle($title, $datetime);
 
     // Verify the title has future activity but is not currently active (future date)
-    $refreshedTitle = $title->fresh();
+    $refreshedTitle = freshModel($title);
     expect($refreshedTitle->hasActivityPeriods())->toBeTrue();
     expect($refreshedTitle->hasFutureActivity())->toBeTrue();
     expect($refreshedTitle->isCurrentlyActive())->toBeFalse(); // Future date, so not currently active
     expect($refreshedTitle->isInactive())->toBeTrue(); // isInactive() = !isCurrentlyActive(), so still inactive until future date
 
     // Verify the reinstatement was created with the specific datetime
-    $activityPeriod = $refreshedTitle->futureActivityPeriod;
-    expect($activityPeriod)->not()->toBeNull();
-    expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    $activityPeriod = $refreshedTitle->futureActivityPeriod()->firstOrFail();
+    expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 });
 
 test('it activates a retired title at the current datetime by default', function () {
@@ -119,20 +115,18 @@ test('it activates a retired title at the current datetime by default', function
     resolve(ActivateAction::class)->handle($title);
 
     // Verify the title is now active and no longer retired
-    $refreshedTitle = $title->fresh();
+    $refreshedTitle = freshModel($title);
     expect($refreshedTitle->isCurrentlyActive())->toBeTrue();
     expect($refreshedTitle->isRetired())->toBeFalse();
 
     // Verify the reinstatement was created with correct datetime
-    $activityPeriod = $refreshedTitle->currentActivityPeriod;
-    expect($activityPeriod)->not()->toBeNull();
-    expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    $activityPeriod = $refreshedTitle->currentActivityPeriod()->firstOrFail();
+    expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 
     // Verify retirement was ended
-    $latestRetirement = $refreshedTitle->previousRetirement;
-    expect($latestRetirement)->not()->toBeNull();
+    $latestRetirement = $refreshedTitle->previousRetirement()->firstOrFail();
     expect($latestRetirement->ended_at)->not()->toBeNull();
-    expect($latestRetirement->ended_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    expect(requiredDate($latestRetirement->ended_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 });
 
 test('it activates a retired title at a specific datetime', function () {
@@ -148,22 +142,20 @@ test('it activates a retired title at a specific datetime', function () {
     resolve(ActivateAction::class)->handle($title, $datetime);
 
     // Verify the title has future activity but is not currently active (future date) and no longer retired
-    $refreshedTitle = $title->fresh();
+    $refreshedTitle = freshModel($title);
     expect($refreshedTitle->hasActivityPeriods())->toBeTrue();
     expect($refreshedTitle->hasFutureActivity())->toBeTrue();
     expect($refreshedTitle->isCurrentlyActive())->toBeFalse(); // Future date, so not currently active
     expect($refreshedTitle->isRetired())->toBeFalse();
 
     // Verify the reinstatement was created with the specific datetime
-    $activityPeriod = $refreshedTitle->futureActivityPeriod;
-    expect($activityPeriod)->not()->toBeNull();
-    expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    $activityPeriod = $refreshedTitle->futureActivityPeriod()->firstOrFail();
+    expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 
     // Verify retirement was ended with the specific datetime
-    $latestRetirement = $refreshedTitle->previousRetirement;
-    expect($latestRetirement)->not()->toBeNull();
+    $latestRetirement = $refreshedTitle->previousRetirement()->firstOrFail();
     expect($latestRetirement->ended_at)->not()->toBeNull();
-    expect($latestRetirement->ended_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    expect(requiredDate($latestRetirement->ended_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 });
 
 test('it throws exception for activating a non activatable title', function ($factoryState) {
@@ -187,7 +179,7 @@ test('it successfully activates a title with future activation', function () {
     resolve(ActivateAction::class)->handle($title);
 
     // Verify the title is now currently active
-    $refreshedTitle = $title->fresh();
+    $refreshedTitle = freshModel($title);
     expect($refreshedTitle->isCurrentlyActive())->toBeTrue();
     expect($refreshedTitle->hasActivityPeriods())->toBeTrue();
 });

--- a/tests/Integration/Actions/Titles/CreateActionTest.php
+++ b/tests/Integration/Actions/Titles/CreateActionTest.php
@@ -34,5 +34,5 @@ test('it activates a title if activation date is filled in request', function ()
     expect($result->name)->toBe('Example Title');
     expect($result->type)->toBe(TitleType::Singles);
     expect($result->activations)->toHaveCount(1);
-    expect($result->activations->first()->started_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    expect(requiredDate($result->activations->firstOrFail()->started_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 });

--- a/tests/Integration/Actions/Titles/UpdateActionTest.php
+++ b/tests/Integration/Actions/Titles/UpdateActionTest.php
@@ -35,7 +35,7 @@ test('it activates an unactivated title if activation date is filled in request'
     expect($title->name)->toBe('New Example Title');
     expect($title->type)->toBe(TitleType::Singles);
     expect($title->activations)->toHaveCount(1);
-    expect($title->activations->first()->started_at->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
+    expect(requiredDate($title->activations->firstOrFail()->started_at)->format('Y-m-d H:i:s'))->toBe($datetime->format('Y-m-d H:i:s'));
 });
 
 test('it updates a title with future activation but does not create new debut since it already has debuted', function () {

--- a/tests/Integration/Actions/Users/RoleAuthorizationTest.php
+++ b/tests/Integration/Actions/Users/RoleAuthorizationTest.php
@@ -157,11 +157,11 @@ describe('User Role Integration Tests', function () {
             // Test authentication state integration with roles
             actingAs($this->administrator);
             expect(auth()->check())->toBeTrue();
-            expect(auth()->user()->isAdministrator())->toBeTrue();
+            expect(requiredModel(auth()->user())->isAdministrator())->toBeTrue();
 
             actingAs($this->basicUser);
             expect(auth()->check())->toBeTrue();
-            expect(auth()->user()->isAdministrator())->toBeFalse();
+            expect(requiredModel(auth()->user())->isAdministrator())->toBeFalse();
         });
     });
 
@@ -184,7 +184,7 @@ describe('User Role Integration Tests', function () {
             expect(Gate::forUser($user)->allows('create', User::class))->toBeTrue();
 
             // Verify in database
-            $userFromDb = User::find($user->id);
+            $userFromDb = User::findOrFail($user->id);
             expect($userFromDb->role)->toBe(Role::Administrator);
             expect($userFromDb->isAdministrator())->toBeTrue();
         });
@@ -207,7 +207,7 @@ describe('User Role Integration Tests', function () {
             expect(Gate::forUser($user)->denies('create', User::class))->toBeTrue();
 
             // Verify in database
-            $userFromDb = User::find($user->id);
+            $userFromDb = User::findOrFail($user->id);
             expect($userFromDb->role)->toBe(Role::Basic);
             expect($userFromDb->isAdministrator())->toBeFalse();
         });
@@ -291,15 +291,15 @@ describe('User Role Integration Tests', function () {
             $admin->delete();
 
             // Role should still be maintained on deleted user
-            $deletedAdmin = User::withTrashed()->find($admin->id);
+            $deletedAdmin = User::withTrashed()->findOrFail($admin->id);
             expect($deletedAdmin->isAdministrator())->toBeTrue();
 
             // Restore user
             $admin->restore();
 
             // Role should still work after restoration
-            expect($admin->fresh()->isAdministrator())->toBeTrue();
-            expect(Gate::forUser($admin->fresh())->allows('create', User::class))->toBeTrue();
+            expect(freshModel($admin)->isAdministrator())->toBeTrue();
+            expect(Gate::forUser(freshModel($admin))->allows('create', User::class))->toBeTrue();
         });
     });
 });

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -146,7 +146,7 @@ describe('Venue Action Integration Tests', function () {
 
             UpdateAction::run($venue, $venueData);
 
-            $retrievedVenue = Venue::find($venue->id);
+            $retrievedVenue = Venue::findOrFail($venue->id);
             expect($retrievedVenue->name)->toBe('Database Updated');
             expect($retrievedVenue->state)->toBe('DU');
         });
@@ -190,7 +190,7 @@ describe('Venue Action Integration Tests', function () {
             $updatedVenue = UpdateAction::run($venue, $venueData);
 
             expect($updatedVenue->events->pluck('id'))->toContain($event->id);
-            expect($event->fresh()->venue_id)->toBe($venue->id);
+            expect(freshModel($event)->venue_id)->toBe($venue->id);
         });
     });
 
@@ -210,8 +210,8 @@ describe('Venue Action Integration Tests', function () {
 
             DeleteAction::run($venue);
 
-            expect($event->fresh()->venue_id)->toBe($venue->id);
-            expect($event->fresh()->venue)->toBeNull(); // Soft deleted venue
+            expect(freshModel($event)->venue_id)->toBe($venue->id);
+            expect(freshModel($event)->venue)->toBeNull(); // Soft deleted venue
         });
 
         test('delete action handles venue with multiple events', function () {
@@ -222,8 +222,8 @@ describe('Venue Action Integration Tests', function () {
             DeleteAction::run($venue);
 
             expect(Venue::find($venue->id))->toBeNull();
-            expect($event1->fresh()->venue_id)->toBe($venue->id);
-            expect($event2->fresh()->venue_id)->toBe($venue->id);
+            expect(freshModel($event1)->venue_id)->toBe($venue->id);
+            expect(freshModel($event2)->venue_id)->toBe($venue->id);
         });
 
         test('delete action handles venue without events', function () {
@@ -244,11 +244,10 @@ describe('Venue Action Integration Tests', function () {
             $venue->delete();
             expect(Venue::find($venueId))->toBeNull();
 
-            $deletedVenue = Venue::onlyTrashed()->find($venueId);
+            $deletedVenue = Venue::onlyTrashed()->findOrFail($venueId);
             RestoreAction::run($deletedVenue);
 
-            $restoredVenue = Venue::find($venueId);
-            expect($restoredVenue)->not()->toBeNull();
+            $restoredVenue = Venue::findOrFail($venueId);
             expect($restoredVenue->name)->toBe('Restoration Test Arena');
         });
 
@@ -257,12 +256,12 @@ describe('Venue Action Integration Tests', function () {
             $event = Event::factory()->atVenue($venue)->create(['name' => 'Restoration Event']);
 
             $venue->delete();
-            $deletedVenue = Venue::onlyTrashed()->find($venue->id);
+            $deletedVenue = Venue::onlyTrashed()->findOrFail($venue->id);
             RestoreAction::run($deletedVenue);
 
-            $restoredVenue = Venue::find($venue->id);
+            $restoredVenue = Venue::findOrFail($venue->id);
             expect($restoredVenue->events->pluck('id'))->toContain($event->id);
-            expect($event->fresh()->venue)->not()->toBeNull();
+            expect(freshModel($event)->venue)->not()->toBeNull();
         });
 
         test('restore action handles venue with complex relationships', function () {
@@ -277,15 +276,15 @@ describe('Venue Action Integration Tests', function () {
             ]);
 
             $venue->delete();
-            $deletedVenue = Venue::onlyTrashed()->find($venue->id);
+            $deletedVenue = Venue::onlyTrashed()->findOrFail($venue->id);
             RestoreAction::run($deletedVenue);
 
-            $restoredVenue = Venue::find($venue->id);
+            $restoredVenue = Venue::findOrFail($venue->id);
             $restoredVenue->load(['events', 'previousEvents']);
 
             expect($restoredVenue->events)->toHaveCount(2);
             expect($restoredVenue->previousEvents)->toHaveCount(1);
-            expect($restoredVenue->previousEvents->first()->name)->toBe('Past Event');
+            expect($restoredVenue->previousEvents->firstOrFail()->name)->toBe('Past Event');
         });
     });
 
@@ -332,7 +331,7 @@ describe('Venue Action Integration Tests', function () {
             DeleteAction::run($venue);
 
             expect(Event::find($event->id))->not()->toBeNull();
-            expect($event->fresh()->venue_id)->toBe($venue->id);
+            expect(freshModel($event)->venue_id)->toBe($venue->id);
         });
     });
 
@@ -390,7 +389,7 @@ describe('Venue Action Integration Tests', function () {
 
             expect($venue->created_at)->not()->toBeNull();
             expect($venue->updated_at)->not()->toBeNull();
-            expect($venue->created_at->format('Y-m-d H:i:s'))->toBe($venue->updated_at->format('Y-m-d H:i:s'));
+            expect(requiredDate($venue->created_at)->format('Y-m-d H:i:s'))->toBe(requiredDate($venue->updated_at)->format('Y-m-d H:i:s'));
         });
 
         test('venue update modifies timestamps appropriately', function () {
@@ -412,7 +411,7 @@ describe('Venue Action Integration Tests', function () {
 
             // Verify the name actually changed to confirm update happened
             expect($updatedVenue->name)->toBe('Timestamp Updated Arena');
-            expect($updatedVenue->updated_at->isAfter($originalUpdatedAt))->toBeTrue();
+            expect(requiredDate($updatedVenue->updated_at)->isAfter(requiredDate($originalUpdatedAt)))->toBeTrue();
         });
 
         test('venue handles concurrent operations safely', function () {
@@ -435,7 +434,7 @@ describe('Venue Action Integration Tests', function () {
             );
 
             $updatedVenue1 = UpdateAction::run($venue, $venueData1);
-            $updatedVenue2 = UpdateAction::run($venue->fresh(), $venueData2);
+            $updatedVenue2 = UpdateAction::run(freshModel($venue), $venueData2);
 
             expect($updatedVenue2->name)->toBe('Concurrent Update 2');
         });

--- a/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
@@ -50,8 +50,7 @@ test('it ends employment before deletion', function () {
     $wrestler = Wrestler::factory()->employed()->create();
 
     // Get current employment to verify it gets ended
-    $currentEmployment = $wrestler->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
+    $currentEmployment = $wrestler->currentEmployment()->firstOrFail();
     expect($currentEmployment->ended_at)->toBeNull();
 
     DeleteAction::run($wrestler);
@@ -71,8 +70,7 @@ test('it ends retirement before deletion', function () {
     $wrestler = Wrestler::factory()->retired()->create();
 
     // Get current retirement to verify it gets ended
-    $currentRetirement = $wrestler->currentRetirement;
-    expect($currentRetirement)->not()->toBeNull();
+    $currentRetirement = $wrestler->currentRetirement()->firstOrFail();
     expect($currentRetirement->ended_at)->toBeNull();
 
     DeleteAction::run($wrestler);
@@ -92,8 +90,7 @@ test('it ends suspension before deletion', function () {
     $wrestler = Wrestler::factory()->suspended()->create();
 
     // Get current suspension to verify it gets ended
-    $currentSuspension = $wrestler->currentSuspension;
-    expect($currentSuspension)->not()->toBeNull();
+    $currentSuspension = $wrestler->currentSuspension()->firstOrFail();
     expect($currentSuspension->ended_at)->toBeNull();
 
     DeleteAction::run($wrestler);
@@ -113,8 +110,7 @@ test('it ends injury before deletion', function () {
     $wrestler = Wrestler::factory()->injured()->create();
 
     // Get current injury to verify it gets ended
-    $currentInjury = $wrestler->currentInjury;
-    expect($currentInjury)->not()->toBeNull();
+    $currentInjury = $wrestler->currentInjury()->firstOrFail();
     expect($currentInjury->ended_at)->toBeNull();
 
     DeleteAction::run($wrestler);

--- a/tests/Integration/Actions/Wrestlers/HealActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/HealActionTest.php
@@ -48,8 +48,7 @@ test('it uses StatusTransitionPipeline for healing', function () {
     $wrestler = Wrestler::factory()->injured()->create();
 
     // Get current injury to verify it gets ended
-    $currentInjury = $wrestler->currentInjury;
-    expect($currentInjury)->not()->toBeNull();
+    $currentInjury = $wrestler->currentInjury()->firstOrFail();
 
     HealAction::run($wrestler);
 

--- a/tests/Integration/Actions/Wrestlers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/ReinstateActionTest.php
@@ -69,8 +69,7 @@ test('it uses StatusTransitionPipeline for reinstatement', function () {
     $wrestler = Wrestler::factory()->suspended()->create();
 
     // Get current suspension to verify it gets ended
-    $currentSuspension = $wrestler->currentSuspension;
-    expect($currentSuspension)->not()->toBeNull();
+    $currentSuspension = $wrestler->currentSuspension()->firstOrFail();
     expect($currentSuspension->ended_at)->toBeNull();
 
     ReinstateAction::run($wrestler);

--- a/tests/Integration/Actions/Wrestlers/ReleaseActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/ReleaseActionTest.php
@@ -48,8 +48,7 @@ test('it uses StatusTransitionPipeline for release', function () {
     $wrestler = Wrestler::factory()->employed()->create();
 
     // Get current employment to verify it gets ended
-    $currentEmployment = $wrestler->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
+    $currentEmployment = $wrestler->currentEmployment()->firstOrFail();
     expect($currentEmployment->ended_at)->toBeNull();
 
     ReleaseAction::run($wrestler);

--- a/tests/Integration/Actions/Wrestlers/RetireActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/RetireActionTest.php
@@ -123,8 +123,7 @@ test('it ends employment when retiring', function () {
     $wrestler = Wrestler::factory()->employed()->create();
 
     // Get the current employment
-    $currentEmployment = $wrestler->currentEmployment;
-    expect($currentEmployment)->not()->toBeNull();
+    $currentEmployment = $wrestler->currentEmployment()->firstOrFail();
     expect($currentEmployment->ended_at)->toBeNull();
 
     RetireAction::run($wrestler);

--- a/tests/Integration/Actions/Wrestlers/UnretireActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/UnretireActionTest.php
@@ -90,8 +90,7 @@ test('it uses StatusTransitionPipeline for unretirement', function () {
     $wrestler = Wrestler::factory()->retired()->create();
 
     // Get current retirement to verify it gets ended
-    $currentRetirement = $wrestler->currentRetirement;
-    expect($currentRetirement)->not()->toBeNull();
+    $currentRetirement = $wrestler->currentRetirement()->firstOrFail();
     expect($currentRetirement->ended_at)->toBeNull();
 
     UnretireAction::run($wrestler);

--- a/tests/Integration/Actions/Wrestlers/UpdateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/UpdateActionTest.php
@@ -110,7 +110,7 @@ test('it updates wrestler without employing when no employment date', function (
 
 test('it does not re-employ already employed wrestler', function () {
     $wrestler = Wrestler::factory()->employed()->create();
-    $originalEmployment = $wrestler->currentEmployment;
+    $originalEmployment = $wrestler->currentEmployment()->firstOrFail();
 
     expect($wrestler->isEmployed())->toBeTrue();
 
@@ -132,7 +132,7 @@ test('it does not re-employ already employed wrestler', function () {
 
     // Should still have only the original employment record
     expect($result->employments()->count())->toBe(1);
-    expect($result->currentEmployment->id)->toBe($originalEmployment->id);
+    expect($result->currentEmployment()->firstOrFail()->id)->toBe($originalEmployment->id);
 });
 
 test('it employs managers when wrestler gets employed', function () {
@@ -299,8 +299,8 @@ test('it preserves wrestler id and timestamps', function () {
     $result = UpdateAction::run($wrestler, $updateData);
 
     expect($result->id)->toBe($originalId);
-    expect($result->created_at->timestamp)->toBe($originalCreatedAt->timestamp);
-    expect($result->updated_at->timestamp)->toBeGreaterThanOrEqual($originalCreatedAt->timestamp);
+    expect(requiredDate($result->created_at)->timestamp)->toBe(requiredDate($originalCreatedAt)->timestamp);
+    expect(requiredDate($result->updated_at)->timestamp)->toBeGreaterThanOrEqual(requiredDate($originalCreatedAt)->timestamp);
 });
 
 test('it handles null signature move', function () {

--- a/tests/Integration/Builders/Concerns/HasNameSearchIntegrationTest.php
+++ b/tests/Integration/Builders/Concerns/HasNameSearchIntegrationTest.php
@@ -49,16 +49,16 @@ describe('HasNameSearch Integration Tests', function () {
             $results = User::query()->whereNameMatches('John')->get();
 
             expect($results)->toHaveCount(1)
-                ->and($results->first()->first_name)->toBe('John')
-                ->and($results->first()->last_name)->toBe('Smith');
+                ->and($results->firstOrFail()->first_name)->toBe('John')
+                ->and($results->firstOrFail()->last_name)->toBe('Smith');
         });
 
         it('finds exact last name matches', function () {
             $results = User::query()->whereNameMatches('Doe')->get();
 
             expect($results)->toHaveCount(1)
-                ->and($results->first()->first_name)->toBe('Jane')
-                ->and($results->first()->last_name)->toBe('Doe');
+                ->and($results->firstOrFail()->first_name)->toBe('Jane')
+                ->and($results->firstOrFail()->last_name)->toBe('Doe');
         });
 
         it('finds first name with space prefix matches', function () {
@@ -72,8 +72,8 @@ describe('HasNameSearch Integration Tests', function () {
             $results = User::query()->whereNameMatches('Mary Jane')->get();
 
             expect($results)->toHaveCount(1)
-                ->and($results->first()->first_name)->toBe('Mary Jane')
-                ->and($results->first()->last_name)->toBe('Watson');
+                ->and($results->firstOrFail()->first_name)->toBe('Mary Jane')
+                ->and($results->firstOrFail()->last_name)->toBe('Watson');
         });
 
         it('does NOT match substrings that are not word boundaries', function () {
@@ -81,8 +81,8 @@ describe('HasNameSearch Integration Tests', function () {
             $results = User::query()->whereNameMatches('John')->get();
 
             expect($results)->toHaveCount(1)
-                ->and($results->first()->first_name)->toBe('John')
-                ->and($results->first()->last_name)->toBe('Smith');
+                ->and($results->firstOrFail()->first_name)->toBe('John')
+                ->and($results->firstOrFail()->last_name)->toBe('Smith');
 
             // Verify Johnny and Johnson are NOT included
             $names = $results->pluck('first_name', 'last_name')->toArray();
@@ -94,12 +94,12 @@ describe('HasNameSearch Integration Tests', function () {
             $results = User::query()->whereNameMatches('JOHN')->get();
 
             expect($results)->toHaveCount(1)
-                ->and($results->first()->first_name)->toBe('John');
+                ->and($results->firstOrFail()->first_name)->toBe('John');
 
             $results2 = User::query()->whereNameMatches('doe')->get();
 
             expect($results2)->toHaveCount(1)
-                ->and($results2->first()->last_name)->toBe('Doe');
+                ->and($results2->firstOrFail()->last_name)->toBe('Doe');
         });
 
         it('returns empty results for non-matching terms', function () {
@@ -152,7 +152,7 @@ describe('HasNameSearch Integration Tests', function () {
                 ->get();
 
             expect($results)->toHaveCount(1)
-                ->and($results->first()->last_name)->toBe('Smith');
+                ->and($results->firstOrFail()->last_name)->toBe('Smith');
         });
 
         it('works with order by clauses', function () {
@@ -164,9 +164,9 @@ describe('HasNameSearch Integration Tests', function () {
             expect($results)->toHaveCount(3);
 
             // Check ordering: Bob (Johnson), John, Johnny
-            expect($results->get(0)->first_name)->toBe('Bob')
-                ->and($results->get(1)->first_name)->toBe('John')
-                ->and($results->get(2)->first_name)->toBe('Johnny');
+            expect($results->slice(0)->firstOrFail()->first_name)->toBe('Bob')
+                ->and($results->slice(1)->firstOrFail()->first_name)->toBe('John')
+                ->and($results->slice(2)->firstOrFail()->first_name)->toBe('Johnny');
         });
     });
 
@@ -189,7 +189,7 @@ describe('HasNameSearch Integration Tests', function () {
             $results = User::query()->whereNameMatches("O'Connor")->get();
 
             expect($results)->toHaveCount(1)
-                ->and($results->first()->first_name)->toBe("O'Connor");
+                ->and($results->firstOrFail()->first_name)->toBe("O'Connor");
         });
 
         it('handles whitespace in search terms', function () {
@@ -197,7 +197,7 @@ describe('HasNameSearch Integration Tests', function () {
 
             // The method should handle whitespace appropriately
             expect($results)->toHaveCount(1)
-                ->and($results->first()->first_name)->toBe('John');
+                ->and($results->firstOrFail()->first_name)->toBe('John');
         });
     });
 });

--- a/tests/Integration/Builders/TitleChampionshipQueryBuilderTest.php
+++ b/tests/Integration/Builders/TitleChampionshipQueryBuilderTest.php
@@ -86,10 +86,8 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             $query = TitleChampionship::query();
 
             // Verify the builder returns TitleChampionship models
-            $championship = $query->first();
-            if ($championship) {
-                expect($championship)->toBeInstanceOf(TitleChampionship::class);
-            }
+            $championship = $query->firstOrFail();
+            expect($championship)->toBeInstanceOf(TitleChampionship::class);
         });
     });
 
@@ -103,8 +101,8 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
 
             // Assert
             expect($currentChampionships)->toHaveCount(1);
-            expect($currentChampionships->first()->id)->toBe($expectedCurrentChampionship->id);
-            expect($currentChampionships->first()->lost_at)->toBeNull();
+            expect($currentChampionships->firstOrFail()->id)->toBe($expectedCurrentChampionship->id);
+            expect($currentChampionships->firstOrFail()->lost_at)->toBeNull();
         });
 
         test('current scope filters out ended championships', function () {
@@ -136,9 +134,9 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             $specificCurrentChampionship = TitleChampionship::query()
                 ->current()
                 ->where('title_id', $this->title->id)
-                ->first();
+                ->firstOrFail();
 
-            expect($specificCurrentChampionship->id)->toBe($this->currentChampionship->id);
+            expect($specificCurrentChampionship->id)->toBe(requiredModel($this->currentChampionship)->id);
             expect($specificCurrentChampionship->lost_at)->toBeNull();
         });
     });
@@ -160,7 +158,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             $previousIds = $previousChampionships->pluck('id');
             expect($previousIds)->toContain($this->recentEndedChampionship->id);
             expect($previousIds)->toContain($this->olderEndedChampionship->id);
-            expect($previousIds)->not->toContain($this->currentChampionship->id);
+            expect($previousIds)->not->toContain(requiredModel($this->currentChampionship)->id);
         });
 
         test('previous scope generates correct SQL', function () {
@@ -177,7 +175,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
                 ->get();
 
             expect($recentPrevious)->toHaveCount(1);
-            expect($recentPrevious->first()->id)->toBe($this->recentEndedChampionship->id);
+            expect($recentPrevious->firstOrFail()->id)->toBe($this->recentEndedChampionship->id);
         });
     });
 
@@ -186,7 +184,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             $championships = TitleChampionship::query()->latestWon()->get();
 
             // Most recent win should be first (2024-01-01)
-            expect($championships->first()->id)->toBe($this->currentChampionship->id);
+            expect($championships->firstOrFail()->id)->toBe(requiredModel($this->currentChampionship)->id);
 
             // Verify ordering
             $wonDates = $championships->pluck('won_at');
@@ -202,7 +200,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
                 ->get();
 
             // Most recently lost should be first (2023-12-31)
-            expect($endedChampionships->first()->id)->toBe($this->recentEndedChampionship->id);
+            expect($endedChampionships->firstOrFail()->id)->toBe($this->recentEndedChampionship->id);
 
             // Verify ordering for ended championships
             $lostDates = $endedChampionships->pluck('lost_at');
@@ -234,7 +232,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             expect($previousByLatestLost)->toHaveCount(2);
 
             // Most recently lost should be first
-            expect($previousByLatestLost->first()->id)->toBe($this->recentEndedChampionship->id);
+            expect($previousByLatestLost->firstOrFail()->id)->toBe($this->recentEndedChampionship->id);
         });
     });
 
@@ -258,7 +256,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             $currentWithLength = TitleChampionship::query()
                 ->current()
                 ->withReignLength()
-                ->first();
+                ->firstOrFail();
 
             // Assert - Just verify the calculation returns a numeric value
             // NOTE: SQLite date calculations differ from MySQL, needs separate investigation
@@ -271,7 +269,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
                 ->previous()
                 ->withReignLength()
                 ->where('id', $this->recentEndedChampionship->id)
-                ->first();
+                ->firstOrFail();
 
             // Assert - Just verify the calculation returns a numeric value
             expect($endedWithLength->reign_length)->toBeNumeric();
@@ -299,7 +297,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
                 ->get();
 
             expect($currentWithLength)->toHaveCount(1);
-            expect($currentWithLength->first()->reign_length)->toBeNumeric();
+            expect($currentWithLength->firstOrFail()->reign_length)->toBeNumeric();
         });
     });
 
@@ -317,7 +315,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
 
             // Assert
             expect($result)->toHaveCount(2);
-            expect($result->first()->id)->toBe($expectedFirstChampionship->id);
+            expect($result->firstOrFail()->id)->toBe($expectedFirstChampionship->id);
 
             foreach ($result as $championship) {
                 expect($championship->reign_length)->toBeNumeric();
@@ -343,9 +341,8 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
                 ->latestLost()
                 ->limit(1);
 
-            $result = $complexQuery->first();
+            $result = $complexQuery->firstOrFail();
 
-            expect($result)->not()->toBeNull();
             expect($result->id)->toBe($this->recentEndedChampionship->id);
             expect($result->reign_length)->toBeNumeric();
         });
@@ -416,7 +413,7 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             $result = TitleChampionship::query()
                 ->where('id', $sameDayChampionship->id)
                 ->withReignLength()
-                ->first();
+                ->firstOrFail();
 
             expect($result->reign_length)->toBe(0);
         });

--- a/tests/Integration/Builders/UserQueryBuilderTest.php
+++ b/tests/Integration/Builders/UserQueryBuilderTest.php
@@ -46,10 +46,8 @@ describe('UserBuilder Unit Tests', function () {
             $query = User::query();
 
             // Verify the builder returns User models
-            $user = $query->first();
-            if ($user) {
-                expect($user)->toBeInstanceOf(User::class);
-            }
+            $user = $query->firstOrFail();
+            expect($user)->toBeInstanceOf(User::class);
         });
         expect(true)->toBeTrue();
     });
@@ -60,7 +58,7 @@ describe('UserBuilder Unit Tests', function () {
 
             expect($users)->toBeInstanceOf(Collection::class);
             expect($users->count())->toBeGreaterThan(0);
-            expect($users->first())->toBeInstanceOf(User::class);
+            expect($users->firstOrFail())->toBeInstanceOf(User::class);
         });
 
         test('builder can filter by specific attributes', function () {
@@ -107,7 +105,7 @@ describe('UserBuilder Unit Tests', function () {
             $result = User::query()
                 ->where('role', Role::Administrator)
                 ->where('status', UserStatus::Active)
-                ->first();
+                ->firstOrFail();
 
             expect($result)->toBeInstanceOf(User::class);
             expect($result->role)->toBe(Role::Administrator);
@@ -139,7 +137,7 @@ describe('UserBuilder Unit Tests', function () {
 
             // Verify ordering (newest first)
             if ($users->count() > 1) {
-                expect($users->first()->created_at->gte($users->last()->created_at))->toBeTrue();
+                expect(requiredDate($users->firstOrFail()->created_at)->gte(requiredDate($users->reverse()->firstOrFail()->created_at)))->toBeTrue();
             }
         });
         expect(true)->toBeTrue();

--- a/tests/Integration/Builders/VenueQueryBuilderTest.php
+++ b/tests/Integration/Builders/VenueQueryBuilderTest.php
@@ -186,7 +186,7 @@ describe('VenueBuilder Query Scopes', function () {
                 ->get();
 
             expect($venues)->toHaveCount(1);
-            expect($venues->first()->name)->toBe('Mixed Events Venue');
+            expect($venues->firstOrFail()->name)->toBe('Mixed Events Venue');
         });
 
         test('can chain withPastEvents and withFutureEvents', function () {
@@ -196,7 +196,7 @@ describe('VenueBuilder Query Scopes', function () {
                 ->get();
 
             expect($venues)->toHaveCount(1);
-            expect($venues->first()->name)->toBe('Mixed Events Venue');
+            expect($venues->firstOrFail()->name)->toBe('Mixed Events Venue');
         });
 
         test('can chain withoutEvents with ordering', function () {
@@ -208,7 +208,7 @@ describe('VenueBuilder Query Scopes', function () {
                 ->get();
 
             expect($venues)->toHaveCount(2);
-            expect($venues->first()->name)->toBe('Another Empty Venue');
+            expect($venues->firstOrFail()->name)->toBe('Another Empty Venue');
         });
 
         test('can chain all scopes for complex filtering', function () {
@@ -223,7 +223,7 @@ describe('VenueBuilder Query Scopes', function () {
                 ->get();
 
             expect($venues)->toHaveCount(1);
-            expect($venues->first()->name)->toBe('Complex Test Venue');
+            expect($venues->firstOrFail()->name)->toBe('Complex Test Venue');
         });
     });
 

--- a/tests/Integration/Database/Seeders/EventsTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/EventsTableSeederTest.php
@@ -114,13 +114,12 @@ describe('EventsTableSeeder Integration Tests', function () {
 
             // Assert
             if ($event) {
-                expect($event->venue)->not()->toBeNull();
-                expect($event->venue->name)->toBeString();
+                expect($event->venue)
+                    ->not()->toBeNull()
+                    ->name->toBeString();
             } else {
-                // If no events have venues, that's also valid (all future events)
                 expect(Event::whereNotNull('venue_id')->count())->toBe(0);
             }
-            expect(true)->toBeTrue();
         });
 
         test('seeder creates consistent data', function () {

--- a/tests/Integration/Database/Seeders/MatchesTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/MatchesTableSeederTest.php
@@ -115,10 +115,10 @@ describe('MatchesTableSeeder Integration Tests', function () {
 
         test('event matches can load relationships', function () {
             // Arrange
-            $eventMatch = EventMatch::with(['event'])->first();
+            $eventMatch = EventMatch::with(['event'])->firstOrFail();
 
             // Assert
-            expect($eventMatch->event->name)->toBeString();
+            expect($eventMatch->event()->firstOrFail()->name)->toBeString();
             expect($eventMatch->match_type)->toBeInstanceOf(MatchType::class);
             expect(true)->toBeTrue();
         });

--- a/tests/Integration/Database/Seeders/UsersTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/UsersTableSeederTest.php
@@ -117,11 +117,11 @@ describe('UsersTableSeeder Integration Tests', function () {
             $basicUsers = User::where('role', Role::Basic)->orderBy('id')->take(5)->get();
 
             // Assert
-            expect($basicUsers[0]->first_name)->toBe('Basic');
-            expect($basicUsers[1]->first_name)->toBe('Second Basic');
-            expect($basicUsers[2]->first_name)->toBe('Third Basic');
-            expect($basicUsers[3]->first_name)->toBe('Fourth Basic');
-            expect($basicUsers[4]->first_name)->toBe('Fifth Basic');
+            expect($basicUsers->slice(0)->firstOrFail()->first_name)->toBe('Basic');
+            expect($basicUsers->slice(1)->firstOrFail()->first_name)->toBe('Second Basic');
+            expect($basicUsers->slice(2)->firstOrFail()->first_name)->toBe('Third Basic');
+            expect($basicUsers->slice(3)->firstOrFail()->first_name)->toBe('Fourth Basic');
+            expect($basicUsers->slice(4)->firstOrFail()->first_name)->toBe('Fifth Basic');
         });
 
         test('basic users have required attributes', function () {

--- a/tests/Integration/Database/Seeders/VenuesTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/VenuesTableSeederTest.php
@@ -72,7 +72,7 @@ describe('VenuesTableSeeder Integration Tests', function () {
 
         test('venues have realistic address data', function () {
             // Arrange
-            $venue = Venue::first();
+            $venue = Venue::query()->firstOrFail();
 
             // Assert
             expect($venue->street_address)->not->toBeEmpty();

--- a/tests/Integration/Livewire/Events/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Events/Tables/MainTest.php
@@ -72,7 +72,7 @@ describe('EventsTable Component Integration', function () {
 
             // Verify venue relationship exists
             expect($event->venue)->not()->toBeNull();
-            expect($event->venue->name)->toBe('Test Arena');
+            expect($event->venue()->firstOrFail()->name)->toBe('Test Arena');
 
             actingAs($this->admin);
 
@@ -215,7 +215,7 @@ describe('EventsTable Component Integration', function () {
 
             // Verify event is restored
             expect(Event::find($deletedEvent->id))->not()->toBeNull();
-            expect($deletedEvent->fresh()->deleted_at)->toBeNull();
+            expect(freshModel($deletedEvent)->deleted_at)->toBeNull();
         });
     });
 

--- a/tests/Integration/Livewire/Managers/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Managers/Components/ActionsTest.php
@@ -75,7 +75,7 @@ describe('ManagersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('manager-updated');
 
-            expect($unemployedManager->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($unemployedManager)->isEmployed())->toBeTrue();
             // Session message verified in unit tests
             expect(true)->toBeTrue();
         });
@@ -100,7 +100,7 @@ describe('ManagersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('manager-updated');
 
-            expect($this->manager->fresh()->isReleased())->toBeTrue();
+            expect(freshModel($this->manager)->isReleased())->toBeTrue();
             // Session success message verified in unit tests
             expect(true)->toBeTrue();
         });
@@ -129,7 +129,7 @@ describe('ManagersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('manager-updated');
 
-            expect($this->manager->fresh()->isInjured())->toBeTrue();
+            expect(freshModel($this->manager)->isInjured())->toBeTrue();
             // expect(session('status'))->toBe('Manager injury recorded.');
             expect(true)->toBeTrue();
         });
@@ -161,7 +161,7 @@ describe('ManagersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('manager-updated');
 
-            expect($injuredManager->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($injuredManager)->isInjured())->toBeFalse();
             // expect(session('status'))->toBe('Manager cleared from injury.');
             expect(true)->toBeTrue();
         });
@@ -188,7 +188,7 @@ describe('ManagersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('manager-updated');
 
-            expect($this->manager->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($this->manager)->isSuspended())->toBeTrue();
             // expect(session('status'))->toBe('Manager successfully suspended.');
             expect(true)->toBeTrue();
         });
@@ -220,7 +220,7 @@ describe('ManagersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('manager-updated');
 
-            expect($suspendedManager->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($suspendedManager)->isSuspended())->toBeFalse();
             // expect(session('status'))->toBe('Manager successfully reinstated.');
             expect(true)->toBeTrue();
         });
@@ -247,7 +247,7 @@ describe('ManagersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('manager-updated');
 
-            expect($this->manager->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($this->manager)->isRetired())->toBeTrue();
             // expect(session('status'))->toBe('Manager successfully retired.');
             expect(true)->toBeTrue();
         });
@@ -279,7 +279,7 @@ describe('ManagersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('manager-updated');
 
-            expect($retiredManager->fresh()->isRetired())->toBeFalse();
+            expect(freshModel($retiredManager)->isRetired())->toBeFalse();
             // expect(session('status'))->toBe('Manager successfully unretired.');
             expect(true)->toBeTrue();
         });
@@ -301,7 +301,7 @@ describe('ManagersActions Integration Tests', function () {
             $this->manager->delete();
             expect($this->manager->trashed())->toBeTrue();
 
-            $trashedManager = Manager::onlyTrashed()->find($this->manager->id);
+            $trashedManager = Manager::onlyTrashed()->findOrFail($this->manager->id);
 
             actingAs($this->admin);
 
@@ -330,32 +330,32 @@ describe('ManagersActions Integration Tests', function () {
 
             // Employ
             $component->call('employ');
-            expect($manager->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($manager)->isEmployed())->toBeTrue();
 
             // Injure (managers can get injured backstage, traveling, etc.)
             $component->call('injure');
-            expect($manager->fresh()->isInjured())->toBeTrue();
+            expect(freshModel($manager)->isInjured())->toBeTrue();
 
             // Heal
             $component->call('healFromInjury');
-            expect($manager->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($manager)->isInjured())->toBeFalse();
 
             // Suspend (for misconduct, contract violations, etc.)
             $component->call('suspend');
-            expect($manager->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($manager)->isSuspended())->toBeTrue();
 
             // Reinstate
             $component->call('reinstate');
-            expect($manager->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($manager)->isSuspended())->toBeFalse();
 
             // Retire
             $component->call('retire');
-            expect($manager->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($manager)->isRetired())->toBeTrue();
 
             // Comeback
             $component->call('unretire');
-            expect($manager->fresh()->isRetired())->toBeFalse();
-            expect($manager->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($manager)->isRetired())->toBeFalse();
+            expect(freshModel($manager)->isEmployed())->toBeTrue();
             expect(true)->toBeTrue();
         });
 
@@ -378,10 +378,10 @@ describe('ManagersActions Integration Tests', function () {
 
             // Can heal first, then suspend
             $component->call('healFromInjury');
-            expect($injuredManager->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($injuredManager)->isInjured())->toBeFalse();
 
             $component->call('suspend');
-            expect($injuredManager->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($injuredManager)->isSuspended())->toBeTrue();
             expect(true)->toBeTrue();
         });
 
@@ -404,11 +404,11 @@ describe('ManagersActions Integration Tests', function () {
 
             // Must reinstate first
             $component->call('reinstate');
-            expect($suspendedManager->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($suspendedManager)->isSuspended())->toBeFalse();
 
             // Now can retire
             $component->call('retire');
-            expect($suspendedManager->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($suspendedManager)->isRetired())->toBeTrue();
             expect(true)->toBeTrue();
         });
     });
@@ -493,7 +493,7 @@ describe('ManagersActions Integration Tests', function () {
             $component->call('release');
 
             // Manager status should reflect in fresh model
-            expect($this->manager->fresh()->isReleased())->toBeTrue();
+            expect(freshModel($this->manager)->isReleased())->toBeTrue();
             expect(true)->toBeTrue();
         });
 
@@ -525,7 +525,7 @@ describe('ManagersActions Integration Tests', function () {
 
             // Display name should remain consistent
             expect($component->get('manager')->display_name)->toBe($originalDisplayName);
-            expect($this->manager->fresh()->display_name)->toBe($originalDisplayName);
+            expect(freshModel($this->manager)->display_name)->toBe($originalDisplayName);
             expect(true)->toBeTrue();
         });
     });

--- a/tests/Integration/Livewire/Managers/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Managers/Modals/FormModalTest.php
@@ -132,7 +132,7 @@ describe('Managers FormModal Tests', function () {
 
             expect(Manager::where('first_name', 'Mike')->where('last_name', 'Johnson')->exists())->toBeTrue();
 
-            $manager = Manager::where('first_name', 'Mike')->where('last_name', 'Johnson')->first();
+            $manager = Manager::where('first_name', 'Mike')->where('last_name', 'Johnson')->firstOrFail();
             expect($manager->first_name)->toBe('Mike');
             expect($manager->last_name)->toBe('Johnson');
         });
@@ -145,8 +145,7 @@ describe('Managers FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $manager = Manager::where('first_name', 'Simple')->where('last_name', 'Manager')->first();
-            expect($manager)->not()->toBeNull();
+            $manager = Manager::where('first_name', 'Simple')->where('last_name', 'Manager')->firstOrFail();
             expect($manager->firstEmployment)->toBeNull();
         });
 
@@ -167,8 +166,7 @@ describe('Managers FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $manager = Manager::where('first_name', "O'Connor")->where('last_name', 'Van Der Berg')->first();
-            expect($manager)->not()->toBeNull();
+            $manager = Manager::where('first_name', "O'Connor")->where('last_name', 'Van Der Berg')->firstOrFail();
             expect($manager->first_name)->toBe("O'Connor");
             expect($manager->last_name)->toBe('Van Der Berg');
         });
@@ -304,9 +302,8 @@ describe('Managers FormModal Tests', function () {
 
                 $manager = Manager::where('first_name', $testCase['first'])
                     ->where('last_name', $testCase['last'])
-                    ->first();
+                    ->firstOrFail();
 
-                expect($manager)->not()->toBeNull("Failed for test case {$index}: {$testCase['first']} {$testCase['last']}");
             }
         });
 
@@ -344,7 +341,6 @@ describe('Managers FormModal Tests', function () {
             if (! $manager) {
                 // If trimming is not implemented, look for the untrimmed version
                 $manager = Manager::where('first_name', '  Trimmed  ')->first();
-                expect($manager)->not()->toBeNull();
             }
         });
     });
@@ -408,9 +404,9 @@ describe('Managers FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $manager = Manager::where('first_name', 'Employment')->where('last_name', 'Test')->first();
+            $manager = Manager::where('first_name', 'Employment')->where('last_name', 'Test')->firstOrFail();
             expect($manager->firstEmployment)->not()->toBeNull();
-            expect($manager->firstEmployment->started_at->toDateString())->toBe('2024-01-01');
+            expect(requiredDate(requiredModel($manager->firstEmployment)->started_at)->toDateString())->toBe('2024-01-01');
         });
 
         test('does not create employment record when date not provided', function () {
@@ -421,7 +417,7 @@ describe('Managers FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $manager = Manager::where('first_name', 'No Employment')->where('last_name', 'Test')->first();
+            $manager = Manager::where('first_name', 'No Employment')->where('last_name', 'Test')->firstOrFail();
             expect($manager->firstEmployment)->toBeNull();
         });
 
@@ -464,9 +460,8 @@ describe('Managers FormModal Tests', function () {
 
                 $manager = Manager::where('first_name', $name['first'])
                     ->where('last_name', $name['last'])
-                    ->first();
+                    ->firstOrFail();
 
-                expect($manager)->not()->toBeNull();
             }
         });
 

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -255,7 +255,7 @@ describe('FormModal Title Championship Integration', function () {
         $component->assertHasNoErrors();
         $component->assertDispatched('matchCreated');
 
-        $match = EventMatch::where('event_id', $this->event->id)->first();
+        $match = EventMatch::where('event_id', $this->event->id)->firstOrFail();
         expect($match->titles->pluck('id'))->toContain($title->id);
     });
 

--- a/tests/Integration/Livewire/Matches/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MainTest.php
@@ -57,7 +57,7 @@ describe('Matches Main Table Component Integration', function () {
             ]);
 
             expect($match->event)->not()->toBeNull();
-            expect($match->event->name)->toBe('Test Event');
+            expect($match->event()->firstOrFail()->name)->toBe('Test Event');
 
             actingAs($this->admin);
 

--- a/tests/Integration/Livewire/Referees/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Referees/Components/ActionsTest.php
@@ -75,7 +75,7 @@ describe('RefereesActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('referee-updated');
 
-            expect($unemployedReferee->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($unemployedReferee)->isEmployed())->toBeTrue();
             // expect(session('status'))->toBe('Referee successfully employed.');
             expect(true)->toBeTrue();
         });
@@ -100,7 +100,7 @@ describe('RefereesActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('referee-updated');
 
-            expect($this->referee->fresh()->isReleased())->toBeTrue();
+            expect(freshModel($this->referee)->isReleased())->toBeTrue();
             // expect(session('status'))->toBe('Referee successfully released.');
             expect(true)->toBeTrue();
         });
@@ -129,7 +129,7 @@ describe('RefereesActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('referee-updated');
 
-            expect($this->referee->fresh()->isInjured())->toBeTrue();
+            expect(freshModel($this->referee)->isInjured())->toBeTrue();
             // expect(session('status'))->toBe('Referee injury recorded.');
             expect(true)->toBeTrue();
         });
@@ -161,7 +161,7 @@ describe('RefereesActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('referee-updated');
 
-            expect($injuredReferee->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($injuredReferee)->isInjured())->toBeFalse();
             // expect(session('status'))->toBe('Referee cleared from injury.');
             expect(true)->toBeTrue();
         });
@@ -188,7 +188,7 @@ describe('RefereesActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('referee-updated');
 
-            expect($this->referee->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($this->referee)->isSuspended())->toBeTrue();
             // expect(session('status'))->toBe('Referee successfully suspended.');
             expect(true)->toBeTrue();
         });
@@ -220,7 +220,7 @@ describe('RefereesActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('referee-updated');
 
-            expect($suspendedReferee->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($suspendedReferee)->isSuspended())->toBeFalse();
             // expect(session('status'))->toBe('Referee successfully reinstated.');
             expect(true)->toBeTrue();
         });
@@ -247,7 +247,7 @@ describe('RefereesActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('referee-updated');
 
-            expect($this->referee->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($this->referee)->isRetired())->toBeTrue();
             // expect(session('status'))->toBe('Referee successfully retired.');
             expect(true)->toBeTrue();
         });
@@ -279,7 +279,7 @@ describe('RefereesActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('referee-updated');
 
-            expect($retiredReferee->fresh()->isRetired())->toBeFalse();
+            expect(freshModel($retiredReferee)->isRetired())->toBeFalse();
             // expect(session('status'))->toBe('Referee successfully unretired.');
             expect(true)->toBeTrue();
         });
@@ -301,7 +301,7 @@ describe('RefereesActions Integration Tests', function () {
             $this->referee->delete();
             expect($this->referee->trashed())->toBeTrue();
 
-            $trashedReferee = Referee::onlyTrashed()->find($this->referee->id);
+            $trashedReferee = Referee::onlyTrashed()->findOrFail($this->referee->id);
 
             actingAs($this->admin);
 
@@ -330,32 +330,32 @@ describe('RefereesActions Integration Tests', function () {
 
             // Employ
             $component->call('employ');
-            expect($referee->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($referee)->isEmployed())->toBeTrue();
 
             // Injure (referee injury during match)
             $component->call('injure');
-            expect($referee->fresh()->isInjured())->toBeTrue();
+            expect(freshModel($referee)->isInjured())->toBeTrue();
 
             // Heal (medical clearance)
             $component->call('healFromInjury');
-            expect($referee->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($referee)->isInjured())->toBeFalse();
 
             // Suspend (for poor performance, missed calls, etc.)
             $component->call('suspend');
-            expect($referee->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($referee)->isSuspended())->toBeTrue();
 
             // Reinstate (after retraining)
             $component->call('reinstate');
-            expect($referee->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($referee)->isSuspended())->toBeFalse();
 
             // Retire
             $component->call('retire');
-            expect($referee->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($referee)->isRetired())->toBeTrue();
 
             // Comeback
             $component->call('unretire');
-            expect($referee->fresh()->isRetired())->toBeFalse();
-            expect($referee->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($referee)->isRetired())->toBeFalse();
+            expect(freshModel($referee)->isEmployed())->toBeTrue();
             expect(true)->toBeTrue();
         });
 
@@ -379,10 +379,10 @@ describe('RefereesActions Integration Tests', function () {
 
             // Can heal first, then suspend
             $component->call('healFromInjury');
-            expect($injuredReferee->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($injuredReferee)->isInjured())->toBeFalse();
 
             $component->call('suspend');
-            expect($injuredReferee->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($injuredReferee)->isSuspended())->toBeTrue();
             expect(true)->toBeTrue();
         });
 
@@ -406,11 +406,11 @@ describe('RefereesActions Integration Tests', function () {
 
             // Must reinstate first
             $component->call('reinstate');
-            expect($suspendedReferee->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($suspendedReferee)->isSuspended())->toBeFalse();
 
             // Now can retire
             $component->call('retire');
-            expect($suspendedReferee->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($suspendedReferee)->isRetired())->toBeTrue();
             expect(true)->toBeTrue();
         });
 
@@ -437,17 +437,17 @@ describe('RefereesActions Integration Tests', function () {
 
             // Both can be injured, suspended, etc.
             $juniorComponent->call('injure');
-            expect($juniorReferee->fresh()->isInjured())->toBeTrue();
+            expect(freshModel($juniorReferee)->isInjured())->toBeTrue();
 
             $seniorComponent->call('suspend');
-            expect($seniorReferee->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($seniorReferee)->isSuspended())->toBeTrue();
 
             // Both can be restored to active status
             $juniorComponent->call('healFromInjury');
-            expect($juniorReferee->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($juniorReferee)->isInjured())->toBeFalse();
 
             $seniorComponent->call('reinstate');
-            expect($seniorReferee->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($seniorReferee)->isSuspended())->toBeFalse();
             expect(true)->toBeTrue();
         });
     });
@@ -532,7 +532,7 @@ describe('RefereesActions Integration Tests', function () {
             $component->call('release');
 
             // Referee status should reflect in fresh model
-            expect($this->referee->fresh()->isReleased())->toBeTrue();
+            expect(freshModel($this->referee)->isReleased())->toBeTrue();
             expect(true)->toBeTrue();
         });
 
@@ -555,7 +555,7 @@ describe('RefereesActions Integration Tests', function () {
 
         test('referee full name consistency maintained', function () {
             // Ensure referee has virtual column loaded
-            $this->referee = $this->referee->fresh();
+            $this->referee = freshModel($this->referee);
 
             actingAs($this->admin);
 
@@ -567,7 +567,7 @@ describe('RefereesActions Integration Tests', function () {
 
             // Full name should remain consistent
             expect($component->get('referee')->full_name)->toBe($originalFullName);
-            expect($this->referee->fresh()->full_name)->toBe($originalFullName);
+            expect(freshModel($this->referee)->full_name)->toBe($originalFullName);
             expect(true)->toBeTrue();
         });
     });

--- a/tests/Integration/Livewire/Referees/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Referees/Modals/FormModalTest.php
@@ -122,7 +122,7 @@ describe('Referees FormModal Tests', function () {
 
             expect(Referee::where('first_name', 'Mike')->where('last_name', 'Johnson')->exists())->toBeTrue();
 
-            $referee = Referee::where('first_name', 'Mike')->where('last_name', 'Johnson')->first();
+            $referee = Referee::where('first_name', 'Mike')->where('last_name', 'Johnson')->firstOrFail();
             expect($referee->first_name)->toBe('Mike');
             expect($referee->last_name)->toBe('Johnson');
         });
@@ -135,8 +135,7 @@ describe('Referees FormModal Tests', function () {
                 ->call('save')
                 ->assertHasNoErrors();
 
-            $referee = Referee::where('first_name', 'Simple')->where('last_name', 'Referee')->first();
-            expect($referee)->not()->toBeNull();
+            $referee = Referee::where('first_name', 'Simple')->where('last_name', 'Referee')->firstOrFail();
             expect($referee->firstEmployment)->toBeNull();
         });
 
@@ -384,8 +383,7 @@ describe('Referees FormModal Tests', function () {
                 ->call('save')
                 ->assertHasNoErrors();
 
-            $referee = Referee::where('first_name', 'Employment')->where('last_name', 'Test')->first();
-            expect($referee)->not()->toBeNull();
+            $referee = Referee::where('first_name', 'Employment')->where('last_name', 'Test')->firstOrFail();
             // Note: Employment creation is not handled by the current RefereeForm implementation
         });
 

--- a/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
@@ -115,9 +115,9 @@ describe('FormModal Create Operations', function () {
         ]);
 
         // Check activity period was created correctly
-        $stable = Stable::where('name', 'The New World Order')->first();
+        $stable = Stable::where('name', 'The New World Order')->firstOrFail();
         expect($stable->firstActivityPeriod)->not()->toBeNull();
-        expect($stable->firstActivityPeriod->started_at->toDateString())->toBe('2024-01-01');
+        expect(requiredModel($stable->firstActivityPeriod)->started_at->toDateString())->toBe('2024-01-01');
     });
 
     it('validates required fields when creating', function () {
@@ -180,10 +180,10 @@ describe('FormModal Create Operations', function () {
         ]);
 
         // Check activity period was created correctly
-        $stable = Stable::where('name', 'Test Stable')->first();
+        $stable = Stable::where('name', 'Test Stable')->firstOrFail();
         expect($stable->firstActivityPeriod)->not()->toBeNull();
-        expect($stable->firstActivityPeriod->started_at->toDateString())->toBe('2024-01-01');
-        expect($stable->firstActivityPeriod->ended_at->toDateString())->toBe('2024-12-31');
+        expect(requiredDate(requiredModel($stable->firstActivityPeriod)->started_at)->toDateString())->toBe('2024-01-01');
+        expect(requiredDate(requiredModel($stable->firstActivityPeriod)->ended_at)->toDateString())->toBe('2024-12-31');
     });
 });
 
@@ -209,7 +209,7 @@ describe('FormModal Edit Operations', function () {
         ]);
 
         // Check activity period was updated
-        expect($stable->fresh()->firstActivityPeriod->started_at->toDateString())->toBe('2024-01-02');
+        expect(requiredModel(freshModel($stable)->firstActivityPeriod)->started_at->toDateString())->toBe('2024-01-02');
     });
 
     it('loads existing stable data in edit mode', function () {
@@ -280,8 +280,8 @@ describe('FormModal Activity Period Management', function () {
 
         $component->assertHasNoErrors();
 
-        $stable = Stable::where('name', 'Test Stable')->first();
-        expect($stable->firstActivityPeriod->started_at)->toBeInstanceOf(Carbon::class);
+        $stable = Stable::where('name', 'Test Stable')->firstOrFail();
+        expect($stable->firstActivityPeriod)->not->toBeNull()->started_at->toBeInstanceOf(Carbon::class);
     });
 
     it('can set ended_at for disbanded stables', function () {
@@ -294,8 +294,8 @@ describe('FormModal Activity Period Management', function () {
 
         $component->assertHasNoErrors();
 
-        $stable = Stable::where('name', 'Disbanded Stable')->first();
-        expect($stable->firstActivityPeriod->ended_at)->toBeInstanceOf(Carbon::class);
+        $stable = Stable::where('name', 'Disbanded Stable')->firstOrFail();
+        expect($stable->firstActivityPeriod)->not->toBeNull()->ended_at->toBeInstanceOf(Carbon::class);
     });
 
     it('validates ended_at is not before started_at', function () {
@@ -324,7 +324,7 @@ describe('FormModal Member Management', function () {
 
         $component->assertHasNoErrors();
 
-        $stable = Stable::where('name', 'Test Stable')->first();
+        $stable = Stable::where('name', 'Test Stable')->firstOrFail();
         $stable->refresh();
         expect($stable->wrestlers->pluck('id'))->toContain($wrestler1->id);
         expect($stable->wrestlers->pluck('id'))->toContain($wrestler2->id);
@@ -343,7 +343,7 @@ describe('FormModal Member Management', function () {
 
         $component->assertHasNoErrors();
 
-        $stable = Stable::where('name', 'Test Stable')->first();
+        $stable = Stable::where('name', 'Test Stable')->firstOrFail();
         $stable->refresh();
         expect($stable->tagTeams->pluck('id'))->toContain($tagTeam1->id);
         expect($stable->tagTeams->pluck('id'))->toContain($tagTeam2->id);

--- a/tests/Integration/Livewire/Stables/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Stables/Tables/MainTest.php
@@ -178,7 +178,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable is disbanded
-            expect($activeStable->fresh()->isDisbanded())->toBeTrue();
+            expect(freshModel($activeStable)->isDisbanded())->toBeTrue();
         });
 
         test('retire action integration works correctly', function () {
@@ -193,7 +193,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable is retired
-            expect($activeStable->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($activeStable)->isRetired())->toBeTrue();
         });
 
         test('unretire action integration works correctly', function () {
@@ -208,7 +208,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable is unretired
-            expect($retiredStable->fresh()->isCurrentlyActive())->toBeTrue();
+            expect(freshModel($retiredStable)->isCurrentlyActive())->toBeTrue();
         });
 
         test('establish action integration works correctly', function () {
@@ -223,7 +223,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable is established
-            expect($inactiveStable->fresh()->isCurrentlyActive())->toBeTrue();
+            expect(freshModel($inactiveStable)->isCurrentlyActive())->toBeTrue();
         });
 
         test('restore action integration works correctly', function () {
@@ -270,7 +270,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable status unchanged
-            expect($activeStable->fresh()->isActive())->toBeTrue();
+            expect(freshModel($activeStable)->isActive())->toBeTrue();
         });
 
         test('disband action fails for inappropriate stable status', function () {
@@ -284,7 +284,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable status unchanged
-            expect($inactiveStable->fresh()->isInactive())->toBeTrue();
+            expect(freshModel($inactiveStable)->isInactive())->toBeTrue();
         });
 
         test('unretire action fails for non-retired stable', function () {
@@ -298,7 +298,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable status unchanged
-            expect($activeStable->fresh()->isActive())->toBeTrue();
+            expect(freshModel($activeStable)->isActive())->toBeTrue();
         });
 
         test('actions respect stable business constraints', function () {
@@ -312,7 +312,7 @@ describe('StablesTable Component', function () {
             $component->call('disband', $disbandedStable)
                 ->assertRedirect();
 
-            expect($disbandedStable->fresh()->isDisbanded())->toBeTrue();
+            expect(freshModel($disbandedStable)->isDisbanded())->toBeTrue();
         });
     });
 

--- a/tests/Integration/Livewire/TagTeams/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/TagTeams/Modals/FormModalTest.php
@@ -73,7 +73,7 @@ describe('TagTeams FormModal Tests', function () {
                 ->call('openModal');
 
             expect($component->instance()->getWrestlers())->toHaveCount(5);
-            expect(array_key_first($component->instance()->getWrestlers()))->toBe($wrestlers->first()->id);
+            expect(array_key_first($component->instance()->getWrestlers()))->toBe($wrestlers->firstOrFail()->id);
         });
     });
 
@@ -211,13 +211,13 @@ describe('TagTeams FormModal Tests', function () {
 
             expect(TagTeam::where('name', 'New Tag Team')->exists())->toBeTrue();
 
-            $tagTeam = TagTeam::where('name', 'New Tag Team')->first();
+            $tagTeam = TagTeam::where('name', 'New Tag Team')->firstOrFail();
             expect($tagTeam->signature_move)->toBe('Team Finisher');
             expect($tagTeam->currentWrestlers)->toHaveCount(2);
             expect($tagTeam->currentWrestlers->pluck('id')->toArray())->toContain($wrestlerA->id);
             expect($tagTeam->currentWrestlers->pluck('id')->toArray())->toContain($wrestlerB->id);
             expect($tagTeam->currentManagers)->toHaveCount(1);
-            expect($tagTeam->currentManagers->first()->id)->toBe($manager->id);
+            expect($tagTeam->currentManagers->firstOrFail()->id)->toBe($manager->id);
         });
 
         test('creates tag team without optional fields', function () {
@@ -232,8 +232,7 @@ describe('TagTeams FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $tagTeam = TagTeam::where('name', 'Simple Tag Team')->first();
-            expect($tagTeam)->not()->toBeNull();
+            $tagTeam = TagTeam::where('name', 'Simple Tag Team')->firstOrFail();
             expect($tagTeam->signature_move)->toBeNull();
             expect($tagTeam->currentManagers)->toHaveCount(0);
             expect($tagTeam->firstEmployment)->toBeNull();
@@ -307,7 +306,7 @@ describe('TagTeams FormModal Tests', function () {
             expect($tagTeam->name)->toBe('Updated Team Name');
             expect($tagTeam->signature_move)->toBe('New Team Finisher');
             expect($tagTeam->currentWrestlers->pluck('id')->toArray())->toEqual([$newWrestlerA->id, $newWrestlerB->id]);
-            expect($tagTeam->currentManagers->first()->id)->toBe($manager->id);
+            expect($tagTeam->currentManagers->firstOrFail()->id)->toBe($manager->id);
         });
 
         test('allows name uniqueness bypass for same tag team', function () {
@@ -349,7 +348,7 @@ describe('TagTeams FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $tagTeam = TagTeam::where('name', 'Relationship Test Team')->first();
+            $tagTeam = TagTeam::where('name', 'Relationship Test Team')->firstOrFail();
             expect($tagTeam->wrestlers)->toHaveCount(2);
             expect($tagTeam->wrestlers->pluck('id')->sort()->values()->toArray())
                 ->toEqual(collect([$wrestlerA->id, $wrestlerB->id])->sort()->values()->toArray());
@@ -413,7 +412,7 @@ describe('TagTeams FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $tagTeam = TagTeam::where('name', 'Manager Test Team')->first();
+            $tagTeam = TagTeam::where('name', 'Manager Test Team')->firstOrFail();
             expect($tagTeam->managers)->toHaveCount(2);
             expect($tagTeam->managers->pluck('id')->sort()->values()->toArray())
                 ->toEqual(collect([$manager1->id, $manager2->id])->sort()->values()->toArray());
@@ -545,9 +544,9 @@ describe('TagTeams FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $tagTeam = TagTeam::where('name', 'Employment Test Team')->first();
+            $tagTeam = TagTeam::where('name', 'Employment Test Team')->firstOrFail();
             expect($tagTeam->firstEmployment)->not()->toBeNull();
-            expect($tagTeam->firstEmployment->started_at->toDateString())->toBe('2024-01-01');
+            expect(requiredDate(requiredModel($tagTeam->firstEmployment)->started_at)->toDateString())->toBe('2024-01-01');
         });
 
         test('does not create employment record when date not provided', function () {
@@ -562,7 +561,7 @@ describe('TagTeams FormModal Tests', function () {
                 ->call('submitForm')
                 ->assertHasNoErrors();
 
-            $tagTeam = TagTeam::where('name', 'No Employment Test Team')->first();
+            $tagTeam = TagTeam::where('name', 'No Employment Test Team')->firstOrFail();
             expect($tagTeam->firstEmployment)->toBeNull();
         });
     });

--- a/tests/Integration/Livewire/Titles/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Titles/Components/ActionsTest.php
@@ -64,7 +64,7 @@ describe('Title Debut Actions', function () {
         $component->assertDispatched('title-updated');
 
         // Verify the title status changed through the action
-        expect($title->fresh()->isCurrentlyActive())->toBeTrue();
+        expect(freshModel($title)->isCurrentlyActive())->toBeTrue();
     });
 
     it('handles debut for already active title', function () {
@@ -93,7 +93,7 @@ describe('Title Retirement Actions', function () {
         $component->assertDispatched('title-updated');
 
         // Verify the title status changed
-        expect($title->fresh()->isRetired())->toBeTrue();
+        expect(freshModel($title)->isRetired())->toBeTrue();
     });
 
     it('can unretire a retired title successfully', function () {
@@ -108,7 +108,7 @@ describe('Title Retirement Actions', function () {
         $component->assertDispatched('title-updated');
 
         // Verify the title is no longer retired
-        expect($title->fresh()->isRetired())->toBeFalse();
+        expect(freshModel($title)->isRetired())->toBeFalse();
     });
 });
 
@@ -143,7 +143,7 @@ describe('Title Restoration Actions', function () {
         $this->title->delete();
         expect($this->title->trashed())->toBeTrue();
 
-        $trashedTitle = Title::onlyTrashed()->find($this->title->id);
+        $trashedTitle = Title::onlyTrashed()->findOrFail($this->title->id);
 
         actingAs($this->admin);
 
@@ -208,15 +208,15 @@ describe('Title Business Logic Integration', function () {
 
         // Debut the title
         $component->call('debut');
-        expect($title->fresh()->isCurrentlyActive())->toBeTrue();
+        expect(freshModel($title)->isCurrentlyActive())->toBeTrue();
 
         // Retire the title
         $component->call('retire');
-        expect($title->fresh()->isRetired())->toBeTrue();
+        expect(freshModel($title)->isRetired())->toBeTrue();
 
         // Unretire the title
         $component->call('unretire');
-        expect($title->fresh()->isRetired())->toBeFalse();
+        expect(freshModel($title)->isRetired())->toBeFalse();
     });
 
     it('maintains title state consistency', function () {

--- a/tests/Integration/Livewire/Titles/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Titles/Modals/FormModalTest.php
@@ -244,7 +244,7 @@ describe('FormModal Business Logic', function () {
 
         $component->assertHasNoErrors();
 
-        $title = Title::with('activations')->where('name', 'New Championship Title')->first();
+        $title = Title::with('activations')->where('name', 'New Championship Title')->firstOrFail();
         expect($title->firstActivityPeriod?->started_at)->toBeInstanceOf(Carbon::class);
     });
 

--- a/tests/Integration/Livewire/Titles/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Titles/Tables/MainTest.php
@@ -232,7 +232,7 @@ describe('TitlesTable Component', function () {
             foreach ($titles as $index => $title) {
                 TitleChampionship::factory()
                     ->for($title, 'title')
-                    ->for($wrestlers[$index], 'champion')
+                    ->for($wrestlers->slice($index)->firstOrFail(), 'champion')
                     ->current()
                     ->create();
             }

--- a/tests/Integration/Livewire/Users/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Users/Modals/FormModalTest.php
@@ -171,7 +171,7 @@ describe('FormModal Create Operations', function () {
             ->set('form.password_confirmation', 'password123')
             ->call('save');
 
-        $user = User::where('email', 'john@example.com')->first();
+        $user = User::where('email', 'john@example.com')->firstOrFail();
         expect($user)->not->toBeNull('User should be created but was not found');
         expect(Hash::check('password123', $user->password))->toBeTrue();
     });
@@ -330,7 +330,7 @@ describe('FormModal Role Management', function () {
 
         $component->assertHasNoErrors();
 
-        $user = User::where('email', 'john@example.com')->first();
+        $user = User::where('email', 'john@example.com')->firstOrFail();
         expect($user->role->value)->toBe('administrator');
     });
 

--- a/tests/Integration/Livewire/Users/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Users/Tables/MainTest.php
@@ -140,9 +140,9 @@ describe('UsersTable Component', function () {
             ]);
 
             // Ensure virtual columns are computed
-            $john->fresh();
-            $jane->fresh();
-            $bob->fresh();
+            freshModel($john);
+            freshModel($jane);
+            freshModel($bob);
 
             $component = testLivewire(Main::class);
 
@@ -277,8 +277,8 @@ describe('UsersTable Component', function () {
             $jane = User::factory()->create(['first_name' => 'SearchExcluded', 'last_name' => 'Fixture']);
 
             // Ensure virtual columns are computed
-            $john->fresh();
-            $jane->fresh();
+            freshModel($john);
+            freshModel($jane);
 
             $component = testLivewire(Main::class);
 

--- a/tests/Integration/Livewire/Venues/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Venues/Modals/FormModalTest.php
@@ -31,7 +31,7 @@ beforeEach(function () {
         ]));
     });
 
-    $this->state = DB::table('states')->where('name', 'California')->first();
+    $this->state = DB::table('states')->where('name', 'California')->firstOrFail();
 });
 
 describe('Form Modal Initialization', function () {

--- a/tests/Integration/Livewire/Venues/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/MainTest.php
@@ -233,7 +233,7 @@ describe('VenuesTable Integration Tests', function () {
 
             // Verify relationship loading doesn't cause N+1 queries
             $venues = Venue::with('events')->get();
-            expect($venues->where('id', $this->venueWithEvents->id)->first()->events)->not->toBeEmpty();
+            expect($venues->where('id', $this->venueWithEvents->id)->firstOrFail()->events)->not->toBeEmpty();
         });
     });
 
@@ -271,7 +271,7 @@ describe('VenuesTable Integration Tests', function () {
             $component->call('delete', $this->activeVenue)
                 ->assertHasNoErrors();
 
-            expect($event->fresh()->venue_id)->toBe($this->activeVenue->id);
+            expect(freshModel($event)->venue_id)->toBe($this->activeVenue->id);
         });
 
         test('restore operation restores event relationships', function () {
@@ -289,11 +289,10 @@ describe('VenuesTable Integration Tests', function () {
             $component->call('restore', $venue->id)
                 ->assertHasNoErrors();
 
-            $restoredVenue = Venue::find($venue->id);
+            $restoredVenue = Venue::findOrFail($venue->id);
             $event->refresh(); // Refresh the event to get latest venue relationship
 
             // Debug the relationship
-            expect($restoredVenue)->not()->toBeNull();
             expect($event->venue_id)->toBe($restoredVenue->id);
             expect($restoredVenue->events()->count())->toBeGreaterThan(0);
         });

--- a/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
@@ -149,8 +149,8 @@ describe('PreviousEventsTable Integration Tests', function () {
             $table->venueId = $this->venue->id;
             $events = $table->builder()->get();
 
-            expect($events->first()->name)->toBe('Upcoming Wrestling Show');
-            expect($events->last()->name)->toBe('Classic Wrestling Event');
+            expect($events->firstOrFail()->name)->toBe('Upcoming Wrestling Show');
+            expect($events->reverse()->firstOrFail()->name)->toBe('Classic Wrestling Event');
         });
 
         test('includes both past and future events in chronological order', function () {
@@ -198,7 +198,7 @@ describe('PreviousEventsTable Integration Tests', function () {
             $component->assertOk();
 
             // Events should display dates in Y-m-d format
-            $expectedDate = $this->recentEvent->date->format('Y-m-d');
+            $expectedDate = requiredDate($this->recentEvent->date)->format('Y-m-d');
             $component->assertSee($expectedDate);
         });
     });
@@ -298,7 +298,7 @@ describe('PreviousEventsTable Integration Tests', function () {
             $events = $table->builder()->get();
 
             expect($events->count())->toBe(3); // Should show 3 events for this venue
-            expect($events->pluck('venue_id')->unique()->first())->toBe($this->venue->id);
+            expect($events->pluck('venue_id')->unique()->firstOrFail())->toBe($this->venue->id);
         });
     });
 

--- a/tests/Integration/Livewire/Wrestlers/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Components/ActionsTest.php
@@ -59,7 +59,7 @@ describe('WrestlersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('wrestler-updated');
 
-            expect($unemployedWrestler->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($unemployedWrestler)->isEmployed())->toBeTrue();
             // expect(session('status'))->toBe('Wrestler successfully employed.');
             expect(true)->toBeTrue();
         });
@@ -84,7 +84,7 @@ describe('WrestlersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('wrestler-updated');
 
-            expect($this->wrestler->fresh()->isReleased())->toBeTrue();
+            expect(freshModel($this->wrestler)->isReleased())->toBeTrue();
             // expect(session('status'))->toBe('Wrestler successfully released.');
             expect(true)->toBeTrue();
         });
@@ -113,7 +113,7 @@ describe('WrestlersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('wrestler-updated');
 
-            expect($this->wrestler->fresh()->isInjured())->toBeTrue();
+            expect(freshModel($this->wrestler)->isInjured())->toBeTrue();
             // expect(session('status'))->toBe('Wrestler injury recorded.');
             expect(true)->toBeTrue();
         });
@@ -142,7 +142,7 @@ describe('WrestlersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('wrestler-updated');
 
-            expect($injuredWrestler->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($injuredWrestler)->isInjured())->toBeFalse();
             // expect(session('status'))->toBe('Wrestler cleared from injury.');
             expect(true)->toBeTrue();
         });
@@ -169,7 +169,7 @@ describe('WrestlersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('wrestler-updated');
 
-            expect($this->wrestler->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($this->wrestler)->isSuspended())->toBeTrue();
             // expect(session('status'))->toBe('Wrestler successfully suspended.');
             expect(true)->toBeTrue();
         });
@@ -198,7 +198,7 @@ describe('WrestlersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('wrestler-updated');
 
-            expect($suspendedWrestler->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($suspendedWrestler)->isSuspended())->toBeFalse();
             // expect(session('status'))->toBe('Wrestler successfully reinstated.');
             expect(true)->toBeTrue();
         });
@@ -225,7 +225,7 @@ describe('WrestlersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('wrestler-updated');
 
-            expect($this->wrestler->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($this->wrestler)->isRetired())->toBeTrue();
             // expect(session('status'))->toBe('Wrestler successfully retired.');
             expect(true)->toBeTrue();
         });
@@ -254,7 +254,7 @@ describe('WrestlersActions Integration Tests', function () {
                 ->assertHasNoErrors()
                 ->assertDispatched('wrestler-updated');
 
-            expect($retiredWrestler->fresh()->isRetired())->toBeFalse();
+            expect(freshModel($retiredWrestler)->isRetired())->toBeFalse();
             // expect(session('status'))->toBe('Wrestler successfully unretired.');
             expect(true)->toBeTrue();
         });
@@ -276,7 +276,7 @@ describe('WrestlersActions Integration Tests', function () {
             $this->wrestler->delete();
             expect($this->wrestler->trashed())->toBeTrue();
 
-            $trashedWrestler = Wrestler::onlyTrashed()->find($this->wrestler->id);
+            $trashedWrestler = Wrestler::onlyTrashed()->findOrFail($this->wrestler->id);
 
             \Pest\Laravel\actingAs($this->admin);
 
@@ -302,31 +302,31 @@ describe('WrestlersActions Integration Tests', function () {
 
             // Employ
             $component->call('employ');
-            expect($wrestler->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($wrestler)->isEmployed())->toBeTrue();
 
             // Injure
             $component->call('injure');
-            expect($wrestler->fresh()->isInjured())->toBeTrue();
+            expect(freshModel($wrestler)->isInjured())->toBeTrue();
 
             // Heal
             $component->call('healFromInjury');
-            expect($wrestler->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($wrestler)->isInjured())->toBeFalse();
 
             // Suspend
             $component->call('suspend');
-            expect($wrestler->fresh()->isSuspended())->toBeTrue();
+            expect(freshModel($wrestler)->isSuspended())->toBeTrue();
 
             // Reinstate
             $component->call('reinstate');
-            expect($wrestler->fresh()->isSuspended())->toBeFalse();
+            expect(freshModel($wrestler)->isSuspended())->toBeFalse();
 
             // Retire
             $component->call('retire');
-            expect($wrestler->fresh()->isRetired())->toBeTrue();
+            expect(freshModel($wrestler)->isRetired())->toBeTrue();
 
             // Comeback
             $component->call('unretire');
-            expect($wrestler->fresh()->isRetired())->toBeFalse();
+            expect(freshModel($wrestler)->isRetired())->toBeFalse();
             expect(true)->toBeTrue();
         });
 
@@ -348,7 +348,7 @@ describe('WrestlersActions Integration Tests', function () {
 
             // Can heal injured wrestler
             $component->call('healFromInjury');
-            expect($injuredWrestler->fresh()->isInjured())->toBeFalse();
+            expect(freshModel($injuredWrestler)->isInjured())->toBeFalse();
             expect(true)->toBeTrue();
         });
     });
@@ -433,7 +433,7 @@ describe('WrestlersActions Integration Tests', function () {
             $component->call('release');
 
             // Wrestler status should reflect in fresh model
-            expect($this->wrestler->fresh()->isReleased())->toBeTrue();
+            expect(freshModel($this->wrestler)->isReleased())->toBeTrue();
             expect(true)->toBeTrue();
         });
 

--- a/tests/Integration/Models/Stables/StableTagTeamTest.php
+++ b/tests/Integration/Models/Stables/StableTagTeamTest.php
@@ -56,7 +56,7 @@ describe('StableTagTeam Pivot Model', function () {
             expect($this->tagTeam->previousStables()->count())->toBe(0);
 
             // Verify pivot data is correct
-            $pivotData = $this->tagTeam->stables()->first()->pivot;
+            $pivotData = $this->tagTeam->stables()->firstOrFail()->pivot;
             expect(Carbon::parse($pivotData->joined_at)->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
             expect($pivotData->left_at)->toBeNull();
             expect($pivotData->tag_team_id)->toBe($this->tagTeam->id);
@@ -81,8 +81,8 @@ describe('StableTagTeam Pivot Model', function () {
             ]);
 
             // Verify all relationships exist
-            expect($this->tagTeam->currentStable->id)->toBe($this->stable->id);
-            expect($this->secondTagTeam->currentStable->id)->toBe($this->stable->id);
+            expect($this->tagTeam->currentStable)->not->toBeNull()->id->toBe($this->stable->id);
+            expect($this->secondTagTeam->currentStable)->not->toBeNull()->id->toBe($this->stable->id);
 
             // Verify stable has both tag teams
             expect($this->stable->currentTagTeams()->count())->toBe(2);
@@ -120,13 +120,13 @@ describe('StableTagTeam Pivot Model', function () {
             expect($this->tagTeam->previousStables()->count())->toBe(1);
 
             // Verify current stable is correct
-            $currentStable = $this->tagTeam->currentStable;
+            $currentStable = requiredModel($this->tagTeam->currentStable);
             expect($currentStable->id)->toBe($this->secondStable->id);
             expect(Carbon::parse(relatedPivotAttribute($currentStable, 'joined_at'))->format('Y-m-d H:i:s'))->toBe($secondPeriodStart->format('Y-m-d H:i:s'));
             expect(relatedPivotAttribute($currentStable, 'left_at'))->toBeNull();
 
             // Verify previous stable is correct
-            $previousStable = $this->tagTeam->previousStables()->first();
+            $previousStable = $this->tagTeam->previousStables()->firstOrFail();
             expect($previousStable->id)->toBe($this->stable->id);
             expect(Carbon::parse($previousStable->pivot->joined_at)->format('Y-m-d H:i:s'))->toBe($firstPeriodStart->format('Y-m-d H:i:s'));
             expect(Carbon::parse($previousStable->pivot->left_at)->format('Y-m-d H:i:s'))->toBe($firstPeriodEnd->format('Y-m-d H:i:s'));
@@ -157,7 +157,7 @@ describe('StableTagTeam Pivot Model', function () {
             expect($this->tagTeam->previousStables()->count())->toBe(1);
 
             // Verify pivot data is updated
-            $previousStable = $this->tagTeam->previousStables()->first();
+            $previousStable = $this->tagTeam->previousStables()->firstOrFail();
             expect(Carbon::parse($previousStable->pivot->left_at)->format('Y-m-d H:i:s'))->toBe($leaveDate->format('Y-m-d H:i:s'));
         });
 
@@ -187,9 +187,8 @@ describe('StableTagTeam Pivot Model', function () {
 
             $pivotRecord = StableTagTeam::where('tag_team_id', $this->tagTeam->id)
                 ->where('stable_id', $this->stable->id)
-                ->first();
+                ->firstOrFail();
 
-            expect($pivotRecord)->not()->toBeNull();
             expect($pivotRecord->tag_team_id)->toBe($this->tagTeam->id);
             expect($pivotRecord->stable_id)->toBe($this->stable->id);
             expect($pivotRecord->joined_at)->toBeInstanceOf(Carbon::class);
@@ -214,12 +213,12 @@ describe('StableTagTeam Pivot Model', function () {
 
             $tagTeamPivot = StableTagTeam::where('tag_team_id', $this->tagTeam->id)
                 ->where('stable_id', $this->stable->id)
-                ->first();
+                ->firstOrFail();
 
             expect($tagTeamPivot->joined_at)->toBeInstanceOf(Carbon::class);
             expect($tagTeamPivot->left_at)->toBeInstanceOf(Carbon::class);
             expect($tagTeamPivot->joined_at->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
-            expect($tagTeamPivot->left_at->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($tagTeamPivot->left_at)->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -241,9 +240,8 @@ describe('StableTagTeam Pivot Model', function () {
         });
 
         test('current stable query returns only active relationship', function () {
-            $currentStable = $this->tagTeam->currentStable;
+            $currentStable = requiredModel($this->tagTeam->currentStable);
 
-            expect($currentStable)->not()->toBeNull();
             expect($currentStable->id)->toBe($this->secondStable->id);
             expect(relatedPivotAttribute($currentStable, 'left_at'))->toBeNull();
         });
@@ -252,8 +250,8 @@ describe('StableTagTeam Pivot Model', function () {
             $previousStables = $this->tagTeam->previousStables()->get();
 
             expect($previousStables)->toHaveCount(1);
-            expect($previousStables->first()->id)->toBe($this->stable->id);
-            expect(relatedPivotAttribute($previousStables->first(), 'left_at'))->not()->toBeNull();
+            expect($previousStables->firstOrFail()->id)->toBe($this->stable->id);
+            expect(relatedPivotAttribute($previousStables->firstOrFail(), 'left_at'))->not()->toBeNull();
         });
 
         test('all stables query returns complete membership history', function () {

--- a/tests/Integration/Models/Stables/StableWrestlerTest.php
+++ b/tests/Integration/Models/Stables/StableWrestlerTest.php
@@ -58,7 +58,7 @@ describe('StableWrestler Pivot Model', function () {
             expect($this->wrestler->previousStables()->count())->toBe(0);
 
             // Verify pivot data is correct
-            $pivotData = $this->wrestler->stables()->first()->pivot;
+            $pivotData = $this->wrestler->stables()->firstOrFail()->pivot;
             expect(Carbon::parse($pivotData->joined_at)->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
             expect($pivotData->left_at)->toBeNull();
             expect($pivotData->wrestler_id)->toBe($this->wrestler->id);
@@ -83,8 +83,8 @@ describe('StableWrestler Pivot Model', function () {
             ]);
 
             // Verify all relationships exist
-            expect($this->wrestler->currentStable->id)->toBe($this->stable->id);
-            expect($this->secondWrestler->currentStable->id)->toBe($this->stable->id);
+            expect($this->wrestler->currentStable)->not->toBeNull()->id->toBe($this->stable->id);
+            expect($this->secondWrestler->currentStable)->not->toBeNull()->id->toBe($this->stable->id);
 
             // Verify stable has both wrestlers
             expect($this->stable->currentWrestlers()->count())->toBe(2);
@@ -122,13 +122,13 @@ describe('StableWrestler Pivot Model', function () {
             expect($this->wrestler->previousStables()->count())->toBe(1);
 
             // Verify current stable is correct
-            $currentStable = $this->wrestler->currentStable;
+            $currentStable = requiredModel($this->wrestler->currentStable);
             expect($currentStable->id)->toBe($this->secondStable->id);
             expect(Carbon::parse(relatedPivotAttribute($currentStable, 'joined_at'))->format('Y-m-d H:i:s'))->toBe($secondPeriodStart->format('Y-m-d H:i:s'));
             expect(relatedPivotAttribute($currentStable, 'left_at'))->toBeNull();
 
             // Verify previous stable is correct
-            $previousStable = $this->wrestler->previousStables()->first();
+            $previousStable = $this->wrestler->previousStables()->firstOrFail();
             expect($previousStable->id)->toBe($this->stable->id);
             expect(Carbon::parse($previousStable->pivot->joined_at)->format('Y-m-d H:i:s'))->toBe($firstPeriodStart->format('Y-m-d H:i:s'));
             expect(Carbon::parse($previousStable->pivot->left_at)->format('Y-m-d H:i:s'))->toBe($firstPeriodEnd->format('Y-m-d H:i:s'));
@@ -159,7 +159,7 @@ describe('StableWrestler Pivot Model', function () {
             expect($this->wrestler->previousStables()->count())->toBe(1);
 
             // Verify pivot data is updated
-            $previousStable = $this->wrestler->previousStables()->first();
+            $previousStable = $this->wrestler->previousStables()->firstOrFail();
             expect(Carbon::parse($previousStable->pivot->left_at)->format('Y-m-d H:i:s'))->toBe($leaveDate->format('Y-m-d H:i:s'));
         });
 
@@ -189,9 +189,8 @@ describe('StableWrestler Pivot Model', function () {
 
             $pivotRecord = StableWrestler::where('wrestler_id', $this->wrestler->id)
                 ->where('stable_id', $this->stable->id)
-                ->first();
+                ->firstOrFail();
 
-            expect($pivotRecord)->not()->toBeNull();
             expect($pivotRecord->wrestler_id)->toBe($this->wrestler->id);
             expect($pivotRecord->stable_id)->toBe($this->stable->id);
             expect($pivotRecord->joined_at)->toBeInstanceOf(Carbon::class);
@@ -216,12 +215,12 @@ describe('StableWrestler Pivot Model', function () {
 
             $wrestlerPivot = StableWrestler::where('wrestler_id', $this->wrestler->id)
                 ->where('stable_id', $this->stable->id)
-                ->first();
+                ->firstOrFail();
 
             expect($wrestlerPivot->joined_at)->toBeInstanceOf(Carbon::class);
             expect($wrestlerPivot->left_at)->toBeInstanceOf(Carbon::class);
             expect($wrestlerPivot->joined_at->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
-            expect($wrestlerPivot->left_at->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($wrestlerPivot->left_at)->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -243,9 +242,8 @@ describe('StableWrestler Pivot Model', function () {
         });
 
         test('current stable query returns only active relationship', function () {
-            $currentStable = $this->wrestler->currentStable;
+            $currentStable = requiredModel($this->wrestler->currentStable);
 
-            expect($currentStable)->not()->toBeNull();
             expect($currentStable->id)->toBe($this->secondStable->id);
             expect(relatedPivotAttribute($currentStable, 'left_at'))->toBeNull();
         });
@@ -254,8 +252,8 @@ describe('StableWrestler Pivot Model', function () {
             $previousStables = $this->wrestler->previousStables()->get();
 
             expect($previousStables)->toHaveCount(1);
-            expect($previousStables->first()->id)->toBe($this->stable->id);
-            expect(relatedPivotAttribute($previousStables->first(), 'left_at'))->not()->toBeNull();
+            expect($previousStables->firstOrFail()->id)->toBe($this->stable->id);
+            expect(relatedPivotAttribute($previousStables->firstOrFail(), 'left_at'))->not()->toBeNull();
         });
 
         test('all stables query returns complete membership history', function () {

--- a/tests/Integration/Models/TagTeams/TagTeamWrestlerTest.php
+++ b/tests/Integration/Models/TagTeams/TagTeamWrestlerTest.php
@@ -85,8 +85,8 @@ describe('TagTeamWrestler Pivot Model', function () {
             expect($this->secondWrestler->isAMemberOfCurrentTagTeam())->toBeTrue();
 
             // Verify both wrestlers are in the same tag team
-            expect($this->wrestler->currentTagTeam->id)->toBe($this->tagTeam->id);
-            expect($this->secondWrestler->currentTagTeam->id)->toBe($this->tagTeam->id);
+            expect($this->wrestler->currentTagTeam)->not->toBeNull()->id->toBe($this->tagTeam->id);
+            expect($this->secondWrestler->currentTagTeam)->not->toBeNull()->id->toBe($this->tagTeam->id);
 
             // Verify tag team has both wrestlers
             expect($this->tagTeam->currentWrestlers()->count())->toBe(2);
@@ -116,12 +116,12 @@ describe('TagTeamWrestler Pivot Model', function () {
             expect($this->wrestler->previousTagTeams()->count())->toBe(1);
 
             // Verify current tag team is correct
-            $currentTagTeam = $this->wrestler->currentTagTeam;
+            $currentTagTeam = requiredModel($this->wrestler->currentTagTeam);
             expect($currentTagTeam->id)->toBe($this->secondTagTeam->id);
             expect(relatedPivotAttribute($currentTagTeam, 'left_at'))->toBeNull();
 
             // Verify previous tag team is correct
-            $previousTagTeam = $this->wrestler->previousTagTeams()->first();
+            $previousTagTeam = $this->wrestler->previousTagTeams()->firstOrFail();
             expect($previousTagTeam->id)->toBe($this->tagTeam->id);
             expect($previousTagTeam->pivot->left_at)->not()->toBeNull();
         });
@@ -140,8 +140,8 @@ describe('TagTeamWrestler Pivot Model', function () {
             expect($this->wrestler->isAMemberOfCurrentTagTeam())->toBeFalse();
             expect($this->wrestler->previousTagTeams()->count())->toBe(1);
 
-            $previousTagTeam = $this->wrestler->previousTagTeams()->first();
-            expect($previousTagTeam->pivot->left_at->format('Y-m-d H:i:s'))->toBe($leaveDate->format('Y-m-d H:i:s'));
+            $previousTagTeam = $this->wrestler->previousTagTeams()->firstOrFail();
+            expect(requiredDate($previousTagTeam->pivot->left_at)->format('Y-m-d H:i:s'))->toBe($leaveDate->format('Y-m-d H:i:s'));
         });
 
         test('detaching wrestler completely removes relationship', function () {
@@ -182,9 +182,8 @@ describe('TagTeamWrestler Pivot Model', function () {
         });
 
         test('current tag team query returns only active relationship', function () {
-            $currentTagTeam = $this->wrestler->currentTagTeam;
+            $currentTagTeam = requiredModel($this->wrestler->currentTagTeam);
 
-            expect($currentTagTeam)->not()->toBeNull();
             expect($currentTagTeam->id)->toBe($this->secondTagTeam->id);
             expect(relatedPivotAttribute($currentTagTeam, 'left_at'))->toBeNull();
         });
@@ -193,8 +192,8 @@ describe('TagTeamWrestler Pivot Model', function () {
             $previousTagTeams = $this->wrestler->previousTagTeams()->get();
 
             expect($previousTagTeams)->toHaveCount(1);
-            expect($previousTagTeams->first()->id)->toBe($this->tagTeam->id);
-            expect(relatedPivotAttribute($previousTagTeams->first(), 'left_at'))->not()->toBeNull();
+            expect($previousTagTeams->firstOrFail()->id)->toBe($this->tagTeam->id);
+            expect(relatedPivotAttribute($previousTagTeams->firstOrFail(), 'left_at'))->not()->toBeNull();
         });
 
         test('all tag teams query returns complete relationship history', function () {
@@ -219,8 +218,9 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             $mostRecentPrevious = $this->wrestler->previousTagTeam;
 
-            expect($mostRecentPrevious)->not()->toBeNull();
-            expect($mostRecentPrevious->id)->toBe($this->tagTeam->id); // More recent than the third team
+            expect($mostRecentPrevious)
+                ->not()->toBeNull()
+                ->id->toBe($this->tagTeam->id); // More recent than the third team
         });
 
         test('isAMemberOfCurrentTagTeam accurately checks current status', function () {
@@ -234,8 +234,8 @@ describe('TagTeamWrestler Pivot Model', function () {
                 ->orderBy('joined_at', 'asc')
                 ->get();
 
-            expect($tagTeamsChronological->first()->id)->toBe($this->tagTeam->id);
-            expect($tagTeamsChronological->last()->id)->toBe($this->secondTagTeam->id);
+            expect($tagTeamsChronological->firstOrFail()->id)->toBe($this->tagTeam->id);
+            expect($tagTeamsChronological->reverse()->firstOrFail()->id)->toBe($this->secondTagTeam->id);
         });
 
         test('can query tag teams within specific date ranges', function () {
@@ -244,7 +244,7 @@ describe('TagTeamWrestler Pivot Model', function () {
                 ->get();
 
             expect($recentTagTeams)->toHaveCount(1);
-            expect($recentTagTeams->first()->id)->toBe($this->secondTagTeam->id);
+            expect($recentTagTeams->firstOrFail()->id)->toBe($this->secondTagTeam->id);
         });
     });
 
@@ -254,9 +254,8 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             $pivotRecord = TagTeamWrestler::where('wrestler_id', $this->wrestler->id)
                 ->where('tag_team_id', $this->tagTeam->id)
-                ->first();
+                ->firstOrFail();
 
-            expect($pivotRecord)->not()->toBeNull();
             expect($pivotRecord->wrestler_id)->toBe($this->wrestler->id);
             expect($pivotRecord->tag_team_id)->toBe($this->tagTeam->id);
             expect($pivotRecord->joined_at)->toBeInstanceOf(Carbon::class);
@@ -268,11 +267,11 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             $pivotRecord = TagTeamWrestler::where('wrestler_id', $this->wrestler->id)
                 ->where('tag_team_id', $this->tagTeam->id)
-                ->first();
+                ->firstOrFail();
 
             // Test pivot relationships
-            expect($pivotRecord->wrestler->id)->toBe($this->wrestler->id);
-            expect($pivotRecord->tagTeam->id)->toBe($this->tagTeam->id);
+            expect(requiredModel($pivotRecord->wrestler)->id)->toBe($this->wrestler->id);
+            expect(requiredModel($pivotRecord->tagTeam)->id)->toBe($this->tagTeam->id);
         });
 
         test('pivot model handles date casting correctly', function () {
@@ -286,12 +285,12 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             $pivotRecord = TagTeamWrestler::where('wrestler_id', $this->wrestler->id)
                 ->where('tag_team_id', $this->tagTeam->id)
-                ->first();
+                ->firstOrFail();
 
             expect($pivotRecord->joined_at)->toBeInstanceOf(Carbon::class);
             expect($pivotRecord->left_at)->toBeInstanceOf(Carbon::class);
             expect($pivotRecord->joined_at->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
-            expect($pivotRecord->left_at->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($pivotRecord->left_at)->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -340,10 +339,10 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             $pivotRecord = TagTeamWrestler::where('wrestler_id', $this->wrestler->id)
                 ->where('tag_team_id', $this->tagTeam->id)
-                ->first();
+                ->firstOrFail();
 
             // Data is stored as-is; validation should happen in business logic
-            expect($pivotRecord->joined_at->greaterThan($pivotRecord->left_at))->toBeTrue();
+            expect($pivotRecord->joined_at->greaterThan(requiredDate($pivotRecord->left_at)))->toBeTrue();
         });
     });
 
@@ -372,7 +371,7 @@ describe('TagTeamWrestler Pivot Model', function () {
             expect($this->wrestler->previousTagTeams()->count())->toBe(2);
 
             // Verify current tag team is the original team
-            $currentTagTeam = $this->wrestler->currentTagTeam;
+            $currentTagTeam = requiredModel($this->wrestler->currentTagTeam);
             expect($currentTagTeam->id)->toBe($this->tagTeam->id);
 
             // Verify relationship history includes both tag teams
@@ -396,14 +395,14 @@ describe('TagTeamWrestler Pivot Model', function () {
             ]);
 
             // Calculate duration of completed period
-            $completedPeriod = $this->wrestler->previousTagTeams()->first();
+            $completedPeriod = $this->wrestler->previousTagTeams()->firstOrFail();
             $joinedAt = Carbon::parse(relatedPivotAttribute($completedPeriod, 'joined_at'));
             $leftAt = Carbon::parse(relatedPivotAttribute($completedPeriod, 'left_at'));
             $duration = $joinedAt->diffInDays($leftAt);
             expect($duration)->toBeGreaterThan(150); // Approximately 6 months
 
             // Calculate duration of current period
-            $currentPeriod = $this->wrestler->currentTagTeam;
+            $currentPeriod = requiredModel($this->wrestler->currentTagTeam);
             $currentJoinedAt = Carbon::parse(relatedPivotAttribute($currentPeriod, 'joined_at'));
             $currentDuration = $currentJoinedAt->diffInDays(Carbon::now());
             expect($currentDuration)->toBeGreaterThan(80); // Approximately 3 months
@@ -452,7 +451,7 @@ describe('TagTeamWrestler Pivot Model', function () {
             expect($wrestlers)->toHaveCount(3); // wrestler, secondWrestler, thirdWrestler from beforeEach
 
             // Verify relationships are loaded
-            $wrestlerWithTagTeam = $wrestlers->firstWhere('id', $this->wrestler->id);
+            $wrestlerWithTagTeam = requiredModel($wrestlers->firstWhere('id', $this->wrestler->id));
             expect($wrestlerWithTagTeam->relationLoaded('currentTagTeam'))->toBeTrue();
             expect($wrestlerWithTagTeam->currentTagTeam)->not()->toBeNull();
         });
@@ -494,16 +493,17 @@ describe('TagTeamWrestler Pivot Model', function () {
             ]);
 
             // Test BelongsToOne relationships return single models, not collections
-            $currentTagTeam = $this->wrestler->currentTagTeam;
+            $currentTagTeam = requiredModel($this->wrestler->currentTagTeam);
             $previousTagTeam = $this->wrestler->previousTagTeam;
 
-            expect($currentTagTeam)->not()->toBeNull();
-            expect($currentTagTeam)->toBeInstanceOf(TagTeam::class);
-            expect($currentTagTeam->id)->toBe($this->secondTagTeam->id);
+            expect($currentTagTeam)
+                ->toBeInstanceOf(TagTeam::class)
+                ->id->toBe($this->secondTagTeam->id);
 
-            expect($previousTagTeam)->not()->toBeNull();
-            expect($previousTagTeam)->toBeInstanceOf(TagTeam::class);
-            expect($previousTagTeam->id)->toBe($this->tagTeam->id);
+            expect($previousTagTeam)
+                ->not->toBeNull()
+                ->toBeInstanceOf(TagTeam::class)
+                ->id->toBe($this->tagTeam->id);
         });
     });
 });

--- a/tests/Integration/Models/Titles/TitleChampionshipTest.php
+++ b/tests/Integration/Models/Titles/TitleChampionshipTest.php
@@ -98,8 +98,8 @@ describe('TitleChampionship Model', function () {
             expect($tagTeamChampionship->champion)->toBeInstanceOf(TagTeam::class);
             expect($wrestlerChampionship->champion_type)->toBe('wrestler');
             expect($tagTeamChampionship->champion_type)->toBe('tagTeam');
-            expect($wrestlerChampionship->champion->id)->toBe($this->wrestler->id);
-            expect($tagTeamChampionship->champion->id)->toBe($this->tagTeam->id);
+            expect($wrestlerChampionship->champion()->firstOrFail()->getKey())->toBe($this->wrestler->id);
+            expect($tagTeamChampionship->champion()->firstOrFail()->getKey())->toBe($this->tagTeam->id);
         });
     });
 
@@ -129,9 +129,9 @@ describe('TitleChampionship Model', function () {
                 ]);
 
             // Verify succession
-            expect($this->title->fresh()->currentChampionship->champion->id)->toBe($toChampion->id);
-            expect($fromChampion->fresh()->isChampion())->toBeFalse();
-            expect($toChampion->fresh()->isChampion())->toBeTrue();
+            expect(freshModel($this->title)->currentChampionship()->firstOrFail()->champion()->firstOrFail()->getKey())->toBe($toChampion->id);
+            expect($fromChampion->refresh()->isChampion())->toBeFalse();
+            expect($toChampion->refresh()->isChampion())->toBeTrue();
         })->with([
             'wrestler to tag team' => [Wrestler::class, TagTeam::class, 'John Champion', 'Tag Team Champions'],
             'tag team to wrestler' => [TagTeam::class, Wrestler::class, 'Team Champions', 'Jane Challenger'],
@@ -186,10 +186,9 @@ describe('TitleChampionship Model', function () {
         });
 
         test('current championship query returns only active championship', function () {
-            $currentChampionship = $this->title->currentChampionship;
+            $currentChampionship = $this->title->currentChampionship()->firstOrFail();
 
-            expect($currentChampionship)->not()->toBeNull();
-            expect($currentChampionship->champion->id)->toBe($this->secondWrestler->id);
+            expect($currentChampionship->champion()->firstOrFail()->getKey())->toBe($this->secondWrestler->id);
             expect($currentChampionship->lost_at)->toBeNull();
         });
 
@@ -208,8 +207,8 @@ describe('TitleChampionship Model', function () {
                 ->orderBy('won_at', 'asc')
                 ->get();
 
-            expect($championshipsChronological->first()->champion->id)->toBe($this->wrestler->id);
-            expect($championshipsChronological->last()->champion->id)->toBe($this->secondWrestler->id);
+            expect($championshipsChronological->firstOrFail()->champion()->firstOrFail()->getKey())->toBe($this->wrestler->id);
+            expect($championshipsChronological->reverse()->firstOrFail()->champion()->firstOrFail()->getKey())->toBe($this->secondWrestler->id);
         });
     });
 
@@ -245,10 +244,10 @@ describe('TitleChampionship Model', function () {
 
             expect($championshipsWithRelations)->toHaveCount(1);
 
-            $championship = $championshipsWithRelations->first();
+            $championship = $championshipsWithRelations->firstOrFail();
             expect($championship->relationLoaded('title'))->toBeTrue();
             expect($championship->relationLoaded('champion'))->toBeTrue();
-            expect($championship->title->name)->toBe('World Championship');
+            expect(requiredModel($championship->title)->name)->toBe('World Championship');
         });
 
         test('complex filtering scenarios work correctly', function () {
@@ -271,7 +270,7 @@ describe('TitleChampionship Model', function () {
             // Filter current championships
             $currentChampionships = TitleChampionship::whereNull('lost_at')->get();
             expect($currentChampionships)->toHaveCount(1);
-            expect($currentChampionships->first()->champion_type)->toBe('tagTeam');
+            expect($currentChampionships->firstOrFail()->champion_type)->toBe('tagTeam');
 
             // Filter by champion type
             $wrestlerChampionships = TitleChampionship::where('champion_type', 'wrestler')->get();
@@ -322,7 +321,7 @@ describe('TitleChampionship Model', function () {
                 ]);
 
             // Data is stored as-is; validation should happen in business logic
-            expect($championship->won_at->greaterThan($championship->lost_at))->toBeTrue();
+            expect($championship->won_at->greaterThan(requiredDate($championship->lost_at)))->toBeTrue();
         });
     });
 
@@ -348,7 +347,7 @@ describe('TitleChampionship Model', function () {
             expect($this->title->championships()->count())->toBe(3);
 
             // Verify current champion is the wrestler (who regained the title)
-            $currentChampion = $this->title->currentChampionship->champion;
+            $currentChampion = $this->title->currentChampionship()->firstOrFail()->champion;
             expect($currentChampion->id)->toBe($this->wrestler->id);
 
             // Verify championship history includes both wrestlers
@@ -382,12 +381,12 @@ describe('TitleChampionship Model', function () {
             expect($currentChampionships)->toHaveCount(1);
 
             // Calculate duration of completed championship
-            $completedChampionship = $completedChampionships->first();
+            $completedChampionship = $completedChampionships->firstOrFail();
             $duration = $completedChampionship->won_at->diffInDays($completedChampionship->lost_at);
             expect($duration)->toBeGreaterThan(150); // Approximately 6 months
 
             // Calculate current championship duration
-            $currentChampionship = $currentChampionships->first();
+            $currentChampionship = $currentChampionships->firstOrFail();
             $currentDuration = $currentChampionship->won_at->diffInDays(Carbon::now());
             expect($currentDuration)->toBeGreaterThan(80); // Approximately 3 months
         });
@@ -434,8 +433,8 @@ describe('TitleChampionship Model', function () {
             $championships = TitleChampionship::with('champion')->get();
 
             expect($championships)->toHaveCount(2);
-            expect($championships->first()->champion)->toBeInstanceOf(Wrestler::class);
-            expect($championships->last()->champion)->toBeInstanceOf(TagTeam::class);
+            expect($championships->firstOrFail()->champion)->toBeInstanceOf(Wrestler::class);
+            expect($championships->reverse()->firstOrFail()->champion)->toBeInstanceOf(TagTeam::class);
         });
     });
 
@@ -450,15 +449,15 @@ describe('TitleChampionship Model', function () {
                 ]);
 
             // Verify wrestler is champion
-            expect($this->wrestler->fresh()->titleChampionships)->toHaveCount(1);
-            expect($this->title->fresh()->currentChampionship)->not()->toBeNull();
+            expect(freshModel($this->wrestler)->titleChampionships)->toHaveCount(1);
+            expect(freshModel($this->title)->currentChampionship)->not()->toBeNull();
 
             // Retire wrestler
             WrestlerRetireAction::run($this->wrestler, Carbon::now());
 
             // Business rule: Champion retirement should vacate title
-            $refreshedWrestler = $this->wrestler->fresh();
-            $refreshedTitle = $this->title->fresh();
+            $refreshedWrestler = freshModel($this->wrestler);
+            $refreshedTitle = freshModel($this->title);
 
             expect($refreshedWrestler->isRetired())->toBeTrue();
 
@@ -482,7 +481,7 @@ describe('TitleChampionship Model', function () {
             // Injure wrestler
             InjureAction::run($this->wrestler, Carbon::now());
 
-            $refreshedWrestler = $this->wrestler->fresh();
+            $refreshedWrestler = freshModel($this->wrestler);
 
             expect($refreshedWrestler->isInjured())->toBeTrue();
             expect($refreshedWrestler->isBookable())->toBeFalse();
@@ -504,7 +503,7 @@ describe('TitleChampionship Model', function () {
             // Release wrestler from employment
             ReleaseAction::run($this->wrestler, Carbon::now());
 
-            $refreshedWrestler = $this->wrestler->fresh();
+            $refreshedWrestler = freshModel($this->wrestler);
 
             expect($refreshedWrestler->isReleased())->toBeTrue();
             expect($refreshedWrestler->isBookable())->toBeFalse();
@@ -526,7 +525,7 @@ describe('TitleChampionship Model', function () {
             // Retire title
             RetireAction::run($this->title, Carbon::now());
 
-            $refreshedTitle = $this->title->fresh();
+            $refreshedTitle = freshModel($this->title);
 
             expect($refreshedTitle->isRetired())->toBeTrue();
 
@@ -535,7 +534,7 @@ describe('TitleChampionship Model', function () {
             expect($championship->lost_at)->not()->toBeNull();
 
             // Wrestler should no longer have current championships for this title
-            $refreshedWrestler = $this->wrestler->fresh();
+            $refreshedWrestler = freshModel($this->wrestler);
             expect($refreshedWrestler->titleChampionships()->where('title_id', $this->title->id)->whereNull('lost_at')->count())->toBe(0);
         });
 
@@ -565,7 +564,7 @@ describe('TitleChampionship Model', function () {
             $unificationDate = Carbon::now();
 
             // End champion2's reign
-            $title2->currentChampionship->update(['lost_at' => $unificationDate]);
+            $title2->currentChampionship()->firstOrFail()->update(['lost_at' => $unificationDate]);
 
             // Champion1 wins the second title
             TitleChampionship::factory()
@@ -577,8 +576,8 @@ describe('TitleChampionship Model', function () {
                 ]);
 
             // Verify unification
-            expect($champion1->fresh()->titleChampionships()->whereNull('lost_at')->count())->toBe(2);
-            expect($title2->fresh()->currentChampionship->champion->id)->toBe($champion1->id);
+            expect(freshModel($champion1)->titleChampionships()->whereNull('lost_at')->count())->toBe(2);
+            expect(freshModel($title2)->currentChampionship()->firstOrFail()->champion()->firstOrFail()->getKey())->toBe($champion1->id);
         });
     });
 
@@ -615,11 +614,11 @@ describe('TitleChampionship Model', function () {
                 ]);
 
             // Title should be vacant
-            expect($title->fresh()->currentChampionship)->toBeNull();
+            expect(freshModel($title)->currentChampionship)->toBeNull();
 
             // Verify championship history exists
             expect($title->championships)->toHaveCount(1);
-            expect($title->championships->first()->lost_at)->not()->toBeNull();
+            expect($title->championships->firstOrFail()->lost_at)->not()->toBeNull();
         });
 
         test('handles championship on exact same timestamp', function () {
@@ -647,8 +646,8 @@ describe('TitleChampionship Model', function () {
                 ]);
 
             // Verify proper handling of exact timestamps
-            expect($title->fresh()->currentChampionship->champion->id)->toBe($wrestler2->id);
-            expect($championship1->fresh()->lost_at->eq($championship2->fresh()->won_at))->toBeTrue();
+            expect(freshModel($title)->currentChampionship()->firstOrFail()->champion()->firstOrFail()->getKey())->toBe($wrestler2->id);
+            expect(requiredDate(freshModel($championship1)->lost_at)->eq(freshModel($championship2)->won_at))->toBeTrue();
         });
 
         test('handles extremely long championship reigns', function () {
@@ -669,8 +668,8 @@ describe('TitleChampionship Model', function () {
             expect($reignLength)->toBeGreaterThan(3650); // More than 10 years
 
             // Verify current championship is still valid
-            expect($title->fresh()->currentChampionship)->not()->toBeNull();
-            expect($title->currentChampionship->champion->id)->toBe($wrestler->id);
+            expect(freshModel($title)->currentChampionship)->not()->toBeNull();
+            expect($title->currentChampionship()->firstOrFail()->champion()->firstOrFail()->getKey())->toBe($wrestler->id);
         });
     });
 });

--- a/tests/Integration/Models/Validation/Strategies/TagTeamRetirementValidationTest.php
+++ b/tests/Integration/Models/Validation/Strategies/TagTeamRetirementValidationTest.php
@@ -55,7 +55,7 @@ describe('TagTeamRetirementValidation', function () {
         ]);
 
         // Tag team retirement validation should consider wrestler states
-        $this->strategy->validate($tagTeam->fresh());
+        $this->strategy->validate(freshModel($tagTeam));
         expect(true)->toBeTrue();
     });
 });

--- a/tests/Integration/Models/Wrestlers/WrestlerManagerTest.php
+++ b/tests/Integration/Models/Wrestlers/WrestlerManagerTest.php
@@ -55,7 +55,7 @@ describe('WrestlerManager Pivot Model', function () {
                 'previousManagers' => 0,
             ]);
 
-            $pivotData = $this->wrestler->managers()->first()->pivot;
+            $pivotData = $this->wrestler->managers()->firstOrFail()->pivot;
             expect($pivotData->hired_at->timestamp)->toBe($hiredDate->timestamp);
             expect($pivotData->fired_at)->toBeNull();
         });
@@ -99,11 +99,11 @@ describe('WrestlerManager Pivot Model', function () {
                 'previousManagers' => 1,
             ]);
 
-            $currentManager = $this->wrestler->currentManagers()->first();
+            $currentManager = $this->wrestler->currentManagers()->firstOrFail();
             expect($currentManager->id)->toBe($this->secondManager->id);
             expectCurrentRelationshipsActive($this->wrestler);
 
-            $previousManager = $this->wrestler->previousManagers()->first();
+            $previousManager = $this->wrestler->previousManagers()->firstOrFail();
             expect($previousManager->id)->toBe($this->manager->id);
             expectPreviousRelationshipsEnded($this->wrestler);
         });
@@ -126,8 +126,8 @@ describe('WrestlerManager Pivot Model', function () {
 
             expectPreviousRelationshipsEnded($this->wrestler);
 
-            $previousManager = $this->wrestler->previousManagers()->first();
-            expect($previousManager->pivot->fired_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            $previousManager = $this->wrestler->previousManagers()->firstOrFail();
+            expect(requiredDate($previousManager->pivot->fired_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
         });
 
         test('detaching manager completely removes relationship', function () {
@@ -171,16 +171,16 @@ describe('WrestlerManager Pivot Model', function () {
             $currentManagers = $this->wrestler->currentManagers()->get();
 
             expect($currentManagers)->toHaveCount(1);
-            expect($currentManagers->first()->id)->toBe($this->secondManager->id);
-            expect(relatedPivotAttribute($currentManagers->first(), 'fired_at'))->toBeNull();
+            expect($currentManagers->firstOrFail()->id)->toBe($this->secondManager->id);
+            expect(relatedPivotAttribute($currentManagers->firstOrFail(), 'fired_at'))->toBeNull();
         });
 
         test('previous managers query returns only completed relationships', function () {
             $previousManagers = $this->wrestler->previousManagers()->get();
 
             expect($previousManagers)->toHaveCount(1);
-            expect($previousManagers->first()->id)->toBe($this->manager->id);
-            expect(relatedPivotAttribute($previousManagers->first(), 'fired_at'))->not()->toBeNull();
+            expect($previousManagers->firstOrFail()->id)->toBe($this->manager->id);
+            expect(relatedPivotAttribute($previousManagers->firstOrFail(), 'fired_at'))->not()->toBeNull();
         });
 
         test('all managers query returns complete relationship history', function () {
@@ -198,8 +198,8 @@ describe('WrestlerManager Pivot Model', function () {
                 ->orderBy('hired_at', 'asc')
                 ->get();
 
-            expect($managersChronological->first()->id)->toBe($this->manager->id);
-            expect($managersChronological->last()->id)->toBe($this->secondManager->id);
+            expect($managersChronological->firstOrFail()->id)->toBe($this->manager->id);
+            expect($managersChronological->reverse()->firstOrFail()->id)->toBe($this->secondManager->id);
         });
 
         test('can query managers within specific date ranges', function () {
@@ -208,7 +208,7 @@ describe('WrestlerManager Pivot Model', function () {
                 ->get();
 
             expect($recentManagers)->toHaveCount(1);
-            expect($recentManagers->first()->id)->toBe($this->secondManager->id);
+            expect($recentManagers->firstOrFail()->id)->toBe($this->secondManager->id);
         });
     });
 
@@ -218,9 +218,8 @@ describe('WrestlerManager Pivot Model', function () {
 
             $pivotRecord = WrestlerManager::where('wrestler_id', $this->wrestler->id)
                 ->where('manager_id', $this->manager->id)
-                ->first();
+                ->firstOrFail();
 
-            expect($pivotRecord)->not()->toBeNull();
             expect($pivotRecord->wrestler_id)->toBe($this->wrestler->id);
             expect($pivotRecord->manager_id)->toBe($this->manager->id);
             expect($pivotRecord->hired_at)->toBeInstanceOf(Carbon::class);
@@ -232,7 +231,7 @@ describe('WrestlerManager Pivot Model', function () {
 
             $pivotRecord = WrestlerManager::where('wrestler_id', $this->wrestler->id)
                 ->where('manager_id', $this->manager->id)
-                ->first();
+                ->firstOrFail();
 
             // Test pivot relationships
             expect($pivotRecord->wrestler->id)->toBe($this->wrestler->id);
@@ -250,12 +249,12 @@ describe('WrestlerManager Pivot Model', function () {
 
             $pivotRecord = WrestlerManager::where('wrestler_id', $this->wrestler->id)
                 ->where('manager_id', $this->manager->id)
-                ->first();
+                ->firstOrFail();
 
             expect($pivotRecord->hired_at)->toBeInstanceOf(Carbon::class);
             expect($pivotRecord->fired_at)->toBeInstanceOf(Carbon::class);
             expect($pivotRecord->hired_at->format('Y-m-d H:i:s'))->toBe($hiredDate->format('Y-m-d H:i:s'));
-            expect($pivotRecord->fired_at->format('Y-m-d H:i:s'))->toBe($firedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($pivotRecord->fired_at)->format('Y-m-d H:i:s'))->toBe($firedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -295,10 +294,10 @@ describe('WrestlerManager Pivot Model', function () {
 
             $pivotRecord = WrestlerManager::where('wrestler_id', $this->wrestler->id)
                 ->where('manager_id', $this->manager->id)
-                ->first();
+                ->firstOrFail();
 
             // Data is stored as-is; validation should happen in business logic
-            expect($pivotRecord->hired_at->greaterThan($pivotRecord->fired_at))->toBeTrue();
+            expect($pivotRecord->hired_at->greaterThan(requiredDate($pivotRecord->fired_at)))->toBeTrue();
         });
     });
 
@@ -329,7 +328,7 @@ describe('WrestlerManager Pivot Model', function () {
             ]);
 
             // Verify current manager is the original manager
-            $currentManager = $this->wrestler->currentManagers()->first();
+            $currentManager = $this->wrestler->currentManagers()->firstOrFail();
             expect($currentManager->id)->toBe($this->manager->id);
 
             // Verify relationship history includes both managers
@@ -353,12 +352,12 @@ describe('WrestlerManager Pivot Model', function () {
             ]);
 
             // Calculate duration of completed period
-            $completedPeriod = $this->wrestler->previousManagers()->first();
+            $completedPeriod = $this->wrestler->previousManagers()->firstOrFail();
             $duration = $completedPeriod->pivot->hired_at->diffInDays($completedPeriod->pivot->fired_at);
             expect($duration)->toBeGreaterThan(150); // Approximately 6 months
 
             // Calculate duration of current period
-            $currentPeriod = $this->wrestler->currentManagers()->first();
+            $currentPeriod = $this->wrestler->currentManagers()->firstOrFail();
             $currentDuration = $currentPeriod->pivot->hired_at->diffInDays(Carbon::now());
             expect($currentDuration)->toBeGreaterThan(80); // Approximately 3 months
         });
@@ -375,7 +374,7 @@ describe('WrestlerManager Pivot Model', function () {
             expect($wrestlers)->toHaveCount(2);
 
             // Verify relationships are loaded
-            $wrestlerWithManager = $wrestlers->firstWhere('id', $this->wrestler->id);
+            $wrestlerWithManager = requiredModel($wrestlers->firstWhere('id', $this->wrestler->id));
             expect($wrestlerWithManager->relationLoaded('currentManagers'))->toBeTrue();
             expect($wrestlerWithManager->currentManagers)->toHaveCount(1);
         });

--- a/tests/Integration/Workflows/Managers/EmploymentTest.php
+++ b/tests/Integration/Workflows/Managers/EmploymentTest.php
@@ -30,18 +30,18 @@ describe('Manager Employment Workflows', function () {
 
             // Initial employ
             EmployAction::run($manager, Carbon::now());
-            $employed = $manager->fresh();
+            $employed = freshModel($manager);
             expect($employed->isEmployed())->toBeTrue();
 
             // Release
             ReleaseAction::run($employed, Carbon::now());
-            $released = $manager->fresh();
+            $released = freshModel($manager);
             expect($released->isReleased())->toBeTrue();
             expect($released->isEmployed())->toBeFalse();
 
             // Re-employ
             EmployAction::run($released, Carbon::now());
-            $reEmployed = $manager->fresh();
+            $reEmployed = freshModel($manager);
             expect($reEmployed->isEmployed())->toBeTrue();
             expect($reEmployed->isReleased())->toBeFalse();
         });
@@ -56,13 +56,13 @@ describe('Manager Employment Workflows', function () {
 
             // Employ manager
             EmployAction::run($manager, Carbon::now());
-            $afterEmployment = $manager->fresh();
+            $afterEmployment = freshModel($manager);
             expect($afterEmployment->status)->toBe(EmploymentStatus::Employed);
             expect($afterEmployment->isEmployed())->toBeTrue();
 
             // Release manager
             ReleaseAction::run($afterEmployment, Carbon::now());
-            $afterRelease = $manager->fresh();
+            $afterRelease = freshModel($manager);
 
             // Verify release status synchronization
             expect($afterRelease->status)->toBe(EmploymentStatus::Released);
@@ -77,11 +77,11 @@ describe('Manager Employment Workflows', function () {
 
             // Execute multi-action workflow within transaction context
             EmployAction::run($manager, Carbon::now());
-            $employed = $manager->fresh();
+            $employed = freshModel($manager);
 
             // Then suspend the manager
             SuspendAction::run($employed, Carbon::now());
-            $suspended = $manager->fresh();
+            $suspended = freshModel($manager);
 
             // Verify all state changes are consistent
             expect($suspended->isEmployed())->toBeTrue(); // Still employed
@@ -97,7 +97,7 @@ describe('Manager Employment Workflows', function () {
             // For now, just verify normal operation doesn't leave partial state
             EmployAction::run($manager, Carbon::now());
 
-            $refreshedManager = $manager->fresh();
+            $refreshedManager = freshModel($manager);
 
             // Verify all state is consistent - no orphaned records
             if ($refreshedManager->isEmployed()) {
@@ -114,7 +114,7 @@ describe('Manager Employment Workflows', function () {
             // Test that employment follows business rules
             EmployAction::run($manager, Carbon::now());
 
-            $refreshedManager = $manager->fresh();
+            $refreshedManager = freshModel($manager);
 
             // Verify business rule compliance
             expect($refreshedManager->isEmployed())->toBeTrue();
@@ -130,7 +130,7 @@ describe('Manager Employment Workflows', function () {
             EmployAction::run($manager, Carbon::now());
 
             // Employed manager should be available for management duties
-            expect($manager->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($manager)->isEmployed())->toBeTrue();
         });
 
         test('complex multi-action management workflows maintain data consistency', function () {
@@ -138,16 +138,16 @@ describe('Manager Employment Workflows', function () {
 
             // Retire -> Employ -> Suspend -> Release workflow
             EmployAction::run($manager, Carbon::now());
-            $employed = $manager->fresh();
+            $employed = freshModel($manager);
             expect($employed->isEmployed())->toBeTrue();
 
             SuspendAction::run($employed, Carbon::now());
-            $suspended = $manager->fresh();
+            $suspended = freshModel($manager);
             expect($suspended->isEmployed())->toBeTrue();
             expect($suspended->isSuspended())->toBeTrue();
 
             ReleaseAction::run($suspended, Carbon::now());
-            $released = $manager->fresh();
+            $released = freshModel($manager);
             expect($released->isReleased())->toBeTrue();
             expect($released->isEmployed())->toBeFalse();
             expect($released->isSuspended())->toBeFalse();

--- a/tests/Integration/Workflows/Referees/EmploymentTest.php
+++ b/tests/Integration/Workflows/Referees/EmploymentTest.php
@@ -33,13 +33,13 @@ describe('Referee Employment Workflows', function () {
 
             // Employ referee
             EmployAction::run($referee, Carbon::now());
-            $afterEmployment = $referee->fresh();
+            $afterEmployment = freshModel($referee);
             expect($afterEmployment->status)->toBe(EmploymentStatus::Employed);
             expect($afterEmployment->isEmployed())->toBeTrue();
 
             // Release referee
             ReleaseAction::run($afterEmployment, Carbon::now());
-            $afterRelease = $referee->fresh();
+            $afterRelease = freshModel($referee);
 
             // Verify release status synchronization
             expect($afterRelease->status)->toBe(EmploymentStatus::Released);
@@ -52,18 +52,18 @@ describe('Referee Employment Workflows', function () {
 
             // Initial employ
             EmployAction::run($referee, Carbon::now());
-            $employed = $referee->fresh();
+            $employed = freshModel($referee);
             expect($employed->isEmployed())->toBeTrue();
 
             // Release
             ReleaseAction::run($employed, Carbon::now());
-            $released = $referee->fresh();
+            $released = freshModel($referee);
             expect($released->isReleased())->toBeTrue();
             expect($released->isEmployed())->toBeFalse();
 
             // Re-employ
             EmployAction::run($released, Carbon::now());
-            $reEmployed = $referee->fresh();
+            $reEmployed = freshModel($referee);
             expect($reEmployed->isEmployed())->toBeTrue();
             expect($reEmployed->isReleased())->toBeFalse();
         });
@@ -75,11 +75,11 @@ describe('Referee Employment Workflows', function () {
 
             // Execute multi-action workflow within transaction context
             EmployAction::run($referee, Carbon::now());
-            $employed = $referee->fresh();
+            $employed = freshModel($referee);
 
             // Then suspend the referee
             SuspendAction::run($employed, Carbon::now());
-            $suspended = $referee->fresh();
+            $suspended = freshModel($referee);
 
             // Verify all state changes are consistent
             expect($suspended->isEmployed())->toBeTrue(); // Still employed
@@ -95,7 +95,7 @@ describe('Referee Employment Workflows', function () {
             // For now, just verify normal operation doesn't leave partial state
             EmployAction::run($referee, Carbon::now());
 
-            $refreshedReferee = $referee->fresh();
+            $refreshedReferee = freshModel($referee);
 
             // Verify all state is consistent - no orphaned records
             if ($refreshedReferee->isEmployed()) {
@@ -112,7 +112,7 @@ describe('Referee Employment Workflows', function () {
             // Test that employment follows business rules
             EmployAction::run($referee, Carbon::now());
 
-            $refreshedReferee = $referee->fresh();
+            $refreshedReferee = freshModel($referee);
 
             // Verify business rule compliance
             expect($refreshedReferee->isEmployed())->toBeTrue();
@@ -129,7 +129,7 @@ describe('Referee Employment Workflows', function () {
             EmployAction::run($referee, Carbon::now());
 
             // Employed referee should be bookable
-            expect($referee->fresh()->isBookable())->toBeTrue();
+            expect(freshModel($referee)->isBookable())->toBeTrue();
         });
 
         test('complex multi-action employment workflows maintain data consistency', function () {
@@ -137,16 +137,16 @@ describe('Referee Employment Workflows', function () {
 
             // Retire -> Employ -> Suspend -> Release workflow
             EmployAction::run($referee, Carbon::now());
-            $employed = $referee->fresh();
+            $employed = freshModel($referee);
             expect($employed->isEmployed())->toBeTrue();
 
             SuspendAction::run($employed, Carbon::now());
-            $suspended = $referee->fresh();
+            $suspended = freshModel($referee);
             expect($suspended->isEmployed())->toBeTrue();
             expect($suspended->isSuspended())->toBeTrue();
 
             ReleaseAction::run($suspended, Carbon::now());
-            $released = $referee->fresh();
+            $released = freshModel($referee);
             expect($released->isReleased())->toBeTrue();
             expect($released->isEmployed())->toBeFalse();
             expect($released->isSuspended())->toBeFalse();

--- a/tests/Integration/Workflows/TagTeams/EmploymentTest.php
+++ b/tests/Integration/Workflows/TagTeams/EmploymentTest.php
@@ -33,12 +33,12 @@ describe('TagTeam Employment Workflows', function () {
 
             // Initial employ
             EmployAction::run($tagTeam, Carbon::now());
-            $employed = $tagTeam->fresh();
+            $employed = freshModel($tagTeam);
             expect($employed->isEmployed())->toBeTrue();
 
             // Release
             ReleaseAction::run($employed, Carbon::now());
-            $released = $tagTeam->fresh();
+            $released = freshModel($tagTeam);
             expect($released->isReleased())->toBeTrue();
             expect($released->isEmployed())->toBeFalse();
 
@@ -56,13 +56,13 @@ describe('TagTeam Employment Workflows', function () {
 
             // Employ tag team
             EmployAction::run($tagTeam, Carbon::now());
-            $afterEmployment = $tagTeam->fresh();
+            $afterEmployment = freshModel($tagTeam);
             expect($afterEmployment->status)->toBe(EmploymentStatus::Employed);
             expect($afterEmployment->isEmployed())->toBeTrue();
 
             // Release tag team
             ReleaseAction::run($afterEmployment, Carbon::now());
-            $afterRelease = $tagTeam->fresh();
+            $afterRelease = freshModel($tagTeam);
 
             // Verify release status synchronization
             expect($afterRelease->status)->toBe(EmploymentStatus::Released);
@@ -84,7 +84,7 @@ describe('TagTeam Employment Workflows', function () {
             // Current employment
             EmployAction::run($tagTeam, Carbon::now()->subMonths(1));
 
-            $refreshedTagTeam = $tagTeam->fresh();
+            $refreshedTagTeam = freshModel($tagTeam);
             expect($refreshedTagTeam->isEmployed())->toBeTrue();
             expect($refreshedTagTeam->employments()->count())->toBe(3);
             expect($refreshedTagTeam->previousEmployments()->count())->toBe(2);
@@ -99,7 +99,7 @@ describe('TagTeam Employment Workflows', function () {
             EmployAction::run($tagTeam, Carbon::now());
 
             // All changes should be committed together
-            $refreshedTagTeam = $tagTeam->fresh();
+            $refreshedTagTeam = freshModel($tagTeam);
             expect($refreshedTagTeam->isEmployed())->toBeTrue();
             expect($refreshedTagTeam->status)->toBe(EmploymentStatus::Employed);
             expect($refreshedTagTeam->currentEmployment)->not()->toBeNull();
@@ -115,7 +115,7 @@ describe('TagTeam Employment Workflows', function () {
             // For now, just verify normal operation doesn't leave partial state
             EmployAction::run($tagTeam, Carbon::now());
 
-            $refreshedTagTeam = $tagTeam->fresh();
+            $refreshedTagTeam = freshModel($tagTeam);
 
             // Verify all state is consistent - no orphaned records
             if ($refreshedTagTeam->isEmployed()) {
@@ -132,7 +132,7 @@ describe('TagTeam Employment Workflows', function () {
             // Test that employment follows business rules
             EmployAction::run($tagTeam, Carbon::now());
 
-            $refreshedTagTeam = $tagTeam->fresh();
+            $refreshedTagTeam = freshModel($tagTeam);
 
             // Verify business rule compliance
             expect($refreshedTagTeam->isEmployed())->toBeTrue();
@@ -148,7 +148,7 @@ describe('TagTeam Employment Workflows', function () {
 
             // Employ tag team
             EmployAction::run($tagTeam, Carbon::now());
-            $employed = $tagTeam->fresh();
+            $employed = freshModel($tagTeam);
 
             // Employed tag team has different capabilities
             expect($employed->isEmployed())->toBeTrue();
@@ -156,7 +156,7 @@ describe('TagTeam Employment Workflows', function () {
 
             // Release tag team
             ReleaseAction::run($employed, Carbon::now());
-            $released = $tagTeam->fresh();
+            $released = freshModel($tagTeam);
 
             // Released tag team capabilities
             expect($released->isEmployed())->toBeFalse();
@@ -171,12 +171,12 @@ describe('TagTeam Employment Workflows', function () {
 
             EmployAction::run($tagTeam, $futureDate);
 
-            $refreshedTagTeam = $tagTeam->fresh();
+            $refreshedTagTeam = freshModel($tagTeam);
             expect($refreshedTagTeam->status)->toBe(EmploymentStatus::FutureEmployment);
 
             // Future employment won't be current until the date arrives
-            $futureEmployment = $refreshedTagTeam->employments()->latest()->first();
-            expect($futureEmployment->started_at->toDateTimeString())
+            $futureEmployment = $refreshedTagTeam->employments()->latest()->firstOrFail();
+            expect(requiredDate($futureEmployment->started_at)->toDateTimeString())
                 ->toBe($futureDate->toDateTimeString());
         });
 
@@ -185,18 +185,18 @@ describe('TagTeam Employment Workflows', function () {
 
             // Employ tag team
             EmployAction::run($tagTeam, Carbon::now());
-            expect($tagTeam->fresh()->employments()->whereNull('ended_at')->count())->toBe(1);
+            expect(freshModel($tagTeam)->employments()->whereNull('ended_at')->count())->toBe(1);
 
             // Multiple release/employ cycles
             ReleaseAction::run($tagTeam, Carbon::now());
-            expect($tagTeam->fresh()->employments()->whereNull('ended_at')->count())->toBe(0);
+            expect(freshModel($tagTeam)->employments()->whereNull('ended_at')->count())->toBe(0);
 
             EmployAction::run($tagTeam, Carbon::now());
-            expect($tagTeam->fresh()->employments()->whereNull('ended_at')->count())->toBe(1);
+            expect(freshModel($tagTeam)->employments()->whereNull('ended_at')->count())->toBe(1);
 
             // Should maintain single active employment
-            expect($tagTeam->fresh()->employments()->count())->toBe(2); // Total employments
-            expect($tagTeam->fresh()->employments()->whereNull('ended_at')->count())->toBe(1); // Active
+            expect(freshModel($tagTeam)->employments()->count())->toBe(2); // Total employments
+            expect(freshModel($tagTeam)->employments()->whereNull('ended_at')->count())->toBe(1); // Active
         });
     });
 });

--- a/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
+++ b/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
@@ -36,18 +36,18 @@ describe('Wrestler Employment Workflows', function () {
 
             // Initial employ
             EmployAction::run($wrestler, Carbon::now());
-            $employed = $wrestler->fresh();
+            $employed = freshModel($wrestler);
             expect($employed->isEmployed())->toBeTrue();
 
             // Release
             ReleaseAction::run($employed, Carbon::now());
-            $released = $wrestler->fresh();
+            $released = freshModel($wrestler);
             expect($released->isReleased())->toBeTrue();
             expect($released->isEmployed())->toBeFalse();
 
             // Re-employ
             EmployAction::run($released, Carbon::now());
-            $reEmployed = $wrestler->fresh();
+            $reEmployed = freshModel($wrestler);
             expect($reEmployed->isEmployed())->toBeTrue();
             expect($reEmployed->isReleased())->toBeFalse();
         });
@@ -60,13 +60,13 @@ describe('Wrestler Employment Workflows', function () {
 
             // Employ wrestler
             EmployAction::run($wrestler, Carbon::now());
-            $afterEmployment = $wrestler->fresh();
+            $afterEmployment = freshModel($wrestler);
             expect($afterEmployment->status)->toBe(EmploymentStatus::Employed);
             expect($afterEmployment->isEmployed())->toBeTrue();
 
             // Release wrestler
             ReleaseAction::run($afterEmployment, Carbon::now());
-            $afterRelease = $wrestler->fresh();
+            $afterRelease = freshModel($wrestler);
 
             // Verify release status synchronization
             expect($afterRelease->status)->toBe(EmploymentStatus::Released);
@@ -81,20 +81,20 @@ describe('Wrestler Employment Workflows', function () {
 
             // Employ wrestler
             EmployAction::run($wrestler, Carbon::now());
-            $employed = $wrestler->fresh();
+            $employed = freshModel($wrestler);
             expect($employed->isEmployed())->toBeTrue();
             expect($employed->isBookable())->toBeTrue();
 
             // Injure wrestler
             InjureAction::run($employed, Carbon::now());
-            $injured = $wrestler->fresh();
+            $injured = freshModel($wrestler);
             expect($injured->isEmployed())->toBeTrue(); // Still employed
             expect($injured->isInjured())->toBeTrue();
             expect($injured->isBookable())->toBeFalse(); // Not bookable when injured
 
             // Heal wrestler
             HealAction::run($injured, Carbon::now());
-            $healed = $wrestler->fresh();
+            $healed = freshModel($wrestler);
             expect($healed->isEmployed())->toBeTrue();
             expect($healed->isInjured())->toBeFalse();
             expect($healed->isBookable())->toBeTrue(); // Bookable again
@@ -105,20 +105,20 @@ describe('Wrestler Employment Workflows', function () {
 
             // Employ wrestler
             EmployAction::run($wrestler, Carbon::now());
-            $employed = $wrestler->fresh();
+            $employed = freshModel($wrestler);
             expect($employed->isEmployed())->toBeTrue();
             expect($employed->isBookable())->toBeTrue();
 
             // Suspend wrestler
             SuspendAction::run($employed, Carbon::now());
-            $suspended = $wrestler->fresh();
+            $suspended = freshModel($wrestler);
             expect($suspended->isEmployed())->toBeTrue(); // Still employed
             expect($suspended->isSuspended())->toBeTrue();
             expect($suspended->isBookable())->toBeFalse(); // Not bookable when suspended
 
             // Reinstate wrestler
             ReinstateAction::run($suspended, Carbon::now());
-            $reinstated = $wrestler->fresh();
+            $reinstated = freshModel($wrestler);
             expect($reinstated->isEmployed())->toBeTrue();
             expect($reinstated->isSuspended())->toBeFalse();
             expect($reinstated->isBookable())->toBeTrue(); // Bookable again
@@ -129,19 +129,19 @@ describe('Wrestler Employment Workflows', function () {
 
             // Employ wrestler
             EmployAction::run($wrestler, Carbon::now());
-            $employed = $wrestler->fresh();
+            $employed = freshModel($wrestler);
             expect($employed->isEmployed())->toBeTrue();
 
             // Retire wrestler
             RetireAction::run($employed, Carbon::now());
-            $retired = $wrestler->fresh();
+            $retired = freshModel($wrestler);
             expect($retired->isRetired())->toBeTrue();
             expect($retired->isEmployed())->toBeFalse(); // Employment ends on retirement
             expect($retired->status)->toBe(EmploymentStatus::Retired);
 
             // Unretire wrestler
             UnretireAction::run($retired, Carbon::now());
-            $unretired = $wrestler->fresh();
+            $unretired = freshModel($wrestler);
             expect($unretired->isRetired())->toBeFalse();
             expect($unretired->isEmployed())->toBeTrue();
             expect($unretired->status)->toBe(EmploymentStatus::Employed);
@@ -152,38 +152,38 @@ describe('Wrestler Employment Workflows', function () {
 
             // 1. Employ
             EmployAction::run($wrestler, Carbon::now()->subMonths(12));
-            expect($wrestler->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($wrestler)->isEmployed())->toBeTrue();
 
             // 2. Suspend
             SuspendAction::run($wrestler, Carbon::now()->subMonths(10));
-            $suspended = $wrestler->fresh();
+            $suspended = freshModel($wrestler);
             expect($suspended->isEmployed())->toBeTrue();
             expect($suspended->isSuspended())->toBeTrue();
 
             // 3. Reinstate
             ReinstateAction::run($wrestler, Carbon::now()->subMonths(8));
-            expect($wrestler->fresh()->isSuspended())->toBeFalse();
-            expect($wrestler->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($wrestler)->isSuspended())->toBeFalse();
+            expect(freshModel($wrestler)->isEmployed())->toBeTrue();
 
             // 4. Injure
             InjureAction::run($wrestler, Carbon::now()->subMonths(6));
-            $injured = $wrestler->fresh();
+            $injured = freshModel($wrestler);
             expect($injured->isEmployed())->toBeTrue();
             expect($injured->isInjured())->toBeTrue();
 
             // 5. Heal
             HealAction::run($wrestler, Carbon::now()->subMonths(4));
-            expect($wrestler->fresh()->isInjured())->toBeFalse();
-            expect($wrestler->fresh()->isEmployed())->toBeTrue();
+            expect(freshModel($wrestler)->isInjured())->toBeFalse();
+            expect(freshModel($wrestler)->isEmployed())->toBeTrue();
 
             // 6. Retire
             RetireAction::run($wrestler, Carbon::now()->subMonths(2));
-            expect($wrestler->fresh()->isRetired())->toBeTrue();
-            expect($wrestler->fresh()->isEmployed())->toBeFalse();
+            expect(freshModel($wrestler)->isRetired())->toBeTrue();
+            expect(freshModel($wrestler)->isEmployed())->toBeFalse();
 
             // 7. Unretire and employ immediately
             UnretireAction::run($wrestler, Carbon::now());
-            $final = $wrestler->fresh();
+            $final = freshModel($wrestler);
             expect($final->isRetired())->toBeFalse();
             expect($final->isEmployed())->toBeTrue();
             expect($final->status)->toBe(EmploymentStatus::Employed);
@@ -205,27 +205,27 @@ describe('Wrestler Employment Workflows', function () {
 
             // Employ makes wrestler bookable
             EmployAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->isBookable())->toBeTrue();
+            expect(freshModel($wrestler)->isBookable())->toBeTrue();
 
             // Injury makes employed wrestler not bookable
             InjureAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->isBookable())->toBeFalse();
+            expect(freshModel($wrestler)->isBookable())->toBeFalse();
 
             // Healing makes wrestler bookable again
             HealAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->isBookable())->toBeTrue();
+            expect(freshModel($wrestler)->isBookable())->toBeTrue();
 
             // Suspension makes wrestler not bookable
             SuspendAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->isBookable())->toBeFalse();
+            expect(freshModel($wrestler)->isBookable())->toBeFalse();
 
             // Reinstatement makes wrestler bookable again
             ReinstateAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->isBookable())->toBeTrue();
+            expect(freshModel($wrestler)->isBookable())->toBeTrue();
 
             // Release makes wrestler not bookable
             ReleaseAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->isBookable())->toBeFalse();
+            expect(freshModel($wrestler)->isBookable())->toBeFalse();
         });
 
         test('status combination workflow validation maintains business rules', function () {
@@ -233,17 +233,17 @@ describe('Wrestler Employment Workflows', function () {
 
             // Employ wrestler
             EmployAction::run($wrestler, Carbon::now());
-            $employed = $wrestler->fresh();
+            $employed = freshModel($wrestler);
 
             // Injury and suspension are orthogonal states.
             InjureAction::run($employed, Carbon::now());
-            $injured = $wrestler->fresh();
+            $injured = freshModel($wrestler);
             expect($injured->canBeSuspended())->toBeTrue();
             expect($injured->isEmployed())->toBeTrue();
             expect($injured->isInjured())->toBeTrue();
 
             SuspendAction::run($injured, Carbon::now());
-            $injuredAndSuspended = $wrestler->fresh();
+            $injuredAndSuspended = freshModel($wrestler);
             expect($injuredAndSuspended->canBeInjured())->toBeFalse();
             expect($injuredAndSuspended->isEmployed())->toBeTrue();
             expect($injuredAndSuspended->isInjured())->toBeTrue();
@@ -251,13 +251,13 @@ describe('Wrestler Employment Workflows', function () {
 
             // Reinstate, then test retired wrestler cannot be employed
             ReinstateAction::run($injuredAndSuspended, Carbon::now());
-            $reinstated = $wrestler->fresh();
+            $reinstated = freshModel($wrestler);
             expect($reinstated->isSuspended())->toBeFalse();
             expect($reinstated->isInjured())->toBeFalse();
             expect($reinstated->isEmployed())->toBeTrue();
 
             RetireAction::run($reinstated, Carbon::now());
-            $retired = $wrestler->fresh();
+            $retired = freshModel($wrestler);
             expect($retired->canBeEmployed())->toBeFalse();
             expect($retired->isRetired())->toBeTrue();
         });
@@ -272,7 +272,7 @@ describe('Wrestler Employment Workflows', function () {
 
             // Employ wrestler
             EmployAction::run($wrestler, Carbon::now());
-            $employed = $wrestler->fresh();
+            $employed = freshModel($wrestler);
 
             // Employed wrestler has full capabilities
             expect($employed->isBookable())->toBeTrue();
@@ -282,7 +282,7 @@ describe('Wrestler Employment Workflows', function () {
 
             // Release wrestler
             ReleaseAction::run($employed, Carbon::now());
-            $released = $wrestler->fresh();
+            $released = freshModel($wrestler);
 
             // Released wrestler has limited capabilities again
             expect($released->isBookable())->toBeFalse();
@@ -300,7 +300,7 @@ describe('Wrestler Employment Workflows', function () {
             EmployAction::run($wrestler, Carbon::now());
 
             // All changes should be committed together
-            $refreshedWrestler = $wrestler->fresh();
+            $refreshedWrestler = freshModel($wrestler);
             expect($refreshedWrestler->isEmployed())->toBeTrue();
             expect($refreshedWrestler->status)->toBe(EmploymentStatus::Employed);
             expect($refreshedWrestler->currentEmployment)->not()->toBeNull();
@@ -314,13 +314,13 @@ describe('Wrestler Employment Workflows', function () {
 
             // Execute complex workflow
             EmployAction::run($wrestler, Carbon::now());
-            $employed = $wrestler->fresh();
+            $employed = freshModel($wrestler);
 
             SuspendAction::run($employed, Carbon::now());
-            $suspended = $wrestler->fresh();
+            $suspended = freshModel($wrestler);
 
             ReinstateAction::run($suspended, Carbon::now());
-            $reinstated = $wrestler->fresh();
+            $reinstated = freshModel($wrestler);
 
             // Verify all state changes are consistent and complete
             expect($reinstated->isEmployed())->toBeTrue();
@@ -340,7 +340,7 @@ describe('Wrestler Employment Workflows', function () {
             // For now, just verify normal operation doesn't leave partial state
             EmployAction::run($wrestler, Carbon::now());
 
-            $refreshedWrestler = $wrestler->fresh();
+            $refreshedWrestler = freshModel($wrestler);
 
             // Verify all state is consistent - no orphaned records
             if ($refreshedWrestler->isEmployed()) {
@@ -357,12 +357,12 @@ describe('Wrestler Employment Workflows', function () {
 
             EmployAction::run($wrestler, $futureDate);
 
-            $refreshedWrestler = $wrestler->fresh();
+            $refreshedWrestler = freshModel($wrestler);
             expect($refreshedWrestler->status)->toBe(EmploymentStatus::FutureEmployment);
 
             // Future employment won't be current until the date arrives
-            $futureEmployment = $refreshedWrestler->employments()->latest()->first();
-            expect($futureEmployment->started_at->toDateTimeString())
+            $futureEmployment = $refreshedWrestler->employments()->latest()->firstOrFail();
+            expect(requiredDate($futureEmployment->started_at)->toDateTimeString())
                 ->toBe($futureDate->toDateTimeString());
         });
 
@@ -371,20 +371,20 @@ describe('Wrestler Employment Workflows', function () {
 
             // Employ wrestler
             EmployAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->employments()->whereNull('ended_at')->count())->toBe(1);
+            expect(freshModel($wrestler)->employments()->whereNull('ended_at')->count())->toBe(1);
 
             // Multiple injury/heal cycles
             InjureAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->injuries()->whereNull('ended_at')->count())->toBe(1);
+            expect(freshModel($wrestler)->injuries()->whereNull('ended_at')->count())->toBe(1);
 
             HealAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->injuries()->whereNull('ended_at')->count())->toBe(0);
+            expect(freshModel($wrestler)->injuries()->whereNull('ended_at')->count())->toBe(0);
 
             InjureAction::run($wrestler, Carbon::now());
-            expect($wrestler->fresh()->injuries()->whereNull('ended_at')->count())->toBe(1);
+            expect(freshModel($wrestler)->injuries()->whereNull('ended_at')->count())->toBe(1);
 
             // Should still only have one active employment throughout
-            expect($wrestler->fresh()->employments()->whereNull('ended_at')->count())->toBe(1);
+            expect(freshModel($wrestler)->employments()->whereNull('ended_at')->count())->toBe(1);
         });
     });
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,9 +3,11 @@
 declare(strict_types=1);
 
 use App\Models\Users\User;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase;
+use Illuminate\Support\Carbon;
 use Illuminate\Translation\PotentiallyTranslatedString;
 use Illuminate\Translation\Translator;
 
@@ -104,6 +106,57 @@ function reflectionSource(ReflectionClass $reflection): string
     }
 
     return $source;
+}
+
+/**
+ * Return a date that must exist for the tested state.
+ */
+function requiredDate(?Carbon $date): Carbon
+{
+    return $date ?? throw new RuntimeException('Expected the model date to be present.');
+}
+
+/**
+ * Return a model that must exist for the tested state.
+ *
+ * @template TModel of Model
+ *
+ * @param  TModel|null  $model
+ * @return TModel
+ */
+function requiredModel(?Model $model): Model
+{
+    return $model ?? throw new RuntimeException('Expected the model relationship to be present.');
+}
+
+/**
+ * Reload a separate model instance that must still exist.
+ *
+ * @template TModel of Model
+ *
+ * @param  TModel|null  $model
+ * @return TModel
+ */
+function freshModel(?Model $model): Model
+{
+    if ($model === null) {
+        throw new RuntimeException('Expected the model to be present before reloading it.');
+    }
+
+    $freshModel = $model->fresh();
+    if ($freshModel === null) {
+        throw new RuntimeException('Expected the model to exist when reloading it.');
+    }
+
+    return $freshModel;
+}
+
+/**
+ * Return a reflection type that must exist for the tested declaration.
+ */
+function requiredReflectionType(?ReflectionType $type): ReflectionType
+{
+    return $type ?? throw new RuntimeException('Expected the reflected declaration to have a type.');
 }
 
 /*

--- a/tests/Unit/Actions/TagTeams/RetireActionTest.php
+++ b/tests/Unit/Actions/TagTeams/RetireActionTest.php
@@ -23,7 +23,7 @@ test('it retires a bookable tag team at the current datetime by default', functi
     $tagTeam->refresh();
     expect($tagTeam->status)->toBe(EmploymentStatus::Retired);
     expect($tagTeam->retirements)->toHaveCount(1);
-    expect($tagTeam->retirements->first()->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    expect(requiredDate($tagTeam->retirements->firstOrFail()->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });
 
 test('it retires a bookable tag team at a specific datetime', function () {
@@ -36,7 +36,7 @@ test('it retires a bookable tag team at a specific datetime', function () {
     $tagTeam->refresh();
     expect($tagTeam->status)->toBe(EmploymentStatus::Retired);
     expect($tagTeam->retirements)->toHaveCount(1);
-    expect($tagTeam->retirements->first()->started_at->toDateTimeString())->toBe($datetime->toDateTimeString());
+    expect(requiredDate($tagTeam->retirements->firstOrFail()->started_at)->toDateTimeString())->toBe($datetime->toDateTimeString());
 });
 
 test('it prevents retiring a released tag team at the current datetime by default', function () {
@@ -65,7 +65,7 @@ test('it retires a suspended tag team at the current datetime by default', funct
     expect($tagTeam->status)->toBe(EmploymentStatus::Retired);
     expect($tagTeam->isSuspended())->toBeFalse();
     expect($tagTeam->retirements)->toHaveCount(1);
-    expect($tagTeam->retirements->first()->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    expect(requiredDate($tagTeam->retirements->firstOrFail()->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });
 
 test('it retires a suspended tag team at a specific datetime', function () {
@@ -80,7 +80,7 @@ test('it retires a suspended tag team at a specific datetime', function () {
     expect($tagTeam->status)->toBe(EmploymentStatus::Retired);
     expect($tagTeam->isSuspended())->toBeFalse();
     expect($tagTeam->retirements)->toHaveCount(1);
-    expect($tagTeam->retirements->first()->started_at->toDateTimeString())->toBe($datetime->toDateTimeString());
+    expect(requiredDate($tagTeam->retirements->firstOrFail()->started_at)->toDateTimeString())->toBe($datetime->toDateTimeString());
 });
 
 test('it retires an employed tag team at the current datetime by default', function () {
@@ -92,7 +92,7 @@ test('it retires an employed tag team at the current datetime by default', funct
     $tagTeam->refresh();
     expect($tagTeam->status)->toBe(EmploymentStatus::Retired);
     expect($tagTeam->retirements)->toHaveCount(1);
-    expect($tagTeam->retirements->first()->started_at->toDateTimeString())->toBe(now()->toDateTimeString());
+    expect(requiredDate($tagTeam->retirements->firstOrFail()->started_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });
 
 test('it retires an employed tag team at a specific datetime', function () {
@@ -105,7 +105,7 @@ test('it retires an employed tag team at a specific datetime', function () {
     $tagTeam->refresh();
     expect($tagTeam->status)->toBe(EmploymentStatus::Retired);
     expect($tagTeam->retirements)->toHaveCount(1);
-    expect($tagTeam->retirements->first()->started_at->toDateTimeString())->toBe($datetime->toDateTimeString());
+    expect(requiredDate($tagTeam->retirements->firstOrFail()->started_at)->toDateTimeString())->toBe($datetime->toDateTimeString());
 });
 
 test('it throws exception for retiring a non retirable tag team', function ($factoryState) {

--- a/tests/Unit/Livewire/Base/LivewireBaseFormTest.php
+++ b/tests/Unit/Livewire/Base/LivewireBaseFormTest.php
@@ -84,7 +84,7 @@ describe('BaseForm Unit Tests', function () {
             expect($formModelProperty->isProtected())->toBeTrue();
             expect($formModelProperty->hasType())->toBeTrue();
             expect(reflectionTypeName($formModelProperty))->toBe('Illuminate\\Database\\Eloquent\\Model');
-            expect($formModelProperty->getType()->allowsNull())->toBeTrue();
+            expect(requiredReflectionType($formModelProperty->getType())->allowsNull())->toBeTrue();
         });
     });
 

--- a/tests/Unit/Livewire/Concerns/BaseModalTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseModalTest.php
@@ -48,7 +48,7 @@ describe('BaseModal Unit Tests', function () {
             $property = $reflection->getProperty('model');
             expect($property->isProtected())->toBeTrue();
             expect(reflectionTypeName($property))->toBe('Illuminate\\Database\\Eloquent\\Model');
-            expect($property->getType()->allowsNull())->toBeTrue();
+            expect(requiredReflectionType($property->getType())->allowsNull())->toBeTrue();
         });
 
         test('has modelForm property', function () {

--- a/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
+++ b/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
@@ -147,7 +147,7 @@ describe('GeneratesDummyData Unit Tests', function () {
             $dateMethod = $reflection->getMethod('generateFutureDate');
             expect($dateMethod->isProtected())->toBeTrue();
             expect(reflectionReturnTypeName($dateMethod))->toBe('string');
-            expect($dateMethod->getReturnType()->allowsNull())->toBeTrue();
+            expect(requiredReflectionType($dateMethod->getReturnType())->allowsNull())->toBeTrue();
             expect($dateMethod->getNumberOfParameters())->toBe(2);
         });
     });

--- a/tests/Unit/Models/Concerns/HasActivityPeriodsTraitTest.php
+++ b/tests/Unit/Models/Concerns/HasActivityPeriodsTraitTest.php
@@ -49,7 +49,7 @@ describe('HasActivityPeriods Trait Unit Tests', function () {
             ]);
             $model->load('currentActivityPeriod');
             expect($model->currentActivityPeriod)->not->toBeNull();
-            expect($model->currentActivityPeriod->ended_at)->toBeNull();
+            expect($model->currentActivityPeriod)->not->toBeNull()->ended_at->toBeNull();
         });
 
         test('model without current activity period returns null', function () {
@@ -75,7 +75,7 @@ describe('HasActivityPeriods Trait Unit Tests', function () {
             ]);
             $model->load('futureActivityPeriod');
             expect($model->futureActivityPeriod)->not->toBeNull();
-            expect($model->futureActivityPeriod->started_at->gt(now()))->toBeTrue();
+            expect(requiredModel($model->futureActivityPeriod)->started_at->gt(now()))->toBeTrue();
         });
 
         test('model without future activity period returns null', function () {
@@ -122,7 +122,7 @@ describe('HasActivityPeriods Trait Unit Tests', function () {
             ]);
             $model->load('previousActivityPeriod');
             expect($model->previousActivityPeriod)->not->toBeNull();
-            expect($model->previousActivityPeriod->ended_at)->not->toBeNull();
+            expect($model->previousActivityPeriod)->not->toBeNull()->ended_at->not->toBeNull();
         });
     });
 
@@ -146,7 +146,7 @@ describe('HasActivityPeriods Trait Unit Tests', function () {
             ]);
             $model->load('firstActivityPeriod');
             expect($model->firstActivityPeriod)->not->toBeNull();
-            expect($model->firstActivityPeriod->id)->toBe($first->id);
+            expect($model->firstActivityPeriod)->not->toBeNull()->id->toBe($first->id);
         });
     });
 
@@ -322,7 +322,7 @@ describe('HasActivityPeriods Trait Unit Tests', function () {
             $model->load(['activityPeriods', 'currentActivityPeriod']);
             expect($model->activityPeriods)->toHaveCount(2);
             expect($model->currentActivityPeriod)->not->toBeNull();
-            expect($model->currentActivityPeriod->ended_at)->toBeNull();
+            expect($model->currentActivityPeriod)->not->toBeNull()->ended_at->toBeNull();
         });
 
         test('model can exist without activity periods', function () {

--- a/tests/Unit/Models/Concerns/HasChampionshipsTraitTest.php
+++ b/tests/Unit/Models/Concerns/HasChampionshipsTraitTest.php
@@ -49,7 +49,7 @@ describe('HasChampionships Trait Unit Tests', function () {
 
             $model->load('championships');
             expect($model->getCurrentChampionship())->not->toBeNull();
-            expect($model->getCurrentChampionship()->lost_at)->toBeNull();
+            expect(requiredModel($model->getCurrentChampionship())->lost_at)->toBeNull();
         });
 
         test('model without current championship returns null', function () {
@@ -69,7 +69,7 @@ describe('HasChampionships Trait Unit Tests', function () {
             ]);
 
             expect($model->currentChampion())->not->toBeNull();
-            expect($model->currentChampion()->getKey())->toBe($champion->id);
+            expect(requiredModel($model->currentChampion())->getKey())->toBe($champion->id);
         });
 
         test('currentChampion returns null when no current championship', function () {
@@ -103,8 +103,9 @@ describe('HasChampionships Trait Unit Tests', function () {
             ]);
 
             $previous = $model->previousChampionship();
-            expect($previous)->not->toBeNull();
-            expect($previous->champion_id)->toBe($champion1->id);
+            expect($previous)
+                ->not->toBeNull()
+                ->champion_id->toBe($champion1->id);
         });
 
         test('previousChampionship returns null when no previous reigns', function () {
@@ -134,7 +135,7 @@ describe('HasChampionships Trait Unit Tests', function () {
             ]);
 
             expect($model->previousChampion())->not->toBeNull();
-            expect($model->previousChampion()->getKey())->toBe($champion1->id);
+            expect(requiredModel($model->previousChampion())->getKey())->toBe($champion1->id);
         });
 
         test('previousChampion returns null when no previous reigns', function () {
@@ -168,8 +169,9 @@ describe('HasChampionships Trait Unit Tests', function () {
             ]);
 
             $first = $model->firstChampionship();
-            expect($first)->not->toBeNull();
-            expect($first->champion_id)->toBe($champion1->id);
+            expect($first)
+                ->not->toBeNull()
+                ->champion_id->toBe($champion1->id);
         });
 
         test('firstChampionship returns null when no championships', function () {
@@ -198,8 +200,7 @@ describe('HasChampionships Trait Unit Tests', function () {
                 'lost_at' => now()->subMonth(),
             ]);
 
-            expect($model->firstChampion())->not->toBeNull();
-            expect($model->firstChampion()->getKey())->toBe($champion1->id);
+            expect(requiredModel($model->firstChampion())->getKey())->toBe($champion1->id);
         });
 
         test('firstChampion returns null when no championships', function () {
@@ -233,8 +234,9 @@ describe('HasChampionships Trait Unit Tests', function () {
             ]);
 
             $longest = $model->longestChampionship();
-            expect($longest)->not->toBeNull();
-            expect($longest->champion_id)->toBe($champion2->id);
+            expect($longest)
+                ->not->toBeNull()
+                ->champion_id->toBe($champion2->id);
         });
 
         test('longestChampionship returns null when no championships', function () {
@@ -263,8 +265,7 @@ describe('HasChampionships Trait Unit Tests', function () {
                 'lost_at' => now()->subMonth(),
             ]);
 
-            expect($model->longestChampion())->not->toBeNull();
-            expect($model->longestChampion()->getKey())->toBe($champion2->id);
+            expect(requiredModel($model->longestChampion())->getKey())->toBe($champion2->id);
         });
 
         test('longestChampion returns null when no championships', function () {
@@ -326,7 +327,7 @@ describe('HasChampionships Trait Unit Tests', function () {
 
             expect($model->championships)->toHaveCount(2);
             expect($model->getCurrentChampionship())->not->toBeNull();
-            expect($model->getCurrentChampionship()->lost_at)->toBeNull();
+            expect(requiredModel($model->getCurrentChampionship())->lost_at)->toBeNull();
         });
 
         test('model can exist without championships', function () {

--- a/tests/Unit/Models/Concerns/HoldsEventsTest.php
+++ b/tests/Unit/Models/Concerns/HoldsEventsTest.php
@@ -104,7 +104,7 @@ describe('HoldsEvents Trait Unit Tests', function () {
             $venue->load('previousEvents');
 
             expect($venue->previousEvents)->toHaveCount(1);
-            expect($venue->previousEvents->first()->name)->toBe('Past Event');
+            expect($venue->previousEvents->firstOrFail()->name)->toBe('Past Event');
             expect($venue->previousEvents->pluck('name'))->not->toContain('Future Event');
         });
 
@@ -136,7 +136,7 @@ describe('HoldsEvents Trait Unit Tests', function () {
             $venue->load('previousEvents');
 
             expect($venue->previousEvents)->toHaveCount(1);
-            expect($venue->previousEvents->first()->name)->toBe('Past Event');
+            expect($venue->previousEvents->firstOrFail()->name)->toBe('Past Event');
         });
     });
 

--- a/tests/Unit/database/Factories/Events/EventFactoryTest.php
+++ b/tests/Unit/database/Factories/Events/EventFactoryTest.php
@@ -73,7 +73,7 @@ describe('EventFactory Unit Tests', function () {
 
             // Assert
             expect($event->venue_id)->toBe($venue->id);
-            expect($event->date->format('Y-m-d H:i:s'))->toBe($date->format('Y-m-d H:i:s'));
+            expect(requiredDate($event->date)->format('Y-m-d H:i:s'))->toBe($date->format('Y-m-d H:i:s'));
         });
 
         test('with preview content works correctly', function () {
@@ -95,8 +95,8 @@ describe('EventFactory Unit Tests', function () {
             $event = Event::factory()->make(['date' => $pastDate]);
 
             // Assert
-            expect($event->date->format('Y-m-d H:i:s'))->toBe($pastDate->format('Y-m-d H:i:s'));
-            expect($event->date->isPast())->toBeTrue();
+            expect(requiredDate($event->date)->format('Y-m-d H:i:s'))->toBe($pastDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($event->date)->isPast())->toBeTrue();
         });
 
         test('future event state works correctly', function () {
@@ -107,8 +107,8 @@ describe('EventFactory Unit Tests', function () {
             $event = Event::factory()->make(['date' => $futureDate]);
 
             // Assert
-            expect($event->date->format('Y-m-d H:i:s'))->toBe($futureDate->format('Y-m-d H:i:s'));
-            expect($event->date->isFuture())->toBeTrue();
+            expect(requiredDate($event->date)->format('Y-m-d H:i:s'))->toBe($futureDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($event->date)->isFuture())->toBeTrue();
         });
     });
 

--- a/tests/Unit/database/Factories/Managers/ManagerEmploymentFactoryTest.php
+++ b/tests/Unit/database/Factories/Managers/ManagerEmploymentFactoryTest.php
@@ -61,7 +61,7 @@ describe('ManagerEmploymentFactory Unit Tests', function () {
 
             // Assert
             expect($employment->manager_id)->toBe($manager->id);
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
             expect($employment->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('ManagerEmploymentFactory Unit Tests', function () {
 
             // Assert
             expect($employment->manager_id)->toBe($manager->id);
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->isAfter($employment->started_at))->toBeTrue();
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->isAfter($employment->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('ManagerEmploymentFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('ManagerEmploymentFactory Unit Tests', function () {
             // Assert
             expect($employment->started_at)->toBeInstanceOf(Carbon::class);
             if ($employment->ended_at) {
-                expect($employment->ended_at->isAfter($employment->started_at))->toBeTrue();
+                expect(requiredDate($employment->ended_at)->isAfter($employment->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Managers/ManagerInjuryFactoryTest.php
+++ b/tests/Unit/database/Factories/Managers/ManagerInjuryFactoryTest.php
@@ -61,7 +61,7 @@ describe('ManagerInjuryFactory Unit Tests', function () {
 
             // Assert
             expect($injury->manager_id)->toBe($manager->id);
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
             expect($injury->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('ManagerInjuryFactory Unit Tests', function () {
 
             // Assert
             expect($injury->manager_id)->toBe($manager->id);
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->isAfter($injury->started_at))->toBeTrue();
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->isAfter($injury->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('ManagerInjuryFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('ManagerInjuryFactory Unit Tests', function () {
             // Assert
             expect($injury->started_at)->toBeInstanceOf(Carbon::class);
             if ($injury->ended_at) {
-                expect($injury->ended_at->isAfter($injury->started_at))->toBeTrue();
+                expect(requiredDate($injury->ended_at)->isAfter($injury->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Managers/ManagerRetirementFactoryTest.php
+++ b/tests/Unit/database/Factories/Managers/ManagerRetirementFactoryTest.php
@@ -61,7 +61,7 @@ describe('ManagerRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->manager_id)->toBe($manager->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
             expect($retirement->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('ManagerRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->manager_id)->toBe($manager->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('ManagerRetirementFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('ManagerRetirementFactory Unit Tests', function () {
             // Assert
             expect($retirement->started_at)->toBeInstanceOf(Carbon::class);
             if ($retirement->ended_at) {
-                expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+                expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Managers/ManagerSuspensionFactoryTest.php
+++ b/tests/Unit/database/Factories/Managers/ManagerSuspensionFactoryTest.php
@@ -61,7 +61,7 @@ describe('ManagerSuspensionFactory Unit Tests', function () {
 
             // Assert
             expect($suspension->manager_id)->toBe($manager->id);
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
             expect($suspension->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('ManagerSuspensionFactory Unit Tests', function () {
 
             // Assert
             expect($suspension->manager_id)->toBe($manager->id);
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->isAfter($suspension->started_at))->toBeTrue();
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->isAfter($suspension->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('ManagerSuspensionFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('ManagerSuspensionFactory Unit Tests', function () {
             // Assert
             expect($suspension->started_at)->toBeInstanceOf(Carbon::class);
             if ($suspension->ended_at) {
-                expect($suspension->ended_at->isAfter($suspension->started_at))->toBeTrue();
+                expect(requiredDate($suspension->ended_at)->isAfter($suspension->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Matches/MatchFactoryTest.php
+++ b/tests/Unit/database/Factories/Matches/MatchFactoryTest.php
@@ -143,7 +143,7 @@ describe('MatchFactory', function () {
             $eventMatch = EventMatch::factory()->titleMatch($title)->create();
 
             expect($eventMatch->titles)->toHaveCount(1);
-            expect($eventMatch->titles->first()->id)->toBe($title->id);
+            expect($eventMatch->titles->firstOrFail()->id)->toBe($title->id);
             expect($eventMatch->competitors)->not->toBeEmpty();
             expect($eventMatch->result)->not->toBeNull();
         });
@@ -153,10 +153,10 @@ describe('MatchFactory', function () {
             $eventMatch = EventMatch::factory()->titleDefense($title)->create();
 
             expect($eventMatch->titles)->toHaveCount(1);
-            expect($eventMatch->titles->first()->id)->toBe($title->id);
+            expect($eventMatch->titles->firstOrFail()->id)->toBe($title->id);
 
             // Should have a championship record
-            $championship = TitleChampionship::where('title_id', $title->id)->first();
+            $championship = TitleChampionship::where('title_id', $title->id)->firstOrFail();
             expect($championship)->not->toBeNull();
             expect($championship->champion_type)->toBe(Wrestler::class);
 
@@ -173,10 +173,10 @@ describe('MatchFactory', function () {
             $eventMatch = EventMatch::factory()->titleDefense($title)->create();
 
             expect($eventMatch->titles)->toHaveCount(1);
-            expect($eventMatch->titles->first()->id)->toBe($title->id);
+            expect($eventMatch->titles->firstOrFail()->id)->toBe($title->id);
 
             // Should have a championship record
-            $championship = TitleChampionship::where('title_id', $title->id)->first();
+            $championship = TitleChampionship::where('title_id', $title->id)->firstOrFail();
             expect($championship)->not->toBeNull();
             expect($championship->champion_type)->toBe(TagTeam::class);
 
@@ -271,7 +271,7 @@ describe('MatchFactory', function () {
 
             // Assert
             expect($eventMatch->referees)->toHaveCount(1);
-            expect($eventMatch->referees->first()->id)->toBe($referee->id);
+            expect($eventMatch->referees->firstOrFail()->id)->toBe($referee->id);
         });
 
         test('creates match with complete results including decision', function () {
@@ -321,8 +321,8 @@ describe('MatchFactory', function () {
 
             expect($eventMatch->competitors)->toHaveCount(2);
 
-            $competitor1 = $eventMatch->competitors->where('competitor_id', $wrestler1->id)->first();
-            $competitor2 = $eventMatch->competitors->where('competitor_id', $wrestler2->id)->first();
+            $competitor1 = $eventMatch->competitors->where('competitor_id', $wrestler1->id)->firstOrFail();
+            $competitor2 = $eventMatch->competitors->where('competitor_id', $wrestler2->id)->firstOrFail();
 
             expect($competitor1)->not->toBeNull();
             expect($competitor2)->not->toBeNull();

--- a/tests/Unit/database/Factories/Matches/MatchGenerationTest.php
+++ b/tests/Unit/database/Factories/Matches/MatchGenerationTest.php
@@ -226,8 +226,8 @@ describe('Match Comprehensive Generation Unit Tests', function () {
             expect($match->result->winners)->toHaveCount(1);
             expect($match->result->losers)->toHaveCount(1);
 
-            $firstCompetitor = $match->competitors->first();
-            $winner = $match->result->winners->first();
+            $firstCompetitor = $match->competitors->firstOrFail();
+            $winner = $match->result->winners->firstOrFail();
 
             expect($winner->winner_type)->toBe($firstCompetitor->competitor_type);
             expect($winner->winner_id)->toBe($firstCompetitor->competitor_id);
@@ -244,8 +244,8 @@ describe('Match Comprehensive Generation Unit Tests', function () {
             expect($match->result->winners)->toHaveCount(1);
             expect($match->result->losers)->toHaveCount(2);
 
-            $lastCompetitor = $match->competitors->last();
-            $winner = $match->result->winners->first();
+            $lastCompetitor = $match->competitors->reverse()->firstOrFail();
+            $winner = $match->result->winners->firstOrFail();
 
             expect($winner->winner_type)->toBe($lastCompetitor->competitor_type);
             expect($winner->winner_id)->toBe($lastCompetitor->competitor_id);
@@ -382,7 +382,7 @@ describe('Match Comprehensive Generation Unit Tests', function () {
             expect($match->result)->not->toBeNull();
 
             // Challenger should win (last competitor strategy)
-            $winner = $match->result->winners->first();
+            $winner = $match->result->winners->firstOrFail();
             expect($winner->winner_id)->toBe($challenger->id);
         });
 

--- a/tests/Unit/database/Factories/Referees/RefereeEmploymentFactoryTest.php
+++ b/tests/Unit/database/Factories/Referees/RefereeEmploymentFactoryTest.php
@@ -61,7 +61,7 @@ describe('RefereeEmploymentFactory Unit Tests', function () {
 
             // Assert
             expect($employment->referee_id)->toBe($referee->id);
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
             expect($employment->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('RefereeEmploymentFactory Unit Tests', function () {
 
             // Assert
             expect($employment->referee_id)->toBe($referee->id);
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->isAfter($employment->started_at))->toBeTrue();
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->isAfter($employment->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('RefereeEmploymentFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('RefereeEmploymentFactory Unit Tests', function () {
             // Assert
             expect($employment->started_at)->toBeInstanceOf(Carbon::class);
             if ($employment->ended_at) {
-                expect($employment->ended_at->isAfter($employment->started_at))->toBeTrue();
+                expect(requiredDate($employment->ended_at)->isAfter($employment->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Referees/RefereeInjuryFactoryTest.php
+++ b/tests/Unit/database/Factories/Referees/RefereeInjuryFactoryTest.php
@@ -61,7 +61,7 @@ describe('RefereeInjuryFactory Unit Tests', function () {
 
             // Assert
             expect($injury->referee_id)->toBe($referee->id);
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
             expect($injury->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('RefereeInjuryFactory Unit Tests', function () {
 
             // Assert
             expect($injury->referee_id)->toBe($referee->id);
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->isAfter($injury->started_at))->toBeTrue();
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->isAfter($injury->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('RefereeInjuryFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('RefereeInjuryFactory Unit Tests', function () {
             // Assert
             expect($injury->started_at)->toBeInstanceOf(Carbon::class);
             if ($injury->ended_at) {
-                expect($injury->ended_at->isAfter($injury->started_at))->toBeTrue();
+                expect(requiredDate($injury->ended_at)->isAfter($injury->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Referees/RefereeRetirementFactoryTest.php
+++ b/tests/Unit/database/Factories/Referees/RefereeRetirementFactoryTest.php
@@ -61,7 +61,7 @@ describe('RefereeRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->referee_id)->toBe($referee->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
             expect($retirement->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('RefereeRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->referee_id)->toBe($referee->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('RefereeRetirementFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('RefereeRetirementFactory Unit Tests', function () {
             // Assert
             expect($retirement->started_at)->toBeInstanceOf(Carbon::class);
             if ($retirement->ended_at) {
-                expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+                expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Referees/RefereeSuspensionFactoryTest.php
+++ b/tests/Unit/database/Factories/Referees/RefereeSuspensionFactoryTest.php
@@ -61,7 +61,7 @@ describe('RefereeSuspensionFactory Unit Tests', function () {
 
             // Assert
             expect($suspension->referee_id)->toBe($referee->id);
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
             expect($suspension->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('RefereeSuspensionFactory Unit Tests', function () {
 
             // Assert
             expect($suspension->referee_id)->toBe($referee->id);
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->isAfter($suspension->started_at))->toBeTrue();
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->isAfter($suspension->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('RefereeSuspensionFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('RefereeSuspensionFactory Unit Tests', function () {
             // Assert
             expect($suspension->started_at)->toBeInstanceOf(Carbon::class);
             if ($suspension->ended_at) {
-                expect($suspension->ended_at->isAfter($suspension->started_at))->toBeTrue();
+                expect(requiredDate($suspension->ended_at)->isAfter($suspension->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Stables/StableActivityPeriodFactoryTest.php
+++ b/tests/Unit/database/Factories/Stables/StableActivityPeriodFactoryTest.php
@@ -44,7 +44,7 @@ describe('StableActivityPeriodFactory Unit Tests', function () {
             // Assert
             expect($activityPeriod->started_at)->toBeInstanceOf(\Carbon\Carbon::class);
             expect($activityPeriod->started_at->isPast())->toBeTrue();
-            expect($activityPeriod->started_at->isAfter(now()->subYears(3)))->toBeTrue();
+            expect(requiredDate($activityPeriod->started_at)->isAfter(now()->subYears(3)))->toBeTrue();
             expect($activityPeriod->ended_at)->toBeNull(); // Active by default
         });
     });
@@ -64,7 +64,7 @@ describe('StableActivityPeriodFactory Unit Tests', function () {
 
             // Assert
             expect($activityPeriod->stable_id)->toBe($stable->id);
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
             expect($activityPeriod->ended_at)->toBeNull();
         });
 
@@ -83,9 +83,9 @@ describe('StableActivityPeriodFactory Unit Tests', function () {
 
             // Assert
             expect($activityPeriod->stable_id)->toBe($stable->id);
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($activityPeriod->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
-            expect($activityPeriod->ended_at->isAfter($activityPeriod->started_at))->toBeTrue();
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->ended_at)->isAfter($activityPeriod->started_at))->toBeTrue();
         });
     });
 
@@ -113,8 +113,8 @@ describe('StableActivityPeriodFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($activityPeriod->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -135,7 +135,7 @@ describe('StableActivityPeriodFactory Unit Tests', function () {
             // Assert
             expect($activityPeriod->started_at)->toBeInstanceOf(Carbon::class);
             if ($activityPeriod->ended_at) {
-                expect($activityPeriod->ended_at->isAfter($activityPeriod->started_at))->toBeTrue();
+                expect(requiredDate($activityPeriod->ended_at)->isAfter($activityPeriod->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Stables/StableRetirementFactoryTest.php
+++ b/tests/Unit/database/Factories/Stables/StableRetirementFactoryTest.php
@@ -61,7 +61,7 @@ describe('StableRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->stable_id)->toBe($stable->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
             expect($retirement->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('StableRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->stable_id)->toBe($stable->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('StableRetirementFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('StableRetirementFactory Unit Tests', function () {
             // Assert
             expect($retirement->started_at)->toBeInstanceOf(Carbon::class);
             if ($retirement->ended_at) {
-                expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+                expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/TagTeams/TagTeamEmploymentFactoryTest.php
+++ b/tests/Unit/database/Factories/TagTeams/TagTeamEmploymentFactoryTest.php
@@ -61,7 +61,7 @@ describe('TagTeamEmploymentFactory Unit Tests', function () {
 
             // Assert
             expect($employment->tag_team_id)->toBe($tagTeam->id);
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
             expect($employment->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('TagTeamEmploymentFactory Unit Tests', function () {
 
             // Assert
             expect($employment->tag_team_id)->toBe($tagTeam->id);
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->isAfter($employment->started_at))->toBeTrue();
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->isAfter($employment->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('TagTeamEmploymentFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('TagTeamEmploymentFactory Unit Tests', function () {
             // Assert
             expect($employment->started_at)->toBeInstanceOf(Carbon::class);
             if ($employment->ended_at) {
-                expect($employment->ended_at->isAfter($employment->started_at))->toBeTrue();
+                expect(requiredDate($employment->ended_at)->isAfter($employment->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/TagTeams/TagTeamRetirementFactoryTest.php
+++ b/tests/Unit/database/Factories/TagTeams/TagTeamRetirementFactoryTest.php
@@ -61,7 +61,7 @@ describe('TagTeamRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->tag_team_id)->toBe($tagTeam->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
             expect($retirement->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('TagTeamRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->tag_team_id)->toBe($tagTeam->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('TagTeamRetirementFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('TagTeamRetirementFactory Unit Tests', function () {
             // Assert
             expect($retirement->started_at)->toBeInstanceOf(Carbon::class);
             if ($retirement->ended_at) {
-                expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+                expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/TagTeams/TagTeamSuspensionFactoryTest.php
+++ b/tests/Unit/database/Factories/TagTeams/TagTeamSuspensionFactoryTest.php
@@ -61,7 +61,7 @@ describe('TagTeamSuspensionFactory Unit Tests', function () {
 
             // Assert
             expect($suspension->tag_team_id)->toBe($tagTeam->id);
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
             expect($suspension->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('TagTeamSuspensionFactory Unit Tests', function () {
 
             // Assert
             expect($suspension->tag_team_id)->toBe($tagTeam->id);
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->isAfter($suspension->started_at))->toBeTrue();
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->isAfter($suspension->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('TagTeamSuspensionFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('TagTeamSuspensionFactory Unit Tests', function () {
             // Assert
             expect($suspension->started_at)->toBeInstanceOf(Carbon::class);
             if ($suspension->ended_at) {
-                expect($suspension->ended_at->isAfter($suspension->started_at))->toBeTrue();
+                expect(requiredDate($suspension->ended_at)->isAfter($suspension->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/TagTeams/TagTeamWrestlerFactoryTest.php
+++ b/tests/Unit/database/Factories/TagTeams/TagTeamWrestlerFactoryTest.php
@@ -90,9 +90,9 @@ describe('TagTeamWrestlerFactory Unit Tests', function () {
             // Assert
             expect($tagTeamWrestler->tag_team_id)->toBe($tagTeam->id);
             expect($tagTeamWrestler->wrestler_id)->toBe($wrestler->id);
-            expect($tagTeamWrestler->joined_at->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
-            expect($tagTeamWrestler->left_at->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
-            expect($tagTeamWrestler->left_at->isAfter($tagTeamWrestler->joined_at))->toBeTrue();
+            expect(requiredDate($tagTeamWrestler->joined_at)->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($tagTeamWrestler->left_at)->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($tagTeamWrestler->left_at)->isAfter(requiredDate($tagTeamWrestler->joined_at)))->toBeTrue();
         });
     });
 
@@ -131,8 +131,8 @@ describe('TagTeamWrestlerFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($tagTeamWrestler->joined_at->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
-            expect($tagTeamWrestler->left_at->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($tagTeamWrestler->joined_at)->format('Y-m-d H:i:s'))->toBe($joinedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($tagTeamWrestler->left_at)->format('Y-m-d H:i:s'))->toBe($leftDate->format('Y-m-d H:i:s'));
         });
     });
 

--- a/tests/Unit/database/Factories/Titles/TitleActivityPeriodFactoryTest.php
+++ b/tests/Unit/database/Factories/Titles/TitleActivityPeriodFactoryTest.php
@@ -61,7 +61,7 @@ describe('TitleActivityPeriodFactory Unit Tests', function () {
 
             // Assert
             expect($activityPeriod->title_id)->toBe($title->id);
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
             expect($activityPeriod->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('TitleActivityPeriodFactory Unit Tests', function () {
 
             // Assert
             expect($activityPeriod->title_id)->toBe($title->id);
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($activityPeriod->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
-            expect($activityPeriod->ended_at->isAfter($activityPeriod->started_at))->toBeTrue();
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->ended_at)->isAfter($activityPeriod->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('TitleActivityPeriodFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($activityPeriod->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($activityPeriod->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($activityPeriod->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('TitleActivityPeriodFactory Unit Tests', function () {
             // Assert
             expect($activityPeriod->started_at)->toBeInstanceOf(Carbon::class);
             if ($activityPeriod->ended_at) {
-                expect($activityPeriod->ended_at->isAfter($activityPeriod->started_at))->toBeTrue();
+                expect(requiredDate($activityPeriod->ended_at)->isAfter($activityPeriod->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
+++ b/tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
@@ -50,7 +50,7 @@ describe('TitleChampionshipFactory Unit Tests', function () {
 
             // Assert
             expect($championship->won_at->isPast())->toBeTrue();
-            expect($championship->won_at->isAfter(now()->subYear()))->toBeTrue();
+            expect(requiredDate($championship->won_at)->isAfter(now()->subYear()))->toBeTrue();
         });
     });
 
@@ -103,10 +103,10 @@ describe('TitleChampionshipFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($championship->won_at->format('Y-m-d H:i:s'))->toBe($wonDate->format('Y-m-d H:i:s'));
-            expect($championship->lost_at->format('Y-m-d H:i:s'))->toBe($lostDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($championship->won_at)->format('Y-m-d H:i:s'))->toBe($wonDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($championship->lost_at)->format('Y-m-d H:i:s'))->toBe($lostDate->format('Y-m-d H:i:s'));
             expect($championship->lost_match_id)->toBe($lostMatch->id);
-            expect($championship->lost_at->isAfter($championship->won_at))->toBeTrue();
+            expect(requiredDate($championship->lost_at)->isAfter($championship->won_at))->toBeTrue();
         });
     });
 

--- a/tests/Unit/database/Factories/Titles/TitleFactoryTest.php
+++ b/tests/Unit/database/Factories/Titles/TitleFactoryTest.php
@@ -65,7 +65,7 @@ describe('TitleFactory Unit Tests', function () {
             // Assert
             $title->load('currentActivityPeriod');
             expect($title->currentActivityPeriod)->not->toBeNull();
-            expect($title->currentActivityPeriod->ended_at)->toBeNull();
+            expect($title->currentActivityPeriod)->not->toBeNull()->ended_at->toBeNull();
         });
 
         test('inactive state works correctly', function () {

--- a/tests/Unit/database/Factories/Titles/TitleRetirementFactoryTest.php
+++ b/tests/Unit/database/Factories/Titles/TitleRetirementFactoryTest.php
@@ -61,7 +61,7 @@ describe('TitleRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->title_id)->toBe($title->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
             expect($retirement->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('TitleRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->title_id)->toBe($title->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('TitleRetirementFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('TitleRetirementFactory Unit Tests', function () {
             // Assert
             expect($retirement->started_at)->toBeInstanceOf(Carbon::class);
             if ($retirement->ended_at) {
-                expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+                expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Wrestlers/WrestlerEmploymentFactoryTest.php
+++ b/tests/Unit/database/Factories/Wrestlers/WrestlerEmploymentFactoryTest.php
@@ -61,7 +61,7 @@ describe('WrestlerEmploymentFactory Unit Tests', function () {
 
             // Assert
             expect($employment->wrestler_id)->toBe($wrestler->id);
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
             expect($employment->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('WrestlerEmploymentFactory Unit Tests', function () {
 
             // Assert
             expect($employment->wrestler_id)->toBe($wrestler->id);
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->isAfter($employment->started_at))->toBeTrue();
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->isAfter($employment->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('WrestlerEmploymentFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($employment->started_at->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
-            expect($employment->ended_at->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->started_at)->format('Y-m-d H:i:s'))->toBe($startDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($employment->ended_at)->format('Y-m-d H:i:s'))->toBe($endDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('WrestlerEmploymentFactory Unit Tests', function () {
             // Assert
             expect($employment->started_at)->toBeInstanceOf(Carbon::class);
             if ($employment->ended_at) {
-                expect($employment->ended_at->isAfter($employment->started_at))->toBeTrue();
+                expect(requiredDate($employment->ended_at)->isAfter($employment->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Wrestlers/WrestlerFactoryTest.php
+++ b/tests/Unit/database/Factories/Wrestlers/WrestlerFactoryTest.php
@@ -48,7 +48,7 @@ describe('wrestler factory states', function () {
 
         $wrestler->load('currentEmployment');
         expect($wrestler->currentEmployment)->not->toBeNull();
-        expect($wrestler->currentEmployment->ended_at)->toBeNull();
+        expect($wrestler->currentEmployment()->firstOrFail()->ended_at)->toBeNull();
     });
 
     test('wrestler factory can create suspended wrestlers', function () {
@@ -56,7 +56,7 @@ describe('wrestler factory states', function () {
 
         $wrestler->load('currentSuspension');
         expect($wrestler->currentSuspension)->not->toBeNull();
-        expect($wrestler->currentSuspension->ended_at)->toBeNull();
+        expect($wrestler->currentSuspension()->firstOrFail()->ended_at)->toBeNull();
     });
 
     test('wrestler factory can create retired wrestlers', function () {

--- a/tests/Unit/database/Factories/Wrestlers/WrestlerInjuryFactoryTest.php
+++ b/tests/Unit/database/Factories/Wrestlers/WrestlerInjuryFactoryTest.php
@@ -61,7 +61,7 @@ describe('WrestlerInjuryFactory Unit Tests', function () {
 
             // Assert
             expect($injury->wrestler_id)->toBe($wrestler->id);
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
             expect($injury->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('WrestlerInjuryFactory Unit Tests', function () {
 
             // Assert
             expect($injury->wrestler_id)->toBe($wrestler->id);
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->isAfter($injury->started_at))->toBeTrue();
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->isAfter($injury->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('WrestlerInjuryFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($injury->started_at->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
-            expect($injury->ended_at->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->started_at)->format('Y-m-d H:i:s'))->toBe($injuredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($injury->ended_at)->format('Y-m-d H:i:s'))->toBe($clearedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('WrestlerInjuryFactory Unit Tests', function () {
             // Assert
             expect($injury->started_at)->toBeInstanceOf(Carbon::class);
             if ($injury->ended_at) {
-                expect($injury->ended_at->isAfter($injury->started_at))->toBeTrue();
+                expect(requiredDate($injury->ended_at)->isAfter($injury->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Wrestlers/WrestlerRetirementFactoryTest.php
+++ b/tests/Unit/database/Factories/Wrestlers/WrestlerRetirementFactoryTest.php
@@ -61,7 +61,7 @@ describe('WrestlerRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->wrestler_id)->toBe($wrestler->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
             expect($retirement->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('WrestlerRetirementFactory Unit Tests', function () {
 
             // Assert
             expect($retirement->wrestler_id)->toBe($wrestler->id);
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('WrestlerRetirementFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($retirement->started_at->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
-            expect($retirement->ended_at->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->started_at)->format('Y-m-d H:i:s'))->toBe($retiredDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($retirement->ended_at)->format('Y-m-d H:i:s'))->toBe($endedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('WrestlerRetirementFactory Unit Tests', function () {
             // Assert
             expect($retirement->started_at)->toBeInstanceOf(Carbon::class);
             if ($retirement->ended_at) {
-                expect($retirement->ended_at->isAfter($retirement->started_at))->toBeTrue();
+                expect(requiredDate($retirement->ended_at)->isAfter($retirement->started_at))->toBeTrue();
             }
         });
     });

--- a/tests/Unit/database/Factories/Wrestlers/WrestlerSuspensionFactoryTest.php
+++ b/tests/Unit/database/Factories/Wrestlers/WrestlerSuspensionFactoryTest.php
@@ -61,7 +61,7 @@ describe('WrestlerSuspensionFactory Unit Tests', function () {
 
             // Assert
             expect($suspension->wrestler_id)->toBe($wrestler->id);
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
             expect($suspension->ended_at)->toBeNull();
         });
 
@@ -80,9 +80,9 @@ describe('WrestlerSuspensionFactory Unit Tests', function () {
 
             // Assert
             expect($suspension->wrestler_id)->toBe($wrestler->id);
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->isAfter($suspension->started_at))->toBeTrue();
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->isAfter($suspension->started_at))->toBeTrue();
         });
     });
 
@@ -110,8 +110,8 @@ describe('WrestlerSuspensionFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($suspension->started_at->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
-            expect($suspension->ended_at->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->started_at)->format('Y-m-d H:i:s'))->toBe($suspendedDate->format('Y-m-d H:i:s'));
+            expect(requiredDate($suspension->ended_at)->format('Y-m-d H:i:s'))->toBe($reinstatedDate->format('Y-m-d H:i:s'));
         });
     });
 
@@ -132,7 +132,7 @@ describe('WrestlerSuspensionFactory Unit Tests', function () {
             // Assert
             expect($suspension->started_at)->toBeInstanceOf(Carbon::class);
             if ($suspension->ended_at) {
-                expect($suspension->ended_at->isAfter($suspension->started_at))->toBeTrue();
+                expect(requiredDate($suspension->ended_at)->isAfter($suspension->started_at))->toBeTrue();
             }
         });
     });


### PR DESCRIPTION
## Summary

- raise the Pest PHPStan configuration from level 7 to level 8
- use Pest expectation narrowing and explicit required-value helpers for nullable test state
- preserve model reload semantics while making test types explicit

## Verification

- `composer test:types`
- `composer test:rector`
- `composer test:type-coverage` (100%)
- `./vendor/bin/pint --blade --test tests`
- `php -d memory_limit=4G ./vendor/bin/pest --parallel` (3,499 tests, 11,072 assertions)