### PR TITLE
refactor: render table headers as components

### DIFF
--- a/app/Livewire/Concerns/BaseTableTrait.php
+++ b/app/Livewire/Concerns/BaseTableTrait.php
@@ -34,7 +34,7 @@ trait BaseTableTrait
             ->setFiltersStatus(true);
 
         $this->setConfigurableAreas([
-            'before-wrapper' => 'components.'.$this->routeBasePath.'.index.table-pre',
+            'before-wrapper' => $this->routeBasePath.'.index.table-pre',
         ]);
 
         $this->setSearchAttributes();

--- a/resources/views/livewire/table/data-table.blade.php
+++ b/resources/views/livewire/table/data-table.blade.php
@@ -1,7 +1,7 @@
 <div>
     {{-- Before wrapper (configurable area for page header / add buttons) --}}
     @if ($beforeWrapperView)
-        @include($beforeWrapperView)
+        <x-dynamic-component :component="$beforeWrapperView" />
     @endif
 
     {{-- Card wrapper --}}


### PR DESCRIPTION
## Summary
- render configurable table-header areas with Blade's native dynamic component
- supply anonymous component aliases instead of raw view paths
- keep the legacy event matches view and its partial unchanged

## Verification
- 240 focused Livewire table tests passed with 617 assertions
- full Pest suite passed: 3,504 tests and 11,061 assertions
- Blade templates compiled successfully
- application PHPStan passed
- Rector passed
- Pest type coverage remained at 100%

## Local formatter note
The local Pint Blade subprocess reports the existing `NO_COLOR` / `FORCE_COLOR` environment warning without a formatting diagnostic. The GitHub formatter workflow remains the authoritative Blade formatting check for this branch.
