### PR TITLE
refactor: extract injury period lifecycle

### DIFF
--- a/app/Actions/Concerns/StatusTransitionPipeline.php
+++ b/app/Actions/Concerns/StatusTransitionPipeline.php
@@ -13,8 +13,8 @@ use InvalidArgumentException;
 /**
  * Unified status transition pipeline for wrestling promotion entities.
  *
- * This pipeline provides a consistent approach to status changes (employment, suspension,
- * retirement, injury) across all entity types while allowing for entity-specific validation
+ * This pipeline provides a consistent approach to the remaining status changes (employment,
+ * suspension, and retirement) while allowing for entity-specific validation
  * and cascading behaviors.
  *
  * DESIGN PATTERN:
@@ -31,8 +31,7 @@ use InvalidArgumentException;
  * - Suspension (from employed to suspended)
  * - Release (from employed to released)
  * - Retirement (from active to retired)
- * - Injury (from healthy to injured)
- * - Recovery/Reinstatement (from suspended/injured back to active)
+ * - Reinstatement (from suspended or injured back to active)
  */
 class StatusTransitionPipeline
 {
@@ -95,14 +94,6 @@ class StatusTransitionPipeline
     }
 
     /**
-     * Create an injury transition pipeline.
-     */
-    public static function injure(Model $entity, ?Carbon $date = null): self
-    {
-        return new self($entity, 'injure', $date);
-    }
-
-    /**
      * Create a reinstatement transition pipeline.
      */
     public static function reinstate(Model $entity, ?Carbon $date = null): self
@@ -119,16 +110,6 @@ class StatusTransitionPipeline
     public static function delete(Model $entity, ?Carbon $date = null): self
     {
         return new self($entity, 'delete', $date);
-    }
-
-    /**
-     * Create a heal transition pipeline.
-     *
-     * This handles recovery from injury by ending the current injury record.
-     */
-    public static function heal(Model $entity, ?Carbon $date = null): self
-    {
-        return new self($entity, 'heal', $date);
     }
 
     /**
@@ -235,10 +216,8 @@ class StatusTransitionPipeline
             'suspend' => 'ensureCanBeSuspended',
             'release' => 'ensureCanBeReleased',
             'retire' => 'ensureCanBeRetired',
-            'injure' => 'ensureCanBeInjured',
             'reinstate' => 'ensureCanBeReinstated',
             'delete' => 'ensureCanBeDeleted',
-            'heal' => 'ensureCanBeHealed',
             'unretire' => 'ensureCanBeUnretired',
             default => throw new InvalidArgumentException("Unknown transition: {$this->transition}")
         };
@@ -258,10 +237,8 @@ class StatusTransitionPipeline
             'suspend' => $this->createSuspension(),
             'release' => $this->createRelease(),
             'retire' => $this->createRetirement(),
-            'injure' => $this->createInjury(),
             'reinstate' => $this->createReinstatement(),
             'delete' => $this->createDeletion(),
-            'heal' => $this->createHeal(),
             'unretire' => $this->endRetirement(),
             default => throw new InvalidArgumentException("Unknown transition: {$this->transition}")
         };
@@ -371,18 +348,6 @@ class StatusTransitionPipeline
     }
 
     /**
-     * Create injury record using direct Eloquent operations.
-     */
-    protected function createInjury(): void
-    {
-        $table = $this->getTableName('injuries');
-        $this->entity->{$table}()->create([
-            'started_at' => $this->effectiveDate,
-            'ended_at' => null,
-        ]);
-    }
-
-    /**
      * Create reinstatement record using direct Eloquent operations.
      */
     protected function createReinstatement(): void
@@ -433,23 +398,6 @@ class StatusTransitionPipeline
         }
 
         // End injury if active
