### PR TITLE
test: raise Pest PHPStan to level 9

### DIFF
--- a/phpstan-pest.neon
+++ b/phpstan-pest.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 8
+  level: 9
 
   paths:
     - tests

--- a/tests/Helpers/StatusTestExpectations.php
+++ b/tests/Helpers/StatusTestExpectations.php
@@ -217,6 +217,7 @@ function expectCurrentRelationshipsActive(Wrestler $wrestler): void
         $management = WrestlerManager::query()
             ->whereBelongsTo($wrestler)
             ->whereBelongsTo($manager)
+            ->whereNull('fired_at')
             ->firstOrFail();
 
         expect($management->fired_at)->toBeNull();
@@ -227,6 +228,7 @@ function expectCurrentRelationshipsActive(Wrestler $wrestler): void
         $membership = TagTeamWrestler::query()
             ->whereBelongsTo($wrestler)
             ->whereBelongsTo($currentTagTeam, 'tagTeam')
+            ->whereNull('left_at')
             ->firstOrFail();
 
         expect($membership->left_at)->toBeNull();
@@ -243,6 +245,7 @@ function expectPreviousRelationshipsEnded(Wrestler $wrestler): void
         $management = WrestlerManager::query()
             ->whereBelongsTo($wrestler)
             ->whereBelongsTo($manager)
+            ->whereNotNull('fired_at')
             ->firstOrFail();
 
         expect($management->fired_at)->not->toBeNull();
@@ -253,6 +256,7 @@ function expectPreviousRelationshipsEnded(Wrestler $wrestler): void
         $membership = TagTeamWrestler::query()
             ->whereBelongsTo($wrestler)
             ->whereBelongsTo($tagTeam, 'tagTeam')
+            ->whereNotNull('left_at')
             ->firstOrFail();
 
         expect($membership->left_at)->not->toBeNull();

--- a/tests/Helpers/StatusTestExpectations.php
+++ b/tests/Helpers/StatusTestExpectations.php
@@ -9,9 +9,10 @@ use App\Models\Contracts\Retirable;
 use App\Models\Contracts\Suspendable;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
+use App\Models\TagTeams\TagTeamWrestler;
 use App\Models\Wrestlers\Wrestler;
