### PR TITLE
fix: repair user registration

### DIFF
--- a/app/Http/Controllers/Auth/RegisteredUserController.php
+++ b/app/Http/Controllers/Auth/RegisteredUserController.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\Auth;
 
+use App\Enums\Users\Role;
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\RegisterUserRequest;
 use App\Models\Users\User;
 use Illuminate\Auth\Events\Registered;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\View\View;
 
 class RegisteredUserController extends Controller
@@ -25,10 +25,12 @@ class RegisteredUserController extends Controller
 
     public function store(RegisterUserRequest $request): RedirectResponse
     {
-        $user = User::create([
-            'name' => $request->string('name')->value(),
+        $user = User::query()->create([
+            'first_name' => $request->string('first_name')->value(),
+            'last_name' => $request->string('last_name')->value(),
             'email' => $request->string('email')->value(),
-            'password' => Hash::make($request->string('password')->value()),
+            'password' => $request->string('password')->value(),
+            'role' => Role::Basic,
         ]);
 
         event(new Registered($user));

--- a/app/Http/Requests/Auth/RegisterUserRequest.php
+++ b/app/Http/Requests/Auth/RegisterUserRequest.php
@@ -21,7 +21,8 @@ class RegisterUserRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => ['required', 'string', 'max:255'],
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'confirmed', Rules\Password::defaults()],
         ];

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -22,9 +22,8 @@
         <!-- Divider -->
         <x-auth.form-divider />
 
-        <!-- First Name Field -->
         <div class="flex flex-col gap-1">
-            <label class="text-2sm font-normal text-gray-900">First Name</label>
+            <label for="first_name" class="text-2sm font-normal text-gray-900">First Name</label>
             <input
                 class="text-2sm focus:border-primary focus:ring-primary block h-10 w-full appearance-none rounded-md border border-solid border-gray-300 bg-gray-50 px-3 leading-4 font-medium text-gray-700 shadow-none transition-colors outline-none focus:bg-white focus:ring-1"
                 placeholder="Enter your first name"
@@ -39,9 +38,8 @@
             @enderror
         </div>
 
-        <!-- Last Name Field -->
         <div class="flex flex-col gap-1">
-            <label class="text-2sm font-normal text-gray-900">Last Name</label>
+            <label for="last_name" class="text-2sm font-normal text-gray-900">Last Name</label>
             <input
                 class="text-2sm focus:border-primary focus:ring-primary block h-10 w-full appearance-none rounded-md border border-solid border-gray-300 bg-gray-50 px-3 leading-4 font-medium text-gray-700 shadow-none transition-colors outline-none focus:bg-white focus:ring-1"
                 placeholder="Enter your last name"

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -22,19 +22,36 @@
         <!-- Divider -->
         <x-auth.form-divider />
 
-        <!-- Name Field -->
+        <!-- First Name Field -->
         <div class="flex flex-col gap-1">
-            <label class="text-2sm font-normal text-gray-900">Name</label>
+            <label class="text-2sm font-normal text-gray-900">First Name</label>
             <input
                 class="text-2sm focus:border-primary focus:ring-primary block h-10 w-full appearance-none rounded-md border border-solid border-gray-300 bg-gray-50 px-3 leading-4 font-medium text-gray-700 shadow-none transition-colors outline-none focus:bg-white focus:ring-1"
-                placeholder="Enter your full name"
+                placeholder="Enter your first name"
                 type="text"
-                value="{{ old('name') }}"
-                name="name"
-                id="name"
+                value="{{ old('first_name') }}"
+                name="first_name"
+                id="first_name"
                 required
             />
-            @error('name')
+            @error('first_name')
+                <span class="text-xs leading-4 font-medium text-red-500"> {{ $message }} </span>
+            @enderror
+        </div>
+
+        <!-- Last Name Field -->
+        <div class="flex flex-col gap-1">
+            <label class="text-2sm font-normal text-gray-900">Last Name</label>
+            <input
+                class="text-2sm focus:border-primary focus:ring-primary block h-10 w-full appearance-none rounded-md border border-solid border-gray-300 bg-gray-50 px-3 leading-4 font-medium text-gray-700 shadow-none transition-colors outline-none focus:bg-white focus:ring-1"
+                placeholder="Enter your last name"
+                type="text"
+                value="{{ old('last_name') }}"
+                name="last_name"
+                id="last_name"
+                required
+            />
+            @error('last_name')
                 <span class="text-xs leading-4 font-medium text-red-500"> {{ $message }} </span>
             @enderror
         </div>

--- a/tests/Feature/Http/Controllers/Auth/RegisteredUserControllerTest.php
+++ b/tests/Feature/Http/Controllers/Auth/RegisteredUserControllerTest.php
@@ -2,21 +2,48 @@
 
 declare(strict_types=1);
 
+use App\Enums\Users\Role;
+use App\Models\Users\User;
+use Illuminate\Support\Facades\Hash;
+
+use function Pest\Laravel\assertAuthenticatedAs;
+
 test('registration screen can be rendered', function () {
     $this->get(route('register'))
         ->assertSuccessful();
 });
 
+test('a user can register with their account details', function () {
+    $this->post(route('register'), [
+        'first_name' => 'Jeffrey',
+        'last_name' => 'Davidson',
+        'email' => 'jeffrey@example.com',
+        'password' => 'password',
+        'password_confirmation' => 'password',
+    ])->assertRedirect(route('dashboard'));
+
+    $user = User::query()->where('email', 'jeffrey@example.com')->firstOrFail();
+
+    expect($user)
+        ->first_name->toBe('Jeffrey')
+        ->last_name->toBe('Davidson')
+        ->role->toBe(Role::Basic)
+        ->and(Hash::check('password', $user->password))->toBeTrue();
+
+    assertAuthenticatedAs($user);
+});
+
 test('registration requires valid account details', function () {
     $this->from(route('register'))
         ->post(route('register'), [
-            'name' => '',
+            'first_name' => '',
+            'last_name' => '',
             'email' => 'not-an-email',
             'password' => 'secret',
             'password_confirmation' => 'different-secret',
         ])
         ->assertRedirect(route('register'))
-        ->assertSessionHasErrors(['name', 'email', 'password'])
+        ->assertSessionHasErrors(['first_name', 'last_name', 'email', 'password'])
         ->assertSessionHasInput('email')
         ->assertSessionMissing('_old_input.password')
         ->assertSessionMissing('_old_input.password_confirmation');


### PR DESCRIPTION
## Summary
- collect and validate `first_name` and `last_name` during registration
- persist the fields actually defined by the `User` model
- assign public registrations the non-privileged `Role::Basic` role
- pass the validated password to the model mutator so it is hashed exactly once
- add an end-to-end registration regression test

## Verification
- focused registration tests passed
- full Pest suite passed: 3,505 tests and 11,071 assertions
- Blade templates compiled successfully
- application PHPStan passed
- Rector passed
- Pest type coverage remained at 100%

## Local formatter note
The direct Blade formatter reports only the existing `NO_COLOR` / `FORCE_COLOR` environment warning. The GitHub formatter workflow remains the authoritative Blade formatting check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Registration now collects first and last names separately.
  * New accounts are assigned the Basic role automatically.
  * Passwords are securely stored, and successful registration signs users in.

* **Bug Fixes**
  * Improved registration validation and error messages for missing name fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->