### PR TITLE
refactor: move controller authorization to routes

### DIFF
--- a/app/Http/Controllers/Events/IndexController.php
+++ b/app/Http/Controllers/Events/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Events;
 
-use App\Models\Events\Event;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', Event::class);
-
         return view('events.index');
     }
 }

--- a/app/Http/Controllers/Events/ShowController.php
+++ b/app/Http/Controllers/Events/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\Events;
 
 use App\Models\Events\Event;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(Event $event): View
     {
-        Gate::authorize('view', $event);
-
         return view('events.show', [
             'event' => $event->load([
                 'venue',

--- a/app/Http/Controllers/Managers/IndexController.php
+++ b/app/Http/Controllers/Managers/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Managers;
 
-use App\Models\Managers\Manager;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', Manager::class);
-
         return view('managers.index');
     }
 }

--- a/app/Http/Controllers/Managers/ShowController.php
+++ b/app/Http/Controllers/Managers/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\Managers;
 
 use App\Models\Managers\Manager;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(Manager $manager): View
     {
-        Gate::authorize('view', $manager);
-
         return view('managers.show', [
             'manager' => $manager,
         ]);

--- a/app/Http/Controllers/Matches/IndexController.php
+++ b/app/Http/Controllers/Matches/IndexController.php
@@ -5,16 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Matches;
 
 use App\Models\Events\Event;
-use App\Models\Matches\EventMatch;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(Event $event): View
     {
-        Gate::authorize('viewList', EventMatch::class);
-
         return view('matches.index', [
             'event' => $event,
         ]);

--- a/app/Http/Controllers/Referees/IndexController.php
+++ b/app/Http/Controllers/Referees/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Referees;
 
-use App\Models\Referees\Referee;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', Referee::class);
-
         return view('referees.index');
     }
 }

--- a/app/Http/Controllers/Referees/ShowController.php
+++ b/app/Http/Controllers/Referees/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\Referees;
 
 use App\Models\Referees\Referee;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(Referee $referee): View
     {
-        Gate::authorize('view', $referee);
-
         return view('referees.show', [
             'referee' => $referee,
         ]);

--- a/app/Http/Controllers/Stables/IndexController.php
+++ b/app/Http/Controllers/Stables/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Stables;
 
-use App\Models\Stables\Stable;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', Stable::class);
-
         return view('stables.index');
     }
 }

--- a/app/Http/Controllers/Stables/ShowController.php
+++ b/app/Http/Controllers/Stables/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\Stables;
 
 use App\Models\Stables\Stable;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(Stable $stable): View
     {
-        Gate::authorize('view', $stable);
-
         return view('stables.show', [
             'stable' => $stable,
         ]);

--- a/app/Http/Controllers/TagTeams/IndexController.php
+++ b/app/Http/Controllers/TagTeams/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\TagTeams;
 
-use App\Models\TagTeams\TagTeam;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', TagTeam::class);
-
         return view('tag-teams.index');
     }
 }

--- a/app/Http/Controllers/TagTeams/ShowController.php
+++ b/app/Http/Controllers/TagTeams/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\TagTeams;
 
 use App\Models\TagTeams\TagTeam;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(TagTeam $tagTeam): View
     {
-        Gate::authorize('view', $tagTeam);
-
         return view('tag-teams.show', [
             'tagTeam' => $tagTeam,
         ]);

--- a/app/Http/Controllers/Titles/IndexController.php
+++ b/app/Http/Controllers/Titles/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Titles;
 
-use App\Models\Titles\Title;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', Title::class);
-
         return view('titles.index');
     }
 }

--- a/app/Http/Controllers/Titles/ShowController.php
+++ b/app/Http/Controllers/Titles/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\Titles;
 
 use App\Models\Titles\Title;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(Title $title): View
     {
-        Gate::authorize('view', $title);
-
         return view('titles.show', [
             'title' => $title,
         ]);

--- a/app/Http/Controllers/Users/IndexController.php
+++ b/app/Http/Controllers/Users/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Users;
 
-use App\Models\Users\User;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', User::class);
-
         return view('users.index');
     }
 }

--- a/app/Http/Controllers/Users/ShowController.php
+++ b/app/Http/Controllers/Users/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\Users;
 
 use App\Models\Users\User;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(User $user): View
     {
-        Gate::authorize('view', $user);
-
         return view('users.show', [
             'user' => $user,
         ]);

--- a/app/Http/Controllers/Venues/IndexController.php
+++ b/app/Http/Controllers/Venues/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Venues;
 
-use App\Models\Events\Venue;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', Venue::class);
-
         return view('venues.index');
     }
 }

