### PR TITLE
refactor: simplify stable unretirement

### DIFF
--- a/app/Actions/Stables/UnretireAction.php
+++ b/app/Actions/Stables/UnretireAction.php
@@ -4,18 +4,12 @@ declare(strict_types=1);
 
 namespace App\Actions\Stables;
 
-use App\Actions\Managers\UnretireAction as ManagersUnretireAction;
-use App\Actions\TagTeams\UnretireAction as TagTeamsUnretireAction;
-use App\Actions\Wrestlers\UnretireAction as WrestlersUnretireAction;
 use App\Enums\Stables\StableStatus;
 use App\Exceptions\Roster\Stables\CannotBeUnretiredException;
 use App\Lifecycle\RetirementPeriodManager;
 use App\Models\Stables\Stable;
-use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Log;
-use InvalidArgumentException;
 
 class UnretireAction
 {
@@ -23,9 +17,6 @@ class UnretireAction
      * Create a new unretire action instance.
      */
     public function __construct(
-        protected WrestlersUnretireAction $wrestlersUnretireAction,
-        protected TagTeamsUnretireAction $tagTeamsUnretireAction,
-        protected ManagersUnretireAction $managersUnretireAction,
         protected EstablishAction $establishAction,
         protected RetirementPeriodManager $retirementPeriods,
     ) {}
@@ -36,7 +27,7 @@ class UnretireAction
      * This handles the complete stable unretirement workflow with flexible options:
      * - Validates the stable can be unretired (business rule compliance)
      * - Ends the current retirement period with the specified date
-     * - Optionally unretires available former members for reunion storylines
+     * - Leaves former members' individual retirement state unchanged
      * - Optionally establishes the stable immediately or leaves inactive for manual setup
      * - Flexible member requirements for different unretirement scenarios
      * - Makes the stable available for new storylines and championship opportunities
@@ -44,7 +35,6 @@ class UnretireAction
      *
      * @param  Stable  $stable  The stable to unretire
      * @param  Carbon|null  $unretiredDate  The unretirement date (defaults to now)
-     * @param  bool  $unretireMembers  Whether to unretire available former members (default: true)
      * @param  bool  $establishImmediately  Whether to establish the stable immediately (default: true)
      * @param  bool  $requireFormerMembers  Whether to require available former members (default: true)
      * @throws CannotBeUnretiredException When stable cannot be unretired due to business rules
@@ -52,77 +42,21 @@ class UnretireAction
     public function handle(
         Stable $stable,
         ?Carbon $unretiredDate = null,
-        bool $unretireMembers = true,
         bool $establishImmediately = true,
         bool $requireFormerMembers = true
     ): void {
         $stable->ensureCanBeUnretired($requireFormerMembers);
 
         $unretiredDate = $unretiredDate ?? now();
-        $successCount = 0;
-        $failureCount = 0;
 
-        DB::transaction(function () use ($stable, $unretiredDate, $unretireMembers, $establishImmediately, &$successCount, &$failureCount): void {
+        DB::transaction(function () use ($stable, $unretiredDate, $establishImmediately): void {
             $this->retirementPeriods->end($stable, $unretiredDate);
 
-            // Attempt to unretire available former members
-            if ($unretireMembers) {
-                $availableFormerMembers = $stable->getAvailableFormerMembers();
-
-                foreach ($availableFormerMembers as $member) {
-                    if (! $member->isRetired()) {
-                        continue; // Skip members who are not retired
-                    }
-
-                    try {
-                        if (method_exists($member, 'getMorphClass')) {
-                            $morphClass = $member->getMorphClass();
-                            if ($morphClass === 'wrestler') {
-                                $this->wrestlersUnretireAction->handle($member, $unretiredDate);
-                                $successCount++;
-                            } elseif ($morphClass === 'tag_team') {
-                                $this->tagTeamsUnretireAction->handle($member, $unretiredDate);
-                                $successCount++;
-                            } else {
-                                throw new InvalidArgumentException("Cannot unretire member: unsupported member type '{$morphClass}' for {$member->name}.");
-                            }
-                        }
-                    } catch (InvalidArgumentException $e) {
-                        // Re-throw programming errors - these indicate system issues
-                        throw $e;
-                    } catch (Exception $e) {
-                        $failureCount++;
-                        // Log failure for administrative review
-                        Log::warning('Member unretirement failed during stable unretirement', [
-                            'stable_id' => $stable->id,
-                            'stable_name' => $stable->name,
-                            'member_id' => $member->id,
-                            'member_name' => $member->name,
-                            'error' => $e->getMessage(),
-                            'unretirement_date' => $unretiredDate->toDateTimeString(),
-                        ]);
-                    }
-                }
-            }
-
-            // Update status to inactive (no longer retired, but not active)
             $stable->update(['status' => StableStatus::Inactive]);
 
-            // Establish immediately if requested
             if ($establishImmediately) {
                 $this->establishAction->handle($stable, $unretiredDate);
             }
         });
-
-        // Log summary of member unretirement results
-        if ($unretireMembers && ($successCount > 0 || $failureCount > 0)) {
-            Log::info('Stable unretirement completed', [
-                'stable_id' => $stable->id,
-                'stable_name' => $stable->name,
-                'members_unretired' => $successCount,
-                'members_failed' => $failureCount,
-                'unretirement_date' => $unretiredDate->toDateTimeString(),
-            ]);
-        }
     }
 }

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -86,6 +86,8 @@ Tag-team suspension delegates eligible current wrestler and manager transitions 
 
 Tag-team reinstatement mirrors that boundary through `ReinstateCurrentMembersAction`, which invokes complete typed reinstatement actions only for suspended current wrestlers and managers. The coordinating tag-team action retains validation, suspension-period persistence, date handling, and transaction ownership.
 
+Stable unretirement changes only the stable's retirement and activity state. It does not infer which former wrestlers or tag teams should be unretired because the application does not record whether an individual retirement was caused by the stable. Those member transitions remain explicit operations.
+
 ### Transition policies
 
 A transition policy decides whether a lifecycle transition is permitted and provides the relevant domain failure.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -19,18 +19,6 @@ parameters:
 			path: app/Actions/Stables/MergeStablesAction.php
 
 		-
-			message: '#^Cannot access property \$id on class\-string\|object\.$#'
-			identifier: property.nonObject
-			count: 1
-			path: app/Actions/Stables/UnretireAction.php
-
-		-
-			message: '#^Cannot access property \$name on class\-string\|object\.$#'
-			identifier: property.nonObject
-			count: 2
-			path: app/Actions/Stables/UnretireAction.php
-
-		-
 			message: '#^Parameter \#2 \$wrestlers of method App\\Services\\TagTeamMembershipService\:\:addFoundingMembers\(\) expects Illuminate\\Support\\Collection\<int, App\\Models\\Wrestlers\\Wrestler\>, Illuminate\\Database\\Eloquent\\Collection given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/Integration/Actions/Stables/LifecycleTest.php
+++ b/tests/Integration/Actions/Stables/LifecycleTest.php
@@ -12,6 +12,8 @@ use App\Exceptions\Roster\Stables\CannotBeDisbandedException;
 use App\Exceptions\Roster\Stables\CannotBeEstablishedException;
 use App\Exceptions\Roster\Stables\CannotBeUnretiredException;
 use App\Models\Stables\Stable;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Carbon;
 
 /**
@@ -195,6 +197,29 @@ describe('Stable Activation Action Integration', function () {
             $refreshedStable = freshModel($this->retiredStable);
             expect($refreshedStable->activityPeriods()->count())->toBe($originalPeriodCount);
             expect($refreshedStable->isInactive())->toBeTrue();
+        });
+
+        test('unretire action preserves former members retirement state', function () {
+            $retiredWrestler = Wrestler::factory()->retired()->create();
+            $retiredTagTeam = TagTeam::factory()->retired()->create();
+
+            $this->retiredStable->wrestlers()->attach($retiredWrestler, [
+                'joined_at' => now()->subMonth(),
+                'left_at' => now()->subWeek(),
+            ]);
+            $this->retiredStable->tagTeams()->attach($retiredTagTeam, [
+                'joined_at' => now()->subMonth(),
+                'left_at' => now()->subWeek(),
+            ]);
+
+            resolve(UnretireAction::class)->handle(
+                $this->retiredStable,
+                establishImmediately: false,
+                requireFormerMembers: false,
+            );
+
+            expect($retiredWrestler->refresh()->isRetired())->toBeTrue()
+                ->and($retiredTagTeam->refresh()->isRetired())->toBeTrue();
         });
     });
 


### PR DESCRIPTION
## Summary
- keep stable unretirement scoped to the stable lifecycle itself
- remove nonfunctional automatic former-member unretirement and morph-string dispatch
- preserve wrestler and tag-team retirement state as explicit independent transitions
- remove obsolete PHPStan suppressions and document the lifecycle boundary

## Verification
- Pint
- Rector
- full application and Pest PHPStan analysis
- 19 focused tests with 52 assertions
- full suite: 3,541 tests with 11,256 assertions