### PR TITLE
refactor: type business failure reasons

### DIFF
--- a/.ai/rules/exceptions.md
+++ b/.ai/rules/exceptions.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/Exceptions/**'
+---
+
+# Exceptions
+
+## Use typed business failure reasons
+Business exception messages are technical context and may change. When presentation must distinguish a failure, create the exception with self::forReason() and a stable BusinessRuleReason case; never derive application behavior by parsing getMessage(). General failures retain BusinessRuleReason::General.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -11,6 +11,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/Http/Controllers/** | .ai/rules/controllers.md |
 | app/Data/** | .ai/rules/data.md |
 | app/Enums/** | .ai/rules/enums.md |
+| app/Exceptions/** | .ai/rules/exceptions.md |
 | tests/Feature/** | .ai/rules/feature.md |
 | tests/Integration/** | .ai/rules/integration.md |
 | app/Livewire/** | .ai/rules/livewire.md |

--- a/app/Enums/BusinessRuleReason.php
+++ b/app/Enums/BusinessRuleReason.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums;
+
+enum BusinessRuleReason: string
+{
+    case AlreadyEmployed = 'already_employed';
+    case AlreadyInjured = 'already_injured';
+    case AlreadyRetired = 'already_retired';
+    case AlreadySuspended = 'already_suspended';
+    case General = 'general';
+    case Injured = 'injured';
+    case NotDeleted = 'not_deleted';
+    case NotInjured = 'not_injured';
+    case NotRetired = 'not_retired';
+    case NotSuspended = 'not_suspended';
+    case Retired = 'retired';
+    case Suspended = 'suspended';
+    case Unemployed = 'unemployed';
+}

--- a/app/Exceptions/BaseBusinessException.php
+++ b/app/Exceptions/BaseBusinessException.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Exceptions;
 
+use App\Enums\BusinessRuleReason;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
+use Throwable;
 
 /**
  * Base class for all business logic exceptions in the wrestling promotion management system.
@@ -191,6 +193,25 @@ use Illuminate\Support\Carbon;
  */
 abstract class BaseBusinessException extends Exception
 {
+    final public function __construct(
+        string $message = '',
+        int $code = 0,
+        ?Throwable $previous = null,
+        private readonly BusinessRuleReason $reason = BusinessRuleReason::General,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public function reason(): BusinessRuleReason
+    {
+        return $this->reason;
+    }
+
+    protected static function forReason(BusinessRuleReason $reason, string $message): static
+    {
+        return new static($message, reason: $reason);
+    }
+
     /**
      * Build consistent entity context for error messages.
      *

--- a/app/Exceptions/Data/CannotBeRestoredException.php
+++ b/app/Exceptions/Data/CannotBeRestoredException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Data;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use Illuminate\Database\Eloquent\Model;
 
@@ -41,7 +42,7 @@ final class CannotBeRestoredException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is not deleted and cannot be restored.");
+        return self::forReason(BusinessRuleReason::NotDeleted, "{$context} is not deleted and cannot be restored.");
     }
 
     /**

--- a/app/Exceptions/Roster/CannotBeClearedFromInjuryException.php
+++ b/app/Exceptions/Roster/CannotBeClearedFromInjuryException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
 
@@ -46,7 +47,7 @@ final class CannotBeClearedFromInjuryException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is not currently injured and cannot be cleared from injury.");
+        return self::forReason(BusinessRuleReason::NotInjured, "{$context} is not currently injured and cannot be cleared from injury.");
     }
 
     /**

--- a/app/Exceptions/Roster/CannotBeEmployedException.php
+++ b/app/Exceptions/Roster/CannotBeEmployedException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
 
@@ -41,7 +42,7 @@ final class CannotBeEmployedException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is already employed and cannot be re-employed.");
+        return self::forReason(BusinessRuleReason::AlreadyEmployed, "{$context} is already employed and cannot be re-employed.");
     }
 
     /**
@@ -53,7 +54,7 @@ final class CannotBeEmployedException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new static("{$context} is retired and cannot be employed.");
+        return self::forReason(BusinessRuleReason::Retired, "{$context} is retired and cannot be employed.");
     }
 
     /**
@@ -67,7 +68,7 @@ final class CannotBeEmployedException extends BaseBusinessException
         $context = self::formatModelContext($entity);
         $reason = $suspensionReason ? " ({$suspensionReason})" : '';
 
-        return new static("{$context} is currently suspended{$reason} and cannot be employed.");
+        return self::forReason(BusinessRuleReason::Suspended, "{$context} is currently suspended{$reason} and cannot be employed.");
     }
 
     /**

--- a/app/Exceptions/Roster/CannotBeInjuredException.php
+++ b/app/Exceptions/Roster/CannotBeInjuredException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
 
@@ -46,7 +47,7 @@ final class CannotBeInjuredException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is unemployed and cannot be injured.");
+        return self::forReason(BusinessRuleReason::Unemployed, "{$context} is unemployed and cannot be injured.");
     }
 
     /**
@@ -96,7 +97,7 @@ final class CannotBeInjuredException extends BaseBusinessException
         $context = self::formatModelContext($entity);
         $injury = $currentInjury ? " ({$currentInjury})" : '';
 
-        return new static("{$context} is already currently injured{$injury}.");
+        return self::forReason(BusinessRuleReason::AlreadyInjured, "{$context} is already currently injured{$injury}.");
     }
 
     /**
@@ -110,7 +111,7 @@ final class CannotBeInjuredException extends BaseBusinessException
         $context = self::formatModelContext($entity);
         $reason = $suspensionReason ? " ({$suspensionReason})" : '';
 
-        return new static("{$context} is suspended{$reason} and cannot be injured.");
+        return self::forReason(BusinessRuleReason::Suspended, "{$context} is suspended{$reason} and cannot be injured.");
     }
 
     /**

--- a/app/Exceptions/Roster/CannotBeReinstatedException.php
+++ b/app/Exceptions/Roster/CannotBeReinstatedException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
 
@@ -109,7 +110,7 @@ final class CannotBeReinstatedException extends BaseBusinessException
         $context = self::formatModelContext($entity);
         $injury = $injuryDetails ? " ({$injuryDetails})" : '';
 
-        return new static("{$context} is injured{$injury} and cannot be reinstated until medically cleared.");
+        return self::forReason(BusinessRuleReason::Injured, "{$context} is injured{$injury} and cannot be reinstated until medically cleared.");
     }
 
     /**
@@ -121,7 +122,7 @@ final class CannotBeReinstatedException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new static("{$context} is already available and does not need reinstatement.");
+        return self::forReason(BusinessRuleReason::NotSuspended, "{$context} is already available and does not need reinstatement.");
     }
 
     /**

--- a/app/Exceptions/Roster/CannotBeReleasedException.php
+++ b/app/Exceptions/Roster/CannotBeReleasedException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
 
@@ -47,7 +48,7 @@ final class CannotBeReleasedException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is unemployed and cannot be released.");
+        return self::forReason(BusinessRuleReason::Unemployed, "{$context} is unemployed and cannot be released.");
     }
 
     /**

--- a/app/Exceptions/Roster/CannotBeRetiredException.php
+++ b/app/Exceptions/Roster/CannotBeRetiredException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
 use App\Models\Stables\Stable;
@@ -44,7 +45,7 @@ final class CannotBeRetiredException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is currently unemployed and cannot be retired.");
+        return self::forReason(BusinessRuleReason::Unemployed, "{$context} is currently unemployed and cannot be retired.");
     }
 
     /**
@@ -56,7 +57,7 @@ final class CannotBeRetiredException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is already retired and cannot be retired again.");
+        return self::forReason(BusinessRuleReason::AlreadyRetired, "{$context} is already retired and cannot be retired again.");
     }
 
     /**
@@ -144,7 +145,7 @@ final class CannotBeRetiredException extends BaseBusinessException
         $tagTeamContext = self::formatModelContext($tagTeam);
         $wrestlerContext = self::formatModelContext($wrestler);
 
-        return new self("{$tagTeamContext} cannot be retired because {$wrestlerContext} is currently suspended.");
+        return self::forReason(BusinessRuleReason::Suspended, "{$tagTeamContext} cannot be retired because {$wrestlerContext} is currently suspended.");
     }
 
     /**

--- a/app/Exceptions/Roster/CannotBeSuspendedException.php
+++ b/app/Exceptions/Roster/CannotBeSuspendedException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
 
@@ -47,7 +48,7 @@ final class CannotBeSuspendedException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is unemployed and cannot be suspended.");
+        return self::forReason(BusinessRuleReason::Unemployed, "{$context} is unemployed and cannot be suspended.");
     }
 
     /**
@@ -97,7 +98,7 @@ final class CannotBeSuspendedException extends BaseBusinessException
         $context = self::formatModelContext($entity);
         $reason = $currentSuspensionReason ? " ({$currentSuspensionReason})" : '';
 
-        return new static("{$context} is already suspended{$reason}.");
+        return self::forReason(BusinessRuleReason::AlreadySuspended, "{$context} is already suspended{$reason}.");
     }
 
     /**
@@ -111,7 +112,7 @@ final class CannotBeSuspendedException extends BaseBusinessException
         $context = self::formatModelContext($entity);
         $injury = $injuryDetails ? " ({$injuryDetails})" : '';
 
-        return new static("{$context} is injured{$injury} and cannot be suspended.");
+        return self::forReason(BusinessRuleReason::Injured, "{$context} is injured{$injury} and cannot be suspended.");
     }
 
     /**

--- a/app/Exceptions/Roster/CannotBeUnretiredException.php
+++ b/app/Exceptions/Roster/CannotBeUnretiredException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
 use App\Models\Stables\Stable;
@@ -42,7 +43,7 @@ final class CannotBeUnretiredException extends BaseBusinessException
     {
         $context = self::formatModelContext($entity);
 
-        return new self("{$context} is not currently retired and cannot be unretired.");
+        return self::forReason(BusinessRuleReason::NotRetired, "{$context} is not currently retired and cannot be unretired.");
     }
 
     /**

--- a/app/Exceptions/Roster/TagTeams/CannotBeReinstatedException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeReinstatedException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
 
@@ -52,7 +53,7 @@ class CannotBeReinstatedException extends BaseBusinessException
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} cannot be reinstated because it is not currently suspended. Only suspended tag teams can be reinstated to active competition.");
+        return self::forReason(BusinessRuleReason::NotSuspended, "{$context} cannot be reinstated because it is not currently suspended. Only suspended tag teams can be reinstated to active competition.");
     }
 
     /**

--- a/app/Services/ErrorMessageMappingService.php
+++ b/app/Services/ErrorMessageMappingService.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace App\Services;
 
+use App\Enums\BusinessRuleReason;
+use App\Exceptions\BaseBusinessException;
 use App\Exceptions\Data\CannotBeRestoredException;
 use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
 use App\Exceptions\Roster\CannotBeEmployedException;
 use App\Exceptions\Roster\CannotBeInjuredException;
-use App\Exceptions\Roster\CannotBeReinstatedException as RosterCannotBeReinstatedException;
+use App\Exceptions\Roster\CannotBeReinstatedException;
 use App\Exceptions\Roster\CannotBeReleasedException;
 use App\Exceptions\Roster\CannotBeRetiredException;
 use App\Exceptions\Roster\CannotBeSuspendedException;
@@ -16,622 +18,140 @@ use App\Exceptions\Roster\CannotBeUnretiredException;
 use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException as TagTeamCannotBeReinstatedException;
 use Throwable;
 
-/**
- * Service to map technical exceptions to user-friendly error messages.
- *
- * This service provides a centralized way to convert detailed business
- * exception messages into user-friendly error messages while preserving
- * the technical details for logging and debugging purposes.
- */
-class ErrorMessageMappingService
+final class ErrorMessageMappingService
 {
-    /**
-     * Map a wrestler-related exception to a user-friendly error message key.
-     *
-     * @param  Throwable  $exception  The exception to map
-     * @return string Language file key for user-friendly error message
-     */
     public static function mapWrestlerException(Throwable $exception): string
     {
-        $exceptionMessage = $exception->getMessage();
-
-        return match (get_class($exception)) {
-            CannotBeEmployedException::class => self::mapEmploymentException($exceptionMessage),
-            CannotBeReleasedException::class => self::mapReleaseException($exceptionMessage),
-            CannotBeRetiredException::class => self::mapRetirementException($exceptionMessage),
-            CannotBeUnretiredException::class => self::mapUnretirementException($exceptionMessage),
-            CannotBeSuspendedException::class => self::mapSuspensionException($exceptionMessage),
-            RosterCannotBeReinstatedException::class => self::mapReinstatementException($exceptionMessage),
-            CannotBeInjuredException::class => self::mapInjuryException($exceptionMessage),
-            CannotBeClearedFromInjuryException::class => self::mapHealingException($exceptionMessage),
-            CannotBeRestoredException::class => self::mapRestorationException($exceptionMessage),
-            default => 'wrestlers.errors.general_error',
-        };
+        return self::map($exception, 'wrestlers');
     }
 
-    /**
-     * Map a referee-related exception to a user-friendly error message key.
-     *
-     * @param  Throwable  $exception  The exception to map
-     * @return string Language file key for user-friendly error message
-     */
     public static function mapRefereeException(Throwable $exception): string
     {
-        $exceptionMessage = $exception->getMessage();
-
-        return match (get_class($exception)) {
-            CannotBeEmployedException::class => self::mapRefereeEmploymentException($exceptionMessage),
-            CannotBeReleasedException::class => self::mapRefereeReleaseException($exceptionMessage),
-            CannotBeRetiredException::class => self::mapRefereeRetirementException($exceptionMessage),
-            CannotBeUnretiredException::class => self::mapRefereeUnretirementException($exceptionMessage),
-            CannotBeSuspendedException::class => self::mapRefereeSuspensionException($exceptionMessage),
-            RosterCannotBeReinstatedException::class => self::mapRefereeReinstatementException($exceptionMessage),
-            CannotBeInjuredException::class => self::mapRefereeInjuryException($exceptionMessage),
-            CannotBeClearedFromInjuryException::class => self::mapRefereeHealingException($exceptionMessage),
-            CannotBeRestoredException::class => self::mapRefereeRestorationException($exceptionMessage),
-            default => 'referees.errors.general_error',
-        };
+        return self::map($exception, 'referees');
     }
 
-    /**
-     * Map a manager-related exception to a user-friendly error message key.
-     *
-     * @param  Throwable  $exception  The exception to map
-     * @return string Language file key for user-friendly error message
-     */
     public static function mapManagerException(Throwable $exception): string
     {
-        $exceptionMessage = $exception->getMessage();
-
-        return match (get_class($exception)) {
-            CannotBeEmployedException::class => self::mapManagerEmploymentException($exceptionMessage),
-            CannotBeReleasedException::class => self::mapManagerReleaseException($exceptionMessage),
-            CannotBeRetiredException::class => self::mapManagerRetirementException($exceptionMessage),
-            CannotBeUnretiredException::class => self::mapManagerUnretirementException($exceptionMessage),
-            CannotBeSuspendedException::class => self::mapManagerSuspensionException($exceptionMessage),
-            RosterCannotBeReinstatedException::class => self::mapManagerReinstatementException($exceptionMessage),
-            CannotBeInjuredException::class => self::mapManagerInjuryException($exceptionMessage),
-            CannotBeClearedFromInjuryException::class => self::mapManagerHealingException($exceptionMessage),
-            CannotBeRestoredException::class => self::mapManagerRestorationException($exceptionMessage),
-            default => 'managers.errors.general_error',
-        };
+        return self::map($exception, 'managers');
     }
 
-    /**
-     * Map a tag team-related exception to a user-friendly error message key.
-     *
-     * @param  Throwable  $exception  The exception to map
-     * @return string Language file key for user-friendly error message
-     */
     public static function mapTagTeamException(Throwable $exception): string
     {
-        $exceptionMessage = $exception->getMessage();
+        return self::map($exception, 'tag-teams');
+    }
 
-        return match (get_class($exception)) {
-            CannotBeEmployedException::class => self::mapTagTeamEmploymentException($exceptionMessage),
-            CannotBeReleasedException::class => self::mapTagTeamReleaseException($exceptionMessage),
-            CannotBeRetiredException::class => self::mapTagTeamRetirementException($exceptionMessage),
-            CannotBeUnretiredException::class => self::mapTagTeamUnretirementException($exceptionMessage),
-            CannotBeSuspendedException::class => self::mapTagTeamSuspensionException($exceptionMessage),
-            TagTeamCannotBeReinstatedException::class => self::mapTagTeamReinstatementException($exceptionMessage),
-            CannotBeRestoredException::class => self::mapTagTeamRestorationException($exceptionMessage),
-            default => 'tag-teams.errors.general_error',
+    private static function map(Throwable $exception, string $entity): string
+    {
+        $reason = $exception instanceof BaseBusinessException
+            ? $exception->reason()
+            : BusinessRuleReason::General;
+
+        $key = match ($exception::class) {
+            CannotBeEmployedException::class => self::employmentKey($reason, $entity),
+            CannotBeReleasedException::class => self::releaseKey($reason, $entity),
+            CannotBeRetiredException::class => self::retirementKey($reason, $entity),
+            CannotBeUnretiredException::class => self::unretirementKey($reason),
+            CannotBeSuspendedException::class => self::suspensionKey($reason, $entity),
+            CannotBeReinstatedException::class,
+            TagTeamCannotBeReinstatedException::class => self::reinstatementKey($reason),
+            CannotBeInjuredException::class => self::injuryKey($reason, $entity),
+            CannotBeClearedFromInjuryException::class => self::healingKey($reason),
+            CannotBeRestoredException::class => self::restorationKey($reason),
+            default => 'general_error',
+        };
+
+        return "{$entity}.errors.{$key}";
+    }
+
+    private static function employmentKey(BusinessRuleReason $reason, string $entity): string
+    {
+        return match ($reason) {
+            BusinessRuleReason::AlreadyEmployed => 'already_employed',
+            BusinessRuleReason::Suspended => 'cannot_employ_suspended',
+            BusinessRuleReason::Retired => 'cannot_employ_retired',
+            BusinessRuleReason::Injured => $entity === 'managers' ? 'cannot_employ_injured' : 'cannot_employ',
+            default => 'cannot_employ',
         };
     }
 
-    /**
-     * Map employment-specific exception messages to user-friendly keys.
-     */
-    private static function mapEmploymentException(string $message): string
+    private static function releaseKey(BusinessRuleReason $reason, string $entity): string
     {
-        if (str_contains($message, 'already employed')) {
-            return 'wrestlers.errors.already_employed';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'wrestlers.errors.cannot_employ_suspended';
-        }
-
-        if (str_contains($message, 'retired')) {
-            return 'wrestlers.errors.cannot_employ_retired';
-        }
-
-        return 'wrestlers.errors.cannot_employ';
+        return match ($reason) {
+            BusinessRuleReason::Unemployed => 'not_employed',
+            BusinessRuleReason::Suspended => in_array($entity, ['managers', 'tag-teams'], true)
+                ? 'cannot_release_suspended'
+                : 'cannot_release',
+            default => 'cannot_release',
+        };
     }
 
-    /**
-     * Map release-specific exception messages to user-friendly keys.
-     */
-    private static function mapReleaseException(string $message): string
+    private static function retirementKey(BusinessRuleReason $reason, string $entity): string
     {
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'wrestlers.errors.not_employed';
-        }
-
-        return 'wrestlers.errors.cannot_release';
+        return match ($reason) {
+            BusinessRuleReason::Unemployed => 'cannot_retire_unemployed',
+            BusinessRuleReason::AlreadyRetired => 'already_retired',
+            BusinessRuleReason::Suspended => in_array($entity, ['managers', 'tag-teams'], true)
+                ? 'cannot_retire_suspended'
+                : 'cannot_retire',
+            default => 'cannot_retire',
+        };
     }
 
-    /**
-     * Map retirement-specific exception messages to user-friendly keys.
-     */
-    private static function mapRetirementException(string $message): string
+    private static function unretirementKey(BusinessRuleReason $reason): string
     {
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'wrestlers.errors.cannot_retire_unemployed';
-        }
-
-        if (str_contains($message, 'already retired')) {
-            return 'wrestlers.errors.already_retired';
-        }
-
-        return 'wrestlers.errors.cannot_retire';
+        return $reason === BusinessRuleReason::NotRetired
+            ? 'not_retired'
+            : 'cannot_unretire';
     }
 
-    /**
-     * Map unretirement-specific exception messages to user-friendly keys.
-     */
-    private static function mapUnretirementException(string $message): string
+    private static function suspensionKey(BusinessRuleReason $reason, string $entity): string
     {
-        if (str_contains($message, 'not retired')) {
-            return 'wrestlers.errors.not_retired';
-        }
-
-        return 'wrestlers.errors.cannot_unretire';
+        return match ($reason) {
+            BusinessRuleReason::AlreadySuspended => 'already_suspended',
+            BusinessRuleReason::Unemployed => match ($entity) {
+                'managers', 'tag-teams' => 'not_employed_suspend',
+                'referees' => 'cannot_suspend_unemployed',
+                default => 'cannot_suspend',
+            },
+            BusinessRuleReason::Injured => $entity === 'managers' ? 'cannot_suspend_injured' : 'cannot_suspend',
+            default => 'cannot_suspend',
+        };
     }
 
-    /**
-     * Map suspension-specific exception messages to user-friendly keys.
-     */
-    private static function mapSuspensionException(string $message): string
+    private static function reinstatementKey(BusinessRuleReason $reason): string
     {
-        if (str_contains($message, 'already suspended')) {
-            return 'wrestlers.errors.already_suspended';
-        }
-
-        return 'wrestlers.errors.cannot_suspend';
+        return match ($reason) {
+            BusinessRuleReason::NotSuspended => 'not_suspended',
+            BusinessRuleReason::Injured => 'cannot_reinstate_injured',
+            default => 'cannot_reinstate',
+        };
     }
 
-    /**
-     * Map reinstatement-specific exception messages to user-friendly keys.
-     */
-    private static function mapReinstatementException(string $message): string
+    private static function injuryKey(BusinessRuleReason $reason, string $entity): string
     {
-        if (str_contains($message, 'injured')) {
-            return 'wrestlers.errors.cannot_reinstate_injured';
-        }
-
-        if (str_contains($message, 'not suspended') || str_contains($message, 'already available')) {
-            return 'wrestlers.errors.not_suspended';
-        }
-
-        return 'wrestlers.errors.cannot_reinstate';
+        return match ($reason) {
+            BusinessRuleReason::AlreadyInjured => 'already_injured',
+            BusinessRuleReason::Unemployed => match ($entity) {
+                'managers' => 'not_employed_injure',
+                'referees' => 'cannot_injure_unemployed',
+                default => 'cannot_injure',
+            },
+            BusinessRuleReason::Suspended => $entity === 'managers' ? 'cannot_injure_suspended' : 'cannot_injure',
+            default => 'cannot_injure',
+        };
     }
 
-    /**
-     * Map injury-specific exception messages to user-friendly keys.
-     */
-    private static function mapInjuryException(string $message): string
+    private static function healingKey(BusinessRuleReason $reason): string
     {
-        if (str_contains($message, 'already injured')) {
-            return 'wrestlers.errors.already_injured';
-        }
-
-        return 'wrestlers.errors.cannot_injure';
+        return $reason === BusinessRuleReason::NotInjured
+            ? 'not_injured'
+            : 'cannot_heal';
     }
 
-    /**
-     * Map healing-specific exception messages to user-friendly keys.
-     */
-    private static function mapHealingException(string $message): string
+    private static function restorationKey(BusinessRuleReason $reason): string
     {
-        if (str_contains($message, 'not injured')) {
-            return 'wrestlers.errors.not_injured';
-        }
-
-        return 'wrestlers.errors.cannot_heal';
-    }
-
-    /**
-     * Map restoration-specific exception messages to user-friendly keys.
-     */
-    private static function mapRestorationException(string $message): string
-    {
-        if (str_contains($message, 'not deleted')) {
-            return 'wrestlers.errors.not_deleted';
-        }
-
-        return 'wrestlers.errors.cannot_restore';
-    }
-
-    /**
-     * Map referee employment-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeEmploymentException(string $message): string
-    {
-        if (str_contains($message, 'already employed')) {
-            return 'referees.errors.already_employed';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'referees.errors.cannot_employ_suspended';
-        }
-
-        if (str_contains($message, 'retired')) {
-            return 'referees.errors.cannot_employ_retired';
-        }
-
-        return 'referees.errors.cannot_employ';
-    }
-
-    /**
-     * Map referee release-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeReleaseException(string $message): string
-    {
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'referees.errors.not_employed';
-        }
-
-        return 'referees.errors.cannot_release';
-    }
-
-    /**
-     * Map referee retirement-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeRetirementException(string $message): string
-    {
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'referees.errors.cannot_retire_unemployed';
-        }
-
-        if (str_contains($message, 'already retired')) {
-            return 'referees.errors.already_retired';
-        }
-
-        return 'referees.errors.cannot_retire';
-    }
-
-    /**
-     * Map referee unretirement-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeUnretirementException(string $message): string
-    {
-        if (str_contains($message, 'not retired')) {
-            return 'referees.errors.not_retired';
-        }
-
-        return 'referees.errors.cannot_unretire';
-    }
-
-    /**
-     * Map referee suspension-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeSuspensionException(string $message): string
-    {
-        if (str_contains($message, 'already suspended')) {
-            return 'referees.errors.already_suspended';
-        }
-
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'referees.errors.cannot_suspend_unemployed';
-        }
-
-        return 'referees.errors.cannot_suspend';
-    }
-
-    /**
-     * Map referee reinstatement-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeReinstatementException(string $message): string
-    {
-        if (str_contains($message, 'injured')) {
-            return 'referees.errors.cannot_reinstate_injured';
-        }
-
-        if (str_contains($message, 'not suspended') || str_contains($message, 'already available')) {
-            return 'referees.errors.not_suspended';
-        }
-
-        return 'referees.errors.cannot_reinstate';
-    }
-
-    /**
-     * Map referee injury-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeInjuryException(string $message): string
-    {
-        if (str_contains($message, 'already injured')) {
-            return 'referees.errors.already_injured';
-        }
-
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'referees.errors.cannot_injure_unemployed';
-        }
-
-        return 'referees.errors.cannot_injure';
-    }
-
-    /**
-     * Map referee healing-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeHealingException(string $message): string
-    {
-        if (str_contains($message, 'not injured')) {
-            return 'referees.errors.not_injured';
-        }
-
-        return 'referees.errors.cannot_heal';
-    }
-
-    /**
-     * Map referee restoration-specific exception messages to user-friendly keys.
-     */
-    private static function mapRefereeRestorationException(string $message): string
-    {
-        if (str_contains($message, 'not deleted')) {
-            return 'referees.errors.not_deleted';
-        }
-
-        return 'referees.errors.cannot_restore';
-    }
-
-    /**
-     * Map manager employment-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerEmploymentException(string $message): string
-    {
-        if (str_contains($message, 'already employed')) {
-            return 'managers.errors.already_employed';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'managers.errors.cannot_employ_suspended';
-        }
-
-        if (str_contains($message, 'retired')) {
-            return 'managers.errors.cannot_employ_retired';
-        }
-
-        if (str_contains($message, 'injured')) {
-            return 'managers.errors.cannot_employ_injured';
-        }
-
-        return 'managers.errors.cannot_employ';
-    }
-
-    /**
-     * Map manager release-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerReleaseException(string $message): string
-    {
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'managers.errors.not_employed';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'managers.errors.cannot_release_suspended';
-        }
-
-        return 'managers.errors.cannot_release';
-    }
-
-    /**
-     * Map manager retirement-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerRetirementException(string $message): string
-    {
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'managers.errors.cannot_retire_unemployed';
-        }
-
-        if (str_contains($message, 'already retired')) {
-            return 'managers.errors.already_retired';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'managers.errors.cannot_retire_suspended';
-        }
-
-        return 'managers.errors.cannot_retire';
-    }
-
-    /**
-     * Map manager unretirement-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerUnretirementException(string $message): string
-    {
-        if (str_contains($message, 'not retired')) {
-            return 'managers.errors.not_retired';
-        }
-
-        return 'managers.errors.cannot_unretire';
-    }
-
-    /**
-     * Map manager suspension-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerSuspensionException(string $message): string
-    {
-        if (str_contains($message, 'already suspended')) {
-            return 'managers.errors.already_suspended';
-        }
-
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'managers.errors.not_employed_suspend';
-        }
-
-        if (str_contains($message, 'injured')) {
-            return 'managers.errors.cannot_suspend_injured';
-        }
-
-        return 'managers.errors.cannot_suspend';
-    }
-
-    /**
-     * Map manager reinstatement-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerReinstatementException(string $message): string
-    {
-        if (str_contains($message, 'not suspended') || str_contains($message, 'already available')) {
-            return 'managers.errors.not_suspended';
-        }
-
-        if (str_contains($message, 'injured')) {
-            return 'managers.errors.cannot_reinstate_injured';
-        }
-
-        return 'managers.errors.cannot_reinstate';
-    }
-
-    /**
-     * Map manager injury-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerInjuryException(string $message): string
-    {
-        if (str_contains($message, 'already injured')) {
-            return 'managers.errors.already_injured';
-        }
-
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'managers.errors.not_employed_injure';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'managers.errors.cannot_injure_suspended';
-        }
-
-        return 'managers.errors.cannot_injure';
-    }
-
-    /**
-     * Map manager healing-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerHealingException(string $message): string
-    {
-        if (str_contains($message, 'not injured')) {
-            return 'managers.errors.not_injured';
-        }
-
-        return 'managers.errors.cannot_heal';
-    }
-
-    /**
-     * Map manager restoration-specific exception messages to user-friendly keys.
-     */
-    private static function mapManagerRestorationException(string $message): string
-    {
-        if (str_contains($message, 'not deleted')) {
-            return 'managers.errors.not_deleted';
-        }
-
-        return 'managers.errors.cannot_restore';
-    }
-
-    /**
-     * Map tag team employment-specific exception messages to user-friendly keys.
-     */
-    private static function mapTagTeamEmploymentException(string $message): string
-    {
-        if (str_contains($message, 'already employed')) {
-            return 'tag-teams.errors.already_employed';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'tag-teams.errors.cannot_employ_suspended';
-        }
-
-        if (str_contains($message, 'retired')) {
-            return 'tag-teams.errors.cannot_employ_retired';
-        }
-
-        return 'tag-teams.errors.cannot_employ';
-    }
-
-    /**
-     * Map tag team release-specific exception messages to user-friendly keys.
-     */
-    private static function mapTagTeamReleaseException(string $message): string
-    {
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'tag-teams.errors.not_employed';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'tag-teams.errors.cannot_release_suspended';
-        }
-
-        return 'tag-teams.errors.cannot_release';
-    }
-
-    /**
-     * Map tag team retirement-specific exception messages to user-friendly keys.
-     */
-    private static function mapTagTeamRetirementException(string $message): string
-    {
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'tag-teams.errors.cannot_retire_unemployed';
-        }
-
-        if (str_contains($message, 'already retired')) {
-            return 'tag-teams.errors.already_retired';
-        }
-
-        if (str_contains($message, 'suspended')) {
-            return 'tag-teams.errors.cannot_retire_suspended';
-        }
-
-        return 'tag-teams.errors.cannot_retire';
-    }
-
-    /**
-     * Map tag team unretirement-specific exception messages to user-friendly keys.
-     */
-    private static function mapTagTeamUnretirementException(string $message): string
-    {
-        if (str_contains($message, 'not retired')) {
-            return 'tag-teams.errors.not_retired';
-        }
-
-        return 'tag-teams.errors.cannot_unretire';
-    }
-
-    /**
-     * Map tag team suspension-specific exception messages to user-friendly keys.
-     */
-    private static function mapTagTeamSuspensionException(string $message): string
-    {
-        if (str_contains($message, 'already suspended')) {
-            return 'tag-teams.errors.already_suspended';
-        }
-
-        if (str_contains($message, 'unemployed') || str_contains($message, 'not employed')) {
-            return 'tag-teams.errors.not_employed_suspend';
-        }
-
-        return 'tag-teams.errors.cannot_suspend';
-    }
-
-    /**
-     * Map tag team reinstatement-specific exception messages to user-friendly keys.
-     */
-    private static function mapTagTeamReinstatementException(string $message): string
-    {
-        if (str_contains($message, 'not suspended')) {
-            return 'tag-teams.errors.not_suspended';
-        }
-
-        return 'tag-teams.errors.cannot_reinstate';
-    }
-
-    /**
-     * Map tag team restoration-specific exception messages to user-friendly keys.
-     */
-    private static function mapTagTeamRestorationException(string $message): string
-    {
-        if (str_contains($message, 'not deleted')) {
-            return 'tag-teams.errors.not_deleted';
-        }
-
-        return 'tag-teams.errors.cannot_restore';
+        return $reason === BusinessRuleReason::NotDeleted
+            ? 'not_deleted'
+            : 'cannot_restore';
     }
 }

