### PR TITLE
refactor: extract suspension period persistence

### DIFF
--- a/app/Actions/Concerns/ReinstatementCascadeStrategy.php
+++ b/app/Actions/Concerns/ReinstatementCascadeStrategy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Actions\Concerns;
 
+use App\Actions\Managers\ReinstateAction as ReinstateManagerAction;
+use App\Actions\Wrestlers\ReinstateAction as ReinstateWrestlerAction;
 use App\Models\Managers\Manager;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Model;
@@ -20,9 +22,7 @@ use Illuminate\Support\Carbon;
  * When a tag team is reinstated from suspension, their suspended wrestlers and
  * managers should also be reinstated to restore the complete team unit.
  *
- * DESIGN PATTERN:
- * Strategy pattern - each method returns a callable strategy that can be used
- * with StatusTransitionPipeline.withCascade().
+ * Each method returns a callable strategy for tag-team reinstatement orchestration.
  */
 class ReinstatementCascadeStrategy
 {
@@ -51,7 +51,7 @@ class ReinstatementCascadeStrategy
 
             // Reinstate each suspended wrestler
             foreach ($suspendedWrestlers as $wrestler) {
-                StatusTransitionPipeline::reinstate($wrestler, $date)->execute();
+                resolve(ReinstateWrestlerAction::class)->handle($wrestler, $date);
             }
         };
     }
@@ -81,7 +81,7 @@ class ReinstatementCascadeStrategy
 
             // Reinstate each suspended manager
             foreach ($suspendedManagers as $manager) {
-                StatusTransitionPipeline::reinstate($manager, $date)->execute();
+                resolve(ReinstateManagerAction::class)->handle($manager, $date);
             }
         };
     }

--- a/app/Actions/Concerns/StatusTransitionPipeline.php
+++ b/app/Actions/Concerns/StatusTransitionPipeline.php
@@ -14,7 +14,7 @@ use InvalidArgumentException;
  * Unified status transition pipeline for wrestling promotion entities.
  *
  * This pipeline provides a consistent approach to the remaining status changes (employment,
- * suspension, and retirement) while allowing for entity-specific validation
+ * release, retirement, deletion, and unretirement) while allowing for entity-specific validation
  * and cascading behaviors.
  *
  * DESIGN PATTERN:
@@ -28,10 +28,8 @@ use InvalidArgumentException;
  *
  * SUPPORTED TRANSITIONS:
  * - Employment (from unemployed to employed)
- * - Suspension (from employed to suspended)
  * - Release (from employed to released)
  * - Retirement (from active to retired)
