### PR TITLE
refactor: declare pivot fillable attributes

### DIFF
--- a/app/Models/Matches/MatchCompetitor.php
+++ b/app/Models/Matches/MatchCompetitor.php
@@ -9,6 +9,7 @@ use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Database\Factories\Matches\MatchCompetitorFactory;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -37,6 +38,7 @@ use Illuminate\Support\Carbon;
  * @mixin \Eloquent
  */
 #[CollectedBy(MatchCompetitorsCollection::class)]
+#[Fillable('match_id', 'competitor_id', 'competitor_type', 'side_number')]
 #[UseFactory(MatchCompetitorFactory::class)]
 class MatchCompetitor extends MorphPivot
 {
@@ -49,18 +51,6 @@ class MatchCompetitor extends MorphPivot
      * @var string
      */
     protected $table = 'events_matches_competitors';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'match_id',
-        'competitor_id',
-        'competitor_type',
-        'side_number',
-    ];
 
     /**
      * Get the competitor for the match (Wrestler or TagTeam).

--- a/app/Models/Stables/StableTagTeam.php
+++ b/app/Models/Stables/StableTagTeam.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Stables;
 
 use App\Models\TagTeams\TagTeam;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
@@ -33,6 +34,7 @@ use Illuminate\Support\Carbon;
  *
  * @mixin \Eloquent
  */
+#[Fillable('stable_id', 'tag_team_id', 'joined_at', 'left_at')]
 class StableTagTeam extends Pivot
 {
     /**
@@ -41,18 +43,6 @@ class StableTagTeam extends Pivot
      * @var string
      */
     protected $table = 'stables_tag_teams';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'stable_id',
-        'tag_team_id',
-        'joined_at',
-        'left_at',
-    ];
 
     /**
      * Get the attributes that should be cast.

--- a/app/Models/Stables/StableWrestler.php
+++ b/app/Models/Stables/StableWrestler.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Stables;
 
 use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
@@ -33,6 +34,7 @@ use Illuminate\Support\Carbon;
  *
  * @mixin \Eloquent
  */
+#[Fillable('stable_id', 'wrestler_id', 'joined_at', 'left_at')]
 class StableWrestler extends Pivot
 {
     /**
@@ -41,18 +43,6 @@ class StableWrestler extends Pivot
      * @var string
      */
     protected $table = 'stables_wrestlers';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'stable_id',
-        'wrestler_id',
-        'joined_at',
-        'left_at',
-    ];
 
     /**
      * Get the attributes that should be cast.

--- a/app/Models/TagTeams/TagTeamManager.php
+++ b/app/Models/TagTeams/TagTeamManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\TagTeams;
 
 use App\Models\Managers\Manager;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
@@ -27,21 +28,10 @@ use Illuminate\Support\Carbon;
  *
  * @mixin \Eloquent
  */
+#[Fillable('tag_team_id', 'manager_id', 'hired_at', 'fired_at')]
 class TagTeamManager extends Pivot
 {
     protected $table = 'tag_teams_managers';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'tag_team_id',
-        'manager_id',
-        'hired_at',
-        'fired_at',
-    ];
 
     /**
      * Get the attributes that should be cast.

--- a/app/Models/Wrestlers/WrestlerManager.php
+++ b/app/Models/Wrestlers/WrestlerManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Wrestlers;
 
 use App\Models\Managers\Manager;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
@@ -27,21 +28,10 @@ use Illuminate\Support\Carbon;
  *
  * @mixin \Eloquent
  */
+#[Fillable('wrestler_id', 'manager_id', 'hired_at', 'fired_at')]
 class WrestlerManager extends Pivot
 {
     protected $table = 'wrestlers_managers';
-
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var list<string>
-     */
-    protected $fillable = [
-        'wrestler_id',
-        'manager_id',
-        'hired_at',
-        'fired_at',
-    ];
 
     /**
      * Get the attributes that should be cast.


### PR DESCRIPTION
## Summary
- replace `$fillable` properties on all five custom pivot models with Laravel's `#[Fillable]` attribute
- preserve the existing mass-assignment allow-lists exactly
- align every model in `app/Models` with the recorded attribute-based convention

## Verification
- 66 focused pivot-model tests passed with 194 assertions
- full Pest suite passed: 3,504 tests and 11,061 assertions
- application PHPStan passed
- Rector passed
- Pint passed
- Pest type coverage remained at 100%


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal data handling across competitor, stable, tag team, and wrestler records.
  * Mass-assignment configuration is now declared using modern framework conventions.
  * Existing record creation and update behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->