### PR TITLE
refactor: simplify stable restoration

### DIFF
--- a/app/Actions/Stables/RestoreAction.php
+++ b/app/Actions/Stables/RestoreAction.php
@@ -5,67 +5,25 @@ declare(strict_types=1);
 namespace App\Actions\Stables;
 
 use App\Models\Stables\Stable;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 class RestoreAction
 {
     /**
-     * Create a new restore action instance.
-     */
-    public function __construct(
-        protected ReuniteAction $reuniteAction
-    ) {}
-
-    /**
      * Restore a soft-deleted stable.
      *
-     * This handles the complete stable restoration workflow:
-     * - Validates the stable can be restored (business rules and member availability)
+     * This handles the stable restoration workflow:
+     * - Validates the stable is deleted and has no active name conflict
      * - Restores the soft-deleted stable record from trash
-     * - Optionally reunites available former members for immediate storyline viability
      * - Preserves all historical member relationships and match history
-     * - Makes the stable available for new storylines and operations
-     *
-     * RESTORATION OPTIONS:
-     * - Basic restoration: Just undeletes the stable record (inactive state)
-     * - With reunion: Automatically reunites available former members (active state)
-     * - Member checking: Validates former member availability before restoration
-     *
-     * @param  Stable  $stable  The soft-deleted stable to restore
-     * @param  bool  $reuniteMembers  Whether to automatically reunite available former members
-     * @param  bool  $requireFormerMembers  Whether to require available former members for restoration
-     * @param  Carbon|null  $restorationDate  The restoration date (defaults to now)
+     * - Leaves reunion and activation as explicit subsequent operations
      */
-    public function handle(
-        Stable $stable,
-        bool $reuniteMembers = false,
-        bool $requireFormerMembers = true,
-        ?Carbon $restorationDate = null
-    ): void {
-        $stable->ensureCanBeRestored($requireFormerMembers);
+    public function handle(Stable $stable): void
+    {
+        $stable->ensureCanBeRestored();
 
-        $restorationDate = $restorationDate ?? now();
-
-        DB::transaction(function () use ($stable, $reuniteMembers, $restorationDate): void {
-            // Restore the soft-deleted stable record
+        DB::transaction(function () use ($stable): void {
             $stable->restore();
-
-            if ($reuniteMembers) {
-                // Get available former members for reunion
-                $availableFormerMembers = $stable->getAvailableFormerMembers();
-
-                if ($availableFormerMembers->isNotEmpty()) {
-                    // Use ReuniteAction to bring back available former members
-                    $this->reuniteAction->handle($stable, $restorationDate);
-                }
-                // If no members available but reunion requested, stable stays inactive
-                // This allows for manual member addition later
-
-            }
-
-            // Note: If not reuniting members, stable remains in inactive state
-            // This allows for manual configuration before reactivation
         });
     }
 }

--- a/app/Models/Concerns/ValidatesStableLifecycle.php
+++ b/app/Models/Concerns/ValidatesStableLifecycle.php
@@ -337,7 +337,6 @@ trait ValidatesStableLifecycle
      * Checks business rules for stable restoration:
      * - Must be soft deleted (trashed)
      * - Name must not conflict with existing active stables
-     * - Should have available former members for viable restoration
      *
      * @return bool True if the stable can be restored, false otherwise
      */
@@ -347,7 +346,6 @@ trait ValidatesStableLifecycle
             return false;
         }
 
-        // Check for name conflicts with existing active stables
         $nameConflict = static::where('name', $this->name)
             ->whereNull('deleted_at')
             ->exists();
@@ -356,26 +354,20 @@ trait ValidatesStableLifecycle
             return false;
         }
 
-        // Basic restoration is possible if no conflicts
         return true;
     }
 
     /**
      * Ensure the stable can be restored from soft deletion, throwing an exception if not.
      *
-     * Validates that the stable is in a valid state for restoration while checking
-     * for business rule violations and member availability for reunion storylines.
-     *
-     * @param  bool  $requireFormerMembers  Whether to require available former members
      * @throws CannotBeRestoredException When restoration is not allowed
      */