- * - Reinstatement (from suspended back to active)
  */
 class StatusTransitionPipeline
 {
@@ -48,8 +46,6 @@ class StatusTransitionPipeline
 
     /** @var array<int, mixed> */
     protected array $validationStrategies = [];
-
-    protected ?string $notes = null;
 
     /**
      * Create a new status transition pipeline instance.
@@ -70,14 +66,6 @@ class StatusTransitionPipeline
     }
 
     /**
-     * Create a suspension transition pipeline.
-     */
-    public static function suspend(Model $entity, ?Carbon $date = null): self
-    {
-        return new self($entity, 'suspend', $date);
-    }
-
-    /**
      * Create a release transition pipeline.
      */
     public static function release(Model $entity, ?Carbon $date = null): self
@@ -91,14 +79,6 @@ class StatusTransitionPipeline
     public static function retire(Model $entity, ?Carbon $date = null): self
     {
         return new self($entity, 'retire', $date);
-    }
-
-    /**
-     * Create a reinstatement transition pipeline.
-     */
-    public static function reinstate(Model $entity, ?Carbon $date = null): self
-    {
-        return new self($entity, 'reinstate', $date);
     }
 
     /**
@@ -145,16 +125,6 @@ class StatusTransitionPipeline
     public function withValidation(callable $validator): self
     {
         $this->validationStrategies[] = $validator;
-
-        return $this;
-    }
-
-    /**
-     * Add notes to the status transition.
-     */
-    public function withNotes(string $notes): self
-    {
-        $this->notes = $notes;
 
         return $this;
     }
@@ -213,10 +183,8 @@ class StatusTransitionPipeline
     {
         return match ($this->transition) {
             'employ' => 'ensureCanBeEmployed',
-            'suspend' => 'ensureCanBeSuspended',
             'release' => 'ensureCanBeReleased',
             'retire' => 'ensureCanBeRetired',
-            'reinstate' => 'ensureCanBeReinstated',
             'delete' => 'ensureCanBeDeleted',
             'unretire' => 'ensureCanBeUnretired',
             default => throw new InvalidArgumentException("Unknown transition: {$this->transition}")
@@ -234,10 +202,8 @@ class StatusTransitionPipeline
         // Execute the main transition using direct Eloquent operations
         match ($this->transition) {
             'employ' => $this->createEmployment(),
-            'suspend' => $this->createSuspension(),
             'release' => $this->createRelease(),
             'retire' => $this->createRetirement(),
-            'reinstate' => $this->createReinstatement(),
             'delete' => $this->createDeletion(),
             'unretire' => $this->endRetirement(),
             default => throw new InvalidArgumentException("Unknown transition: {$this->transition}")
@@ -267,24 +233,6 @@ class StatusTransitionPipeline
             'started_at' => $this->effectiveDate,
             'ended_at' => null,
         ]);
-    }
-
-    /**
-     * Create suspension record using direct Eloquent operations.
-     */
-    protected function createSuspension(): void
-    {
-        $table = $this->getTableName('suspensions');
-        $data = [
-            'started_at' => $this->effectiveDate,
-            'ended_at' => null,
-        ];
-
-        if ($this->notes) {
-            $data['notes'] = $this->notes;
-        }
-
-        $this->entity->{$table}()->create($data);
     }
 
     /**
@@ -344,19 +292,6 @@ class StatusTransitionPipeline
         $this->entity->{$table}()->create([
             'started_at' => $this->effectiveDate,
             'ended_at' => null,
-        ]);
-    }
-
-    /**
-     * Create reinstatement record using direct Eloquent operations.
-     */
-    protected function createReinstatement(): void
-    {
-        // End the current suspension.
-        $suspensionTable = $this->getTableName('suspensions');
-
-        $this->entity->{$suspensionTable}()->whereNull('ended_at')->update([
-            'ended_at' => $this->effectiveDate,
         ]);
     }
 

--- a/app/Actions/Concerns/SuspensionCascadeStrategy.php
+++ b/app/Actions/Concerns/SuspensionCascadeStrategy.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Actions\Concerns;
 
+use App\Actions\Managers\SuspendAction as SuspendManagerAction;
+use App\Actions\Wrestlers\SuspendAction as SuspendWrestlerAction;
 use App\Models\Managers\Manager;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Model;
@@ -21,9 +23,7 @@ use Illuminate\Support\Carbon;
  * suspended to maintain team suspension integrity. Only employed, non-suspended
  * members are affected to avoid duplicate suspensions.
  *
- * DESIGN PATTERN:
- * Strategy pattern - each method returns a callable strategy that can be used
- * with StatusTransitionPipeline.withCascade().
+ * Each method returns a callable strategy for tag-team suspension orchestration.
  */
 class SuspensionCascadeStrategy
 {
@@ -55,7 +55,7 @@ class SuspensionCascadeStrategy
 
             // Suspend each eligible wrestler
             foreach ($eligibleWrestlers as $wrestler) {
-                StatusTransitionPipeline::suspend($wrestler, $date)->execute();
+                resolve(SuspendWrestlerAction::class)->handle($wrestler, $date);
             }
         };
     }
@@ -88,7 +88,7 @@ class SuspensionCascadeStrategy
 
             // Suspend each eligible manager
             foreach ($eligibleManagers as $manager) {
-                StatusTransitionPipeline::suspend($manager, $date)->execute();
+                resolve(SuspendManagerAction::class)->handle($manager, $date);
             }
         };
     }

--- a/app/Actions/Managers/ReinstateAction.php
+++ b/app/Actions/Managers/ReinstateAction.php
@@ -4,27 +4,24 @@ declare(strict_types=1);
 
 namespace App\Actions\Managers;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeReinstatedException;
