### PR TITLE
refactor: consolidate stable relationship mapping

### DIFF
--- a/app/Models/Concerns/CanJoinStables.php
+++ b/app/Models/Concerns/CanJoinStables.php
@@ -18,192 +18,85 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use InvalidArgumentException;
 
 /**
- * Provides relationship accessors and utilities for models that can belong to one or more stables.
- *
- * This trait enables models to participate in stable memberships with proper
- * tracking of join/leave dates through pivot models. It provides methods to
- * access current, previous, and all stable relationships.
- *
- * @template TPivotModel of Pivot The pivot model for stable relationships
- * @template TModel of Model The model that can join stables
+ * @template TPivotModel of Pivot
+ * @template TModel of Model
  *
  * @phpstan-require-implements CanBeAStableMember<TPivotModel, TModel>
- *
- * @example
- * ```php
- * class Wrestler extends Model implements CanBeAStableMember
- * {
- *     use CanJoinStables;
- * }
- *
- * $wrestler = Wrestler::find(1);
- * $allStables = $wrestler->stables;
- * $currentStable = $wrestler->currentStable;
- * ```
  */
 trait CanJoinStables
 {
     use HasBelongsToOne;
 
     /**
-     * The resolved stable pivot model class name.
-     *
-     * @var class-string<TPivotModel>|null
+     * @return array{table: string, foreignKey: string, pivot: class-string<Pivot>}
      */
-    protected static ?string $resolvedStablePivotModel = null;
-
-    /**
-     * Get the name of the pivot table for the stable relationship.
-     *
-     * Returns the appropriate pivot table based on the model type.
-     * Uses separate tables for wrestlers and tag teams.
-     *
-     * @return string The pivot table name
-     */
-    protected function getStablePivotTable(): string
+    private function stableMembershipRelationConfiguration(): array
     {
-        $morphClass = $this->getMorphClass();
-
-        return match ($morphClass) {
-            'wrestler', Wrestler::class => 'stables_wrestlers',
-            'tag_team', 'tagTeam', TagTeam::class => 'stables_tag_teams',
-            default => str_contains($morphClass, '@anonymous') ? 'stables_members' : throw new InvalidArgumentException("Unknown stable member type: {$morphClass}"),
+        return match (true) {
+            $this instanceof Wrestler => [
+                'table' => 'stables_wrestlers',
+                'foreignKey' => 'wrestler_id',
+                'pivot' => StableWrestler::class,
+            ],
+            $this instanceof TagTeam => [
+                'table' => 'stables_tag_teams',
+                'foreignKey' => 'tag_team_id',
+                'pivot' => StableTagTeam::class,
+            ],
+            default => throw new InvalidArgumentException('Unsupported stable member type: '.static::class),
         };
     }
 
     /**
-     * Define a many-to-many relationship between the model and stables.
-     *
-     * Returns all stable relationships regardless of their current status
-     * (active or completed). Includes pivot data for join/leave tracking.
-     *
      * @return BelongsToMany<Stable, static, TPivotModel>
-     *                                                    A relationship instance for accessing all stables
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $allStables = $wrestler->stables;
-     * $stableCount = $wrestler->stables()->count();
-     * ```
      */
     public function stables(): BelongsToMany
     {
-        $table = $this->getStablePivotTable();
-        $morphClass = $this->getMorphClass();
-        $foreignKey = match ($morphClass) {
-            'wrestler', Wrestler::class => 'wrestler_id',
-            'tag_team', 'tagTeam', TagTeam::class => 'tag_team_id',
-            default => str_contains($morphClass, '@anonymous') ? 'member_id' : throw new InvalidArgumentException("Unknown stable member type: {$morphClass}"),
-        };
-
-        $pivotClass = match ($morphClass) {
-            'wrestler', Wrestler::class => StableWrestler::class,
-            'tag_team', 'tagTeam', TagTeam::class => StableTagTeam::class,
-            default => str_contains($morphClass, '@anonymous') ? 'App\Models\StableMembers' : throw new InvalidArgumentException("Unknown stable member type: {$morphClass}"),
-        };
+        $configuration = $this->stableMembershipRelationConfiguration();
 
         /** @var BelongsToMany<Stable, static, TPivotModel> $relation */
         $relation = $this->belongsToMany(
             Stable::class,
-            $table,
-            $foreignKey,
+            $configuration['table'],
+            $configuration['foreignKey'],
             'stable_id'
         )
-            ->using($pivotClass)
+            ->using($configuration['pivot'])
             ->withPivot(['joined_at', 'left_at'])
             ->withTimestamps();
 
         return $relation;
     }
 
-    /**
-     * Define a one-to-one relationship for the current stable.
-     *
-     * Uses the `BelongsToOne` relationship to identify the currently joined stable
-     * (i.e., where `left_at` is null).
-     *
-     * @return BelongsToOne
-     *                      A relationship instance for accessing the current stable
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $currentStable = $wrestler->currentStable;
-     *
-     * if ($wrestler->currentStable()->exists()) {
-     *     echo "Wrestler is currently in a stable";
-     * }
-     * ```
-     */
     public function currentStable(): BelongsToOne
     {
-        $table = $this->getStablePivotTable();
-        $morphClass = $this->getMorphClass();
-        $foreignKey = match ($morphClass) {
-            'wrestler', Wrestler::class => 'wrestler_id',
-            'tag_team', 'tagTeam', TagTeam::class => 'tag_team_id',
-            default => str_contains($morphClass, '@anonymous') ? 'member_id' : throw new InvalidArgumentException("Unknown stable member type: {$morphClass}"),
-        };
-
-        $pivotClass = match ($morphClass) {
-            'wrestler', Wrestler::class => StableWrestler::class,
-            'tag_team', 'tagTeam', TagTeam::class => StableTagTeam::class,
-            default => str_contains($morphClass, '@anonymous') ? 'App\Models\StableMembers' : throw new InvalidArgumentException("Unknown stable member type: {$morphClass}"),
-        };
+        $configuration = $this->stableMembershipRelationConfiguration();
 
         return $this->belongsToOne(
             Stable::class,
-            $table,
-            $foreignKey,
+            $configuration['table'],
+            $configuration['foreignKey'],
             'stable_id'
         )
-            ->using($pivotClass)
+            ->using($configuration['pivot'])
             ->wherePivotNull('left_at')
             ->withPivot(['joined_at', 'left_at'])
             ->withTimestamps();
     }
 
-    /**
-     * Get all stables the model previously belonged to.
-     *
-     * Returns stables that the model has left (where 'left_at' is not null).
-     * These represent completed stable memberships.
-     *
-     * @return BelongsToMany<Stable, static, TPivotModel>
-     *                                                    A relationship instance for accessing previous stables
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $formerStables = $wrestler->previousStables;
-     * $stableHistory = $wrestler->previousStables()->orderBy('pivot_left_at', 'desc')->get();
-     * ```
-     */
+    /** @return BelongsToMany<Stable, static, TPivotModel> */
     public function previousStables(): BelongsToMany
     {
-        $table = $this->getStablePivotTable();
-        $morphClass = $this->getMorphClass();
-        $foreignKey = match ($morphClass) {
-            'wrestler', Wrestler::class => 'wrestler_id',
-            'tag_team', 'tagTeam', TagTeam::class => 'tag_team_id',
-            default => str_contains($morphClass, '@anonymous') ? 'member_id' : throw new InvalidArgumentException("Unknown stable member type: {$morphClass}"),
-        };
-
-        $pivotClass = match ($morphClass) {
-            'wrestler', Wrestler::class => StableWrestler::class,
-            'tag_team', 'tagTeam', TagTeam::class => StableTagTeam::class,
-            default => str_contains($morphClass, '@anonymous') ? 'App\Models\StableMembers' : throw new InvalidArgumentException("Unknown stable member type: {$morphClass}"),
-        };
+        $configuration = $this->stableMembershipRelationConfiguration();
 
         /** @var BelongsToMany<Stable, static, TPivotModel> $relation */
         $relation = $this->belongsToMany(
             Stable::class,
-            $table,
-            $foreignKey,
+            $configuration['table'],
+            $configuration['foreignKey'],
             'stable_id'
         )
-            ->using($pivotClass)
+            ->using($configuration['pivot'])
             ->withPivot(['joined_at', 'left_at'])
             ->withTimestamps()
             ->wherePivotNotNull('left_at');
@@ -211,25 +104,6 @@ trait CanJoinStables
         return $relation;
     }
 
-    /**
-     * Determine whether the model is not currently a member of the given stable.
-     *
-     * Checks if the model's current stable is different from the provided stable.
-     * Returns true if the model is not in the specified stable.
-     *
-     * @param  Stable  $stable  The stable to check against
-     * @return bool True if the model is not in the specified stable, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $stable = Stable::find(1);
-     *
-     * if ($wrestler->isNotCurrentlyInStable($stable)) {
-     *     echo "Wrestler is not in this stable";
-     * }
-     * ```
-     */
     public function isNotCurrentlyInStable(Stable $stable): bool
     {
         $currentStable = $this->currentStable;

--- a/tests/Unit/Models/Concerns/CanJoinStablesTest.php
+++ b/tests/Unit/Models/Concerns/CanJoinStablesTest.php
@@ -2,256 +2,69 @@
 
 declare(strict_types=1);
 
-/**
- * Trait Isolation Test for CanJoinStables
- *
- * This test ensures the CanJoinStables trait is agnostic, reusable, and not tied to any business/domain model.
- * It verifies relationship types, related model resolution, static override, cache reset, and error handling.
- *
- * This is NOT a business logic test. It is meant to guarantee the trait can be safely reused across any model.
- */
-
 namespace Tests\Unit\Models\Concerns;
 
 use Ankurk91\Eloquent\Relations\BelongsToOne;
-use App\Models\Concerns\CanJoinStables;
-use App\Models\Contracts\CanBeAStableMember;
 use App\Models\Stables\Stable;
+use App\Models\Stables\StableTagTeam;
 use App\Models\Stables\StableWrestler;
-use Illuminate\Database\Eloquent\Model;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 
-describe('CanJoinStables Trait Unit Tests', function () {
-    describe('stable relationships', function () {
-        test('provides stables relationship', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
+dataset('stable members', [
+    'wrestler' => [new Wrestler()],
+    'tag team' => [new TagTeam()],
+]);
 
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            expect($model->stables())->toBeInstanceOf(BelongsToMany::class);
-        });
+dataset('stable relationship configurations', [
+    'wrestler' => [new Wrestler(), 'stables_wrestlers', 'wrestler_id', StableWrestler::class],
+    'tag team' => [new TagTeam(), 'stables_tag_teams', 'tag_team_id', StableTagTeam::class],
+]);
 
-        test('provides current stable relationship', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
+it('defines all stable relationships', function (Wrestler|TagTeam $member) {
+    $stables = $member->stables();
+    $currentStable = $member->currentStable();
+    $previousStables = $member->previousStables();
 
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            expect($model->currentStable())->toBeInstanceOf(BelongsToOne::class);
-        });
+    expect($stables)->toBeInstanceOf(BelongsToMany::class)
+        ->and($currentStable)->toBeInstanceOf(BelongsToOne::class)
+        ->and($previousStables)->toBeInstanceOf(BelongsToMany::class)
+        ->and($stables->getRelated())->toBeInstanceOf(Stable::class)
+        ->and($currentStable->getRelated())->toBeInstanceOf(Stable::class)
+        ->and($previousStables->getRelated())->toBeInstanceOf(Stable::class);
+})->with('stable members');
 
-        test('provides previous stables relationship', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
+it('uses the configured stable membership table and pivot model', function (
+    Wrestler|TagTeam $member,
+    string $table,
+    string $foreignKey,
+    string $pivotClass,
+) {
+    $relationship = $member->stables();
+    $pivot = $relationship->newPivot();
 
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            expect($model->previousStables())->toBeInstanceOf(BelongsToMany::class);
-        });
+    expect($relationship->getTable())->toBe($table)
+        ->and($relationship->getForeignPivotKeyName())->toBe($foreignKey)
+        ->and($pivot)->toBeInstanceOf(Pivot::class)
+        ->and($pivot)->toBeInstanceOf($pivotClass);
+})->with('stable relationship configurations');
 
-        test('stables relationship uses the correct related model', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
+it('includes stable membership dates and timestamps', function (Wrestler|TagTeam $member) {
+    expect($member->stables()->getPivotColumns())
+        ->toContain('joined_at', 'left_at', 'created_at', 'updated_at');
+})->with('stable members');
 
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            $relation = $model->stables();
-            expect($relation)->toBeInstanceOf(BelongsToMany::class);
-            expect($relation->getRelated())->toBeInstanceOf(Stable::class);
-        });
+it('filters current and previous stable memberships by the departure date', function (
+    Wrestler|TagTeam $member,
+    string $table,
+) {
+    $qualifiedDepartureColumn = "\"{$table}\".\"left_at\"";
 
-        test('currentStable relationship uses the correct related model', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            $relation = $model->currentStable();
-            expect($relation)->toBeInstanceOf(BelongsToOne::class);
-            expect($relation->getRelated())->toBeInstanceOf(Stable::class);
-        });
-
-        test('previousStables relationship uses the correct related model', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            $relation = $model->previousStables();
-            expect($relation)->toBeInstanceOf(BelongsToMany::class);
-            expect($relation->getRelated())->toBeInstanceOf(Stable::class);
-        });
-    });
-
-    describe('stable pivot model resolution', function () {
-        test('resolves to StableMember model by default', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-
-                public function testResolveStablePivotModel(): string
-                {
-                    return $this->resolveStablePivotModel();
-                }
-            };
-            expect($model->testResolveStablePivotModel())->toBe(StableWrestler::class);
-        });
-
-        test('can override stable pivot model class', function () {
-            $customPivotClass = 'CustomStableMember';
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                protected static ?string $resolvedStablePivotModel = null;
-
-                public function resolveStablePivotModel(): string
-                {
-                    return self::$resolvedStablePivotModel ?? StableWrestler::class;
-                }
-
-                public function setCustomPivotClass(string $customClass): void
-                {
-                    self::$resolvedStablePivotModel = $customClass;
-                }
-
-                public function testResolveStablePivotModel(): string
-                {
-                    return $this->resolveStablePivotModel();
-                }
-            };
-            $model->setCustomPivotClass($customPivotClass);
-            expect($model->testResolveStablePivotModel())->toBe($customPivotClass);
-        });
-    });
-
-    describe('stable pivot table naming', function () {
-        test('uses polymorphic stables_members table', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                public function testGetStablePivotTable(): string
-                {
-                    return $this->getStablePivotTable();
-                }
-            };
-            $pivotTable = $model->testGetStablePivotTable();
-            // All entities now use the same polymorphic table
-            expect($pivotTable)->toBe('stables_members');
-        });
-    });
-
-    describe('stable relationship queries', function () {
-        test('stables relationship includes pivot data', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            $relation = $model->stables();
-            $pivotColumns = $relation->getPivotColumns();
-            expect($pivotColumns)->toContain('joined_at');
-            expect($pivotColumns)->toContain('left_at');
-        });
-
-        test('currentStable relationship includes wherePivotNull constraint', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            $relation = $model->currentStable();
-            expect($relation)->toBeInstanceOf(BelongsToOne::class);
-            // The wherePivotNull constraint is applied internally by Laravel
-            // We can verify the relationship type and that it's properly configured
-        });
-
-        test('previousStables relationship includes wherePivot constraints', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            $relation = $model->previousStables();
-            expect($relation)->toBeInstanceOf(BelongsToMany::class);
-            // The wherePivot constraints are applied internally by Laravel
-            // We can verify the relationship type and that it's properly configured
-        });
-
-        test('all stable relationships use timestamps', function () {
-            $model = new class extends Model implements CanBeAStableMember
-            {
-                /** @use CanJoinStables<StableWrestler, self> */
-                use CanJoinStables;
-
-                public function resolveStablePivotModel(): string
-                {
-                    return StableWrestler::class;
-                }
-            };
-            $stablesRelation = $model->stables();
-            $currentStableRelation = $model->currentStable();
-            $previousStablesRelation = $model->previousStables();
-
-            // All relationships should use timestamps
-            expect($stablesRelation)->toBeInstanceOf(BelongsToMany::class);
-            expect($currentStableRelation)->toBeInstanceOf(BelongsToOne::class);
-            expect($previousStablesRelation)->toBeInstanceOf(BelongsToMany::class);
-        });
-    });
-});
+    expect($member->currentStable()->toRawSql())->toContain("{$qualifiedDepartureColumn} is null")
+        ->and($member->previousStables()->toRawSql())->toContain("{$qualifiedDepartureColumn} is not null");
+})->with([
+    'wrestler' => [new Wrestler(), 'stables_wrestlers'],
+    'tag team' => [new TagTeam(), 'stables_tag_teams'],
+]);