-        if (method_exists($this->entity, 'isInjured') && $this->entity->isInjured()) {
-            $injuryTable = $this->getTableName('injuries');
-            $this->entity->{$injuryTable}()->whereNull('ended_at')->update([
-                'ended_at' => $this->effectiveDate,
-            ]);
-        }
-    }
-
-    /**
-     * Handle heal transition by ending the current injury.
-     *
-     * This ends the active injury record, allowing the entity to return to
-     * active competition or duties.
-     */
-    protected function createHeal(): void
-    {
-        // End current injury if active
         if (method_exists($this->entity, 'isInjured') && $this->entity->isInjured()) {
             $injuryTable = $this->getTableName('injuries');
             $this->entity->{$injuryTable}()->whereNull('ended_at')->update([

--- a/app/Actions/Managers/HealAction.php
+++ b/app/Actions/Managers/HealAction.php
@@ -4,28 +4,25 @@ declare(strict_types=1);
 
 namespace App\Actions\Managers;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
+use App\Lifecycle\InjuryPeriodManager;
 use App\Models\Managers\Manager;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class HealAction
 {
+    public function __construct(private readonly InjuryPeriodManager $injuryPeriods) {}
+
     /**
      * Heal a manager from injury and return them to active management.
      *
      * This handles the complete injury recovery workflow:
-     * - Uses StatusTransitionPipeline for consistent injury healing
      * - Validates the manager can be healed from injury (currently injured)
-     * - Ends the current injury period with the specified recovery date
+     * - Ends the injury period through the shared lifecycle component
      * - Restores the manager to active talent management duties
      * - Makes the manager available for wrestler and tag team assignments again
      * - Preserves injury history for medical and administrative records
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistent status handling, following the same
-     * pattern as other manager actions for consistency.
      *
      * @param  Manager  $manager  The injured manager to heal
      * @param  Carbon|null  $recoveryDate  The recovery date (defaults to now)
@@ -37,7 +34,6 @@ class HealAction
 
         $recoveryDate = DateHelper::resolveDate($recoveryDate);
 
-        // Use StatusTransitionPipeline for consistent injury healing
-        StatusTransitionPipeline::heal($manager, $recoveryDate)->execute();
+        $this->injuryPeriods->end($manager, $recoveryDate);
     }
 }

--- a/app/Actions/Managers/InjureAction.php
+++ b/app/Actions/Managers/InjureAction.php
@@ -4,27 +4,24 @@ declare(strict_types=1);
 
 namespace App\Actions\Managers;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeInjuredException;
+use App\Lifecycle\InjuryPeriodManager;
 use App\Models\Managers\Manager;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class InjureAction
 {
+    public function __construct(private readonly InjuryPeriodManager $injuryPeriods) {}
+
     /**
      * Record a manager injury.
      *
      * This handles the complete manager injury workflow:
-     * - Uses StatusTransitionPipeline for consistent injury handling
      * - Validates the manager can be injured (currently employed, not already injured)
-     * - Creates an injury record with the specified start date
+     * - Creates the injury period through the shared lifecycle component
      * - Temporarily removes the manager from active wrestler/tag team management duties
      * - Maintains employment status while marking as unavailable due to injury
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistent status handling, following the same
-     * pattern as other manager actions.
      *
      * @param  Manager  $manager  The manager to mark as injured
      * @param  Carbon|null  $injureDate  The injury date (defaults to now)
@@ -36,7 +33,6 @@ class InjureAction
 
         $injureDate = DateHelper::resolveDate($injureDate);
 
-        // Use StatusTransitionPipeline for consistent injury handling
-        StatusTransitionPipeline::injure($manager, $injureDate)->execute();
+        $this->injuryPeriods->start($manager, $injureDate);
     }
 }

--- a/app/Actions/Referees/HealAction.php
+++ b/app/Actions/Referees/HealAction.php
@@ -4,28 +4,25 @@ declare(strict_types=1);
 
 namespace App\Actions\Referees;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
+use App\Lifecycle\InjuryPeriodManager;
 use App\Models\Referees\Referee;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class HealAction
 {
+    public function __construct(private readonly InjuryPeriodManager $injuryPeriods) {}
+
     /**
      * Heal a referee from injury and return them to active officiating.
      *
      * This handles the complete injury recovery workflow:
-     * - Uses StatusTransitionPipeline for consistent injury healing
      * - Validates the referee can be healed from injury (currently injured)
-     * - Ends the current injury period with the specified recovery date
+     * - Ends the injury period through the shared lifecycle component
      * - Restores the referee to active officiating status
      * - Makes the referee available for match assignments again
      * - Preserves injury history for medical and administrative records
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistent status handling, following the same
-     * pattern as other referee actions.
      *
      * @param  Referee  $referee  The injured referee to heal
      * @param  Carbon|null  $recoveryDate  The recovery date (defaults to now)
@@ -37,7 +34,6 @@ class HealAction
 
         $recoveryDate = DateHelper::resolveDate($recoveryDate);
 
-        // Use StatusTransitionPipeline for consistent injury healing
-        StatusTransitionPipeline::heal($referee, $recoveryDate)->execute();
+        $this->injuryPeriods->end($referee, $recoveryDate);
     }
 }

--- a/app/Actions/Referees/InjureAction.php
+++ b/app/Actions/Referees/InjureAction.php
@@ -5,18 +5,21 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Exceptions\Roster\CannotBeInjuredException;
+use App\Lifecycle\InjuryPeriodManager;
 use App\Models\Referees\Referee;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class InjureAction
 {
+    public function __construct(private readonly InjuryPeriodManager $injuryPeriods) {}
+
     /**
      * Record a referee injury.
      *
      * This handles the complete referee injury workflow:
      * - Validates the referee can be injured (currently employed, not already injured)
-     * - Creates an injury record with the specified start date
+     * - Creates the injury period through the shared lifecycle component
      * - Removes the referee from active match officiating duties
      * - Maintains employment status while marking as unavailable due to injury
      *
@@ -30,6 +33,6 @@ class InjureAction
 
         $injureDate = DateHelper::resolveDate($injureDate);
 
-        $referee->injuries()->create(['started_at' => $injureDate]);
+        $this->injuryPeriods->start($referee, $injureDate);
     }
 }

--- a/app/Actions/Wrestlers/HealAction.php
+++ b/app/Actions/Wrestlers/HealAction.php
@@ -4,24 +4,22 @@ declare(strict_types=1);
 
 namespace App\Actions\Wrestlers;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
+use App\Lifecycle\InjuryPeriodManager;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class HealAction
 {
+    public function __construct(private readonly InjuryPeriodManager $injuryPeriods) {}
+
     /**
      * Heal a wrestler from injury.
      *
      * This handles the complete injury recovery workflow:
-     * - Uses StatusTransitionPipeline for consistent injury ending
+     * - Ends the injury period through the shared lifecycle component
      * - Potentially restores tag team bookability if all members are now available
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistent status handling, following the same
-     * pattern as other wrestler actions.
      *
      * @throws CannotBeClearedFromInjuryException
      */
@@ -31,8 +29,7 @@ class HealAction
 
         $recoveryDate = DateHelper::resolveDate($recoveryDate);
 
-        // Use StatusTransitionPipeline for consistent injury healing
-        StatusTransitionPipeline::heal($wrestler, $recoveryDate)->execute();
+        $this->injuryPeriods->end($wrestler, $recoveryDate);
 
         // Note: Tag team bookability is handled automatically by the isBookable() method
         // which checks if all current wrestlers are available for competition

--- a/app/Actions/Wrestlers/InjureAction.php
+++ b/app/Actions/Wrestlers/InjureAction.php
@@ -4,27 +4,24 @@ declare(strict_types=1);
 
 namespace App\Actions\Wrestlers;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeInjuredException;
+use App\Lifecycle\InjuryPeriodManager;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class InjureAction
 {
+    public function __construct(private readonly InjuryPeriodManager $injuryPeriods) {}
+
     /**
      * Injure a wrestler and make them unavailable for competition.
      *
-     * This handles the complete wrestler injury workflow using StatusTransitionPipeline:
-     * - Validates the wrestler can be injured through pipeline validation
-     * - Uses StatusTransitionPipeline to properly create injury record
-     * - Maintains transaction boundaries and error handling through pipeline
+     * This handles the complete wrestler injury workflow:
+     * - Validates the wrestler can be injured
+     * - Creates the injury period through the shared lifecycle component
      * - Makes the wrestler unavailable for match bookings
      * - May affect tag team bookability if wrestler is in a team
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistency with other entity injury operations
-     * and proper status transition management.
      *
      * @param  Wrestler  $wrestler  The wrestler to injure
      * @param  Carbon|null  $injuryDate  The injury start date (defaults to now)
@@ -36,6 +33,6 @@ class InjureAction
 
         $injuryDate = DateHelper::resolveDate($injuryDate);
 
-        StatusTransitionPipeline::injure($wrestler, $injuryDate)->execute();
+        $this->injuryPeriods->start($wrestler, $injuryDate);
     }
 }

--- a/app/Lifecycle/InjuryPeriodManager.php
+++ b/app/Lifecycle/InjuryPeriodManager.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Models\Contracts\Injurable;
+use Illuminate\Support\Carbon;
+
+final class InjuryPeriodManager
+{
+    /**
+     * Start an injury period.
+     *
+     * @param  Injurable<*, *>  $injurable
+     */
+    public function start(Injurable $injurable, Carbon $date): void
+    {
+        $injurable->injuries()->create([
+            'started_at' => $date,
+            'ended_at' => null,
+        ]);
+    }
+
+    /**
+     * End the active injury period.
+     *
+     * @param  Injurable<*, *>  $injurable
+     */
+    public function end(Injurable $injurable, Carbon $date): void
+    {
+        $injurable->currentInjury()->update([
+            'ended_at' => $date,
+        ]);
+    }
+}

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -113,6 +113,8 @@ The existing concrete classes under `app/Actions/{Domain}` are the active applic
 
 Although active and widely used, it behaves as a generic transition executor rather than a composable pipeline. Its responsibilities should be separated by lifecycle dimension without changing behavior.
 
+Injury creation and explicit healing persistence have been extracted to the typed `InjuryPeriodManager`. Concrete wrestler, manager, and referee actions retain injury and healing validation and effective-date resolution, then delegate only starting or ending the injury record. The manager accepts the `Injurable` contract and does not own validation, transaction orchestration, cascade behavior, or dynamic capability discovery. The obsolete `injure` and `heal` transition-string branches have been removed from `StatusTransitionPipeline`. Multi-dimension operations such as release, retirement, reinstatement, and deletion still close injury periods inside the existing pipeline until those operations receive their own structural review.
+
 The following generalized classes were confirmed to have no production, configuration, container, console, route, or test consumers and were removed rather than retained as foundations for the target architecture:
 
 - `ActionPipeline`;
@@ -132,7 +134,7 @@ The migration must remain behavior-preserving and proceed in small pull requests
 1. Add characterization tests for lifecycle record mutations, effective dates, cascades, and transaction rollback. (Completed.)
 2. Confirm whether the isolated generalized classes have any dynamic runtime consumers. (Completed.)
 3. Remove unused generalized abstractions independently of the active transition path. (Completed.)
-4. Extract one shared lifecycle dimension from `StatusTransitionPipeline` at a time.
+4. Extract one shared lifecycle dimension from `StatusTransitionPipeline` at a time. (In progress: injury creation and explicit healing completed.)
 5. Keep concrete entity actions as the public entry points while moving only shared mechanics behind them.
 6. Replace callable cascades with typed collaborators where the existing reuse and complexity justify it.
 7. Review the eligibility rules for each lifecycle dimension separately.

--- a/tests/Integration/Lifecycle/InjuryPeriodManagerTest.php
+++ b/tests/Integration/Lifecycle/InjuryPeriodManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Lifecycle\InjuryPeriodManager;
+use App\Models\Wrestlers\Wrestler;
+
+use function Spatie\PestPluginTestTime\testTime;
+
+beforeEach(function () {
+    testTime()->freeze();
+});
+
+test('it starts an injury period on the effective date', function () {
+    $wrestler = Wrestler::factory()->employed()->create();
+    $effectiveDate = now()->subDay();
+
+    resolve(InjuryPeriodManager::class)->start($wrestler, $effectiveDate);
+
+    $this->assertDatabaseHas('wrestlers_injuries', [
+        'wrestler_id' => $wrestler->id,
+        'started_at' => $effectiveDate->toDateTimeString(),
+        'ended_at' => null,
+    ]);
+});
+
+test('it ends and preserves the active injury period', function () {
+    $wrestler = Wrestler::factory()->injured()->create();
+    $effectiveDate = now()->subHour();
+    $injuryId = $wrestler->currentInjury()->firstOrFail()->id;
+
+    resolve(InjuryPeriodManager::class)->end($wrestler, $effectiveDate);
+
+    $this->assertDatabaseHas('wrestlers_injuries', [
+        'id' => $injuryId,
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+});


### PR DESCRIPTION
## Summary

- add a typed `InjuryPeriodManager` that starts and ends injury records through the existing `Injurable` contract
- keep validation and effective-date resolution in the concrete wrestler, manager, and referee actions
- remove the obsolete `injure` and `heal` transition-string branches from `StatusTransitionPipeline`
- document the completed injury creation and explicit healing extraction

Multi-dimension operations such as release, retirement, reinstatement, and deletion remain unchanged and continue closing injury periods through the existing pipeline until those operations are reviewed separately.

## Verification

- focused injury, healing, and pipeline suites: 63 tests, 178 assertions
- full Pest suite: 3,523 tests, 11,194 assertions
- application PHPStan
- Pest PHPStan
- application Rector
- Pest Rector
- Pest type coverage: 100%
- focused Pint formatting

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added centralized handling for starting and ending injury periods.
  * Injury and recovery actions now consistently record injury lifecycle changes.
  * Reinstatement continues to support suspension and injury recovery.

* **Bug Fixes**
  * Improved consistency when closing active injury periods while preserving their existing records.

* **Tests**
  * Added coverage for injury start dates and closing active injury periods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->