+use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\Managers\Manager;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 final class ReinstateAction
 {
+    public function __construct(private readonly SuspensionPeriodManager $suspensionPeriods) {}
+
     /**
      * Reinstate a suspended manager.
      *
      * This handles the complete manager reinstatement workflow:
-     * - Uses StatusTransitionPipeline for consistent reinstatement handling
      * - Validates the manager can be reinstated (currently suspended)
-     * - Ends the current suspension period with the specified date
+     * - Ends the current suspension period through the shared lifecycle component
      * - Restores the manager to active management duties
      * - Makes the manager available for wrestler/tag team assignments
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistent status handling, following the same
-     * pattern as other manager actions.
      *
      * @param  Manager  $manager  The manager to reinstate
      * @param  Carbon|null  $reinstatementDate  The reinstatement date (defaults to now)
@@ -36,7 +33,6 @@ final class ReinstateAction
 
         $reinstatementDate = DateHelper::resolveDate($reinstatementDate);
 
-        // Use StatusTransitionPipeline for consistent reinstatement handling
-        StatusTransitionPipeline::reinstate($manager, $reinstatementDate)->execute();
+        $this->suspensionPeriods->end($manager, $reinstatementDate);
     }
 }

--- a/app/Actions/Managers/SuspendAction.php
+++ b/app/Actions/Managers/SuspendAction.php
@@ -4,27 +4,24 @@ declare(strict_types=1);
 
 namespace App\Actions\Managers;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeSuspendedException;
+use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\Managers\Manager;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class SuspendAction
 {
+    public function __construct(private readonly SuspensionPeriodManager $suspensionPeriods) {}
+
     /**
      * Suspend a manager.
      *
      * This handles the complete manager suspension workflow:
-     * - Uses StatusTransitionPipeline for consistent suspension handling
      * - Validates the manager can be suspended (currently employed, not already suspended)
-     * - Creates a suspension record with the specified start date
+     * - Creates a suspension record through the shared lifecycle component
      * - Temporarily removes the manager from active wrestler/tag team management duties
      * - Maintains employment status while restricting availability
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistent status handling, following the same
-     * pattern as other manager actions.
      *
      * @param  Manager  $manager  The manager to suspend
      * @param  Carbon|null  $suspensionDate  The suspension start date (defaults to now)
@@ -36,7 +33,6 @@ class SuspendAction
 
         $suspensionDate = DateHelper::resolveDate($suspensionDate);
 
-        // Use StatusTransitionPipeline for consistent suspension handling
-        StatusTransitionPipeline::suspend($manager, $suspensionDate)->execute();
+        $this->suspensionPeriods->start($manager, $suspensionDate);
     }
 }

--- a/app/Actions/Referees/ReinstateAction.php
+++ b/app/Actions/Referees/ReinstateAction.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Exceptions\Roster\CannotBeReinstatedException;
+use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\Referees\Referee;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 
 class ReinstateAction
 {
+    public function __construct(private readonly SuspensionPeriodManager $suspensionPeriods) {}
+
     /**
      * Reinstate a suspended referee.
      *
@@ -31,8 +33,6 @@ class ReinstateAction
 
         $reinstatementDate = DateHelper::resolveDate($reinstatementDate);
 
-        DB::transaction(function () use ($referee, $reinstatementDate): void {
-            $referee->currentSuspension()->first()?->update(['ended_at' => $reinstatementDate]);
-        });
+        $this->suspensionPeriods->end($referee, $reinstatementDate);
     }
 }

--- a/app/Actions/Referees/SuspendAction.php
+++ b/app/Actions/Referees/SuspendAction.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Exceptions\Roster\CannotBeSuspendedException;
+use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\Referees\Referee;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class SuspendAction
 {
+    public function __construct(private readonly SuspensionPeriodManager $suspensionPeriods) {}
+
     /**
      * Suspend a referee.
      *
@@ -30,6 +33,6 @@ class SuspendAction
 
         $suspensionDate = DateHelper::resolveDate($suspensionDate);
 
-        $referee->suspensions()->create(['started_at' => $suspensionDate]);
+        $this->suspensionPeriods->start($referee, $suspensionDate);
     }
 }

--- a/app/Actions/TagTeams/ReinstateAction.php
+++ b/app/Actions/TagTeams/ReinstateAction.php
@@ -5,27 +5,26 @@ declare(strict_types=1);
 namespace App\Actions\TagTeams;
 
 use App\Actions\Concerns\ReinstatementCascadeStrategy;
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeReinstatedException;
+use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\TagTeams\TagTeam;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class ReinstateAction
 {
+    public function __construct(private readonly SuspensionPeriodManager $suspensionPeriods) {}
+
     /**
      * Reinstate a suspended tag team.
      *
-     * This handles the complete tag team reinstatement workflow using StatusTransitionPipeline:
+     * This handles the complete tag team reinstatement workflow:
      * - Validates the tag team can be reinstated (currently suspended)
-     * - Uses StatusTransitionPipeline to properly end suspension and restore active status
+     * - Ends the suspension through the shared lifecycle component
      * - Automatically cascades reinstatement to suspended wrestlers and managers
      * - Makes the team available for match bookings and championships again
-     * - Maintains transaction boundaries and error handling through pipeline
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline with ReinstatementCascadeStrategy for consistency
-     * with other entity status transitions (wrestlers, managers, etc.)
+     * - Keeps the primary change and member cascades in one transaction
      *
      * @param  TagTeam  $tagTeam  The tag team to reinstate
      * @param  Carbon|null  $reinstatementDate  The reinstatement date (defaults to now)
@@ -33,11 +32,13 @@ class ReinstateAction
      */
     public function handle(TagTeam $tagTeam, ?Carbon $reinstatementDate = null): void
     {
+        $tagTeam->ensureCanBeReinstated();
+
         $reinstatementDate = DateHelper::resolveDate($reinstatementDate);
 
-        StatusTransitionPipeline::reinstate($tagTeam, $reinstatementDate)
-            ->withCascade(ReinstatementCascadeStrategy::wrestlers())
-            ->withCascade(ReinstatementCascadeStrategy::managers())
-            ->execute();
+        DB::transaction(function () use ($tagTeam, $reinstatementDate): void {
+            $this->suspensionPeriods->end($tagTeam, $reinstatementDate);
+            ReinstatementCascadeStrategy::allMembers()($tagTeam, $reinstatementDate, 'reinstate');
+        });
     }
 }