--- a/app/Http/Controllers/Venues/ShowController.php
+++ b/app/Http/Controllers/Venues/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\Venues;
 
 use App\Models\Events\Venue;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(Venue $venue): View
     {
-        Gate::authorize('view', $venue);
-
         return view('venues.show', [
             'venue' => $venue,
         ]);

--- a/app/Http/Controllers/Wrestlers/IndexController.php
+++ b/app/Http/Controllers/Wrestlers/IndexController.php
@@ -4,16 +4,12 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Wrestlers;
 
-use App\Models\Wrestlers\Wrestler;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class IndexController
 {
     public function __invoke(): View
     {
-        Gate::authorize('viewList', Wrestler::class);
-
         return view('wrestlers.index');
     }
 }

--- a/app/Http/Controllers/Wrestlers/ShowController.php
+++ b/app/Http/Controllers/Wrestlers/ShowController.php
@@ -6,14 +6,11 @@ namespace App\Http\Controllers\Wrestlers;
 
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 
 class ShowController
 {
     public function __invoke(Wrestler $wrestler): View
     {
-        Gate::authorize('view', $wrestler);
-
         return view('wrestlers.show', [
             'wrestler' => $wrestler,
         ]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -22,6 +22,16 @@ use App\Http\Controllers\Venues\IndexController as VenuesIndexController;
 use App\Http\Controllers\Venues\ShowController as VenuesShowController;
 use App\Http\Controllers\Wrestlers\IndexController as WrestlersIndexController;
 use App\Http\Controllers\Wrestlers\ShowController as WrestlersShowController;
+use App\Models\Events\Event;
+use App\Models\Events\Venue;
+use App\Models\Managers\Manager;
+use App\Models\Matches\EventMatch;
+use App\Models\Referees\Referee;
+use App\Models\Stables\Stable;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Users\User;
+use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Facades\Route;
 
 require __DIR__.'/auth.php';
@@ -30,30 +40,30 @@ Route::middleware('auth')->group(function () {
     Route::get('dashboard', DashboardController::class)->name('dashboard');
 
     Route::prefix('roster')->group(function () {
-        Route::get('stables', StablesIndexController::class)->name('stables.index');
-        Route::get('stables/{stable}', StablesShowController::class)->name('stables.show');
-        Route::get('wrestlers', WrestlersIndexController::class)->name('wrestlers.index');
-        Route::get('wrestlers/{wrestler}', WrestlersShowController::class)->name('wrestlers.show');
-        Route::get('managers', ManagersIndexController::class)->name('managers.index');
-        Route::get('managers/{manager}', ManagersShowController::class)->name('managers.show');
-        Route::get('referees', RefereesIndexController::class)->name('referees.index');
-        Route::get('referees/{referee}', RefereesShowController::class)->name('referees.show');
-        Route::get('tag-teams', TagTeamsIndexController::class)->name('tag-teams.index');
-        Route::get('tag-teams/{tagTeam}', TagTeamsShowController::class)->name('tag-teams.show');
+        Route::get('stables', StablesIndexController::class)->can('viewList', Stable::class)->name('stables.index');
+        Route::get('stables/{stable}', StablesShowController::class)->can('view', 'stable')->name('stables.show');
+        Route::get('wrestlers', WrestlersIndexController::class)->can('viewList', Wrestler::class)->name('wrestlers.index');
+        Route::get('wrestlers/{wrestler}', WrestlersShowController::class)->can('view', 'wrestler')->name('wrestlers.show');
+        Route::get('managers', ManagersIndexController::class)->can('viewList', Manager::class)->name('managers.index');
+        Route::get('managers/{manager}', ManagersShowController::class)->can('view', 'manager')->name('managers.show');
+        Route::get('referees', RefereesIndexController::class)->can('viewList', Referee::class)->name('referees.index');
+        Route::get('referees/{referee}', RefereesShowController::class)->can('view', 'referee')->name('referees.show');
+        Route::get('tag-teams', TagTeamsIndexController::class)->can('viewList', TagTeam::class)->name('tag-teams.index');
+        Route::get('tag-teams/{tagTeam}', TagTeamsShowController::class)->can('view', 'tagTeam')->name('tag-teams.show');
     });
 
-    Route::get('titles', TitlesIndexController::class)->name('titles.index');
-    Route::get('titles/{title}', TitlesShowController::class)->name('titles.show');
+    Route::get('titles', TitlesIndexController::class)->can('viewList', Title::class)->name('titles.index');
+    Route::get('titles/{title}', TitlesShowController::class)->can('view', 'title')->name('titles.show');
 
-    Route::get('events/{event}/matches', MatchesIndexController::class)->name('events.matches');
-    Route::get('events', EventsIndexController::class)->name('events.index');
-    Route::get('events/{event}', EventsShowController::class)->name('events.show');
+    Route::get('events/{event}/matches', MatchesIndexController::class)->can('viewList', EventMatch::class)->name('events.matches');
+    Route::get('events', EventsIndexController::class)->can('viewList', Event::class)->name('events.index');
+    Route::get('events/{event}', EventsShowController::class)->can('view', 'event')->name('events.show');
 
-    Route::get('venues', VenuesIndexController::class)->name('venues.index');
-    Route::get('venues/{venue}', VenuesShowController::class)->name('venues.show');
+    Route::get('venues', VenuesIndexController::class)->can('viewList', Venue::class)->name('venues.index');
+    Route::get('venues/{venue}', VenuesShowController::class)->can('view', 'venue')->name('venues.show');
 
     Route::prefix('user-management')->group(function () {
-        Route::get('users', UsersIndexController::class)->name('users.index');
-        Route::get('users/{user}', UsersShowController::class)->name('users.show');
+        Route::get('users', UsersIndexController::class)->can('viewList', User::class)->name('users.index');
+        Route::get('users/{user}', UsersShowController::class)->can('view', 'user')->name('users.show');
     });
 });


### PR DESCRIPTION
## Summary
- enforce domain controller authorization through route policy middleware
- remove duplicated controller-level Gate authorization
- keep controllers focused on response and view composition

## Verification
- 3,499 Pest tests passed with 11,043 assertions
- 193 focused controller and authorization tests passed
- application PHPStan passed
- Rector passed
- Pint passed
- Pest type coverage remained at 100%

## Follow-up audit work
- move remaining inline controller validation into Form Requests
- convert custom pivot models to attribute-based fillable declarations
- replace service-location inside Actions with dependency injection
- review remaining Blade includes
- investigate Pest PHPStan assertSeeLivewire extension discovery