### PR TITLE
refactor: inject action collaborators

### DIFF
--- a/app/Actions/Matches/AddCompetitorsToMatchAction.php
+++ b/app/Actions/Matches/AddCompetitorsToMatchAction.php
@@ -14,6 +14,11 @@ use InvalidArgumentException;
 
 class AddCompetitorsToMatchAction
 {
+    public function __construct(
+        protected AddTagTeamsToMatchAction $addTagTeamsToMatchAction,
+        protected AddWrestlersToMatchAction $addWrestlersToMatchAction,
+    ) {}
+
     /**
      * Add competitors to an event match.
      *
@@ -61,7 +66,7 @@ class AddCompetitorsToMatchAction
     {
         // Add wrestlers to this side
         if (Arr::exists($sideCompetitors, 'wrestlers') && ! empty($sideCompetitors['wrestlers'])) {
-            resolve(AddWrestlersToMatchAction::class)->handle(
+            $this->addWrestlersToMatchAction->handle(
                 $eventMatch,
                 collect((array) Arr::get($sideCompetitors, 'wrestlers')),
                 $sideNumber
@@ -70,7 +75,7 @@ class AddCompetitorsToMatchAction
 
         // Add tag teams to this side
         if (Arr::exists($sideCompetitors, 'tag_teams') && ! empty($sideCompetitors['tag_teams'])) {
-            resolve(AddTagTeamsToMatchAction::class)->handle(
+            $this->addTagTeamsToMatchAction->handle(
                 $eventMatch,
                 collect((array) Arr::get($sideCompetitors, 'tag_teams')),
                 $sideNumber

--- a/app/Actions/Stables/CreateAction.php
+++ b/app/Actions/Stables/CreateAction.php
@@ -16,7 +16,9 @@ class CreateAction
      * Create a new create action instance.
      */
     public function __construct(
-        protected EstablishAction $establishAction
+        protected EstablishAction $establishAction,
+        protected StableMembershipService $membershipService,
+        protected StableValidationService $validationService,
     ) {}
 
     /**
@@ -36,9 +38,8 @@ class CreateAction
     {
         return DB::transaction(function () use ($stableData): Stable {
             // Validate business rules before creation
-            $validationService = app(StableValidationService::class);
-            $validationService->validateUniqueName($stableData->getTrimmedName());
-            $validationService->validateMembersAvailable($stableData->members);
+            $this->validationService->validateUniqueName($stableData->getTrimmedName());
+            $this->validationService->validateMembersAvailable($stableData->members);
 
             $stable = Stable::create([
                 'name' => $stableData->getTrimmedName(),
@@ -48,8 +49,7 @@ class CreateAction
             $joinDate = $stableData->getJoinDate();
 
             // Add members using service
-            $membershipService = app(StableMembershipService::class);
-            $membershipService->addMembers($stable, $stableData->members, $joinDate);
+            $this->membershipService->addMembers($stable, $stableData->members, $joinDate);
 
             // Use enhanced DTO method instead of isset check
             if ($stableData->shouldEstablish()) {

--- a/app/Actions/Stables/RemoveStableMembersAction.php
+++ b/app/Actions/Stables/RemoveStableMembersAction.php
@@ -19,6 +19,10 @@ use InvalidArgumentException;
  */
 class RemoveStableMembersAction
 {
+    public function __construct(
+        protected StableMembershipService $membershipService,
+    ) {}
+
     /**
      * Remove members from a stable.
      *
@@ -35,8 +39,7 @@ class RemoveStableMembersAction
         }
 
         if ($members->isNotEmpty()) {
-            $membershipService = app(StableMembershipService::class);
-            $membershipService->removeMembers($stable, $members, $removalDate);
+            $this->membershipService->removeMembers($stable, $members, $removalDate);
         }
     }
 }

--- a/app/Actions/Stables/SplitStableAction.php
+++ b/app/Actions/Stables/SplitStableAction.php
@@ -20,7 +20,9 @@ class SplitStableAction
      * Create a new split stable action instance.
      */
     public function __construct(
-        protected CreateAction $createAction
+        protected CreateAction $createAction,
+        protected StableMembershipService $membershipService,
+        protected StableValidationService $validationService,
     ) {}
 
     /**
@@ -49,8 +51,7 @@ class SplitStableAction
             $this->validateSplitMembers($originalStable, $membersForNewStable);
 
             // Validate name uniqueness using service
-            $validationService = app(StableValidationService::class);
-            $validationService->validateUniqueName(mb_trim($newStableName));
+            $this->validationService->validateUniqueName(mb_trim($newStableName));
 
             // Use enhanced DTO method to filter employed members
             $employedMembers = $membersForNewStable->filterEmployedMembers();
@@ -71,8 +72,7 @@ class SplitStableAction
             $newStable = $this->createAction->handle($stableData);
 
             // Remove transferred members from original stable using service
-            $membershipService = app(StableMembershipService::class);
-            $membershipService->removeMembers($originalStable, $employedMembers, $date);
+            $this->membershipService->removeMembers($originalStable, $employedMembers, $date);
 
             return $newStable;
         });

--- a/app/Actions/Stables/UpdateAction.php
+++ b/app/Actions/Stables/UpdateAction.php
@@ -16,7 +16,9 @@ class UpdateAction
      * Create a new update action instance.
      */
     public function __construct(
-        protected EstablishAction $establishAction
+        protected EstablishAction $establishAction,
+        protected StableMembershipService $membershipService,
+        protected StableValidationService $validationService,
     ) {}
 
     /**
@@ -36,9 +38,8 @@ class UpdateAction
     {
         return DB::transaction(function () use ($stable, $stableData): Stable {
             // Validate business rules before updating
-            $validationService = app(StableValidationService::class);
-            $validationService->validateUniqueName($stableData->getTrimmedName(), $stable);
-            $validationService->validateMembersAvailable($stableData->members);
+            $this->validationService->validateUniqueName($stableData->getTrimmedName(), $stable);
+            $this->validationService->validateMembersAvailable($stableData->members);
 
             $stable->update([
                 'name' => $stableData->getTrimmedName(),
@@ -46,13 +47,12 @@ class UpdateAction
 
             // Use enhanced DTO method and centralized validation
             if ($stableData->hasStartDate()) {
-                $validationService->validateEstablishmentDateChange($stable);
+                $this->validationService->validateEstablishmentDateChange($stable);
                 $this->establishAction->handle($stable, $stableData->start_date);
             }
 
             // Update stable membership using service
-            $membershipService = app(StableMembershipService::class);
-            $membershipService->updateMembership($stable, $stableData->members, now());
+            $this->membershipService->updateMembership($stable, $stableData->members, now());
 
             return $stable;
         });


### PR DESCRIPTION
## Summary
- inject stable validation and membership services into stable Actions
- inject match competitor Actions into `AddCompetitorsToMatchAction`
- remove service-location calls for fixed, statically known collaborators
- preserve container-based collaborator replacement in tests

## Verification
- 41 focused Action tests passed with 118 assertions
- full Pest suite passed: 3,504 tests and 11,061 assertions
- application PHPStan passed
- Rector passed
- Pint passed
- Pest type coverage remained at 100%

## Deferred architecture work
Dynamic resolution inside static factories, recursive trait workflows, and class-string dispatch remains unchanged. Those cases require an explicit API and architecture redesign rather than a mechanical constructor-injection change.