--- a/app/Actions/TagTeams/SuspendAction.php
+++ b/app/Actions/TagTeams/SuspendAction.php
@@ -4,38 +4,40 @@ declare(strict_types=1);
 
 namespace App\Actions\TagTeams;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Actions\Concerns\SuspensionCascadeStrategy;
+use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\TagTeams\TagTeam;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class SuspendAction
 {
+    public function __construct(private readonly SuspensionPeriodManager $suspensionPeriods) {}
+
     /**
      * Suspend a tag team.
      *
-     * This handles the complete tag team suspension workflow using StatusTransitionPipeline:
+     * This handles the complete tag team suspension workflow:
      * - Validates the tag team can be suspended (currently employed, not already suspended)
-     * - Uses StatusTransitionPipeline to properly create suspension record
+     * - Creates the suspension record through the shared lifecycle component
      * - Automatically cascades suspension to eligible wrestlers and managers
      * - Temporarily removes the tag team from active competition
      * - Maintains employment status while restricting availability
      * - Ensures all members are properly suspended to maintain team suspension integrity
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline with SuspensionCascadeStrategy for consistency
-     * with other entity status transitions and proper member suspension management.
      *
      * @param  TagTeam  $tagTeam  The tag team to suspend
      * @param  Carbon|null  $suspensionDate  The suspension start date (defaults to now)
      */
     public function handle(TagTeam $tagTeam, ?Carbon $suspensionDate = null): void
     {
+        $tagTeam->ensureCanBeSuspended();
+
         $suspensionDate = DateHelper::resolveDate($suspensionDate);
 
-        StatusTransitionPipeline::suspend($tagTeam, $suspensionDate)
-            ->withCascade(SuspensionCascadeStrategy::allMembers())
-            ->execute();
+        DB::transaction(function () use ($tagTeam, $suspensionDate): void {
+            $this->suspensionPeriods->start($tagTeam, $suspensionDate);
+            SuspensionCascadeStrategy::allMembers()($tagTeam, $suspensionDate, 'suspend');
+        });
     }
 }

