### PR TITLE
fix: register Livewire PHPStan assertions

### DIFF
--- a/phpstan-pest.neon
+++ b/phpstan-pest.neon
@@ -7,6 +7,11 @@ parameters:
   bootstrapFiles:
     - bootstrap/app.php
 
+  stubFiles:
+    - stubs/Illuminate/Http/Response.stub
+    - stubs/Illuminate/Testing/TestResponse.stub
+    - stubs/Symfony/Component/HttpFoundation/Response.stub
+
   excludePaths:
     - bootstrap/cache
     - storage

--- a/stubs/Illuminate/Http/Response.stub
+++ b/stubs/Illuminate/Http/Response.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Illuminate\Http;
+
+class Response
+{
+}

--- a/stubs/Illuminate/Testing/TestResponse.stub
+++ b/stubs/Illuminate/Testing/TestResponse.stub
@@ -1,0 +1,15 @@
+<?php
+
+namespace Illuminate\Testing;
+
+/**
+ * @template TResponse of \Symfony\Component\HttpFoundation\Response
+ *
+ * @mixin \Illuminate\Http\Response
+ *
+ * @method $this assertSeeLivewire(string $component)
+ * @method $this assertDontSeeLivewire(string $component)
+ */
+class TestResponse
+{
+}

--- a/stubs/Symfony/Component/HttpFoundation/Response.stub
+++ b/stubs/Symfony/Component/HttpFoundation/Response.stub
@@ -1,0 +1,7 @@
+<?php
+
+namespace Symfony\Component\HttpFoundation;
+
+class Response
+{
+}


### PR DESCRIPTION
## Summary
- describe Livewire testing macros to PHPStan
- preserve Laravel TestResponse generic and mixin metadata
- make Pest static analysis consistent between local development and CI

## Verification
- `composer test:types`
- clean-cache Pest PHPStan analysis
- `git diff --check`