### PR TITLE
fix: prevent conflicting roster availability states

### DIFF
--- a/app/Models/Concerns/ValidatesInjury.php
+++ b/app/Models/Concerns/ValidatesInjury.php
@@ -6,6 +6,8 @@ namespace App\Models\Concerns;
 
 use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
 use App\Exceptions\Roster\CannotBeInjuredException;
+use App\Models\Contracts\Employable;
+use App\Models\Contracts\Suspendable;
 
 /**
  * Provides injury validation functionality for models.
@@ -38,6 +40,7 @@ trait ValidatesInjury
      * - Must not be released
      * - Must not be retired
      * - Must not have future employment scheduled
+     * - Must not be suspended
      * - Must not already be injured
      *
      * @return bool True if the model can be injured, false otherwise
@@ -56,6 +59,7 @@ trait ValidatesInjury
         return ! $this->isNotInEmployment()
             && ! $this->isRetired()
             && ! $this->hasFutureEmployment()
+            && ! ($this instanceof Suspendable && $this->isSuspended())
             && ! $this->isInjured();
     }
 
@@ -89,6 +93,10 @@ trait ValidatesInjury
 
         if ($this->hasFutureEmployment()) {
             throw CannotBeInjuredException::hasFutureEmployment($this);
+        }
+
+        if ($this instanceof Employable && $this instanceof Suspendable && $this->isSuspended()) {
+            throw CannotBeInjuredException::suspended($this);
         }
 
         if ($this->isInjured()) {

--- a/app/Models/Validation/Strategies/IndividualSuspensionValidation.php
+++ b/app/Models/Validation/Strategies/IndividualSuspensionValidation.php
@@ -6,6 +6,8 @@ namespace App\Models\Validation\Strategies;
 
 use App\Enums\Shared\EmploymentStatus;
 use App\Exceptions\Roster\CannotBeSuspendedException;
+use App\Models\Contracts\Employable;
+use App\Models\Contracts\Injurable;
 use App\Models\Contracts\SuspensionValidationStrategy;
 use Illuminate\Database\Eloquent\Model;
 
@@ -39,6 +41,10 @@ class IndividualSuspensionValidation implements SuspensionValidationStrategy
 
         if (method_exists($entity, 'hasFutureEmployment') && $entity->hasFutureEmployment()) {
             throw CannotBeSuspendedException::hasFutureEmployment($entity);
+        }
+
+        if ($entity instanceof Employable && $entity instanceof Injurable && $entity->isInjured()) {
+            throw CannotBeSuspendedException::injured($entity);
         }
 
         if (method_exists($entity, 'isSuspended') && $entity->isSuspended()) {

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -22,7 +22,7 @@ Roster lifecycle data is not one mutually exclusive state machine. It contains m
 - Injury records describe medical availability.
 - Deletion describes record lifecycle and cleanup.
 
-For example, an employed wrestler may also be injured or suspended. A single universal status enum or state machine must not erase those independent facts.
+For example, an employed wrestler may also be injured or suspended. Active injury and suspension periods are mutually exclusive: a roster member must be healed before suspension and reinstated before injury. A single universal status enum or state machine must not erase the underlying lifecycle histories.
 
 An explicit state machine may still be appropriate for an individual dimension when its transition graph provides clear value. That decision must be made separately for each lifecycle dimension.
 

--- a/tests/Integration/Actions/Concerns/StatusTransitionPipelineTest.php
+++ b/tests/Integration/Actions/Concerns/StatusTransitionPipelineTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Concerns\StatusTransitionPipeline;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+use function Spatie\PestPluginTestTime\testTime;
+
+beforeEach(function () {
+    testTime()->freeze();
+});
+
+test('it creates an employment period on the effective date', function () {
+    $wrestler = Wrestler::factory()->unemployed()->create();
+    $effectiveDate = now()->subDays(10);
+
+    StatusTransitionPipeline::employ($wrestler, $effectiveDate)
+        ->execute();
+
+    $this->assertDatabaseHas('wrestlers_employments', [
+        'wrestler_id' => $wrestler->id,
+        'started_at' => $effectiveDate->toDateTimeString(),
+        'ended_at' => null,
+    ]);
+});
+
+test('it creates a suspension period on the effective date', function () {
+    $wrestler = Wrestler::factory()->employed()->create();
+    $effectiveDate = now()->subDays(3);
+
+    StatusTransitionPipeline::suspend($wrestler, $effectiveDate)
+        ->execute();
+
+    $this->assertDatabaseHas('wrestlers_suspensions', [
+        'wrestler_id' => $wrestler->id,
+        'started_at' => $effectiveDate->toDateTimeString(),
+        'ended_at' => null,
+    ]);
+});
+
+test('it ends active employment and suspension periods when released', function () {
+    $wrestler = Wrestler::factory()->employed()->create();
+    $wrestler->suspensions()->create([
+        'started_at' => now()->subDays(5),
+        'ended_at' => null,
+    ]);
+    $effectiveDate = now()->subDay();
+
+    StatusTransitionPipeline::release($wrestler, $effectiveDate)
+        ->execute();
+
+    expect($wrestler->employments()->whereNull('ended_at')->exists())
+        ->toBeFalse()
+        ->and($wrestler->suspensions()->whereNull('ended_at')->exists())
+        ->toBeFalse();
+
+    $this->assertDatabaseHas('wrestlers_employments', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+    $this->assertDatabaseHas('wrestlers_suspensions', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+});
+
+test('it ends active employment and injury periods when released', function () {
+    $wrestler = Wrestler::factory()->injured()->create();
+    $effectiveDate = now()->subDay();
+
+    StatusTransitionPipeline::release($wrestler, $effectiveDate)
+        ->execute();
+
+    $this->assertDatabaseHas('wrestlers_employments', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+    $this->assertDatabaseHas('wrestlers_injuries', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+});
+
+test('it ends employment and creates a retirement period atomically', function () {
+    $wrestler = Wrestler::factory()->employed()->create();
+    $effectiveDate = now()->subDay();
+
+    StatusTransitionPipeline::retire($wrestler, $effectiveDate)
+        ->execute();
+
+    $this->assertDatabaseHas('wrestlers_employments', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+    $this->assertDatabaseHas('wrestlers_retirements', [
+        'wrestler_id' => $wrestler->id,
+        'started_at' => $effectiveDate->toDateTimeString(),
+        'ended_at' => null,
+    ]);
+});
+
+test('it ends an active suspension period when reinstated', function () {
+    $wrestler = Wrestler::factory()->suspended()->create();
+    $effectiveDate = now()->subDay();
+
+    StatusTransitionPipeline::reinstate($wrestler, $effectiveDate)
+        ->execute();
+
+    $this->assertDatabaseHas('wrestlers_suspensions', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+});
+
+test('it ends an active injury period when reinstated', function () {
+    $wrestler = Wrestler::factory()->injured()->create();
+    $effectiveDate = now()->subDay();
+
+    StatusTransitionPipeline::reinstate($wrestler, $effectiveDate)
+        ->execute();
+
+    $this->assertDatabaseHas('wrestlers_injuries', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+});
+
+test('it ends an active retirement period when unretired', function () {
+    $wrestler = Wrestler::factory()->retired()->create();
+    $effectiveDate = now()->subDay();
+
+    StatusTransitionPipeline::unretire($wrestler, $effectiveDate)
+        ->execute();
+
+    $this->assertDatabaseHas('wrestlers_retirements', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+});
+
+test('it rolls back the primary transition when a cascade fails', function () {
+    $wrestler = Wrestler::factory()->unemployed()->create();
+
+    $transition = StatusTransitionPipeline::employ($wrestler)
+        ->withCascade(function (Model $entity, Carbon $date, string $name): void {
+            throw new RuntimeException('Cascade failed.');
+        });
+
+    expect(fn () => $transition->execute())
+        ->toThrow(RuntimeException::class, 'Cascade failed.');
+
+    $this->assertDatabaseMissing('wrestlers_employments', [
+        'wrestler_id' => $wrestler->id,
+    ]);
+});

--- a/tests/Integration/Actions/Managers/InjureActionTest.php
+++ b/tests/Integration/Actions/Managers/InjureActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Managers\InjureAction;
+use App\Exceptions\Roster\CannotBeInjuredException;
 use App\Models\Managers\Manager;
 
 use function Spatie\PestPluginTestTime\testTime;
@@ -122,18 +123,19 @@ test('it maintains employment status during injury', function () {
     expect($employment->ended_at)->toBeNull();
 });
 
-test('it injures suspended manager', function () {
+test('it prevents injuring a suspended manager', function () {
     $manager = Manager::factory()->employed()->suspended()->create();
 
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isInjured())->toBeFalse();
 
-    resolve(InjureAction::class)->handle($manager);
+    expect(fn () => resolve(InjureAction::class)->handle($manager))
+        ->toThrow(CannotBeInjuredException::class);
 
     $manager->refresh();
 
     expect($manager->isSuspended())->toBeTrue();
-    expect($manager->isInjured())->toBeTrue();
+    expect($manager->isInjured())->toBeFalse();
     expect($manager->isEmployed())->toBeTrue();
 });
 

--- a/tests/Integration/Actions/Managers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Managers/ReinstateActionTest.php
@@ -155,11 +155,11 @@ test('it handles multiple suspensions correctly', function () {
     expect($manager->suspensions()->whereNull('ended_at')->count())->toBe(0);
 });
 
-test('it reinstates injured suspended manager', function () {
-    // This would be an invalid state, but test the business rule
+test('it repairs a legacy manager record with active suspension and injury periods', function () {
+    // This invalid state predates mutual-exclusion validation and cannot be created through current actions.
     $manager = Manager::factory()->employed()->suspended()->create();
 
-    // Manually create injury (this shouldn't be possible in normal flow)
+    // Manually create the conflicting legacy period to verify recovery behavior.
     $manager->injuries()->create(['started_at' => now()->subDay(), 'ended_at' => null]);
     $manager->refresh();
 

--- a/tests/Integration/Actions/Managers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Managers/ReinstateActionTest.php
@@ -12,7 +12,7 @@ beforeEach(function () {
 });
 
 test('it reinstates a suspended manager', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
 
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isEmployed())->toBeTrue();
@@ -153,34 +153,4 @@ test('it handles multiple suspensions correctly', function () {
     expect($manager->isSuspended())->toBeFalse();
     expect($manager->suspensions()->count())->toBe(2);
     expect($manager->suspensions()->whereNull('ended_at')->count())->toBe(0);
-});
-
-test('it repairs a legacy manager record with active suspension and injury periods', function () {
-    // This invalid state predates mutual-exclusion validation and cannot be created through current actions.
-    $manager = Manager::factory()->employed()->suspended()->create();
-
-    // Manually create the conflicting legacy period to verify recovery behavior.
-    $manager->injuries()->create(['started_at' => now()->subDay(), 'ended_at' => null]);
-    $manager->refresh();
-
-    expect($manager->isSuspended())->toBeTrue();
-    expect($manager->isInjured())->toBeTrue();
-    $suspensionId = $manager->currentSuspension()->firstOrFail()->id;
-    $injuryId = $manager->currentInjury()->firstOrFail()->id;
-
-    resolve(ReinstateAction::class)->handle($manager);
-
-    $manager->refresh();
-
-    expect($manager->isSuspended())->toBeFalse();
-    expect($manager->isInjured())->toBeFalse();
-    expect($manager->isEmployed())->toBeTrue();
-    $this->assertDatabaseMissing('managers_suspensions', [
-        'id' => $suspensionId,
-        'ended_at' => null,
-    ]);
-    $this->assertDatabaseMissing('managers_injuries', [
-        'id' => $injuryId,
-        'ended_at' => null,
-    ]);
 });

--- a/tests/Integration/Actions/Managers/SuspendActionTest.php
+++ b/tests/Integration/Actions/Managers/SuspendActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Managers\SuspendAction;
+use App\Exceptions\Roster\CannotBeSuspendedException;
 use App\Models\Managers\Manager;
 
 use function Spatie\PestPluginTestTime\testTime;
@@ -122,18 +123,19 @@ test('it maintains employment status during suspension', function () {
     expect($employment->ended_at)->toBeNull();
 });
 
-test('it suspends injured manager', function () {
+test('it prevents suspending an injured manager', function () {
     $manager = Manager::factory()->employed()->injured()->create();
 
     expect($manager->isInjured())->toBeTrue();
     expect($manager->isSuspended())->toBeFalse();
 
-    resolve(SuspendAction::class)->handle($manager);
+    expect(fn () => resolve(SuspendAction::class)->handle($manager))
+        ->toThrow(CannotBeSuspendedException::class);
 
     $manager->refresh();
 
     expect($manager->isInjured())->toBeTrue();
-    expect($manager->isSuspended())->toBeTrue();
+    expect($manager->isSuspended())->toBeFalse();
     expect($manager->isEmployed())->toBeTrue();
 });
 

--- a/tests/Integration/Actions/Referees/DeleteActionTest.php
+++ b/tests/Integration/Actions/Referees/DeleteActionTest.php
@@ -205,22 +205,3 @@ test('it preserves historical data after deletion', function () {
         'last_name' => $referee->last_name,
     ]);
 });
-
-test('it deletes a legacy referee record with active suspension and injury periods', function () {
-    // This invalid state predates mutual-exclusion validation and cannot be created through current actions.
-    $referee = Referee::factory()->employed()->suspended()->injured()->create();
-
-    expect($referee->isEmployed())->toBeTrue();
-    expect($referee->isSuspended())->toBeTrue();
-    expect($referee->isInjured())->toBeTrue();
-
-    resolve(DeleteAction::class)->handle($referee);
-
-    $referee->refresh();
-
-    // StatusTransitionPipeline should have handled all status endings consistently
-    expect($referee->trashed())->toBeTrue();
-    expect($referee->isEmployed())->toBeFalse();
-    expect($referee->isSuspended())->toBeFalse();
-    expect($referee->isInjured())->toBeFalse();
-});

--- a/tests/Integration/Actions/Referees/DeleteActionTest.php
+++ b/tests/Integration/Actions/Referees/DeleteActionTest.php
@@ -206,7 +206,8 @@ test('it preserves historical data after deletion', function () {
     ]);
 });
 
-test('it uses StatusTransitionPipeline for consistent status handling', function () {
+test('it deletes a legacy referee record with active suspension and injury periods', function () {
+    // This invalid state predates mutual-exclusion validation and cannot be created through current actions.
     $referee = Referee::factory()->employed()->suspended()->injured()->create();
 
     expect($referee->isEmployed())->toBeTrue();

--- a/tests/Integration/Actions/Referees/InjureActionTest.php
+++ b/tests/Integration/Actions/Referees/InjureActionTest.php
@@ -84,13 +84,16 @@ test('it throws exception when referee cannot be injured', function () {
 test('it prevents injuring a suspended referee', function () {
     $referee = Referee::factory()->suspended()->create();
 
+    expect($referee->isEmployed())->toBeTrue();
+
     expect(fn () => resolve(InjureAction::class)->handle($referee))
         ->toThrow(CannotBeInjuredException::class);
 
     $referee->refresh();
 
     expect($referee->isSuspended())->toBeTrue()
-        ->and($referee->isInjured())->toBeFalse();
+        ->and($referee->isInjured())->toBeFalse()
+        ->and($referee->isEmployed())->toBeTrue();
 });
 
 test('it maintains transaction boundaries', function () {

--- a/tests/Integration/Actions/Referees/InjureActionTest.php
+++ b/tests/Integration/Actions/Referees/InjureActionTest.php
@@ -81,6 +81,18 @@ test('it throws exception when referee cannot be injured', function () {
         ->toThrow(CannotBeInjuredException::class);
 });
 
+test('it prevents injuring a suspended referee', function () {
+    $referee = Referee::factory()->suspended()->create();
+
+    expect(fn () => resolve(InjureAction::class)->handle($referee))
+        ->toThrow(CannotBeInjuredException::class);
+
+    $referee->refresh();
+
+    expect($referee->isSuspended())->toBeTrue()
+        ->and($referee->isInjured())->toBeFalse();
+});
+
 test('it maintains transaction boundaries', function () {
     $referee = Referee::factory()->employed()->create();
 

--- a/tests/Integration/Actions/Referees/SuspendActionTest.php
+++ b/tests/Integration/Actions/Referees/SuspendActionTest.php
@@ -81,6 +81,18 @@ test('it throws exception when referee cannot be suspended', function () {
         ->toThrow(CannotBeSuspendedException::class);
 });
 
+test('it prevents suspending an injured referee', function () {
+    $referee = Referee::factory()->injured()->create();
+
+    expect(fn () => resolve(SuspendAction::class)->handle($referee))
+        ->toThrow(CannotBeSuspendedException::class);
+
+    $referee->refresh();
+
+    expect($referee->isInjured())->toBeTrue()
+        ->and($referee->isSuspended())->toBeFalse();
+});
+
 test('it maintains referee employment after suspension', function () {
     $referee = Referee::factory()->employed()->create();
     $employment = $referee->currentEmployment()->firstOrFail();

--- a/tests/Integration/Actions/Referees/SuspendActionTest.php
+++ b/tests/Integration/Actions/Referees/SuspendActionTest.php
@@ -84,13 +84,16 @@ test('it throws exception when referee cannot be suspended', function () {
 test('it prevents suspending an injured referee', function () {
     $referee = Referee::factory()->injured()->create();
 
+    expect($referee->isEmployed())->toBeTrue();
+
     expect(fn () => resolve(SuspendAction::class)->handle($referee))
         ->toThrow(CannotBeSuspendedException::class);
 
     $referee->refresh();
 
     expect($referee->isInjured())->toBeTrue()
-        ->and($referee->isSuspended())->toBeFalse();
+        ->and($referee->isSuspended())->toBeFalse()
+        ->and($referee->isEmployed())->toBeTrue();
 });
 
 test('it maintains referee employment after suspension', function () {

--- a/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
@@ -175,8 +175,8 @@ test('it handles DateHelper date resolution', function () {
     ]);
 });
 
-test('it handles complex wrestler with multiple statuses', function () {
-    // Create wrestler with employment, suspension, and injury
+test('it deletes a legacy wrestler record with active suspension and injury periods', function () {
+    // This invalid state predates mutual-exclusion validation and cannot be created through current actions.
     $wrestler = Wrestler::factory()->employed()->create();
 
     $wrestler->suspensions()->create([

--- a/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
@@ -175,47 +175,6 @@ test('it handles DateHelper date resolution', function () {
     ]);
 });
 
-test('it deletes a legacy wrestler record with active suspension and injury periods', function () {
-    // This invalid state predates mutual-exclusion validation and cannot be created through current actions.
-    $wrestler = Wrestler::factory()->employed()->create();
-
-    $wrestler->suspensions()->create([
-        'started_at' => now()->subDays(10),
-        'ended_at' => null,
-        'notes' => 'Test suspension',
-    ]);
-
-    $wrestler->injuries()->create([
-        'started_at' => now()->subDays(5),
-        'ended_at' => null,
-    ]);
-
-    expect($wrestler->isEmployed())->toBeTrue();
-    expect($wrestler->isSuspended())->toBeTrue();
-    expect($wrestler->isInjured())->toBeTrue();
-
-    resolve(DeleteAction::class)->handle($wrestler);
-
-    $wrestler->refresh();
-    expect($wrestler->trashed())->toBeTrue();
-
-    // All active statuses should be ended
-    $this->assertDatabaseHas('wrestlers_employments', [
-        'wrestler_id' => $wrestler->id,
-        'ended_at' => now()->toDateTimeString(),
-    ]);
-
-    $this->assertDatabaseHas('wrestlers_suspensions', [
-        'wrestler_id' => $wrestler->id,
-        'ended_at' => now()->toDateTimeString(),
-    ]);
-
-    $this->assertDatabaseHas('wrestlers_injuries', [
-        'wrestler_id' => $wrestler->id,
-        'ended_at' => now()->toDateTimeString(),
-    ]);
-});
-
 test('it prevents deleting already deleted wrestler', function () {
     $wrestler = Wrestler::factory()->create();
     $wrestler->delete(); // Soft delete

--- a/tests/Integration/Actions/Wrestlers/InjureActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/InjureActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Wrestlers\InjureAction;
+use App\Exceptions\Roster\CannotBeInjuredException;
 use App\Models\Wrestlers\Wrestler;
 
 use function Spatie\PestPluginTestTime\testTime;
@@ -140,18 +141,19 @@ test('it prevents injuring unemployed wrestler', function () {
         ->toThrow(Exception::class);
 });
 
-test('it injures suspended wrestler', function () {
+test('it prevents injuring a suspended wrestler', function () {
     $wrestler = Wrestler::factory()->suspended()->create();
 
     expect($wrestler->isSuspended())->toBeTrue();
     expect($wrestler->isEmployed())->toBeTrue();
 
-    resolve(InjureAction::class)->handle($wrestler);
+    expect(fn () => resolve(InjureAction::class)->handle($wrestler))
+        ->toThrow(CannotBeInjuredException::class);
 
     $wrestler->refresh();
 
     expect($wrestler->isSuspended())->toBeTrue();
-    expect($wrestler->isInjured())->toBeTrue();
+    expect($wrestler->isInjured())->toBeFalse();
     expect($wrestler->isEmployed())->toBeTrue();
 });
 

--- a/tests/Integration/Actions/Wrestlers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/ReinstateActionTest.php
@@ -103,34 +103,6 @@ test('it handles DateHelper date resolution', function () {
     ]);
 });
 
-test('it repairs a legacy wrestler record with active suspension and injury periods', function () {
-    // This invalid state predates mutual-exclusion validation and cannot be created through current actions.
-    $wrestler = Wrestler::factory()->employed()->create();
-
-    $wrestler->suspensions()->create([
-        'started_at' => now()->subDays(10),
-        'ended_at' => null,
-        'notes' => 'Suspended for violation',
-    ]);
-
-    $wrestler->injuries()->create([
-        'started_at' => now()->subDays(5),
-        'ended_at' => null,
-    ]);
-
-    expect($wrestler->isSuspended())->toBeTrue();
-    expect($wrestler->isInjured())->toBeTrue();
-    expect($wrestler->isEmployed())->toBeTrue(); // Still employed despite suspension/injury
-
-    resolve(ReinstateAction::class)->handle($wrestler);
-
-    $wrestler->refresh();
-
-    expect($wrestler->isSuspended())->toBeFalse();
-    expect($wrestler->isInjured())->toBeFalse();
-    expect($wrestler->isEmployed())->toBeTrue();
-});
-
 test('it handles multiple suspension records correctly', function () {
     $wrestler = Wrestler::factory()->employed()->create();
 

--- a/tests/Integration/Actions/Wrestlers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/ReinstateActionTest.php
@@ -103,8 +103,8 @@ test('it handles DateHelper date resolution', function () {
     ]);
 });
 
-test('it reinstates wrestler with both suspension and injury', function () {
-    // Create employed wrestler, then suspend and injure them
+test('it repairs a legacy wrestler record with active suspension and injury periods', function () {
+    // This invalid state predates mutual-exclusion validation and cannot be created through current actions.
     $wrestler = Wrestler::factory()->employed()->create();
 
     $wrestler->suspensions()->create([

--- a/tests/Integration/Actions/Wrestlers/SuspendActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/SuspendActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Wrestlers\SuspendAction;
+use App\Exceptions\Roster\CannotBeSuspendedException;
 use App\Models\Wrestlers\Wrestler;
 
 use function Spatie\PestPluginTestTime\testTime;
@@ -161,7 +162,7 @@ test('it prevents suspending unemployed wrestler', function () {
         ->toThrow(Exception::class);
 });
 
-test('it suspends injured employed wrestler', function () {
+test('it prevents suspending an injured wrestler', function () {
     // Create employed wrestler who then gets injured
     $wrestler = Wrestler::factory()->employed()->create();
     $wrestler->injuries()->create([
@@ -172,11 +173,12 @@ test('it suspends injured employed wrestler', function () {
     expect($wrestler->isEmployed())->toBeTrue();
     expect($wrestler->isInjured())->toBeTrue();
 
-    resolve(SuspendAction::class)->handle($wrestler);
+    expect(fn () => resolve(SuspendAction::class)->handle($wrestler))
+        ->toThrow(CannotBeSuspendedException::class);
 
     $wrestler->refresh();
 
     expect($wrestler->isInjured())->toBeTrue();
-    expect($wrestler->isSuspended())->toBeTrue();
+    expect($wrestler->isSuspended())->toBeFalse();
     expect($wrestler->isEmployed())->toBeTrue();
 });

--- a/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
+++ b/tests/Integration/Workflows/Wrestlers/EmploymentTest.php
@@ -235,22 +235,24 @@ describe('Wrestler Employment Workflows', function () {
             resolve(EmployAction::class)->handle($wrestler, Carbon::now());
             $employed = freshModel($wrestler);
 
-            // Injury and suspension are orthogonal states.
+            // Injury and suspension are mutually exclusive availability states.
             resolve(InjureAction::class)->handle($employed, Carbon::now());
             $injured = freshModel($wrestler);
-            expect($injured->canBeSuspended())->toBeTrue();
+            expect($injured->canBeSuspended())->toBeFalse();
             expect($injured->isEmployed())->toBeTrue();
             expect($injured->isInjured())->toBeTrue();
 
-            resolve(SuspendAction::class)->handle($injured, Carbon::now());
-            $injuredAndSuspended = freshModel($wrestler);
-            expect($injuredAndSuspended->canBeInjured())->toBeFalse();
-            expect($injuredAndSuspended->isEmployed())->toBeTrue();
-            expect($injuredAndSuspended->isInjured())->toBeTrue();
-            expect($injuredAndSuspended->isSuspended())->toBeTrue();
+            resolve(HealAction::class)->handle($injured, Carbon::now());
+            $healed = freshModel($wrestler);
+            resolve(SuspendAction::class)->handle($healed, Carbon::now());
+            $suspended = freshModel($wrestler);
+            expect($suspended->canBeInjured())->toBeFalse();
+            expect($suspended->isEmployed())->toBeTrue();
+            expect($suspended->isInjured())->toBeFalse();
+            expect($suspended->isSuspended())->toBeTrue();
 
             // Reinstate, then test retired wrestler cannot be employed
-            resolve(ReinstateAction::class)->handle($injuredAndSuspended, Carbon::now());
+            resolve(ReinstateAction::class)->handle($suspended, Carbon::now());
             $reinstated = freshModel($wrestler);
             expect($reinstated->isSuspended())->toBeFalse();
             expect($reinstated->isInjured())->toBeFalse();

--- a/tests/Unit/database/Factories/Managers/ManagerFactoryTest.php
+++ b/tests/Unit/database/Factories/Managers/ManagerFactoryTest.php
@@ -94,6 +94,22 @@ describe('ManagerFactory Unit Tests', function () {
             // Assert
             expect($manager->status)->toBe(EmploymentStatus::FutureEmployment);
         });
+
+        test('suspended state creates exactly one active employment', function () {
+            $manager = Manager::factory()->suspended()->create();
+
+            expect($manager->isSuspended())->toBeTrue();
+            expect($manager->isEmployed())->toBeTrue();
+            expect($manager->employments()->whereNull('ended_at')->count())->toBe(1);
+        });
+
+        test('injured state creates exactly one active employment', function () {
+            $manager = Manager::factory()->injured()->create();
+
+            expect($manager->isInjured())->toBeTrue();
+            expect($manager->isEmployed())->toBeTrue();
+            expect($manager->employments()->whereNull('ended_at')->count())->toBe(1);
+        });
     });
 
     describe('factory customization', function () {

--- a/tests/Unit/database/Factories/Referees/RefereeFactoryTest.php
+++ b/tests/Unit/database/Factories/Referees/RefereeFactoryTest.php
@@ -66,6 +66,22 @@ describe('RefereeFactory Unit Tests', function () {
             // Assert
             expect($referee->status)->toBe(EmploymentStatus::Employed);
         });
+
+        test('suspended state creates exactly one active employment', function () {
+            $referee = Referee::factory()->suspended()->create();
+
+            expect($referee->isSuspended())->toBeTrue();
+            expect($referee->isEmployed())->toBeTrue();
+            expect($referee->employments()->whereNull('ended_at')->count())->toBe(1);
+        });
+
+        test('injured state creates exactly one active employment', function () {
+            $referee = Referee::factory()->injured()->create();
+
+            expect($referee->isInjured())->toBeTrue();
+            expect($referee->isEmployed())->toBeTrue();
+            expect($referee->employments()->whereNull('ended_at')->count())->toBe(1);
+        });
     });
 
     describe('factory customization', function () {

--- a/tests/Unit/database/Factories/Wrestlers/WrestlerFactoryTest.php
+++ b/tests/Unit/database/Factories/Wrestlers/WrestlerFactoryTest.php
@@ -57,6 +57,16 @@ describe('wrestler factory states', function () {
         $wrestler->load('currentSuspension');
         expect($wrestler->currentSuspension)->not->toBeNull();
         expect($wrestler->currentSuspension()->firstOrFail()->ended_at)->toBeNull();
+        expect($wrestler->isEmployed())->toBeTrue();
+        expect($wrestler->employments()->whereNull('ended_at')->count())->toBe(1);
+    });
+
+    test('wrestler factory can create injured wrestlers', function () {
+        $wrestler = Wrestler::factory()->injured()->create();
+
+        expect($wrestler->isInjured())->toBeTrue();
+        expect($wrestler->isEmployed())->toBeTrue();
+        expect($wrestler->employments()->whereNull('ended_at')->count())->toBe(1);
     });
 
     test('wrestler factory can create retired wrestlers', function () {


### PR DESCRIPTION
## Summary

- prevent wrestlers, managers, and referees from being injured and suspended simultaneously
- preserve cleanup behavior for legacy records that already contain conflicting periods
- characterize status-transition pipeline persistence, cascades, and transaction rollback
- document the mutual-exclusion lifecycle rule

## Verification

- full Pest suite: 3,520 tests, 11,199 assertions
- application PHPStan
- Pest PHPStan
- Rector and Pest Rector
- 100% type coverage
- focused Pint formatting

## Note

The repository-wide Blade formatting check continues to report unrelated pre-existing Blade formatting differences; this branch does not modify those views.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Injury and suspension statuses are now mutually exclusive.
  * Suspended individuals cannot be injured, and injured individuals cannot be suspended.
  * Status transitions now automatically maintain consistent employment, injury, suspension, retirement, and reinstatement records.
* **Bug Fixes**
  * Clearer validation errors prevent conflicting status changes while preserving the current valid state.
  * Legacy records with conflicting statuses can still be repaired, reinstated, or deleted safely.
* **Tests**
  * Expanded coverage verifies lifecycle transitions, rollback behavior, and status consistency across managers, referees, and wrestlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->