--- a/app/Actions/Wrestlers/ReinstateAction.php
+++ b/app/Actions/Wrestlers/ReinstateAction.php
@@ -4,26 +4,23 @@ declare(strict_types=1);
 
 namespace App\Actions\Wrestlers;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeReinstatedException;
+use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class ReinstateAction
 {
+    public function __construct(private readonly SuspensionPeriodManager $suspensionPeriods) {}
+
     /**
      * Reinstate a wrestler and make them available for employment.
      *
-     * This handles the complete wrestler reinstatement workflow using StatusTransitionPipeline:
-     * - Validates the wrestler can be reinstated through pipeline validation
-     * - Uses StatusTransitionPipeline to end the suspension period
-     * - Maintains transaction boundaries and error handling through pipeline
+     * This handles the complete wrestler reinstatement workflow:
+     * - Validates the wrestler can be reinstated
+     * - Ends the suspension period through the shared lifecycle component
      * - Makes the wrestler available for new employment opportunities
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistency with other entity reinstatement operations
-     * and proper status transition management.
      *
      * @param  Wrestler  $wrestler  The wrestler to reinstate
      * @param  Carbon|null  $reinstatementDate  The reinstatement date (defaults to now)
@@ -35,6 +32,6 @@ class ReinstateAction
 
         $reinstatementDate = DateHelper::resolveDate($reinstatementDate);
 
-        StatusTransitionPipeline::reinstate($wrestler, $reinstatementDate)->execute();
+        $this->suspensionPeriods->end($wrestler, $reinstatementDate);
     }
 }

--- a/app/Actions/Wrestlers/SuspendAction.php
+++ b/app/Actions/Wrestlers/SuspendAction.php
@@ -4,27 +4,24 @@ declare(strict_types=1);
 
 namespace App\Actions\Wrestlers;
 
-use App\Actions\Concerns\StatusTransitionPipeline;
 use App\Exceptions\Roster\CannotBeSuspendedException;
+use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
 
 class SuspendAction
 {
+    public function __construct(private readonly SuspensionPeriodManager $suspensionPeriods) {}
+
     /**
      * Suspend a wrestler and make them unavailable for competition.
      *
-     * This handles the complete wrestler suspension workflow using StatusTransitionPipeline:
-     * - Validates the wrestler can be suspended through pipeline validation
-     * - Uses StatusTransitionPipeline to properly create suspension record
-     * - Maintains transaction boundaries and error handling through pipeline
+     * This handles the complete wrestler suspension workflow:
+     * - Validates the wrestler can be suspended
+     * - Creates the suspension record through the shared lifecycle component
      * - Makes the wrestler unavailable for match bookings
      * - May affect tag team bookability if wrestler is in a team
-     *
-     * ARCHITECTURAL PATTERN:
-     * Uses StatusTransitionPipeline for consistency with other entity suspension operations
-     * and proper status transition management.
      *
      * @param  Wrestler  $wrestler  The wrestler to suspend
      * @param  Carbon|null  $suspensionDate  The suspension start date (defaults to now)
@@ -36,6 +33,6 @@ class SuspendAction
 
         $suspensionDate = DateHelper::resolveDate($suspensionDate);
 
-        StatusTransitionPipeline::suspend($wrestler, $suspensionDate)->execute();
+        $this->suspensionPeriods->start($wrestler, $suspensionDate);
     }
 }

--- a/app/Lifecycle/SuspensionPeriodManager.php
+++ b/app/Lifecycle/SuspensionPeriodManager.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Models\Contracts\Suspendable;
+use Illuminate\Support\Carbon;
+
+final class SuspensionPeriodManager
+{
+    /**
+     * @param  Suspendable<*, *>  $suspendable
+     */
+    public function start(Suspendable $suspendable, Carbon $date): void
+    {
+        $suspendable->suspensions()->create([
+            'started_at' => $date,
+            'ended_at' => null,
+        ]);
+    }
+
+    /**
+     * @param  Suspendable<*, *>  $suspendable
+     */
+    public function end(Suspendable $suspendable, Carbon $date): void
+    {
+        $suspendable->currentSuspension()->update([
+            'ended_at' => $date,
+        ]);
+    }
+}

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -115,7 +115,7 @@ The existing concrete classes under `app/Actions/{Domain}` are the active applic
 
 Although active and widely used, it behaves as a generic transition executor rather than a composable pipeline. Its responsibilities should be separated by lifecycle dimension without changing behavior.
 
