### PR TITLE
refactor: simplify tag team membership operations

### DIFF
--- a/.ai/rules/services.md
+++ b/.ai/rules/services.md
@@ -13,3 +13,6 @@ Acquire Action and service collaborators through constructor injection inside se
 
 ## Idempotent lifecycle periods
 Create the current lifecycle or activity period through relationship updateOrCreate(), identifying the open record with ended_at => null.
+
+## Membership services preserve relationship history
+Keep membership Services focused on establishing and synchronizing relationship records while dating ended pivots instead of deleting history. Validate eligibility before Actions, and orchestrate employment or other lifecycle cascades through typed Actions rather than membership Services.

--- a/app/Actions/TagTeams/CreateAction.php
+++ b/app/Actions/TagTeams/CreateAction.php
@@ -34,16 +34,12 @@ class CreateAction
             // Get membership data
             $membershipData = $tagTeamData->getMembershipData();
 
-            // Add founding members through membership service
-            $this->membershipService->addFoundingMembers(
+            $this->membershipService->establishMembership(
                 $tagTeam,
-                $membershipData->getWrestlers(),
-                $membershipData->getManagers(),
+                $membershipData,
                 $tagTeamData->getJoinDate(),
-                false // Don't employ through membership service - handle separately if needed
             );
 
-            // Handle employment through the typed action when requested
             if ($tagTeamData->employment_date) {
                 $this->employAction->handle($tagTeam, $tagTeamData->employment_date);
             }

--- a/app/Actions/TagTeams/UpdateAction.php
+++ b/app/Actions/TagTeams/UpdateAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\TagTeams;
 
+use App\Actions\Managers\EmployCurrentManagersAction;
 use App\Data\TagTeams\TagTeamData;
 use App\Models\TagTeams\TagTeam;
 use App\Services\TagTeamMembershipService;
@@ -17,6 +18,8 @@ class UpdateAction
     public function __construct(
         protected TagTeamMembershipService $membershipService,
         protected EmployAction $employAction,
+        protected EmployCurrentWrestlersAction $employCurrentWrestlersAction,
+        protected EmployCurrentManagersAction $employCurrentManagersAction,
     ) {}
 
     /**
@@ -36,31 +39,18 @@ class UpdateAction
             // Handle partnership changes through membership service using membership data
             $membershipData = $tagTeamData->getMembershipData();
 
-            $newWrestlers = $this->membershipService->updatePartnerships(
+            $this->membershipService->updateMembership(
                 $tagTeam,
-                $membershipData->wrestlers ?? collect(),
+                $membershipData,
                 $updateDate,
-                false // Don't employ through membership service - handle separately if needed
             );
 
-            $newManagers = $this->membershipService->updateManagerRelationships(
-                $tagTeam,
-                $membershipData->managers ?? collect(),
-                $updateDate,
-                false // Don't employ through membership service - handle separately if needed
-            );
-
-            // Handle employment for newly added members if employment date provided
             if ($tagTeamData->employment_date) {
-                // Employ new members first
-                if ($newWrestlers->isNotEmpty() || $newManagers->isNotEmpty()) {
-                    $allNewMembers = $newWrestlers->merge($newManagers);
-                    $this->membershipService->employMembers($allNewMembers, $tagTeamData->employment_date);
-                }
-
-                // Handle tag team employment if not already employed
                 if (! $tagTeam->isEmployed()) {
                     $this->employAction->handle($tagTeam, $tagTeamData->employment_date);
+                } else {
+                    $this->employCurrentWrestlersAction->handle($tagTeam, $tagTeamData->employment_date);
+                    $this->employCurrentManagersAction->handle($tagTeam, $tagTeamData->employment_date);
                 }
             }
 

--- a/app/Data/TagTeams/TagTeamData.php
+++ b/app/Data/TagTeams/TagTeamData.php
@@ -20,8 +20,8 @@ readonly class TagTeamData
         public string $name,
         public ?string $signature_move,
         public ?Carbon $employment_date,
-        public ?Wrestler $wrestlerA,
-        public ?Wrestler $wrestlerB,
+        public Wrestler $wrestlerA,
+        public Wrestler $wrestlerB,
         public ?Collection $managers = null,
     ) {}
 

--- a/app/Data/TagTeams/TagTeamMembershipData.php
+++ b/app/Data/TagTeams/TagTeamMembershipData.php
@@ -30,12 +30,10 @@ readonly class TagTeamMembershipData
     /**
      * Create membership data from individual wrestler properties.
      */
-    public static function fromWrestlers(?Wrestler $wrestlerA, ?Wrestler $wrestlerB, ?Collection $managers = null): self
+    public static function fromWrestlers(Wrestler $wrestlerA, Wrestler $wrestlerB, ?Collection $managers = null): self
     {
-        $wrestlers = new Collection(array_filter([$wrestlerA, $wrestlerB]));
-
         return new self(
-            wrestlers: $wrestlers->isNotEmpty() ? $wrestlers : null,
+            wrestlers: new Collection([$wrestlerA, $wrestlerB]),
             managers: $managers
         );
     }

--- a/app/Services/TagTeamMembershipService.php
+++ b/app/Services/TagTeamMembershipService.php
@@ -4,398 +4,110 @@ declare(strict_types=1);
 
 namespace App\Services;
 
-use App\Actions\Managers\EmployAction as ManagersEmployAction;
-use App\Actions\Wrestlers\EmployAction as WrestlersEmployAction;
-use App\Models\Managers\Manager;
+use App\Data\TagTeams\TagTeamMembershipData;
 use App\Models\TagTeams\TagTeam;
-use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
-use InvalidArgumentException;
 
-/**
- * Service for managing tag team membership operations.
- *
- * This service centralizes all tag team membership-related operations including
- * partnership management, manager relationships, and member employment handling.
- * It provides a consistent interface for managing complex membership transitions
- * while maintaining data integrity and business rule compliance.
- *
- * BUSINESS CONTEXT:
- * Tag team membership involves complex relationships between wrestlers, managers,
- * and the tag team entity itself. This service ensures consistent handling of:
- * - Partnership additions and removals with proper date tracking
- * - Manager relationship management with hiring/firing workflows
- * - Employment cascading for new and existing members
- * - Business rule validation for membership changes
- *
- * DESIGN PATTERN:
- * Service pattern - Centralizes complex business logic away from Actions
- * Repository pattern - Provides clean interface for membership operations
- * Strategy pattern - Different handling for different membership types
- *
- * @example
- * ```php
- * $service = app(TagTeamMembershipService::class);
- *
- * // Add founding members to new tag team
- * $service->addFoundingMembers($tagTeam, $wrestlers, $managers, $joinDate);
- *
- * // Update existing partnerships
- * $newPartners = $service->updatePartnerships($tagTeam, $newWrestlers, $changeDate);
- *
- * // Handle employment for members
- * $service->employMembers($members, $employmentDate);
- * ```
- */
 class TagTeamMembershipService
 {
-    /**
-     * Create a new tag team membership service instance.
-     */
-    public function __construct(
-        protected WrestlersEmployAction $wrestlersEmployAction,
-        protected ManagersEmployAction $managersEmployAction
-    ) {}
+    public function establishMembership(TagTeam $tagTeam, TagTeamMembershipData $members, Carbon $date): void
+    {
+        $this->addMembersToRelationship(
+            $tagTeam->wrestlers(),
+            $members->wrestlers,
+            $date,
+            'joined_at',
+            'left_at',
+        );
+        $this->addMembersToRelationship(
+            $tagTeam->managers(),
+            $members->managers,
+            $date,
+            'hired_at',
+            'fired_at',
+        );
+    }
+
+    public function updateMembership(TagTeam $tagTeam, TagTeamMembershipData $members, Carbon $date): void
+    {
+        $this->synchronizeRelationship(
+            $tagTeam->wrestlers(),
+            $tagTeam->currentWrestlers,
+            $members->wrestlers,
+            $date,
+            'joined_at',
+            'left_at',
+        );
+        $this->synchronizeRelationship(
+            $tagTeam->managers(),
+            $tagTeam->currentManagers,
+            $members->managers,
+            $date,
+            'hired_at',
+            'fired_at',
+        );
+    }
 
     /**
-     * Add founding members to a newly created tag team.
+     * @template TRelatedModel of Model
+     * @template TPivotModel of Pivot
      *
-     * This method handles the initial membership setup for new tag teams with
-     * proper validation, date tracking, and optional employment handling.
-     *
-     * @param  TagTeam  $tagTeam  The tag team to add founding members to
-     * @param  Collection<int, Wrestler>  $wrestlers  Collection of founding wrestler partners
-     * @param  Collection<int, Manager>|null  $managers  Collection of founding managers
-     * @param  Carbon  $joinDate  The founding date for all members
-     * @param  bool  $employIfNeeded  Whether to employ unemployed members
-     *
-     * @example
-     * ```php
-     * $wrestlers = collect([$matt, $jeff]);
-     * $managers = collect([$lita]);
-     * $service->addFoundingMembers($tagTeam, $wrestlers, $managers, now(), true);
-     * ```
+     * @param  BelongsToMany<TRelatedModel, TagTeam, TPivotModel>  $relationship
+     * @param  Collection<int, TRelatedModel>|null  $members
      */
-    public function addFoundingMembers(
-        TagTeam $tagTeam,
-        Collection $wrestlers,
-        ?Collection $managers,
-        Carbon $joinDate,
-        bool $employIfNeeded = false
+    private function addMembersToRelationship(
+        BelongsToMany $relationship,
+        ?Collection $members,
+        Carbon $date,
+        string $startedAtColumn,
+        string $endedAtColumn,
     ): void {
-        // Validate founding members
-        $this->validateFoundingMembers($wrestlers, $managers);
-
-        // Add wrestlers as founding partners
-        $this->attachWrestlersToTeam($tagTeam, $wrestlers, $joinDate);
-
-        // Add managers if provided
-        if ($managers && $managers->isNotEmpty()) {
-            $this->attachManagersToTeam($tagTeam, $managers, $joinDate);
+        if ($members === null || $members->isEmpty()) {
+            return;
         }
 
-        // Handle employment if requested
-        if ($employIfNeeded) {
-            $this->employMembers($wrestlers, $joinDate);
-            if ($managers && $managers->isNotEmpty()) {
-                $this->employMembers($managers, $joinDate);
-            }
-        }
+        $relationship->attach($members->modelKeys(), [
+            $startedAtColumn => $date,
+            $endedAtColumn => null,
+        ]);
     }
 
     /**
-     * Update wrestler partnerships for an existing tag team.
+     * @template TRelatedModel of Model
+     * @template TPivotModel of Pivot
      *
-     * This method handles partnership transitions by comparing current and desired
-     * partner configurations, ending old partnerships and creating new ones.
-     *
-     * @param  TagTeam  $tagTeam  The tag team to update partnerships for
-     * @param  Collection<int, Wrestler>  $newWrestlers  Desired new partner configuration
-     * @param  Carbon  $changeDate  The date of partnership changes
-     * @param  bool  $employIfNeeded  Whether to employ newly added partners
-     * @return Collection<int, Wrestler> Collection of newly added partners
-     *
-     * @example
-     * ```php
-     * $newPartners = collect([$kofi, $bigE]);
-     * $addedPartners = $service->updatePartnerships($tagTeam, $newPartners, now(), true);
-     * ```
+     * @param  BelongsToMany<TRelatedModel, TagTeam, TPivotModel>  $relationship
+     * @param  Collection<int, TRelatedModel>  $currentMembers
+     * @param  Collection<int, TRelatedModel>|null  $desiredMembers
      */
-    public function updatePartnerships(
-        TagTeam $tagTeam,
-        Collection $newWrestlers,
-        Carbon $changeDate,
-        bool $employIfNeeded = false
-    ): Collection {
-        // Validate new wrestler collection
-        $newWrestlers->ensure(Wrestler::class);
-
-        // Get current partnerships
-        $currentWrestlers = $tagTeam->currentWrestlers;
-
-        // Identify partnerships to end and add
-        $partnersToRemove = $currentWrestlers->diff($newWrestlers);
-        $partnersToAdd = $newWrestlers->diff($currentWrestlers);
-
-        // Validate new partners before making changes
-        if ($partnersToAdd->isNotEmpty()) {
-            $this->validateNewPartners($tagTeam, $partnersToAdd);
+    private function synchronizeRelationship(
+        BelongsToMany $relationship,
+        Collection $currentMembers,
+        ?Collection $desiredMembers,
+        Carbon $date,
+        string $startedAtColumn,
+        string $endedAtColumn,
+    ): void {
+        if ($desiredMembers === null) {
+            return;
         }
 
-        // End old partnerships
-        if ($partnersToRemove->isNotEmpty()) {
-            $this->detachWrestlersFromTeam($tagTeam, $partnersToRemove, $changeDate);
-        }
-
-        // Add new partnerships
-        if ($partnersToAdd->isNotEmpty()) {
-            $this->attachWrestlersToTeam($tagTeam, $partnersToAdd, $changeDate);
-
-            // Handle employment for new partners
-            if ($employIfNeeded) {
-                $this->employMembers($partnersToAdd, $changeDate);
-            }
-        }
-
-        return $partnersToAdd;
-    }
-
-    /**
-     * Update manager relationships for an existing tag team.
-     *
-     * This method handles manager relationship transitions by comparing current
-     * and desired manager configurations, ending old relationships and creating new ones.
-     *
-     * @param  TagTeam  $tagTeam  The tag team to update manager relationships for
-     * @param  Collection<int, Manager>|array<int, Manager>  $newManagers  Desired new managers
-     * @param  Carbon  $changeDate  The date of relationship changes
-     * @param  bool  $employIfNeeded  Whether to employ newly added managers
-     * @return Collection<int, Manager> Collection of newly added managers
-     *
-     * @example
-     * ```php
-     * $newManagers = collect([$paulHeyman]);
-     * $addedManagers = $service->updateManagerRelationships($tagTeam, $newManagers, now(), true);
-     * ```
-     */
-    public function updateManagerRelationships(
-        TagTeam $tagTeam,
-        Collection|array $newManagers,
-        Carbon $changeDate,
-        bool $employIfNeeded = false
-    ): Collection {
-        // Normalize to collection and validate
-        $newManagersCollection = collect($newManagers)->ensure(Manager::class);
-
-        // Get current manager relationships
-        $currentManagers = $tagTeam->currentManagers;
-
-        // Identify relationships to end and add
-        $managersToRemove = $currentManagers->diff($newManagersCollection);
-        $managersToAdd = $newManagersCollection->diff($currentManagers);
-
-        // End old relationships
-        if ($managersToRemove->isNotEmpty()) {
-            $this->detachManagersFromTeam($tagTeam, $managersToRemove, $changeDate);
-        }
-
-        // Add new relationships
-        if ($managersToAdd->isNotEmpty()) {
-            $this->attachManagersToTeam($tagTeam, $managersToAdd, $changeDate);
-
-            // Handle employment for new managers
-            if ($employIfNeeded) {
-                $this->employMembers($managersToAdd, $changeDate);
-            }
-        }
-
-        return $managersToAdd;
-    }
-
-    /**
-     * Add new partners to an existing tag team.
-     *
-     * This method adds new wrestlers as partners without affecting existing partnerships.
-     * Useful for expanding tag teams or adding temporary members.
-     *
-     * @param  TagTeam  $tagTeam  The tag team to add partners to
-     * @param  Collection<int, Wrestler>  $wrestlers  Wrestlers to add as partners
-     * @param  Carbon  $joinDate  The partnership start date
-     * @param  bool  $employIfNeeded  Whether to employ new partners
-     * @return Collection<int, Wrestler> Collection of actually added partners
-     *
-     * @example
-     * ```php
-     * $newPartners = collect([$xavier]);
-     * $addedPartners = $service->addPartners($tagTeam, $newPartners, now(), true);
-     * ```
-     */
-    public function addPartners(
-        TagTeam $tagTeam,
-        Collection $wrestlers,
-        Carbon $joinDate,
-        bool $employIfNeeded = false
-    ): Collection {
-        // Validate input
-        if ($wrestlers->isEmpty()) {
-            throw new InvalidArgumentException('Cannot add partners: No wrestlers provided.');
-        }
-
-        $wrestlers->ensure(Wrestler::class);
-
-        // Filter out existing partners
-        $currentPartnerIds = $tagTeam->currentWrestlers->pluck('id');
-        $newPartners = $wrestlers->reject(fn (Wrestler $wrestler) => $currentPartnerIds->contains($wrestler->id));
-
-        if ($newPartners->isEmpty()) {
-            throw new InvalidArgumentException('Cannot add partners: All provided wrestlers are already current partners.');
-        }
-
-        // Validate new partners
-        $this->validateNewPartners($tagTeam, $newPartners);
-
-        // Add new partners
-        $this->attachWrestlersToTeam($tagTeam, $newPartners, $joinDate);
-
-        // Handle employment
-        if ($employIfNeeded) {
-            $this->employMembers($newPartners, $joinDate);
-        }
-
-        return $newPartners;
-    }
-
-    /**
-     * Employ members who are not already employed.
-     *
-     * This method handles employment for collections of wrestlers or managers,
-     * filtering out those who are already employed to avoid conflicts.
-     *
-     * @param  Collection<int, Wrestler|Manager>  $members  Members to potentially employ
-     * @param  Carbon  $employmentDate  The employment date
-     *
-     * @example
-     * ```php
-     * $service->employMembers($newPartners, now());
-     * ```
-     */
-    public function employMembers(Collection $members, Carbon $employmentDate): void
-    {
-        foreach ($members as $member) {
-            if (! $member->isEmployed()) {
-                if ($member instanceof Wrestler) {
-                    $this->wrestlersEmployAction->handle($member, $employmentDate);
-                } elseif ($member instanceof Manager) {
-                    $this->managersEmployAction->handle($member, $employmentDate);
-                }
-            }
-        }
-    }
-
-    /**
-     * Attach wrestlers to tag team with proper pivot data.
-     *
-     * @param  TagTeam  $tagTeam  The tag team
-     * @param  Collection<int, Wrestler>  $wrestlers  Wrestlers to attach
-     * @param  Carbon  $joinDate  The join date
-     */
-    private function attachWrestlersToTeam(TagTeam $tagTeam, Collection $wrestlers, Carbon $joinDate): void
-    {
-        foreach ($wrestlers as $wrestler) {
-            $tagTeam->wrestlers()->attach($wrestler->id, [
-                'joined_at' => $joinDate,
-                'left_at' => null,
+        foreach ($currentMembers->diff($desiredMembers) as $member) {
+            $relationship->updateExistingPivot($member->getKey(), [
+                $endedAtColumn => $date,
             ]);
         }
-    }
 
-    /**
-     * Detach wrestlers from tag team with proper date tracking.
-     *
-     * @param  TagTeam  $tagTeam  The tag team
-     * @param  Collection<int, Wrestler>  $wrestlers  Wrestlers to detach
-     * @param  Carbon  $leftDate  The leave date
-     */
-    private function detachWrestlersFromTeam(TagTeam $tagTeam, Collection $wrestlers, Carbon $leftDate): void
-    {
-        foreach ($wrestlers as $wrestler) {
-            $tagTeam->wrestlers()->updateExistingPivot($wrestler->id, [
-                'left_at' => $leftDate,
-            ]);
-        }
-    }
-
-    /**
-     * Attach managers to tag team with proper pivot data.
-     *
-     * @param  TagTeam  $tagTeam  The tag team
-     * @param  Collection<int, Manager>  $managers  Managers to attach
-     * @param  Carbon  $hiredDate  The hired date
-     */
-    private function attachManagersToTeam(TagTeam $tagTeam, Collection $managers, Carbon $hiredDate): void
-    {
-        foreach ($managers as $manager) {
-            $tagTeam->managers()->attach($manager->id, [
-                'hired_at' => $hiredDate,
-                'fired_at' => null,
-            ]);
-        }
-    }
-
-    /**
-     * Detach managers from tag team with proper date tracking.
-     *
-     * @param  TagTeam  $tagTeam  The tag team
-     * @param  Collection<int, Manager>  $managers  Managers to detach
-     * @param  Carbon  $firedDate  The fired date
-     */
-    private function detachManagersFromTeam(TagTeam $tagTeam, Collection $managers, Carbon $firedDate): void
-    {
-        foreach ($managers as $manager) {
-            $tagTeam->managers()->updateExistingPivot($manager->id, [
-                'fired_at' => $firedDate,
-            ]);
-        }
-    }
-
-    /**
-     * Validate founding members for new tag team.
-     *
-     * @param  Collection<int, Wrestler>  $wrestlers  Founding wrestlers
-     * @param  Collection<int, Manager>|null  $managers  Founding managers
-     */
-    private function validateFoundingMembers(Collection $wrestlers, ?Collection $managers): void
-    {
-        if ($wrestlers->count() < 2) {
-            throw new InvalidArgumentException('Tag teams require at least 2 founding wrestlers for viable competition.');
-        }
-
-        $wrestlers->ensure(Wrestler::class);
-
-        if ($managers) {
-            $managers->ensure(Manager::class);
-        }
-    }
-
-    /**
-     * Validate new partners for business rule compliance.
-     *
-     * @param  TagTeam  $tagTeam  The tag team receiving new partners
-     * @param  Collection<int, Wrestler>  $newWrestlers  New wrestlers to validate
-     */
-    private function validateNewPartners(TagTeam $tagTeam, Collection $newWrestlers): void
-    {
-        foreach ($newWrestlers as $wrestler) {
-            // Check for conflicting tag team memberships
-            $activeTeamMemberships = $wrestler->tagTeams()
-                ->wherePivot('left_at', null)
-                ->where('tag_team_id', '!=', $tagTeam->id)
-                ->count();
-
-            if ($activeTeamMemberships > 0) {
-                throw new InvalidArgumentException("Cannot add partner: Wrestler '{$wrestler->name}' is already an active member of another tag team. End existing partnerships first.");
-            }
-        }
+        $this->addMembersToRelationship(
+            $relationship,
+            $desiredMembers->diff($currentMembers),
+            $date,
+            $startedAtColumn,
+            $endedAtColumn,
+        );
     }
 }

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -82,6 +82,8 @@ Wrestler unretirement does not require a cascade collaborator merely to choose w
 
 Employment cascades use explicit capability and domain collaborators. Both tag teams and wrestlers delegate current-manager employment to `Managers\EmployCurrentManagersAction`, which accepts the existing `Manageable` contract. Tag teams separately delegate current-wrestler employment to `TagTeams\EmployCurrentWrestlersAction`. Each collaborator invokes complete typed employment actions only for currently unemployed related entities.
 
+Tag-team membership persistence remains separate from employment orchestration. `TagTeamMembershipService` establishes and synchronizes current wrestler and manager relationships, dates relationships that have ended, and preserves their historical pivot rows. Eligibility is validated before the Action receives its data, while `CreateAction` and `UpdateAction` explicitly coordinate the typed employment cascades when an employment date is supplied.
+
 Tag-team suspension delegates eligible current wrestler and manager transitions to `SuspendCurrentMembersAction`. The collaborator invokes each member's complete typed suspension action, while the tag-team action retains its own validation, suspension-period persistence, effective-date handling, and transaction boundary.
 
 Tag-team reinstatement mirrors that boundary through `ReinstateCurrentMembersAction`, which invokes complete typed reinstatement actions only for suspended current wrestlers and managers. The coordinating tag-team action retains validation, suspension-period persistence, date handling, and transaction ownership.

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -13,18 +13,6 @@ parameters:
 			path: app/Actions/Stables/MergeStablesAction.php
 
 		-
-			message: '#^Parameter \#2 \$wrestlers of method App\\Services\\TagTeamMembershipService\:\:addFoundingMembers\(\) expects Illuminate\\Support\\Collection\<int, App\\Models\\Wrestlers\\Wrestler\>, Illuminate\\Database\\Eloquent\\Collection given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Actions/TagTeams/CreateAction.php
-
-		-
-			message: '#^Parameter \#3 \$managers of method App\\Services\\TagTeamMembershipService\:\:addFoundingMembers\(\) expects Illuminate\\Support\\Collection\<int, App\\Models\\Managers\\Manager\>\|null, Illuminate\\Database\\Eloquent\\Collection given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Actions/TagTeams/CreateAction.php
-
-		-
 			message: '#^PHPDoc tag @throws with type App\\Actions\\Titles\\CannotBeDeactivatedException is not subtype of Throwable$#'
 			identifier: throws.notThrowable
 			count: 1
@@ -1529,21 +1517,3 @@ parameters:
 			identifier: missingType.generics
 			count: 1
 			path: app/Providers/AppServiceProvider.php
-
-		-
-			message: '#^Parameter \#1 \$members of method App\\Services\\TagTeamMembershipService\:\:employMembers\(\) expects Illuminate\\Support\\Collection\<int, App\\Models\\Managers\\Manager\|App\\Models\\Wrestlers\\Wrestler\>, Illuminate\\Support\\Collection\<\(int\|string\), App\\Models\\Managers\\Manager\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Services/TagTeamMembershipService.php
-
-		-
-			message: '#^Parameter \#1 \$members of method App\\Services\\TagTeamMembershipService\:\:employMembers\(\) expects Illuminate\\Support\\Collection\<int, App\\Models\\Managers\\Manager\|App\\Models\\Wrestlers\\Wrestler\>, Illuminate\\Support\\Collection\<int, App\\Models\\Managers\\Manager\> given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Services/TagTeamMembershipService.php
-
-		-
-			message: '#^Parameter \#1 \$members of method App\\Services\\TagTeamMembershipService\:\:employMembers\(\) expects Illuminate\\Support\\Collection\<int, App\\Models\\Managers\\Manager\|App\\Models\\Wrestlers\\Wrestler\>, Illuminate\\Support\\Collection\<int, App\\Models\\Wrestlers\\Wrestler\> given\.$#'
-			identifier: argument.type
-			count: 3
-			path: app/Services/TagTeamMembershipService.php

--- a/tests/Integration/Actions/TagTeams/CreateActionTest.php
+++ b/tests/Integration/Actions/TagTeams/CreateActionTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 use App\Actions\TagTeams\CreateAction;
 use App\Data\TagTeams\TagTeamData;
+use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeamWrestler;
 use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
 
 test('it creates a new tag team', function () {
     $wrestlerA = Wrestler::factory()->create();
@@ -107,17 +109,20 @@ test('it handles database transactions correctly', function () {
     expect($wrestlers->contains($wrestlerB))->toBeTrue();
 });
 
-test('it prevents creating tag team with missing wrestlers', function () {
+test('it receives validated wrestlers in its data', function () {
+    $wrestlerA = Wrestler::factory()->create();
+    $wrestlerB = Wrestler::factory()->create();
+
     $data = new TagTeamData(
         name: 'Invalid Team',
         signature_move: null,
         employment_date: null,
-        wrestlerA: null,
-        wrestlerB: null,
+        wrestlerA: $wrestlerA,
+        wrestlerB: $wrestlerB,
     );
 
-    expect(fn () => resolve(CreateAction::class)->handle($data))
-        ->toThrow(Exception::class);
+    expect($data->wrestlerA)->toBe($wrestlerA)
+        ->and($data->wrestlerB)->toBe($wrestlerB);
 });
 
 test('it creates tag team with all optional fields', function () {
@@ -164,4 +169,25 @@ test('it creates partnerships with correct timestamps', function () {
         expect($membership->joined_at)->not->toBeNull();
         expect($membership->left_at)->toBeNull();
     }
+});
+
+test('it employs the tag team and its founding members', function () {
+    $wrestlerA = Wrestler::factory()->create();
+    $wrestlerB = Wrestler::factory()->create();
+    $manager = Manager::factory()->create();
+    $employmentDate = now()->subDay();
+
+    $tagTeam = resolve(CreateAction::class)->handle(new TagTeamData(
+        name: 'Employed Team',
+        signature_move: null,
+        employment_date: $employmentDate,
+        wrestlerA: $wrestlerA,
+        wrestlerB: $wrestlerB,
+        managers: new Collection([$manager]),
+    ));
+
+    expect($tagTeam->isEmployed())->toBeTrue()
+        ->and($wrestlerA->isEmployed())->toBeTrue()
+        ->and($wrestlerB->isEmployed())->toBeTrue()
+        ->and($manager->isEmployed())->toBeTrue();
 });

--- a/tests/Integration/Actions/TagTeams/UpdateActionTest.php
+++ b/tests/Integration/Actions/TagTeams/UpdateActionTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 use App\Actions\TagTeams\UpdateAction;
 use App\Data\TagTeams\TagTeamData;
+use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
 
 beforeEach(function () {
     $this->tagTeam = TagTeam::factory()->employed()->create([
@@ -192,4 +195,23 @@ test('it handles special characters in updates', function () {
     $this->tagTeam->refresh();
     expect($this->tagTeam->name)->toBe('The "Elite" & Dangerous Team');
     expect($this->tagTeam->signature_move)->toBe('The \'Ultimate\' Slam (TM)');
+});
+
+test('it employs newly assigned members when the tag team is employed', function () {
+    $newWrestler = Wrestler::factory()->create();
+    $newManager = Manager::factory()->create();
+
+    resolve(UpdateAction::class)->handle($this->tagTeam, new TagTeamData(
+        name: $this->tagTeam->name,
+        signature_move: $this->tagTeam->signature_move,
+        employment_date: now(),
+        wrestlerA: $this->wrestlerA,
+        wrestlerB: $newWrestler,
+        managers: new Collection([$newManager]),
+    ));
+
+    expect($newWrestler->isEmployed())->toBeTrue()
+        ->and($newManager->isEmployed())->toBeTrue()
+        ->and($this->tagTeam->currentWrestlers()->whereKey($this->wrestlerB->id)->exists())->toBeFalse()
+        ->and($this->tagTeam->previousWrestlers()->whereKey($this->wrestlerB->id)->exists())->toBeTrue();
 });

--- a/tests/Unit/Services/TagTeamMembershipServiceTest.php
+++ b/tests/Unit/Services/TagTeamMembershipServiceTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\TagTeams\TagTeamMembershipData;
+use App\Models\Managers\Manager;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+use App\Services\TagTeamMembershipService;
+use Illuminate\Database\Eloquent\Collection;
+
+beforeEach(function () {
+    $this->service = resolve(TagTeamMembershipService::class);
+    $this->tagTeam = TagTeam::factory()->create();
+    $this->membershipDate = now()->subDay();
+});
+
+it('establishes wrestler and manager memberships with the same date', function () {
+    $wrestlers = Wrestler::factory()->count(2)->create();
+    $managers = Manager::factory()->count(2)->create();
+
+    $this->service->establishMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData($wrestlers, $managers),
+        $this->membershipDate,
+    );
+
+    expect($this->tagTeam->currentWrestlers()->pluck('wrestlers.id')->all())
+        ->toEqualCanonicalizing($wrestlers->modelKeys())
+        ->and($this->tagTeam->currentManagers()->pluck('managers.id')->all())
+        ->toEqualCanonicalizing($managers->modelKeys());
+
+    foreach ($wrestlers as $wrestler) {
+        $this->assertDatabaseHas('tag_teams_wrestlers', [
+            'tag_team_id' => $this->tagTeam->id,
+            'wrestler_id' => $wrestler->id,
+            'joined_at' => $this->membershipDate->toDateTimeString(),
+            'left_at' => null,
+        ]);
+    }
+
+    foreach ($managers as $manager) {
+        $this->assertDatabaseHas('tag_teams_managers', [
+            'tag_team_id' => $this->tagTeam->id,
+            'manager_id' => $manager->id,
+            'hired_at' => $this->membershipDate->toDateTimeString(),
+            'fired_at' => null,
+        ]);
+    }
+});
+
+it('synchronizes memberships while preserving relationship history', function () {
+    $retainedWrestler = Wrestler::factory()->create();
+    $removedWrestler = Wrestler::factory()->create();
+    $addedWrestler = Wrestler::factory()->create();
+    $removedManager = Manager::factory()->create();
+    $addedManager = Manager::factory()->create();
+    $this->service->establishMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData(
+            new Collection([$retainedWrestler, $removedWrestler]),
+            new Collection([$removedManager]),
+        ),
+        $this->membershipDate,
+    );
+    $changeDate = now();
+
+    $this->service->updateMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData(
+            new Collection([$retainedWrestler, $addedWrestler]),
+            new Collection([$addedManager]),
+        ),
+        $changeDate,
+    );
+
+    expect($this->tagTeam->currentWrestlers()->pluck('wrestlers.id')->all())
+        ->toEqualCanonicalizing([$retainedWrestler->id, $addedWrestler->id])
+        ->and($this->tagTeam->currentManagers()->pluck('managers.id')->all())
+        ->toEqualCanonicalizing([$addedManager->id]);
+
+    $this->assertDatabaseHas('tag_teams_wrestlers', [
+        'tag_team_id' => $this->tagTeam->id,
+        'wrestler_id' => $removedWrestler->id,
+        'left_at' => $changeDate->toDateTimeString(),
+    ]);
+    $this->assertDatabaseHas('tag_teams_managers', [
+        'tag_team_id' => $this->tagTeam->id,
+        'manager_id' => $removedManager->id,
+        'fired_at' => $changeDate->toDateTimeString(),
+    ]);
+});
+
+it('leaves an omitted membership group unchanged', function () {
+    $wrestlers = Wrestler::factory()->count(2)->create();
+    $manager = Manager::factory()->create();
+    $this->service->establishMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData($wrestlers, new Collection([$manager])),
+        $this->membershipDate,
+    );
+
+    $this->service->updateMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData(wrestlers: $wrestlers),
+        now(),
+    );
+
+    expect($this->tagTeam->currentManagers()->whereKey($manager->id)->exists())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- focus TagTeamMembershipService on establishing and synchronizing relationship history
- move employment cascading to the existing typed tag-team Actions
- require validated wrestler models in TagTeamData
- remove obsolete PHPStan baseline entries
- document and record the membership-service boundary

## Verification
- 22 focused tests passed with 62 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push reached the existing Blade formatter mismatch that is also reproducible on clean development; this PR does not modify those Blade files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tag team creation and updates now keep wrestler and manager memberships synchronized.
  * Replaced members remain recorded as former members with departure dates.
  * Employment details can now be propagated consistently to the tag team, wrestlers, and managers.
* **Bug Fixes**
  * Improved handling of membership updates when adding, replacing, or removing team members.
  * Validated wrestler information is now retained reliably during tag team operations.
* **Documentation**
  * Clarified the separation between membership history and employment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->