--- a/tests/Unit/Models/Concerns/CanJoinStablesTest.php
+++ b/tests/Unit/Models/Concerns/CanJoinStablesTest.php
@@ -14,13 +14,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 dataset('stable members', [
-    'wrestler' => [new Wrestler()],
-    'tag team' => [new TagTeam()],
+    'wrestler' => [fn (): Wrestler => Wrestler::factory()->make()],
+    'tag team' => [fn (): TagTeam => TagTeam::factory()->make()],
 ]);
 
 dataset('stable relationship configurations', [
-    'wrestler' => [new Wrestler(), 'stables_wrestlers', 'wrestler_id', StableWrestler::class],
-    'tag team' => [new TagTeam(), 'stables_tag_teams', 'tag_team_id', StableTagTeam::class],
+    'wrestler' => [fn (): Wrestler => Wrestler::factory()->make(), 'stables_wrestlers', 'wrestler_id', StableWrestler::class],
+    'tag team' => [fn (): TagTeam => TagTeam::factory()->make(), 'stables_tag_teams', 'tag_team_id', StableTagTeam::class],
 ]);
 
 it('defines all stable relationships', function (Wrestler|TagTeam $member) {
@@ -48,7 +48,7 @@ it('uses the configured stable membership table and pivot model', function (
     expect($relationship->getTable())->toBe($table)
         ->and($relationship->getForeignPivotKeyName())->toBe($foreignKey)
         ->and($pivot)->toBeInstanceOf(Pivot::class)
-        ->and($pivot)->toBeInstanceOf($pivotClass);
+        ->and($pivot::class)->toBe($pivotClass);
 })->with('stable relationship configurations');
 
 it('includes stable membership dates and timestamps', function (Wrestler|TagTeam $member) {
@@ -62,9 +62,12 @@ it('filters current and previous stable memberships by the departure date', func
 ) {
     $qualifiedDepartureColumn = "\"{$table}\".\"left_at\"";
 
-    expect($member->currentStable()->toRawSql())->toContain("{$qualifiedDepartureColumn} is null")
-        ->and($member->previousStables()->toRawSql())->toContain("{$qualifiedDepartureColumn} is not null");
+    $currentStableQuery = $member->currentStable()->getQuery()->getQuery();
+    $previousStablesQuery = $member->previousStables()->getQuery()->getQuery();
+
+    expect($currentStableQuery->toRawSql())->toContain("{$qualifiedDepartureColumn} is null")
+        ->and($previousStablesQuery->toRawSql())->toContain("{$qualifiedDepartureColumn} is not null");
 })->with([
-    'wrestler' => [new Wrestler(), 'stables_wrestlers'],
-    'tag team' => [new TagTeam(), 'stables_tag_teams'],
+    'wrestler' => [fn (): Wrestler => Wrestler::factory()->make(), 'stables_wrestlers'],
+    'tag team' => [fn (): TagTeam => TagTeam::factory()->make(), 'stables_tag_teams'],
 ]);


### PR DESCRIPTION
## Summary
- centralize stable member table, foreign key, and pivot model resolution
- remove repeated relationship mapping and anonymous-model fallbacks
- verify the shared relationship behavior against real Wrestler and TagTeam models
- remove redundant trait examples and stale test scaffolding

## Verification
- composer test:push
- 30 focused tests with 130 assertions
- focused PHPStan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stable membership relationship handling for wrestlers and tag teams.
  * Ensured current and previous stable memberships are filtered correctly by departure date.
  * Added consistent pivot metadata, timestamps, and relationship configuration.
  * Unsupported member types now produce a clear error instead of using fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->