-Injury creation and explicit healing persistence have been extracted to the typed `InjuryPeriodManager`. Concrete wrestler, manager, and referee actions retain injury and healing validation and effective-date resolution, then delegate only starting or ending the injury record. The manager accepts the `Injurable` contract and does not own validation, transaction orchestration, cascade behavior, or dynamic capability discovery. The obsolete `injure` and `heal` transition-string branches have been removed from `StatusTransitionPipeline`. Multi-dimension operations such as release, retirement, reinstatement, and deletion still close injury periods inside the existing pipeline until those operations receive their own structural review.
+Injury creation and explicit healing persistence have been extracted to the typed `InjuryPeriodManager`. Suspension creation and explicit reinstatement persistence similarly use the typed `SuspensionPeriodManager`. Concrete entity actions retain validation and effective-date resolution, then delegate only starting or ending the relevant lifecycle record. Tag-team actions also retain transaction ownership around their member cascades, and cascade collaborators invoke each related entity's complete typed action. The managers accept the relevant lifecycle contract and do not own validation, transaction orchestration, cascade behavior, or dynamic capability discovery. The obsolete injury, healing, suspension, and reinstatement transition-string branches have been removed from `StatusTransitionPipeline`. Multi-dimension operations such as release, retirement, and deletion still close injury or suspension periods inside the existing pipeline until those operations receive their own structural review.
 
 The following generalized classes were confirmed to have no production, configuration, container, console, route, or test consumers and were removed rather than retained as foundations for the target architecture:
 
@@ -136,7 +136,7 @@ The migration must remain behavior-preserving and proceed in small pull requests
 1. Add characterization tests for lifecycle record mutations, effective dates, cascades, and transaction rollback. (Completed.)
 2. Confirm whether the isolated generalized classes have any dynamic runtime consumers. (Completed.)
 3. Remove unused generalized abstractions independently of the active transition path. (Completed.)
-4. Extract one shared lifecycle dimension from `StatusTransitionPipeline` at a time. (In progress: injury creation and explicit healing completed.)
+4. Extract one shared lifecycle dimension from `StatusTransitionPipeline` at a time. (In progress: injury/healing and suspension/reinstatement completed.)
 5. Keep concrete entity actions as the public entry points while moving only shared mechanics behind them.
 6. Replace callable cascades with typed collaborators where the existing reuse and complexity justify it.
 7. Review the eligibility rules for each lifecycle dimension separately.