-    public function ensureCanBeRestored(bool $requireFormerMembers = true): void
+    public function ensureCanBeRestored(): void
     {
         if (! $this->trashed()) {
             throw CannotBeRestoredException::notDeleted($this);
         }
 
-        // Check for name conflicts with existing active stables
         $conflictingStable = static::where('name', $this->name)
             ->whereNull('deleted_at')
             ->first();
@@ -383,38 +375,6 @@ trait ValidatesStableLifecycle
         if ($conflictingStable) {
             throw CannotBeRestoredException::nameConflict($this, $conflictingStable->name);
         }
-
-        if ($requireFormerMembers) {
-            // Check if former members are available for restoration
-            $availableFormerMembers = $this->getAvailableFormerMembers();
-
-            if ($availableFormerMembers->isEmpty()) {
-                throw CannotBeRestoredException::noAvailableFormerMembers($this);
-            }
-
-            // Check minimum member count for viable restoration
-            $minimumMembers = static::MIN_MEMBERS_COUNT ?? 2;
-            if ($availableFormerMembers->count() < $minimumMembers) {
-                throw CannotBeRestoredException::insufficientFormerMembers(
-                    $this,
-                    $availableFormerMembers->count(),
-                    $minimumMembers
-                );
-            }
-
-            // Check if key former members are available
-            $unavailableKeyMembers = $this->getUnavailableKeyFormerMembers();
-            if ($unavailableKeyMembers->isNotEmpty()) {
-                $memberNames = $unavailableKeyMembers->pluck('name')->join(', ');
-                throw CannotBeRestoredException::keyMembersUnavailable($this, $memberNames);
-            }
-        }
-
-        // Additional business rule validations could be added here:
-        // - Storyline conflicts with current active stables
-        // - Administrative authorization requirements
-        // - Event timing conflicts
-        // - Member commitment conflicts
     }
 
     /**
@@ -665,7 +625,7 @@ trait ValidatesStableLifecycle
             }
 
             // Check minimum member count for viable unretirement
-            $minimumMembers = static::MIN_MEMBERS_COUNT ?? 2;
+            $minimumMembers = static::MIN_MEMBERS_COUNT;
             if ($availableFormerMembers->count() < $minimumMembers) {
                 throw CannotBeUnretiredException::insufficientFormerMembers(
                     $this,

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -88,6 +88,8 @@ Tag-team reinstatement mirrors that boundary through `ReinstateCurrentMembersAct
 
 Stable unretirement changes only the stable's retirement and activity state. It does not infer which former wrestlers or tag teams should be unretired because the application does not record whether an individual retirement was caused by the stable. Those member transitions remain explicit operations.
 
+Stable restoration only restores the soft-deleted record and preserves its historical state. Reunion and activation remain explicit subsequent operations, so restoration does not depend on current former-member availability.
+
 ### Transition policies
 
 A transition policy decides whether a lifecycle transition is permitted and provides the relevant domain failure.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1315,12 +1315,6 @@ parameters:
 			path: app/Models/Stables/Stable.php
 
 		-
-			message: '#^Expression on left side of \?\? is not nullable\.$#'
-			identifier: nullCoalesce.expr
-			count: 2
-			path: app/Models/Stables/Stable.php
-
-		-
 			message: '#^Method App\\Models\\Stables\\Stable\:\:getAvailableFormerMembers\(\) return type with generic class Illuminate\\Support\\Collection does not specify its types\: TKey, TValue$#'
 			identifier: missingType.generics
 			count: 1

--- a/tests/Integration/Actions/Stables/RestoreActionTest.php
+++ b/tests/Integration/Actions/Stables/RestoreActionTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Stables\RestoreAction;
+use App\Enums\Stables\StableStatus;
+use App\Exceptions\Roster\Stables\CannotBeRestoredException;
+use App\Models\Stables\Stable;
+
+test('it restores a stable without former members', function () {
+    $stable = Stable::factory()->create();
+    $stable->delete();
+
+    resolve(RestoreAction::class)->handle($stable);
+
+    expect($stable->refresh()->trashed())->toBeFalse()
+        ->and($stable->status)->toBe(StableStatus::Unformed)
+        ->and($stable->activityPeriods)->toBeEmpty();
+});
+
+test('it preserves historical activity without reuniting the stable', function () {
+    $stable = Stable::factory()->inactive()->create();
+    $activityPeriodCount = $stable->activityPeriods()->count();
+    $stable->delete();
+
+    resolve(RestoreAction::class)->handle($stable);
+
+    expect($stable->refresh()->status)->toBe(StableStatus::Inactive)
+        ->and($stable->activityPeriods)->toHaveCount($activityPeriodCount)
+        ->and($stable->currentActivityPeriod)->toBeNull();
+});
+
+test('it rejects a stable that is not deleted', function () {
+    $stable = Stable::factory()->create();
+
+    expect(fn () => resolve(RestoreAction::class)->handle($stable))
+        ->toThrow(CannotBeRestoredException::class);
+});
+
+test('it rejects an active stable with the same name', function () {
+    $stable = Stable::factory()->create();
+    $stable->delete();
+    Stable::factory()->active()->create(['name' => $stable->name]);
+
+    expect(fn () => resolve(RestoreAction::class)->handle($stable))
+        ->toThrow(CannotBeRestoredException::class);
+});


### PR DESCRIPTION
## Summary
- keep stable restoration scoped to restoring the soft-deleted record
- remove implicit reunion, activation, and former-member availability requirements
- preserve deletion and active-name-conflict validation
- add the missing stable restoration integration coverage
- remove an obsolete PHPStan suppression and document the lifecycle boundary

## Verification
- Pint
- PHPStan
- Rector
- 4 focused restoration tests with 8 assertions
- full suite: 3,544 tests with 11,262 assertions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Stable restoration now restores the deleted record without automatically reuniting members or creating a new active period.
  - Restoration preserves historical activity and state.

- **Bug Fixes**
  - Restorations are blocked for active records and duplicate active stable names.
  - Restoration no longer depends on former-member availability.

- **Documentation**
  - Clarified that reunion and activation are separate operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->