### PR TITLE
test: enforce controller architecture

### DIFF
--- a/tests/Feature/Architecture/ControllerArchitectureTest.php
+++ b/tests/Feature/Architecture/ControllerArchitectureTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Routing\Route as IlluminateRoute;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Str;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * @return list<class-string>
+ */
+function applicationControllers(): array
+{
+    return array_values(collect(File::allFiles(app_path('Http/Controllers')))
+        ->map(function (SplFileInfo $file): string {
+            $relativePath = Str::beforeLast($file->getRelativePathname(), '.php');
+
+            return 'App\\Http\\Controllers\\'.str_replace(DIRECTORY_SEPARATOR, '\\', $relativePath);
+        })
+        ->filter(fn (string $controller): bool => class_exists($controller))
+        ->values()
+        ->all());
+}
+
+/**
+ * @param  class-string  $controller
+ * @return list<non-empty-string>
+ */
+function declaredPublicMethods(string $controller): array
+{
+    $reflection = new ReflectionClass($controller);
+
+    return array_values(collect($reflection->getMethods(ReflectionMethod::IS_PUBLIC))
+        ->filter(fn (ReflectionMethod $method): bool => $method->getDeclaringClass()->getName() === $controller)
+        ->map(fn (ReflectionMethod $method): string => $method->getName())
+        ->sort()
+        ->values()
+        ->all());
+}
+
+function isDomainControllerRoute(IlluminateRoute $route): bool
+{
+    $action = $route->getActionName();
+
+    return str_starts_with($action, 'App\\Http\\Controllers\\')
+        && ! str_starts_with($action, 'App\\Http\\Controllers\\Auth\\')
+        && str_contains($action, '@');
+}
+
+test('controllers are resourceful or invokable', function () {
+    $resourceMethods = ['create', 'destroy', 'edit', 'index', 'show', 'store', 'update'];
+    $controllerCount = 0;
+
+    foreach (applicationControllers() as $controller) {
+        $reflection = new ReflectionClass($controller);
+
+        if ($reflection->isAbstract()) {
+            continue;
+        }
+
+        $controllerCount++;
+        $methods = declaredPublicMethods($controller);
+
+        expect($methods)->not->toBeEmpty();
+
+        if (in_array('__invoke', $methods, true)) {
+            expect($methods)->toBe(['__invoke']);
+
+            continue;
+        }
+
+        expect(array_diff($methods, $resourceMethods))->toBeEmpty();
+    }
+
+    expect($controllerCount)->toBeGreaterThan(0);
+});
+
+test('domain resource controllers use plural resource names', function () {
+    foreach (applicationControllers() as $controller) {
+        if (str_starts_with($controller, 'App\\Http\\Controllers\\Auth\\')) {
+            continue;
+        }
+
+        $methods = declaredPublicMethods($controller);
+
+        if ($methods === ['__invoke']) {
+            continue;
+        }
+
+        $resource = Str::beforeLast(class_basename($controller), 'Controller');
+
+        expect($resource)->toBe(Str::pluralStudly(Str::singular($resource)));
+    }
+});
+
+test('domain resource routes are named and authorized at the route', function () {
+    $routeCount = 0;
+
+    foreach (Route::getRoutes()->getRoutes() as $route) {
+        if (! isDomainControllerRoute($route)) {
+            continue;
+        }
+
+        $routeCount++;
+        [, $method] = explode('@', $route->getActionName(), 2);
+        $middleware = $route->gatherMiddleware();
+
+        expect($route->getName())
+            ->not->toBeNull()
+            ->toEndWith(".{$method}")
+            ->and(collect($middleware)->contains(
+                fn (mixed $value): bool => is_string($value) && str_starts_with($value, 'can:'),
+            ))
+            ->toBeTrue();
+    }
+
+    expect($routeCount)->toBeGreaterThan(0);
+});

--- a/tests/Feature/Architecture/ControllerArchitectureTest.php
+++ b/tests/Feature/Architecture/ControllerArchitectureTest.php
@@ -6,8 +6,6 @@ use Illuminate\Routing\Route as IlluminateRoute;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Support\Str;
-use ReflectionClass;
-use ReflectionMethod;
 
 /**
  * @return list<class-string>
@@ -106,13 +104,13 @@ test('domain resource routes are named and authorized at the route', function ()
 
         $routeCount++;
         [, $method] = explode('@', $route->getActionName(), 2);
-        $middleware = $route->gatherMiddleware();
+        $middleware = $route->middleware();
 
         expect($route->getName())
             ->not->toBeNull()
             ->toEndWith(".{$method}")
             ->and(collect($middleware)->contains(
-                fn (mixed $value): bool => is_string($value) && str_starts_with($value, 'can:'),
+                fn (string $value): bool => str_starts_with($value, 'can:'),
             ))
             ->toBeTrue();
     }


### PR DESCRIPTION
## Summary
- enforce resourceful or invokable controller shapes
- require plural names for domain resource controllers
- verify domain resource routes use method-aligned names and route-level authorization

## Verification
- focused Pest architecture suite: 4 tests, 102 assertions
- Pest PHPStan
- Pest Rector
- Pest type coverage: 100%
- Pint
- pre-push checks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added automated checks to validate controller structure and supported invocation patterns.
  * Added validation for consistent resource controller naming and route conventions.
  * Added checks ensuring resource routes include the required authorization middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->