--- a/tests/Integration/Actions/Concerns/StatusTransitionPipelineTest.php
+++ b/tests/Integration/Actions/Concerns/StatusTransitionPipelineTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use App\Actions\Concerns\StatusTransitionPipeline;
-use App\Exceptions\Roster\CannotBeReinstatedException;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -22,20 +21,6 @@ test('it creates an employment period on the effective date', function () {
         ->execute();
 
     $this->assertDatabaseHas('wrestlers_employments', [
-        'wrestler_id' => $wrestler->id,
-        'started_at' => $effectiveDate->toDateTimeString(),
-        'ended_at' => null,
-    ]);
-});
-
-test('it creates a suspension period on the effective date', function () {
-    $wrestler = Wrestler::factory()->employed()->create();
-    $effectiveDate = now()->subDays(3);
-
-    StatusTransitionPipeline::suspend($wrestler, $effectiveDate)
-        ->execute();
-
-    $this->assertDatabaseHas('wrestlers_suspensions', [
         'wrestler_id' => $wrestler->id,
         'started_at' => $effectiveDate->toDateTimeString(),
         'ended_at' => null,
@@ -99,32 +84,6 @@ test('it ends employment and creates a retirement period atomically', function (
     $this->assertDatabaseHas('wrestlers_retirements', [
         'wrestler_id' => $wrestler->id,
         'started_at' => $effectiveDate->toDateTimeString(),
-        'ended_at' => null,
-    ]);
-});
-
-test('it ends an active suspension period when reinstated', function () {
-    $wrestler = Wrestler::factory()->suspended()->create();
-    $effectiveDate = now()->subDay();
-
-    StatusTransitionPipeline::reinstate($wrestler, $effectiveDate)
-        ->execute();
-
-    $this->assertDatabaseHas('wrestlers_suspensions', [
-        'wrestler_id' => $wrestler->id,
-        'ended_at' => $effectiveDate->toDateTimeString(),
-    ]);
-});
-
-test('it rejects reinstating an injured roster member', function () {
-    $wrestler = Wrestler::factory()->injured()->create();
-    $injuryId = $wrestler->currentInjury()->firstOrFail()->id;
-
-    expect(fn () => StatusTransitionPipeline::reinstate($wrestler)->execute())
-        ->toThrow(CannotBeReinstatedException::class);
-
-    $this->assertDatabaseHas('wrestlers_injuries', [
-        'id' => $injuryId,
         'ended_at' => null,
     ]);
 });

--- a/tests/Integration/Lifecycle/SuspensionPeriodManagerTest.php
+++ b/tests/Integration/Lifecycle/SuspensionPeriodManagerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Lifecycle\SuspensionPeriodManager;
+use App\Models\Wrestlers\Wrestler;
+
+use function Spatie\PestPluginTestTime\testTime;
+
+beforeEach(function () {
+    testTime()->freeze();
+});
+
+test('it starts a suspension period on the effective date', function () {
+    $wrestler = Wrestler::factory()->employed()->create();
+    $effectiveDate = now()->subDay();
+
+    resolve(SuspensionPeriodManager::class)->start($wrestler, $effectiveDate);
+
+    $this->assertDatabaseHas('wrestlers_suspensions', [
+        'wrestler_id' => $wrestler->id,
+        'started_at' => $effectiveDate->toDateTimeString(),
+        'ended_at' => null,
+    ]);
+});
+
+test('it ends and preserves the active suspension period', function () {
+    $wrestler = Wrestler::factory()->suspended()->create();
+    $effectiveDate = now()->subHour();
+    $suspensionId = $wrestler->currentSuspension()->firstOrFail()->id;
+
+    resolve(SuspensionPeriodManager::class)->end($wrestler, $effectiveDate);
+
+    $this->assertDatabaseHas('wrestlers_suspensions', [
+        'id' => $suspensionId,
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => $effectiveDate->toDateTimeString(),
+    ]);
+});


### PR DESCRIPTION
## Summary
- add a typed suspension-period persistence boundary
- keep validation, effective dates, transactions, and cascades in concrete actions
- remove suspension and reinstatement branches from the generic status pipeline
- document and test the extracted lifecycle boundary

## Verification
- focused Pest suite: 89 tests, 285 assertions
- full Pest suite: 3,527 tests, 11,207 assertions
- PHPStan and Pest PHPStan
- Rector and Pest Rector dry runs
- Pest type coverage: 100%
- Pint on changed PHP files
- git diff --check

## Local lint note
The repository-wide Blade lint still reports existing formatting differences in unrelated Blade templates; those files are intentionally outside this focused refactor.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added consistent suspension-period tracking for wrestlers, managers, referees, and tag teams.
  - Suspension and reinstatement actions now correctly start and end suspension periods, including related member cascades.
  - Reinstatement eligibility is validated before restoring status.

- **Bug Fixes**
  - Improved reliability of suspension and reinstatement workflows through coordinated, transactional updates.
  - Existing release, retirement, deletion, and unretirement behavior remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->