+use App\Models\Wrestlers\WrestlerManager;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
 
 /**
@@ -213,12 +214,22 @@ function expectCurrentRelationshipsActive(Wrestler $wrestler): void
 {
     $currentManagers = $wrestler->currentManagers()->get();
     foreach ($currentManagers as $manager) {
-        expect(relatedPivotAttribute($manager, 'fired_at'))->toBeNull();
+        $management = WrestlerManager::query()
+            ->whereBelongsTo($wrestler)
+            ->whereBelongsTo($manager)
+            ->firstOrFail();
+
+        expect($management->fired_at)->toBeNull();
     }
 
     $currentTagTeam = $wrestler->currentTagTeam;
     if ($currentTagTeam) {
-        expect(relatedPivotAttribute($currentTagTeam, 'left_at'))->toBeNull();
+        $membership = TagTeamWrestler::query()
+            ->whereBelongsTo($wrestler)
+            ->whereBelongsTo($currentTagTeam, 'tagTeam')
+            ->firstOrFail();
+
+        expect($membership->left_at)->toBeNull();
     }
 }
 
@@ -229,20 +240,21 @@ function expectPreviousRelationshipsEnded(Wrestler $wrestler): void
 {
     $previousManagers = $wrestler->previousManagers()->get();
     foreach ($previousManagers as $manager) {
-        expect(relatedPivotAttribute($manager, 'fired_at'))->not->toBeNull();
+        $management = WrestlerManager::query()
+            ->whereBelongsTo($wrestler)
+            ->whereBelongsTo($manager)
+            ->firstOrFail();
+
+        expect($management->fired_at)->not->toBeNull();
     }
 
     $previousTagTeams = $wrestler->previousTagTeams()->get();
     foreach ($previousTagTeams as $tagTeam) {
-        expect(relatedPivotAttribute($tagTeam, 'left_at'))->not->toBeNull();
+        $membership = TagTeamWrestler::query()
+            ->whereBelongsTo($wrestler)
+            ->whereBelongsTo($tagTeam, 'tagTeam')
+            ->firstOrFail();
+
+        expect($membership->left_at)->not->toBeNull();
     }
-}
-
-function relatedPivotAttribute(Model $model, string $attribute): mixed
-{
-    $pivot = $model->getRelation('pivot');
-
-    expect($pivot)->toBeInstanceOf(Pivot::class);
-
-    return $pivot instanceof Pivot ? $pivot->getAttribute($attribute) : null;
 }

--- a/tests/Integration/Actions/Events/LifecycleTest.php
+++ b/tests/Integration/Actions/Events/LifecycleTest.php
@@ -33,7 +33,7 @@ describe('Event Activation Action Integration', function () {
                 preview: 'A test event'
             );
 
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
 
             expect($event->exists)->toBeTrue();
             expect($event->name)->toBe('Test Event');
@@ -53,7 +53,7 @@ describe('Event Activation Action Integration', function () {
                 preview: 'A scheduled event'
             );
 
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
 
             expect($event->exists)->toBeTrue();
             expect($event->name)->toBe('Scheduled Event');
@@ -74,7 +74,7 @@ describe('Event Activation Action Integration', function () {
                 preview: 'An event that happened'
             );
 
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
 
             expect($event->exists)->toBeTrue();
             expect($event->isScheduled())->toBeTrue();
@@ -90,7 +90,7 @@ describe('Event Activation Action Integration', function () {
                 preview: 'Event without venue'
             );
 
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
 
             expect($event->exists)->toBeTrue();
             expect($event->isScheduled())->toBeTrue();
@@ -114,7 +114,7 @@ describe('Event Activation Action Integration', function () {
                 preview: 'Now scheduled'
             );
 
-            UpdateAction::run($this->event, $eventData);
+            UpdateAction::make()->handle($this->event, $eventData);
 
             $refreshedEvent = freshModel($this->event);
             expect($refreshedEvent->name)->toBe('Scheduled Event');
@@ -137,7 +137,7 @@ describe('Event Activation Action Integration', function () {
                 preview: $this->event->preview
             );
 
-            UpdateAction::run($this->event, $eventData);
+            UpdateAction::make()->handle($this->event, $eventData);
 
             $refreshedEvent = freshModel($this->event);
             expect(requiredDate($refreshedEvent->date)->format('Y-m-d H:i:s'))->toBe($newDate->format('Y-m-d H:i:s'));
@@ -155,7 +155,7 @@ describe('Event Activation Action Integration', function () {
                 preview: $this->event->preview
             );
 
-            UpdateAction::run($this->event, $eventData);
+            UpdateAction::make()->handle($this->event, $eventData);
 
             $refreshedEvent = freshModel($this->event);
             expect($refreshedEvent->venue_id)->toBe($newVenue->id);
@@ -172,7 +172,7 @@ describe('Event Activation Action Integration', function () {
                 preview: $this->event->preview
             );
 
-            UpdateAction::run($this->event, $eventData);
+            UpdateAction::make()->handle($this->event, $eventData);
 
             $refreshedEvent = freshModel($this->event);
             expect($refreshedEvent->venue_id)->toBeNull();
@@ -189,7 +189,7 @@ describe('Event Activation Action Integration', function () {
                 preview: 'Unscheduled again'
             );
 
-            UpdateAction::run($this->event, $eventData);
+            UpdateAction::make()->handle($this->event, $eventData);
 
             $refreshedEvent = freshModel($this->event);
             expect($refreshedEvent->isUnscheduled())->toBeTrue();
@@ -204,7 +204,7 @@ describe('Event Activation Action Integration', function () {
         });
 
         test('delete action soft deletes event', function () {
-            DeleteAction::run($this->event);
+            DeleteAction::make()->handle($this->event);
 
             expect(Event::find($this->event->id))->toBeNull();
             expect(Event::onlyTrashed()->find($this->event->id))->not()->toBeNull();
@@ -212,10 +212,10 @@ describe('Event Activation Action Integration', function () {
         });
 
         test('restore action recovers deleted event', function () {
-            DeleteAction::run($this->event);
+            DeleteAction::make()->handle($this->event);
             expect(Event::find($this->event->id))->toBeNull();
 
-            RestoreAction::run($this->event);
+            RestoreAction::make()->handle($this->event);
 
             $restoredEvent = Event::findOrFail($this->event->id);
             expect($restoredEvent->name)->toBe('Deletable Event');
@@ -226,8 +226,8 @@ describe('Event Activation Action Integration', function () {
             $originalDate = $this->event->date;
             $originalVenueId = $this->event->venue_id;
 
-            DeleteAction::run($this->event);
-            RestoreAction::run($this->event);
+            DeleteAction::make()->handle($this->event);
+            RestoreAction::make()->handle($this->event);
 
             $restoredEvent = Event::findOrFail($this->event->id);
             expect(requiredDate($restoredEvent->date)->format('Y-m-d H:i:s'))->toBe(requiredDate($originalDate)->format('Y-m-d H:i:s'));
@@ -245,7 +245,7 @@ describe('Event Activation Action Integration', function () {
                 venue: null,
                 preview: 'Draft event'
             );
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
             expect($event->isUnscheduled())->toBeTrue();
 
             // Schedule the event
@@ -256,7 +256,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $this->venue,
                 preview: 'Scheduled event'
             );
-            UpdateAction::run($event, $updateData);
+            UpdateAction::make()->handle($event, $updateData);
 
             $refreshedEvent = $event->refresh();
             expect($refreshedEvent->isScheduled())->toBeTrue();
@@ -269,7 +269,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $this->venue,
                 preview: 'Updated preview'
             );
-            UpdateAction::run($event, $finalUpdateData);
+            UpdateAction::make()->handle($event, $finalUpdateData);
 
             $finalEvent = $event->refresh();
             expect($finalEvent->name)->toBe('Final Event Name');
@@ -277,10 +277,10 @@ describe('Event Activation Action Integration', function () {
             expect($finalEvent->venue_id)->toBe($this->venue->id);
 
             // Delete and restore
-            DeleteAction::run($event);
+            DeleteAction::make()->handle($event);
             expect(Event::find($event->id))->toBeNull();
 
-            RestoreAction::run($event);
+            RestoreAction::make()->handle($event);
             $restoredEvent = Event::query()->whereKey($event->getKey())->firstOrFail();
             expect($restoredEvent->name)->toBe('Final Event Name');
             expect($restoredEvent->isScheduled())->toBeTrue();
@@ -304,8 +304,8 @@ describe('Event Activation Action Integration', function () {
                 preview: 'Second event'
             );
 
-            $event1 = CreateAction::run($event1Data);
-            $event2 = CreateAction::run($event2Data);
+            $event1 = CreateAction::make()->handle($event1Data);
+            $event2 = CreateAction::make()->handle($event2Data);
 
             expect($event1->venue_id)->toBe($this->venue->id);
             expect($event2->venue_id)->toBe($this->venue->id);
@@ -326,7 +326,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $venue1,
                 preview: 'Initial venue'
             );
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
             expect($event->venue_id)->toBe($venue1->id);
 
             // Change to second venue
@@ -336,7 +336,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $venue2,
                 preview: 'Changed venue'
             );
-            UpdateAction::run($event, $updateData);
+            UpdateAction::make()->handle($event, $updateData);
 
             $refreshedEvent = $event->refresh();
             expect($refreshedEvent->venue_id)->toBe($venue2->id);
@@ -350,7 +350,7 @@ describe('Event Activation Action Integration', function () {
                 venue: null,
                 preview: 'No venue'
             );
-            UpdateAction::run($event, $finalUpdateData);
+            UpdateAction::make()->handle($event, $finalUpdateData);
 
             $finalEvent = $event->refresh();
             expect($finalEvent->venue_id)->toBeNull();
@@ -369,7 +369,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $this->venue,
                 preview: 'Future event'
             );
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
             expect($event->hasFutureDate())->toBeTrue();
             expect($event->hasPastDate())->toBeFalse();
 
@@ -380,7 +380,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $this->venue,
                 preview: 'Past event'
             );
-            UpdateAction::run($event, $updateData);
+            UpdateAction::make()->handle($event, $updateData);
 
             $refreshedEvent = $event->refresh();
             expect($refreshedEvent->hasPastDate())->toBeTrue();
@@ -400,7 +400,7 @@ describe('Event Activation Action Integration', function () {
                 preview: 'Updated preview'
             );
 
-            UpdateAction::run($event, $updateData);
+            UpdateAction::make()->handle($event, $updateData);
 
             $refreshedEvent = freshModel($event);
             $refreshedEvent->load('venue');
@@ -424,7 +424,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $venue2,
                 preview: $event->preview
             );
-            UpdateAction::run($event, $updateData1);
+            UpdateAction::make()->handle($event, $updateData1);
             expect(freshModel($event)->venue_id)->toBe($venue2->id);
 
             // Change to venue3
@@ -434,7 +434,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $venue3,
                 preview: $event->preview
             );
-            UpdateAction::run($event, $updateData2);
+            UpdateAction::make()->handle($event, $updateData2);
             expect(freshModel($event)->venue_id)->toBe($venue3->id);
 
             // Verify venue relationships work
@@ -453,7 +453,7 @@ describe('Event Activation Action Integration', function () {
                 preview: null
             );
 
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
 
             expect($event->exists)->toBeTrue();
             expect($event->name)->toBe('Minimal Event');
@@ -470,7 +470,7 @@ describe('Event Activation Action Integration', function () {
                 preview: 'Date but no venue'
             );
 
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
 
             expect($event->isScheduled())->toBeTrue();
             expect($event->venue_id)->toBeNull();
@@ -485,16 +485,16 @@ describe('Event Activation Action Integration', function () {
                 preview: 'Consistency test'
             );
 
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
             $originalState = [
                 'name' => $event->name,
-                'date' => $event->date,
+                'date' => requiredDate($event->date),
                 'venue_id' => $event->venue_id,
                 'preview' => $event->preview,
             ];
 
-            DeleteAction::run($event);
-            RestoreAction::run($event);
+            DeleteAction::make()->handle($event);
+            RestoreAction::make()->handle($event);
 
             $restoredEvent = Event::query()->whereKey($event->getKey())->firstOrFail();
             expect($restoredEvent->name)->toBe($originalState['name']);
@@ -533,7 +533,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $this->venue,
                 preview: 'Future event'
             );
-            $event = CreateAction::run($eventData);
+            $event = CreateAction::make()->handle($eventData);
             expect($event->hasFutureDate())->toBeTrue();
 
             // Update to past
@@ -543,7 +543,7 @@ describe('Event Activation Action Integration', function () {
                 venue: $this->venue,
                 preview: 'Past event'
             );
-            UpdateAction::run($event, $updateData);
+            UpdateAction::make()->handle($event, $updateData);
 
             $updatedEvent = $event->refresh();
             expect($updatedEvent->hasPastDate())->toBeTrue();

--- a/tests/Integration/Actions/Managers/CreateActionTest.php
+++ b/tests/Integration/Actions/Managers/CreateActionTest.php
@@ -15,7 +15,7 @@ beforeEach(function () {
 test('it creates a manager with basic information', function () {
     $data = new ManagerData('Taylor', 'Otwell', null);
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Manager::class);
     expect($result->first_name)->toBe('Taylor');
@@ -36,7 +36,7 @@ test('it creates a manager with employment when employment date is provided', fu
     $employmentDate = now();
     $data = new ManagerData('Jeffrey', 'Davidson', $employmentDate);
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Manager::class);
     expect($result->first_name)->toBe('Jeffrey');
@@ -66,7 +66,7 @@ test('it creates manager with all optional fields', function () {
         employment_date: $employmentDate
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Manager::class);
     expect($result->first_name)->toBe('John');

--- a/tests/Integration/Actions/Managers/ReleaseActionTest.php
+++ b/tests/Integration/Actions/Managers/ReleaseActionTest.php
@@ -6,6 +6,7 @@ use App\Actions\Managers\ReleaseAction;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
+use App\Models\Wrestlers\WrestlerManager;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -246,11 +247,12 @@ test('it preserves management history during release', function () {
     expect($manager->currentWrestlers)->toHaveCount(0); // Current ended
 
     // Verify the current relationship was ended with release date
-    $currentRelationship = $manager->wrestlers()
-        ->wherePivot('hired_at', now()->subDays(10)->toDateTimeString())
+    $currentRelationship = WrestlerManager::query()
+        ->whereBelongsTo($manager)
+        ->where('hired_at', now()->subDays(10))
         ->firstOrFail();
 
-    expect(relatedPivotAttribute($currentRelationship, 'fired_at'))->toBe(now()->toDateTimeString());
+    expect(requiredDate($currentRelationship->fired_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });
 
 test('it handles manager with no management relationships', function () {

--- a/tests/Integration/Actions/Managers/RestoreActionTest.php
+++ b/tests/Integration/Actions/Managers/RestoreActionTest.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 use App\Actions\Managers\RestoreAction;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
+use App\Models\TagTeams\TagTeamManager;
 use App\Models\Wrestlers\Wrestler;
+use App\Models\Wrestlers\WrestlerManager;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -197,13 +199,19 @@ test('it maintains referential integrity during restoration', function () {
     expect($restoredManager->tagTeams()->count())->toBe(1);
 
     // Verify pivot data integrity
-    $wrestlerPivot = $restoredManager->wrestlers()->firstOrFail()->pivot;
-    expect($wrestlerPivot->getAttribute('hired_at'))->not()->toBeNull();
-    expect($wrestlerPivot->getAttribute('fired_at'))->not()->toBeNull();
+    $wrestlerManagement = WrestlerManager::query()
+        ->whereBelongsTo($restoredManager, 'manager')
+        ->whereBelongsTo($wrestler)
+        ->firstOrFail();
+    expect($wrestlerManagement->hired_at->toDateTimeString())->toBe(now()->subDays(5)->toDateTimeString());
+    expect($wrestlerManagement->fired_at)->not()->toBeNull();
 
-    $tagTeamPivot = $restoredManager->tagTeams()->firstOrFail()->pivot;
-    expect($tagTeamPivot->getAttribute('hired_at'))->not()->toBeNull();
-    expect($tagTeamPivot->getAttribute('fired_at'))->not()->toBeNull();
+    $tagTeamManagement = TagTeamManager::query()
+        ->whereBelongsTo($restoredManager, 'manager')
+        ->whereBelongsTo($tagTeam, 'tagTeam')
+        ->firstOrFail();
+    expect($tagTeamManagement->hired_at->toDateTimeString())->toBe(now()->subDays(4)->toDateTimeString());
+    expect($tagTeamManagement->fired_at)->not()->toBeNull();
 });
 
 test('it allows separate employment after restoration', function () {

--- a/tests/Integration/Actions/Managers/RetireActionTest.php
+++ b/tests/Integration/Actions/Managers/RetireActionTest.php
@@ -6,6 +6,7 @@ use App\Actions\Managers\RetireAction;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
+use App\Models\Wrestlers\WrestlerManager;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -255,9 +256,10 @@ test('it preserves management history during retirement', function () {
     expect($manager->currentWrestlers)->toHaveCount(0); // Current ended
 
     // Verify the current relationship was ended with retirement date
-    $currentRelationship = $manager->wrestlers()
-        ->wherePivot('hired_at', now()->subDays(10)->toDateTimeString())
+    $currentRelationship = WrestlerManager::query()
+        ->whereBelongsTo($manager)
+        ->where('hired_at', now()->subDays(10))
         ->firstOrFail();
 
-    expect(relatedPivotAttribute($currentRelationship, 'fired_at'))->toBe(now()->toDateTimeString());
+    expect(requiredDate($currentRelationship->fired_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 });

--- a/tests/Integration/Actions/Managers/UpdateActionTest.php
+++ b/tests/Integration/Actions/Managers/UpdateActionTest.php
@@ -20,7 +20,7 @@ test('it updates a manager with new information', function () {
 
     $updateData = new ManagerData('Updated', 'Manager', null);
 
-    $result = UpdateAction::run($manager, $updateData);
+    $result = UpdateAction::make()->handle($manager, $updateData);
 
     expect($result)->toBeInstanceOf(Manager::class);
     expect($result->id)->toBe($manager->id);
@@ -43,7 +43,7 @@ test('it updates manager and creates employment when employment date is provided
     $employmentDate = now();
     $updateData = new ManagerData('John', 'Updated', $employmentDate);
 
-    $result = UpdateAction::run($manager, $updateData);
+    $result = UpdateAction::make()->handle($manager, $updateData);
 
     expect($result->last_name)->toBe('Updated');
     expect($result->isEmployed())->toBeTrue();
@@ -71,7 +71,7 @@ test('it updates manager without affecting existing employment', function () {
 
     $updateData = new ManagerData('Still', 'Employed', null);
 
-    $result = UpdateAction::run($manager, $updateData);
+    $result = UpdateAction::make()->handle($manager, $updateData);
 
     expect($result->first_name)->toBe('Still');
     expect($result->last_name)->toBe('Employed');

--- a/tests/Integration/Actions/Referees/CreateActionTest.php
+++ b/tests/Integration/Actions/Referees/CreateActionTest.php
@@ -19,7 +19,7 @@ test('it creates a referee with basic information', function () {
         employment_date: null
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Referee::class);
     expect($result->first_name)->toBe('Earl');
@@ -45,7 +45,7 @@ test('it creates a referee with employment when employment date is provided', fu
         employment_date: $employmentDate
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result->first_name)->toBe('Mike');
     expect($result->last_name)->toBe('Chioda');
@@ -73,7 +73,7 @@ test('it creates referee with proper database transactions', function () {
         employment_date: $employmentDate
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Referee::class);
     expect($result->first_name)->toBe('Charles');
@@ -102,7 +102,7 @@ test('it handles employment creation through EmployAction dependency injection',
         employment_date: $employmentDate
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     // Verify the referee was created and employed using the correct architectural pattern
     expect($result->isEmployed())->toBeTrue();

--- a/tests/Integration/Actions/Referees/UpdateActionTest.php
+++ b/tests/Integration/Actions/Referees/UpdateActionTest.php
@@ -24,7 +24,7 @@ test('it updates referee basic information', function () {
         employment_date: null
     );
 
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     expect($result)->toBeInstanceOf(Referee::class);
     expect($result->first_name)->toBe('Updated');
@@ -49,7 +49,7 @@ test('it updates referee and employs them when employment date provided', functi
         employment_date: $employmentDate
     );
 
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     $result->refresh();
     expect($result->first_name)->toBe('Earl');
@@ -75,7 +75,7 @@ test('it updates referee without employing when no employment date', function ()
         employment_date: null
     );
 
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     $result->refresh();
     expect($result->first_name)->toBe('Mike');
@@ -100,7 +100,7 @@ test('it does not re-employ already employed referee', function () {
         employment_date: now()
     );
 
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     $result->refresh();
     expect($result->first_name)->toBe('Updated');
@@ -121,7 +121,7 @@ test('it handles DateHelper date resolution for employment', function () {
         employment_date: now()->subDays(10) // Past date
     );
 
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     $result->refresh();
     expect($result->isEmployed())->toBeTrue();
@@ -144,7 +144,7 @@ test('it maintains transaction boundaries', function () {
     );
 
     // Simulate transaction - all changes should be atomic
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     $result->refresh();
 
@@ -170,7 +170,7 @@ test('it returns updated referee instance', function () {
         employment_date: null
     );
 
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     expect($result)->toBeInstanceOf(Referee::class);
     expect($result->id)->toBe($referee->id);
@@ -189,7 +189,7 @@ test('it preserves referee id and timestamps', function () {
         employment_date: null
     );
 
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     expect($result->id)->toBe($originalId);
     expect(requiredDate($result->created_at)->timestamp)->toBe(requiredDate($originalCreatedAt)->timestamp);
@@ -206,7 +206,7 @@ test('it validates referee can be updated', function () {
     );
 
     // Should succeed without throwing validation exception
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     expect($result)->toBeInstanceOf(Referee::class);
     expect($result->first_name)->toBe('Valid');
@@ -223,7 +223,7 @@ test('it uses EmployAction for consistent employment handling', function () {
         employment_date: $employmentDate
     );
 
-    $result = UpdateAction::run($referee, $updateData);
+    $result = UpdateAction::make()->handle($referee, $updateData);
 
     // Verify the referee was employed using the correct architectural pattern
     expect($result->isEmployed())->toBeTrue();

--- a/tests/Integration/Actions/Stables/RetireActionTest.php
+++ b/tests/Integration/Actions/Stables/RetireActionTest.php
@@ -5,7 +5,8 @@ declare(strict_types=1);
 use App\Actions\Stables\RetireAction;
 use App\Exceptions\Roster\Stables\CannotBeRetiredException;
 use App\Models\Stables\Stable;
-use Illuminate\Support\Carbon;
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -59,12 +60,22 @@ test('it records a future retirement date while ending current operations now', 
     expect(requiredDate($stable->activityPeriods()->latest('id')->firstOrFail()->ended_at)->toDateTimeString())->toBe(now()->toDateTimeString());
 
     foreach ($stable->previousWrestlers as $wrestler) {
-        expect(Carbon::parse(relatedPivotAttribute($wrestler, 'left_at'))->toDateTimeString())
+        $membership = StableWrestler::query()
+            ->whereBelongsTo($stable)
+            ->whereBelongsTo($wrestler)
+            ->firstOrFail();
+
+        expect(requiredDate($membership->left_at)->toDateTimeString())
             ->toBe(now()->toDateTimeString());
     }
 
     foreach ($stable->previousTagTeams as $tagTeam) {
-        expect(Carbon::parse(relatedPivotAttribute($tagTeam, 'left_at'))->toDateTimeString())
+        $membership = StableTagTeam::query()
+            ->whereBelongsTo($stable)
+            ->whereBelongsTo($tagTeam, 'tagTeam')
+            ->firstOrFail();
+
+        expect(requiredDate($membership->left_at)->toDateTimeString())
             ->toBe(now()->toDateTimeString());
     }
 });

--- a/tests/Integration/Actions/Stables/SplitStableActionTest.php
+++ b/tests/Integration/Actions/Stables/SplitStableActionTest.php
@@ -7,6 +7,8 @@ use App\Data\Stables\StableMembershipData;
 use App\Enums\Shared\EmploymentStatus;
 use App\Exceptions\Roster\Stables\CannotBeSplitException;
 use App\Models\Stables\Stable;
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Carbon;
@@ -64,7 +66,7 @@ describe('SplitStableAction Integration Tests', function () {
             $initialTagTeamCount = $this->originalStable->currentTagTeams()->count();
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -94,7 +96,7 @@ describe('SplitStableAction Integration Tests', function () {
             $transferTagTeamIds = $this->transferTagTeams->pluck('id');
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -123,7 +125,7 @@ describe('SplitStableAction Integration Tests', function () {
             $splitDate = Carbon::now();
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -135,13 +137,21 @@ describe('SplitStableAction Integration Tests', function () {
             $newStableTagTeams = $newStable->tagTeams()->get();
 
             foreach ($newStableWrestlers as $wrestler) {
-                expect($wrestler->pivot->joined_at)->not()->toBeNull();
-                expect(Carbon::parse($wrestler->pivot->joined_at)->gte($splitDate->subSecond()))->toBeTrue();
+                $membership = StableWrestler::query()
+                    ->whereBelongsTo($newStable)
+                    ->whereBelongsTo($wrestler)
+                    ->firstOrFail();
+
+                expect($membership->joined_at->gte($splitDate->subSecond()))->toBeTrue();
             }
 
             foreach ($newStableTagTeams as $tagTeam) {
-                expect($tagTeam->pivot->joined_at)->not()->toBeNull();
-                expect(Carbon::parse($tagTeam->pivot->joined_at)->gte($splitDate->subSecond()))->toBeTrue();
+                $membership = StableTagTeam::query()
+                    ->whereBelongsTo($newStable)
+                    ->whereBelongsTo($tagTeam, 'tagTeam')
+                    ->firstOrFail();
+
+                expect($membership->joined_at->gte($splitDate->subSecond()))->toBeTrue();
             }
 
             // Verify original stable memberships were ended properly
@@ -160,7 +170,7 @@ describe('SplitStableAction Integration Tests', function () {
             $initialTagTeamCount = $this->originalStable->currentTagTeams()->count();
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -186,7 +196,7 @@ describe('SplitStableAction Integration Tests', function () {
                 wrestlers: $this->transferWrestlers,
             );
 
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $membersForSplit,
@@ -210,7 +220,7 @@ describe('SplitStableAction Integration Tests', function () {
                 tagTeams: $this->transferTagTeams,
             );
 
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $membersForSplit,
@@ -230,7 +240,7 @@ describe('SplitStableAction Integration Tests', function () {
             $splitDate = Carbon::now();
 
             // Split with mixed member types
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -254,7 +264,7 @@ describe('SplitStableAction Integration Tests', function () {
 
             $membersForSplit = new StableMembershipData();
 
-            expect(fn () => SplitStableAction::run(
+            expect(fn () => SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $membersForSplit,
@@ -275,7 +285,7 @@ describe('SplitStableAction Integration Tests', function () {
                 tagTeams: $this->tagTeams,
             );
 
-            expect(fn () => SplitStableAction::run(
+            expect(fn () => SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $membersForSplit,
@@ -303,7 +313,7 @@ describe('SplitStableAction Integration Tests', function () {
                 tagTeams: $this->transferTagTeams,
             );
 
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $membersForSplit,
@@ -322,7 +332,7 @@ describe('SplitStableAction Integration Tests', function () {
             $splitDate = Carbon::now();
 
             // Expect validation exception
-            expect(fn () => SplitStableAction::run(
+            expect(fn () => SplitStableAction::make()->handle(
                 $retiredStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -336,7 +346,7 @@ describe('SplitStableAction Integration Tests', function () {
             $splitDate = Carbon::now();
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -361,7 +371,7 @@ describe('SplitStableAction Integration Tests', function () {
             Stable::factory()->create(['name' => $this->newStableName]);
 
             // Try to split with duplicate name
-            expect(fn () => SplitStableAction::run(
+            expect(fn () => SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -378,7 +388,7 @@ describe('SplitStableAction Integration Tests', function () {
             $initialStableCount = Stable::count();
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -401,7 +411,7 @@ describe('SplitStableAction Integration Tests', function () {
 
             // For now, verify that normal split doesn't affect counts negatively
             try {
-                $newStable = SplitStableAction::run(
+                $newStable = SplitStableAction::make()->handle(
                     $this->originalStable,
                     $this->newStableName,
                     $this->membersForNewStable,
@@ -423,7 +433,7 @@ describe('SplitStableAction Integration Tests', function () {
             $splitDate = Carbon::now();
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -445,7 +455,7 @@ describe('SplitStableAction Integration Tests', function () {
             $splitDate = Carbon::now();
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -475,7 +485,7 @@ describe('SplitStableAction Integration Tests', function () {
             $originalTagTeamIds = $this->transferTagTeams->pluck('id');
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,
@@ -496,7 +506,7 @@ describe('SplitStableAction Integration Tests', function () {
             $splitDate = Carbon::now();
 
             // Execute split
-            $newStable = SplitStableAction::run(
+            $newStable = SplitStableAction::make()->handle(
                 $this->originalStable,
                 $this->newStableName,
                 $this->membersForNewStable,

--- a/tests/Integration/Actions/Stables/SplitStableActionTest.php
+++ b/tests/Integration/Actions/Stables/SplitStableActionTest.php
@@ -135,6 +135,7 @@ describe('SplitStableAction Integration Tests', function () {
             // Verify new stable memberships have correct join dates
             $newStableWrestlers = $newStable->wrestlers()->get();
             $newStableTagTeams = $newStable->tagTeams()->get();
+            $membershipCutoff = $splitDate->copy()->subSecond();
 
             foreach ($newStableWrestlers as $wrestler) {
                 $membership = StableWrestler::query()
@@ -142,7 +143,7 @@ describe('SplitStableAction Integration Tests', function () {
                     ->whereBelongsTo($wrestler)
                     ->firstOrFail();
 
-                expect($membership->joined_at->gte($splitDate->subSecond()))->toBeTrue();
+                expect($membership->joined_at->gte($membershipCutoff))->toBeTrue();
             }
 
             foreach ($newStableTagTeams as $tagTeam) {
@@ -151,7 +152,7 @@ describe('SplitStableAction Integration Tests', function () {
                     ->whereBelongsTo($tagTeam, 'tagTeam')
                     ->firstOrFail();
 
-                expect($membership->joined_at->gte($splitDate->subSecond()))->toBeTrue();
+                expect($membership->joined_at->gte($membershipCutoff))->toBeTrue();
             }
 
             // Verify original stable memberships were ended properly

--- a/tests/Integration/Actions/TagTeams/CreateActionTest.php
+++ b/tests/Integration/Actions/TagTeams/CreateActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\TagTeams\CreateAction;
 use App\Data\TagTeams\TagTeamData;
 use App\Models\TagTeams\TagTeam;
+use App\Models\TagTeams\TagTeamWrestler;
 use App\Models\Wrestlers\Wrestler;
 
 test('it creates a new tag team', function () {
@@ -19,9 +20,8 @@ test('it creates a new tag team', function () {
         wrestlerB: $wrestlerB,
     );
 
-    $tagTeam = CreateAction::run($data);
+    $tagTeam = CreateAction::make()->handle($data);
 
-    expect($tagTeam)->not()->toBeNull();
     expect($tagTeam->name)->toBe('The Test Team');
     expect($tagTeam->signature_move)->toBe('Double Suplex');
 
@@ -44,9 +44,8 @@ test('it creates tag team with minimal data', function () {
         wrestlerB: $wrestlerB,
     );
 
-    $tagTeam = CreateAction::run($data);
+    $tagTeam = CreateAction::make()->handle($data);
 
-    expect($tagTeam)->not()->toBeNull();
     expect($tagTeam->name)->toBe('Minimal Team');
     expect($tagTeam->signature_move)->toBeNull();
 
@@ -68,7 +67,7 @@ test('it creates partnerships for both wrestlers', function () {
         wrestlerB: $wrestlerB,
     );
 
-    $tagTeam = CreateAction::run($data);
+    $tagTeam = CreateAction::make()->handle($data);
 
     // Verify partnerships were created
     $this->assertDatabaseHas('tag_teams_wrestlers', [
@@ -98,7 +97,7 @@ test('it handles database transactions correctly', function () {
         wrestlerB: $wrestlerB,
     );
 
-    $tagTeam = CreateAction::run($data);
+    $tagTeam = CreateAction::make()->handle($data);
 
     expect($tagTeam->exists)->toBeTrue();
     expect($tagTeam->wrestlers()->count())->toBe(2);
@@ -120,7 +119,7 @@ test('it prevents creating tag team with same wrestler twice', function () {
         wrestlerB: $wrestler,
     );
 
-    expect(fn () => CreateAction::run($data))
+    expect(fn () => CreateAction::make()->handle($data))
         ->toThrow(Exception::class);
 });
 
@@ -133,7 +132,7 @@ test('it prevents creating tag team with missing wrestlers', function () {
         wrestlerB: null,
     );
 
-    expect(fn () => CreateAction::run($data))
+    expect(fn () => CreateAction::make()->handle($data))
         ->toThrow(Exception::class);
 });
 
@@ -149,7 +148,7 @@ test('it validates required name', function () {
         wrestlerB: $wrestlerB,
     );
 
-    expect(fn () => CreateAction::run($data))
+    expect(fn () => CreateAction::make()->handle($data))
         ->toThrow(Exception::class);
 });
 
@@ -165,7 +164,7 @@ test('it creates tag team with all optional fields', function () {
         wrestlerB: $wrestlerB,
     );
 
-    $tagTeam = CreateAction::run($data);
+    $tagTeam = CreateAction::make()->handle($data);
 
     expect($tagTeam->name)->toBe('Full Data Team');
     expect($tagTeam->signature_move)->toBe('Ultimate Finisher');
@@ -186,7 +185,7 @@ test('it handles unique name validation', function () {
         wrestlerB: $wrestlerB,
     );
 
-    expect(fn () => CreateAction::run($data))
+    expect(fn () => CreateAction::make()->handle($data))
         ->toThrow(Exception::class);
 });
 
@@ -202,12 +201,17 @@ test('it creates partnerships with correct timestamps', function () {
         wrestlerB: $wrestlerB,
     );
 
-    $tagTeam = CreateAction::run($data);
+    $tagTeam = CreateAction::make()->handle($data);
 
     // Check partnerships have current timestamp
     $partnerships = $tagTeam->wrestlers()->get();
     foreach ($partnerships as $wrestler) {
-        expect($wrestler->pivot->joined_at)->not()->toBeNull();
-        expect($wrestler->pivot->left_at)->toBeNull();
+        $membership = TagTeamWrestler::query()
+            ->whereBelongsTo($tagTeam, 'tagTeam')
+            ->whereBelongsTo($wrestler)
+            ->firstOrFail();
+
+        expect($membership->joined_at)->not->toBeNull();
+        expect($membership->left_at)->toBeNull();
     }
 });

--- a/tests/Integration/Actions/Titles/CreateActionTest.php
+++ b/tests/Integration/Actions/Titles/CreateActionTest.php
@@ -16,7 +16,7 @@ beforeEach(function () {
 test('it creates a title', function () {
     $data = new TitleData('Example Title', TitleType::Singles, null);
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Title::class);
     expect($result->name)->toBe('Example Title');
@@ -28,7 +28,7 @@ test('it activates a title if activation date is filled in request', function ()
     $datetime = now();
     $data = new TitleData('Example Title', TitleType::Singles, $datetime);
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Title::class);
     expect($result->name)->toBe('Example Title');

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -41,7 +41,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '12345'
             );
 
-            $venue = CreateAction::run($venueData);
+            $venue = CreateAction::make()->handle($venueData);
 
             expect($venue)->toBeInstanceOf(Venue::class);
             expect($venue->name)->toBe('Integration Test Arena');
@@ -61,7 +61,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '54321'
             );
 
-            $venue = CreateAction::run($venueData);
+            $venue = CreateAction::make()->handle($venueData);
 
             $retrievedVenue = Venue::query()->whereKey($venue->getKey())->firstOrFail();
             expect($retrievedVenue->name)->toBe('Database Test Arena');
@@ -80,7 +80,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '63101'
             );
 
-            $venue = CreateAction::run($venueData);
+            $venue = CreateAction::make()->handle($venueData);
 
             expect($venue->name)->toBe('O\'Malley\'s Arena & Entertainment Center');
             expect($venue->street_address)->toBe('789 O\'Connor St.');
@@ -98,7 +98,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '10000'
             );
 
-            $venue = CreateAction::run($venueData);
+            $venue = CreateAction::make()->handle($venueData);
 
             expect($venue->name)->toBe('Minimal Arena');
             expect($venue->street_address)->toBe('100 Basic St');
@@ -123,7 +123,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: $venue->zipcode
             );
 
-            $updatedVenue = UpdateAction::run($venue, $venueData);
+            $updatedVenue = UpdateAction::make()->handle($venue, $venueData);
 
             expect($updatedVenue->name)->toBe('Updated Arena');
             expect($updatedVenue->city)->toBe('Updated City');
@@ -144,7 +144,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: $venue->zipcode
             );
 
-            UpdateAction::run($venue, $venueData);
+            UpdateAction::make()->handle($venue, $venueData);
 
             $retrievedVenue = Venue::findOrFail($venue->id);
             expect($retrievedVenue->name)->toBe('Database Updated');
@@ -167,7 +167,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '54321'
             );
 
-            $updatedVenue = UpdateAction::run($venue, $venueData);
+            $updatedVenue = UpdateAction::make()->handle($venue, $venueData);
 
             expect($updatedVenue->street_address)->toBe('456 New Avenue');
             expect($updatedVenue->city)->toBe('New City');
@@ -187,7 +187,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: $venue->zipcode
             );
 
-            $updatedVenue = UpdateAction::run($venue, $venueData);
+            $updatedVenue = UpdateAction::make()->handle($venue, $venueData);
 
             expect($updatedVenue->events->pluck('id'))->toContain($event->id);
             expect(freshModel($event)->venue_id)->toBe($venue->id);
@@ -198,7 +198,7 @@ describe('Venue Action Integration Tests', function () {
         test('delete action soft deletes venue', function () {
             $venue = Venue::factory()->create(['name' => 'Deletion Test Arena']);
 
-            DeleteAction::run($venue);
+            DeleteAction::make()->handle($venue);
 
             expect(Venue::find($venue->id))->toBeNull();
             expect(Venue::onlyTrashed()->find($venue->id))->not()->toBeNull();
@@ -208,7 +208,7 @@ describe('Venue Action Integration Tests', function () {
             $venue = Venue::factory()->create();
             $event = Event::factory()->atVenue($venue)->create();
 
-            DeleteAction::run($venue);
+            DeleteAction::make()->handle($venue);
 
             expect(freshModel($event)->venue_id)->toBe($venue->id);
             expect(freshModel($event)->venue)->toBeNull(); // Soft deleted venue
@@ -219,7 +219,7 @@ describe('Venue Action Integration Tests', function () {
             $event1 = Event::factory()->atVenue($venue)->create(['name' => 'Event 1']);
             $event2 = Event::factory()->atVenue($venue)->create(['name' => 'Event 2']);
 
-            DeleteAction::run($venue);
+            DeleteAction::make()->handle($venue);
 
             expect(Venue::find($venue->id))->toBeNull();
             expect(freshModel($event1)->venue_id)->toBe($venue->id);
@@ -229,7 +229,7 @@ describe('Venue Action Integration Tests', function () {
         test('delete action handles venue without events', function () {
             $venue = Venue::factory()->create(['name' => 'No Events Arena']);
 
-            DeleteAction::run($venue);
+            DeleteAction::make()->handle($venue);
 
             expect(Venue::find($venue->id))->toBeNull();
             expect(Venue::onlyTrashed()->find($venue->id))->not()->toBeNull();
@@ -245,7 +245,7 @@ describe('Venue Action Integration Tests', function () {
             expect(Venue::find($venueId))->toBeNull();
 
             $deletedVenue = Venue::onlyTrashed()->findOrFail($venueId);
-            RestoreAction::run($deletedVenue);
+            RestoreAction::make()->handle($deletedVenue);
 
             $restoredVenue = Venue::findOrFail($venueId);
             expect($restoredVenue->name)->toBe('Restoration Test Arena');
@@ -257,7 +257,7 @@ describe('Venue Action Integration Tests', function () {
 
             $venue->delete();
             $deletedVenue = Venue::onlyTrashed()->findOrFail($venue->id);
-            RestoreAction::run($deletedVenue);
+            RestoreAction::make()->handle($deletedVenue);
 
             $restoredVenue = Venue::findOrFail($venue->id);
             expect($restoredVenue->events->pluck('id'))->toContain($event->id);
@@ -277,7 +277,7 @@ describe('Venue Action Integration Tests', function () {
 
             $venue->delete();
             $deletedVenue = Venue::onlyTrashed()->findOrFail($venue->id);
-            RestoreAction::run($deletedVenue);
+            RestoreAction::make()->handle($deletedVenue);
 
             $restoredVenue = Venue::findOrFail($venue->id);
             $restoredVenue->load(['events', 'previousEvents']);
@@ -298,7 +298,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '12345'
             );
 
-            $venue = CreateAction::run($venueData);
+            $venue = CreateAction::make()->handle($venueData);
             $event = Event::factory()->create(['venue_id' => $venue->id]);
 
             $venue->refresh();
@@ -318,7 +318,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: $venue->zipcode
             );
 
-            $updatedVenue = UpdateAction::run($venue, $venueData);
+            $updatedVenue = UpdateAction::make()->handle($venue, $venueData);
 
             expect($updatedVenue->events->pluck('id'))->toContain($event1->id);
             expect($updatedVenue->events->pluck('id'))->toContain($event2->id);
@@ -328,7 +328,7 @@ describe('Venue Action Integration Tests', function () {
             $venue = Venue::factory()->create();
             $event = Event::factory()->atVenue($venue)->create(['name' => 'Preserved Event']);
 
-            DeleteAction::run($venue);
+            DeleteAction::make()->handle($venue);
 
             expect(Event::find($event->id))->not()->toBeNull();
             expect(freshModel($event)->venue_id)->toBe($venue->id);
@@ -345,7 +345,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '12345'
             );
 
-            $venue = CreateAction::run($venueData);
+            $venue = CreateAction::make()->handle($venueData);
 
             expect($venue->name)->not->toBeEmpty();
             expect($venue->street_address)->not->toBeEmpty();
@@ -365,7 +365,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '54321'
             );
 
-            $updatedVenue = UpdateAction::run($venue, $venueData);
+            $updatedVenue = UpdateAction::make()->handle($venue, $venueData);
 
             expect($updatedVenue->name)->toBe('Updated Validation Arena');
             expect($updatedVenue->street_address)->toBe('456 Updated St');
@@ -385,7 +385,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: '12345'
             );
 
-            $venue = CreateAction::run($venueData);
+            $venue = CreateAction::make()->handle($venueData);
 
             expect($venue->created_at)->not()->toBeNull();
             expect($venue->updated_at)->not()->toBeNull();
@@ -407,7 +407,7 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: $venue->zipcode
             );
 
-            $updatedVenue = UpdateAction::run($venue, $venueData);
+            $updatedVenue = UpdateAction::make()->handle($venue, $venueData);
 
             // Verify the name actually changed to confirm update happened
             expect($updatedVenue->name)->toBe('Timestamp Updated Arena');
@@ -433,8 +433,8 @@ describe('Venue Action Integration Tests', function () {
                 zipcode: $venue->zipcode
             );
 
-            $updatedVenue1 = UpdateAction::run($venue, $venueData1);
-            $updatedVenue2 = UpdateAction::run(freshModel($venue), $venueData2);
+            $updatedVenue1 = UpdateAction::make()->handle($venue, $venueData1);
+            $updatedVenue2 = UpdateAction::make()->handle(freshModel($venue), $venueData2);
 
             expect($updatedVenue2->name)->toBe('Concurrent Update 2');
         });

--- a/tests/Integration/Actions/Wrestlers/CreateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/CreateActionTest.php
@@ -23,7 +23,7 @@ test('it creates a wrestler with basic information', function () {
         employment_date: null
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Wrestler::class);
     expect($result->name)->toBe('John Cena');
@@ -58,7 +58,7 @@ test('it creates a wrestler with employment when employment date is provided', f
         employment_date: $employmentDate
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result->name)->toBe('The Rock');
     expect($result->isEmployed())->toBeTrue();
@@ -90,7 +90,7 @@ test('it creates wrestler with all optional fields', function () {
         employment_date: $employmentDate
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result)->toBeInstanceOf(Wrestler::class);
     expect($result->name)->toBe('Stone Cold Steve Austin');
@@ -126,7 +126,7 @@ test('it handles height conversion correctly', function () {
         employment_date: null
     );
 
-    $result = CreateAction::run($data);
+    $result = CreateAction::make()->handle($data);
 
     expect($result->height)->toBeInstanceOf(Height::class);
     expect($result->height->feet)->toBe(5);

--- a/tests/Integration/Actions/Wrestlers/UpdateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/UpdateActionTest.php
@@ -32,7 +32,7 @@ test('it updates wrestler basic information', function () {
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     expect($result)->toBeInstanceOf(Wrestler::class);
     expect($result->name)->toBe('Updated Name');
@@ -67,7 +67,7 @@ test('it updates wrestler and employs them when employment date provided', funct
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     $result->refresh();
     expect($result->name)->toBe('John Cena');
@@ -96,7 +96,7 @@ test('it updates wrestler without employing when no employment date', function (
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     $result->refresh();
     expect($result->name)->toBe('The Rock');
@@ -124,7 +124,7 @@ test('it does not re-employ already employed wrestler', function () {
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     $result->refresh();
     expect($result->name)->toBe('Updated Name');
@@ -159,7 +159,7 @@ test('it employs managers when wrestler gets employed', function () {
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     $result->refresh();
     $manager1->refresh();
@@ -196,7 +196,7 @@ test('it handles DateHelper date resolution for employment', function () {
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     $result->refresh();
     expect($result->isEmployed())->toBeTrue();
@@ -223,7 +223,7 @@ test('it maintains transaction boundaries', function () {
     );
 
     // Simulate transaction - all changes should be atomic
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     $result->refresh();
 
@@ -252,7 +252,7 @@ test('it returns updated wrestler instance', function () {
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     expect($result)->toBeInstanceOf(Wrestler::class);
     expect($result->id)->toBe($wrestler->id);
@@ -274,7 +274,7 @@ test('it handles height conversion correctly', function () {
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     expect($result->height->feet)->toBe(5);
     expect($result->height->inches)->toBe(11);
@@ -296,7 +296,7 @@ test('it preserves wrestler id and timestamps', function () {
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     expect($result->id)->toBe($originalId);
     expect(requiredDate($result->created_at)->timestamp)->toBe(requiredDate($originalCreatedAt)->timestamp);
@@ -316,7 +316,7 @@ test('it handles null signature move', function () {
         managers: null
     );
 
-    $result = UpdateAction::run($wrestler, $updateData);
+    $result = UpdateAction::make()->handle($wrestler, $updateData);
 
     expect($result->signature_move)->toBeNull();
 

--- a/tests/Integration/Builders/TitleChampionshipQueryBuilderTest.php
+++ b/tests/Integration/Builders/TitleChampionshipQueryBuilderTest.php
@@ -187,9 +187,11 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             expect($championships->firstOrFail()->id)->toBe(requiredModel($this->currentChampionship)->id);
 
             // Verify ordering
-            $wonDates = $championships->pluck('won_at');
+            $wonDates = $championships->map(
+                fn (TitleChampionship $championship): Carbon => requiredDate($championship->won_at)
+            )->values();
             for ($i = 0; $i < $wonDates->count() - 1; $i++) {
-                expect($wonDates[$i]->gte($wonDates[$i + 1]))->toBeTrue();
+                expect(requiredDate($wonDates->get($i))->gte(requiredDate($wonDates->get($i + 1))))->toBeTrue();
             }
         });
 
@@ -203,9 +205,11 @@ describe('TitleChampionshipBuilder Unit Tests', function () {
             expect($endedChampionships->firstOrFail()->id)->toBe($this->recentEndedChampionship->id);
 
             // Verify ordering for ended championships
-            $lostDates = $endedChampionships->pluck('lost_at');
+            $lostDates = $endedChampionships->map(
+                fn (TitleChampionship $championship): Carbon => requiredDate($championship->lost_at)
+            )->values();
             for ($i = 0; $i < $lostDates->count() - 1; $i++) {
-                expect($lostDates[$i]->gte($lostDates[$i + 1]))->toBeTrue();
+                expect(requiredDate($lostDates->get($i))->gte(requiredDate($lostDates->get($i + 1))))->toBeTrue();
             }
         });
 

--- a/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
+++ b/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
@@ -138,7 +138,6 @@ describe('VenueForm Integration Tests', function () {
         });
 
         test('getModelData transforms complete venue data correctly', function () {
-            // Set complete test data
             $this->form->name = 'Madison Square Garden';
             $this->form->street_address = '4 Pennsylvania Plaza';
             $this->form->city = 'New York';
@@ -187,7 +186,6 @@ describe('VenueForm Integration Tests', function () {
         test('validates US ZIP code format specifically', function () {
             $rules = $this->form->rulesForTesting();
 
-            // Should enforce exactly 5 digits for US postal codes
             expect($rules['zipcode'])->toContain('digits:5');
         });
 

--- a/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
+++ b/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
@@ -12,6 +12,41 @@ use Illuminate\Validation\Rules\Unique;
 use JMac\Testing\Double;
 use Livewire\Component;
 
+final class VenueFormTestProxy extends CreateEditForm
+{
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rulesForTesting(): array
+    {
+        return $this->rules();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function modelDataForTesting(): array
+    {
+        return $this->getModelData();
+    }
+
+    /**
+     * @return class-string<Venue>
+     */
+    public function modelClassForTesting(): string
+    {
+        return $this->getModelClass();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function validationAttributesForTesting(): array
+    {
+        return $this->validationAttributes();
+    }
+}
+
 /**
  * Integration tests for VenueForm component validation and behavior.
  *
@@ -31,14 +66,12 @@ use Livewire\Component;
 describe('VenueForm Integration Tests', function () {
     beforeEach(function () {
         $mockComponent = Double::for(Component::class);
-        $this->form = new CreateEditForm($mockComponent, 'form');
+        $this->form = new VenueFormTestProxy($mockComponent, 'form');
     });
 
     describe('validation rules configuration', function () {
         test('rules method returns complete address validation structure', function () {
-            $reflection = new ReflectionMethod($this->form, 'rules');
-            $reflection->setAccessible(true);
-            $rules = $reflection->invoke($this->form);
+            $rules = $this->form->rulesForTesting();
 
             expect($rules)->toBeArray();
             expect($rules)->toHaveKeys([
@@ -47,9 +80,7 @@ describe('VenueForm Integration Tests', function () {
         });
 
         test('venue name validation includes uniqueness constraint', function () {
-            $reflection = new ReflectionMethod($this->form, 'rules');
-            $reflection->setAccessible(true);
-            $rules = $reflection->invoke($this->form);
+            $rules = $this->form->rulesForTesting();
 
             expect($rules['name'])->toContain('required');
             expect($rules['name'])->toContain('string');
@@ -57,9 +88,6 @@ describe('VenueForm Integration Tests', function () {
 
             // Should contain Rule::unique validation for venues table
             $nameRules = $rules['name'];
-            if (! is_array($nameRules)) {
-                throw new UnexpectedValueException('Venue name rules must be an array.');
-            }
 
             $hasUniqueRule = collect($nameRules)->contains(function ($rule) {
                 return $rule instanceof Unique;
@@ -68,9 +96,7 @@ describe('VenueForm Integration Tests', function () {
         });
 
         test('address validation enforces complete information', function () {
-            $reflection = new ReflectionMethod($this->form, 'rules');
-            $reflection->setAccessible(true);
-            $rules = $reflection->invoke($this->form);
+            $rules = $this->form->rulesForTesting();
 
             // Street address validation
             expect($rules['street_address'])->toContain('required');
@@ -84,18 +110,13 @@ describe('VenueForm Integration Tests', function () {
         });
 
         test('state validation enforces database referential integrity', function () {
-            $reflection = new ReflectionMethod($this->form, 'rules');
-            $reflection->setAccessible(true);
-            $rules = $reflection->invoke($this->form);
+            $rules = $this->form->rulesForTesting();
 
             expect($rules['state'])->toContain('required');
             expect($rules['state'])->toContain('string');
 
             // Should validate against states table
             $stateRules = $rules['state'];
-            if (! is_array($stateRules)) {
-                throw new UnexpectedValueException('Venue state rules must be an array.');
-            }
 
             $hasExistsRule = collect($stateRules)->contains(function ($rule) {
                 return $rule instanceof Exists;
@@ -104,9 +125,7 @@ describe('VenueForm Integration Tests', function () {
         });
 
         test('zipcode validation enforces US postal format', function () {
-            $reflection = new ReflectionMethod($this->form, 'rules');
-            $reflection->setAccessible(true);
-            $rules = $reflection->invoke($this->form);
+            $rules = $this->form->rulesForTesting();
 
             expect($rules['zipcode'])->toContain('required');
             expect($rules['zipcode'])->toContain('digits:5');
@@ -115,17 +134,10 @@ describe('VenueForm Integration Tests', function () {
 
     describe('data transformation methods', function () {
         test('getModelClass returns correct Venue class', function () {
-            $reflection = new ReflectionMethod($this->form, 'getModelClass');
-            $reflection->setAccessible(true);
-            $modelClass = $reflection->invoke($this->form);
-
-            expect($modelClass)->toBe(Venue::class);
+            expect($this->form->modelClassForTesting())->toBe(Venue::class);
         });
 
         test('getModelData transforms complete venue data correctly', function () {
-            $reflection = new ReflectionMethod($this->form, 'getModelData');
-            $reflection->setAccessible(true);
-
             // Set complete test data
             $this->form->name = 'Madison Square Garden';
             $this->form->street_address = '4 Pennsylvania Plaza';
@@ -133,7 +145,7 @@ describe('VenueForm Integration Tests', function () {
             $this->form->state = 'New York';
             $this->form->zipcode = '10001';
 
-            $data = $reflection->invoke($this->form);
+            $data = $this->form->modelDataForTesting();
 
             expect($data)->toBeArray();
             expect($data)->toHaveKeys([
@@ -149,9 +161,7 @@ describe('VenueForm Integration Tests', function () {
 
     describe('validation attributes customization', function () {
         test('validationAttributes provides readable field names', function () {
-            $reflection = new ReflectionMethod($this->form, 'validationAttributes');
-            $reflection->setAccessible(true);
-            $attributes = $reflection->invoke($this->form);
+            $attributes = $this->form->validationAttributesForTesting();
 
             expect($attributes)->toBeArray();
             expect($attributes)->toHaveKeys(['street_address', 'zipcode']);
@@ -162,15 +172,10 @@ describe('VenueForm Integration Tests', function () {
 
     describe('business logic validation', function () {
         test('enforces venue name uniqueness across all venues', function () {
-            $reflection = new ReflectionMethod($this->form, 'rules');
-            $reflection->setAccessible(true);
-            $rules = $reflection->invoke($this->form);
+            $rules = $this->form->rulesForTesting();
 
             // Check that unique rule is configured for venues table
             $nameRules = $rules['name'];
-            if (! is_array($nameRules)) {
-                throw new UnexpectedValueException('Venue name rules must be an array.');
-            }
 
             $uniqueRule = collect($nameRules)->first(function ($rule) {
                 return $rule instanceof Unique;
@@ -180,24 +185,17 @@ describe('VenueForm Integration Tests', function () {
         });
 
         test('validates US ZIP code format specifically', function () {
-            $reflection = new ReflectionMethod($this->form, 'rules');
-            $reflection->setAccessible(true);
-            $rules = $reflection->invoke($this->form);
+            $rules = $this->form->rulesForTesting();
 
             // Should enforce exactly 5 digits for US postal codes
             expect($rules['zipcode'])->toContain('digits:5');
         });
 
         test('validates state against existing state records', function () {
-            $reflection = new ReflectionMethod($this->form, 'rules');
-            $reflection->setAccessible(true);
-            $rules = $reflection->invoke($this->form);
+            $rules = $this->form->rulesForTesting();
 
             // Should validate that state exists in states table
             $stateRules = $rules['state'];
-            if (! is_array($stateRules)) {
-                throw new UnexpectedValueException('Venue state rules must be an array.');
-            }
 
             $existsRule = collect($stateRules)->first(function ($rule) {
                 return $rule instanceof Exists;

--- a/tests/Integration/Models/Stables/StableTagTeamTest.php
+++ b/tests/Integration/Models/Stables/StableTagTeamTest.php
@@ -122,8 +122,12 @@ describe('StableTagTeam Pivot Model', function () {
             // Verify current stable is correct
             $currentStable = requiredModel($this->tagTeam->currentStable);
             expect($currentStable->id)->toBe($this->secondStable->id);
-            expect(Carbon::parse(relatedPivotAttribute($currentStable, 'joined_at'))->format('Y-m-d H:i:s'))->toBe($secondPeriodStart->format('Y-m-d H:i:s'));
-            expect(relatedPivotAttribute($currentStable, 'left_at'))->toBeNull();
+            $currentMembership = StableTagTeam::query()
+                ->whereBelongsTo($currentStable)
+                ->whereBelongsTo($this->tagTeam, 'tagTeam')
+                ->firstOrFail();
+            expect($currentMembership->joined_at->format('Y-m-d H:i:s'))->toBe($secondPeriodStart->format('Y-m-d H:i:s'));
+            expect($currentMembership->left_at)->toBeNull();
 
             // Verify previous stable is correct
             $previousStable = $this->tagTeam->previousStables()->firstOrFail();
@@ -243,7 +247,11 @@ describe('StableTagTeam Pivot Model', function () {
             $currentStable = requiredModel($this->tagTeam->currentStable);
 
             expect($currentStable->id)->toBe($this->secondStable->id);
-            expect(relatedPivotAttribute($currentStable, 'left_at'))->toBeNull();
+            $membership = StableTagTeam::query()
+                ->whereBelongsTo($currentStable)
+                ->whereBelongsTo($this->tagTeam, 'tagTeam')
+                ->firstOrFail();
+            expect($membership->left_at)->toBeNull();
         });
 
         test('previous stables query returns only completed relationships', function () {
@@ -251,7 +259,11 @@ describe('StableTagTeam Pivot Model', function () {
 
             expect($previousStables)->toHaveCount(1);
             expect($previousStables->firstOrFail()->id)->toBe($this->stable->id);
-            expect(relatedPivotAttribute($previousStables->firstOrFail(), 'left_at'))->not()->toBeNull();
+            $membership = StableTagTeam::query()
+                ->whereBelongsTo($this->stable)
+                ->whereBelongsTo($this->tagTeam, 'tagTeam')
+                ->firstOrFail();
+            expect($membership->left_at)->not->toBeNull();
         });
 
         test('all stables query returns complete membership history', function () {

--- a/tests/Integration/Models/Stables/StableWrestlerTest.php
+++ b/tests/Integration/Models/Stables/StableWrestlerTest.php
@@ -124,8 +124,12 @@ describe('StableWrestler Pivot Model', function () {
             // Verify current stable is correct
             $currentStable = requiredModel($this->wrestler->currentStable);
             expect($currentStable->id)->toBe($this->secondStable->id);
-            expect(Carbon::parse(relatedPivotAttribute($currentStable, 'joined_at'))->format('Y-m-d H:i:s'))->toBe($secondPeriodStart->format('Y-m-d H:i:s'));
-            expect(relatedPivotAttribute($currentStable, 'left_at'))->toBeNull();
+            $currentMembership = StableWrestler::query()
+                ->whereBelongsTo($currentStable)
+                ->whereBelongsTo($this->wrestler)
+                ->firstOrFail();
+            expect($currentMembership->joined_at->format('Y-m-d H:i:s'))->toBe($secondPeriodStart->format('Y-m-d H:i:s'));
+            expect($currentMembership->left_at)->toBeNull();
 
             // Verify previous stable is correct
             $previousStable = $this->wrestler->previousStables()->firstOrFail();
@@ -245,7 +249,11 @@ describe('StableWrestler Pivot Model', function () {
             $currentStable = requiredModel($this->wrestler->currentStable);
 
             expect($currentStable->id)->toBe($this->secondStable->id);
-            expect(relatedPivotAttribute($currentStable, 'left_at'))->toBeNull();
+            $membership = StableWrestler::query()
+                ->whereBelongsTo($currentStable)
+                ->whereBelongsTo($this->wrestler)
+                ->firstOrFail();
+            expect($membership->left_at)->toBeNull();
         });
 
         test('previous stables query returns only completed relationships', function () {
@@ -253,7 +261,11 @@ describe('StableWrestler Pivot Model', function () {
 
             expect($previousStables)->toHaveCount(1);
             expect($previousStables->firstOrFail()->id)->toBe($this->stable->id);
-            expect(relatedPivotAttribute($previousStables->firstOrFail(), 'left_at'))->not()->toBeNull();
+            $membership = StableWrestler::query()
+                ->whereBelongsTo($this->stable)
+                ->whereBelongsTo($this->wrestler)
+                ->firstOrFail();
+            expect($membership->left_at)->not->toBeNull();
         });
 
         test('all stables query returns complete membership history', function () {

--- a/tests/Integration/Models/TagTeams/TagTeamWrestlerTest.php
+++ b/tests/Integration/Models/TagTeams/TagTeamWrestlerTest.php
@@ -118,7 +118,11 @@ describe('TagTeamWrestler Pivot Model', function () {
             // Verify current tag team is correct
             $currentTagTeam = requiredModel($this->wrestler->currentTagTeam);
             expect($currentTagTeam->id)->toBe($this->secondTagTeam->id);
-            expect(relatedPivotAttribute($currentTagTeam, 'left_at'))->toBeNull();
+            $currentMembership = TagTeamWrestler::query()
+                ->whereBelongsTo($currentTagTeam, 'tagTeam')
+                ->whereBelongsTo($this->wrestler)
+                ->firstOrFail();
+            expect($currentMembership->left_at)->toBeNull();
 
             // Verify previous tag team is correct
             $previousTagTeam = $this->wrestler->previousTagTeams()->firstOrFail();
@@ -185,7 +189,11 @@ describe('TagTeamWrestler Pivot Model', function () {
             $currentTagTeam = requiredModel($this->wrestler->currentTagTeam);
 
             expect($currentTagTeam->id)->toBe($this->secondTagTeam->id);
-            expect(relatedPivotAttribute($currentTagTeam, 'left_at'))->toBeNull();
+            $membership = TagTeamWrestler::query()
+                ->whereBelongsTo($currentTagTeam, 'tagTeam')
+                ->whereBelongsTo($this->wrestler)
+                ->firstOrFail();
+            expect($membership->left_at)->toBeNull();
         });
 
         test('previous tag teams query returns only completed relationships', function () {
@@ -193,7 +201,11 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             expect($previousTagTeams)->toHaveCount(1);
             expect($previousTagTeams->firstOrFail()->id)->toBe($this->tagTeam->id);
-            expect(relatedPivotAttribute($previousTagTeams->firstOrFail(), 'left_at'))->not()->toBeNull();
+            $membership = TagTeamWrestler::query()
+                ->whereBelongsTo($this->tagTeam, 'tagTeam')
+                ->whereBelongsTo($this->wrestler)
+                ->firstOrFail();
+            expect($membership->left_at)->not->toBeNull();
         });
 
         test('all tag teams query returns complete relationship history', function () {
@@ -396,15 +408,20 @@ describe('TagTeamWrestler Pivot Model', function () {
 
             // Calculate duration of completed period
             $completedPeriod = $this->wrestler->previousTagTeams()->firstOrFail();
-            $joinedAt = Carbon::parse(relatedPivotAttribute($completedPeriod, 'joined_at'));
-            $leftAt = Carbon::parse(relatedPivotAttribute($completedPeriod, 'left_at'));
-            $duration = $joinedAt->diffInDays($leftAt);
+            $completedMembership = TagTeamWrestler::query()
+                ->whereBelongsTo($completedPeriod, 'tagTeam')
+                ->whereBelongsTo($this->wrestler)
+                ->firstOrFail();
+            $duration = $completedMembership->joined_at->diffInDays(requiredDate($completedMembership->left_at));
             expect($duration)->toBeGreaterThan(150); // Approximately 6 months
 
             // Calculate duration of current period
             $currentPeriod = requiredModel($this->wrestler->currentTagTeam);
-            $currentJoinedAt = Carbon::parse(relatedPivotAttribute($currentPeriod, 'joined_at'));
-            $currentDuration = $currentJoinedAt->diffInDays(Carbon::now());
+            $currentMembership = TagTeamWrestler::query()
+                ->whereBelongsTo($currentPeriod, 'tagTeam')
+                ->whereBelongsTo($this->wrestler)
+                ->firstOrFail();
+            $currentDuration = $currentMembership->joined_at->diffInDays(Carbon::now());
             expect($currentDuration)->toBeGreaterThan(80); // Approximately 3 months
         });
 

--- a/tests/Integration/Models/Wrestlers/WrestlerManagerTest.php
+++ b/tests/Integration/Models/Wrestlers/WrestlerManagerTest.php
@@ -172,7 +172,11 @@ describe('WrestlerManager Pivot Model', function () {
 
             expect($currentManagers)->toHaveCount(1);
             expect($currentManagers->firstOrFail()->id)->toBe($this->secondManager->id);
-            expect(relatedPivotAttribute($currentManagers->firstOrFail(), 'fired_at'))->toBeNull();
+            $management = WrestlerManager::query()
+                ->whereBelongsTo($this->wrestler)
+                ->whereBelongsTo($this->secondManager)
+                ->firstOrFail();
+            expect($management->fired_at)->toBeNull();
         });
 
         test('previous managers query returns only completed relationships', function () {
@@ -180,7 +184,11 @@ describe('WrestlerManager Pivot Model', function () {
 
             expect($previousManagers)->toHaveCount(1);
             expect($previousManagers->firstOrFail()->id)->toBe($this->manager->id);
-            expect(relatedPivotAttribute($previousManagers->firstOrFail(), 'fired_at'))->not()->toBeNull();
+            $management = WrestlerManager::query()
+                ->whereBelongsTo($this->wrestler)
+                ->whereBelongsTo($this->manager)
+                ->firstOrFail();
+            expect($management->fired_at)->not->toBeNull();
         });
 
         test('all managers query returns complete relationship history', function () {


### PR DESCRIPTION
## Summary

- raise the Pest PHPStan configuration from level 8 to level 9
- use typed Laravel Action `make()->handle()` calls where the package `run()` API exposes `mixed`
- replace generic pivot attribute access with concrete membership-model queries and existing datetime casts
- replace reflected form result coercion with a typed test proxy

## Verification

- `composer test:types`
- `composer test:rector`
- `composer test:type-coverage` (100%)
- `./vendor/bin/pint --blade --test tests`
- `php -d memory_limit=4G ./vendor/bin/pest --parallel` (3,499 tests, 11,043 assertions)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal action usage to a consistent fluent invocation pattern.
  * Improved relationship and membership history checks by querying records directly.
  * Simplified form integration testing without reflection-based access.

* **Tests**
  * Strengthened validation of management, stable, tag-team, and membership dates and statuses.
  * Preserved existing integration coverage while improving date handling and assertions.

* **Chores**
  * Raised static analysis strictness to the highest configured level.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->