--- a/docs/development/exception-writing-guide.md
+++ b/docs/development/exception-writing-guide.md
@@ -25,6 +25,7 @@ All business exceptions in this application should:
 4. **Include comprehensive documentation** - Provide business context and scenarios
 5. **Use model-aware parameters** - Accept model objects for type safety
 6. **Generate actionable error messages** - Tell users what went wrong and what to do
+7. **Identify presentation-sensitive failures with a stable reason** - Use `BusinessRuleReason` when the UI distinguishes the failure from the operation's general error
 
 ## Exception Structure
 
@@ -171,6 +172,24 @@ public static function specificCondition(ModelClass $entity, ?string $additional
 ```
 
 ## Static Factory Methods
+
+Factory methods whose failures have specific user-facing translations must call `self::forReason()`. Exception messages remain useful technical context, but application behavior must never parse those messages.
+
+```php
+use App\Enums\BusinessRuleReason;
+
+public static function employed(Employable $entity): static
+{
+    $context = self::formatModelContext($entity);
+
+    return self::forReason(
+        BusinessRuleReason::AlreadyEmployed,
+        "{$context} is already employed.",
+    );
+}
+```
+
+Use a new string-backed enum case only when callers need to distinguish that reason. General failures should retain the default `BusinessRuleReason::General` reason.
 
 ### Method Patterns
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -619,12 +619,6 @@ parameters:
 			path: app/Exceptions/Roster/TagTeams/CannotBeReinstatedException.php
 
 		-
-			message: '#^Method App\\Exceptions\\Roster\\TagTeams\\CannotBeReinstatedException\:\:notSuspended\(\) should return static\(App\\Exceptions\\Roster\\TagTeams\\CannotBeReinstatedException\) but returns App\\Exceptions\\Roster\\TagTeams\\CannotBeReinstatedException\.$#'
-			identifier: return.type
-			count: 1
-			path: app/Exceptions/Roster/TagTeams/CannotBeReinstatedException.php
-
-		-
 			message: '#^Method App\\Exceptions\\Roster\\TagTeams\\CannotBeReinstatedException\:\:partnersUnavailable\(\) should return static\(App\\Exceptions\\Roster\\TagTeams\\CannotBeReinstatedException\) but returns App\\Exceptions\\Roster\\TagTeams\\CannotBeReinstatedException\.$#'
 			identifier: return.type
 			count: 1

--- a/tests/Unit/Services/ErrorMessageMappingServiceTest.php
+++ b/tests/Unit/Services/ErrorMessageMappingServiceTest.php
@@ -2,14 +2,24 @@
 
 declare(strict_types=1);
 
+use App\Enums\BusinessRuleReason;
+use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
+use App\Exceptions\Roster\CannotBeEmployedException;
+use App\Exceptions\Roster\CannotBeInjuredException;
 use App\Exceptions\Roster\CannotBeReinstatedException;
+use App\Exceptions\Roster\CannotBeSuspendedException;
 use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException as TagTeamCannotBeReinstatedException;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
 use App\Services\ErrorMessageMappingService;
+use RuntimeException;
 
-test('it maps injured roster reinstatement failures to healing guidance', function () {
-    $exception = new CannotBeReinstatedException('The roster member is injured and requires medical clearance.');
+test('it maps roster failures from stable reasons instead of message text', function () {
+    $wrestler = new Wrestler(['name' => 'Test Wrestler']);
+    $exception = CannotBeReinstatedException::injured($wrestler, 'wording may change');
 
-    expect(ErrorMessageMappingService::mapWrestlerException($exception))
+    expect($exception->reason())->toBe(BusinessRuleReason::Injured)
+        ->and(ErrorMessageMappingService::mapWrestlerException($exception))
         ->toBe('wrestlers.errors.cannot_reinstate_injured')
         ->and(ErrorMessageMappingService::mapManagerException($exception))
         ->toBe('managers.errors.cannot_reinstate_injured')
@@ -17,10 +27,25 @@ test('it maps injured roster reinstatement failures to healing guidance', functi
         ->toBe('referees.errors.cannot_reinstate_injured');
 });
 
-test('it maps available roster reinstatement failures to suspension guidance', function () {
-    $exception = new CannotBeReinstatedException('The roster member is already available and does not need reinstatement.');
+test('it maps common lifecycle reasons for each roster presentation', function () {
+    $wrestler = new Wrestler(['name' => 'Test Wrestler']);
 
-    expect(ErrorMessageMappingService::mapWrestlerException($exception))
+    expect(ErrorMessageMappingService::mapWrestlerException(CannotBeEmployedException::employed($wrestler)))
+        ->toBe('wrestlers.errors.already_employed')
+        ->and(ErrorMessageMappingService::mapManagerException(CannotBeSuspendedException::unemployed($wrestler)))
+        ->toBe('managers.errors.not_employed_suspend')
+        ->and(ErrorMessageMappingService::mapRefereeException(CannotBeInjuredException::unemployed($wrestler)))
+        ->toBe('referees.errors.cannot_injure_unemployed')
+        ->and(ErrorMessageMappingService::mapWrestlerException(CannotBeClearedFromInjuryException::notInjured($wrestler)))
+        ->toBe('wrestlers.errors.not_injured');
+});
+
+test('it maps available roster reinstatement failures to suspension guidance', function () {
+    $wrestler = new Wrestler(['name' => 'Test Wrestler']);
+    $exception = CannotBeReinstatedException::available($wrestler);
+
+    expect($exception->reason())->toBe(BusinessRuleReason::NotSuspended)
+        ->and(ErrorMessageMappingService::mapWrestlerException($exception))
         ->toBe('wrestlers.errors.not_suspended')
         ->and(ErrorMessageMappingService::mapManagerException($exception))
         ->toBe('managers.errors.not_suspended')
@@ -28,9 +53,16 @@ test('it maps available roster reinstatement failures to suspension guidance', f
         ->toBe('referees.errors.not_suspended');
 });
 
-test('it maps tag team reinstatement failures from the tag team exception', function () {
-    $exception = new TagTeamCannotBeReinstatedException('The tag team is not suspended.');
+test('it maps tag team reinstatement failures from a stable reason', function () {
+    $tagTeam = new TagTeam(['name' => 'Test Team']);
+    $exception = TagTeamCannotBeReinstatedException::notSuspended($tagTeam);
 
-    expect(ErrorMessageMappingService::mapTagTeamException($exception))
+    expect($exception->reason())->toBe(BusinessRuleReason::NotSuspended)
+        ->and(ErrorMessageMappingService::mapTagTeamException($exception))
         ->toBe('tag-teams.errors.not_suspended');
+});
+
+test('it uses a general message for unknown exceptions', function () {
+    expect(ErrorMessageMappingService::mapWrestlerException(new RuntimeException('unexpected wording')))
+        ->toBe('wrestlers.errors.general_error');
 });

--- a/tests/Unit/Services/ErrorMessageMappingServiceTest.php
+++ b/tests/Unit/Services/ErrorMessageMappingServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\BusinessRuleReason;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
 use App\Exceptions\Roster\CannotBeEmployedException;
 use App\Exceptions\Roster\CannotBeInjuredException;
@@ -12,7 +13,6 @@ use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException as TagTeamCannotB
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use App\Services\ErrorMessageMappingService;
-use RuntimeException;
 
 test('it maps roster failures from stable reasons instead of message text', function () {
     $wrestler = new Wrestler(['name' => 'Test Wrestler']);
@@ -63,6 +63,8 @@ test('it maps tag team reinstatement failures from a stable reason', function ()
 });
 
 test('it uses a general message for unknown exceptions', function () {
-    expect(ErrorMessageMappingService::mapWrestlerException(new RuntimeException('unexpected wording')))
+    $exception = InvalidMatchConfigurationException::invalidCompetitorCount(1, 'singles');
+
+    expect(ErrorMessageMappingService::mapWrestlerException($exception))
         ->toBe('wrestlers.errors.general_error');
 });


### PR DESCRIPTION
## Summary
- add stable typed reasons to presentation-sensitive business exceptions
- replace brittle exception message parsing with exact operation and reason mapping
- document and record the exception boundary for future development
- remove the obsolete PHPStan baseline entry

## Verification
- 447 focused tests passed with 1,617 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- changed PHP files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push passed tests, PHPStan, Rector, and type coverage before reaching the inherited Blade formatter mismatch in untouched templates