### PR TITLE
refactor: validate auth requests with form requests

### DIFF
--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -5,10 +5,9 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\SendPasswordResetLinkRequest;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Password;
-use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 
 class PasswordResetLinkController extends Controller
@@ -21,22 +20,13 @@ class PasswordResetLinkController extends Controller
         return view('auth.forgot-password');
     }
 
-    /**
-     * Handle an incoming password reset link request.
-     *
-     * @throws ValidationException
-     */
-    public function store(Request $request): RedirectResponse
+    public function store(SendPasswordResetLinkRequest $request): RedirectResponse
     {
-        $request->validate([
-            'email' => ['required', 'email'],
-        ]);
-
         // We will send the password reset link to this user. Once we have attempted
         // to send the link, we will examine the response then see the message we
         // need to show to the user. Finally, we'll send out a proper response.
         $status = Password::sendResetLink(
-            $request->only('email')
+            $request->validated()
         );
 
         return $status === Password::RESET_LINK_SENT

--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -5,14 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Http\Requests\Auth\RegisterUserRequest;
 use App\Models\Users\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
-use Illuminate\Validation\Rules;
-use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 
 class RegisteredUserController extends Controller
@@ -25,23 +23,12 @@ class RegisteredUserController extends Controller
         return view('auth.register');
     }
 
-    /**
-     * Handle an incoming registration request.
-     *
-     * @throws ValidationException
-     */
-    public function store(Request $request): RedirectResponse
+    public function store(RegisterUserRequest $request): RedirectResponse
     {
-        $request->validate([
-            'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
-            'password' => ['required', 'confirmed', Rules\Password::defaults()],
-        ]);
-
         $user = User::create([
-            'name' => $request->name,
-            'email' => $request->email,
-            'password' => Hash::make($request->password),
+            'name' => $request->string('name')->value(),
+            'email' => $request->string('email')->value(),
+            'password' => Hash::make($request->string('password')->value()),
         ]);
 
         event(new Registered($user));

--- a/app/Http/Requests/Auth/RegisterUserRequest.php
+++ b/app/Http/Requests/Auth/RegisterUserRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use App\Models\Users\User;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rules;
+
+class RegisterUserRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string|Rules\Password>>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
+            'password' => ['required', 'confirmed', Rules\Password::defaults()],
+        ];
+    }
+}

--- a/app/Http/Requests/Auth/SendPasswordResetLinkRequest.php
+++ b/app/Http/Requests/Auth/SendPasswordResetLinkRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Auth;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class SendPasswordResetLinkRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => ['required', 'email'],
+        ];
+    }
+}

--- a/tests/Feature/Http/Controllers/Auth/PasswordResetLinkControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/PasswordResetLinkControllerTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Notification;
+
+test('password reset link screen can be rendered', function () {
+    $this->get(route('password.request'))
+        ->assertSuccessful();
+});
+
+test('password reset link requires a valid email address', function () {
+    $this->from(route('password.request'))
+        ->post(route('password.email'), ['email' => 'not-an-email'])
+        ->assertRedirect(route('password.request'))
+        ->assertSessionHasErrors('email')
+        ->assertSessionHasInput('email');
+});
+
+test('password reset link can be requested', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $this->post(route('password.email'), ['email' => $user->email])
+        ->assertSessionHasNoErrors();
+
+    Notification::assertSentTo($user, ResetPassword::class);
+});

--- a/tests/Feature/Http/Controllers/Auth/RegisteredUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/RegisteredUserControllerTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+test('registration screen can be rendered', function () {
+    $this->get(route('register'))
+        ->assertSuccessful();
+});
+
+test('registration requires valid account details', function () {
+    $this->from(route('register'))
+        ->post(route('register'), [
+            'name' => '',
+            'email' => 'not-an-email',
+            'password' => 'secret',
+            'password_confirmation' => 'different-secret',
+        ])
+        ->assertRedirect(route('register'))
+        ->assertSessionHasErrors(['name', 'email', 'password'])
+        ->assertSessionHasInput('email')
+        ->assertSessionMissing('_old_input.password')
+        ->assertSessionMissing('_old_input.password_confirmation');
+});


### PR DESCRIPTION
## Summary
- move registration validation into `RegisterUserRequest`
- move password reset link validation into `SendPasswordResetLinkRequest`
- keep auth controllers focused on request handling and responses
- add feature coverage for validation and password reset notifications

## Verification
- 3,504 Pest tests passed with 11,061 assertions
- application PHPStan passed
- Rector passed
- Pint passed
- Pest type coverage remained at 100%

## Follow-up
The registration form still submits the legacy `name` field while the `User` model stores `first_name` and `last_name`. This PR intentionally preserves that existing behavior; correcting the registration data model should be handled as a separate functional change.
