### PR TITLE
fix: preserve repeated relationship history

### DIFF
--- a/app/Actions/Stables/RetireAction.php
+++ b/app/Actions/Stables/RetireAction.php
@@ -61,6 +61,10 @@ class RetireAction
             // Retire current members who are available
             $membersToRetire = $stable->getMembersToRetire();
 
+            // End stable memberships before member retirement workflows close
+            // their remaining current relationships at the retirement date.
+            $this->removeStableMembersAction->handle($stable, $currentMembers, $operationalDate);
+
             if ($membersToRetire->wrestlers) {
                 foreach ($membersToRetire->wrestlers as $wrestler) {
                     if ($wrestler->canBeRetired()) {
@@ -76,9 +80,6 @@ class RetireAction
                     }
                 }
             }
-
-            // Remove all current members using injected Action
-            $this->removeStableMembersAction->handle($stable, $currentMembers, $operationalDate);
 
             $this->retirementPeriods->start($stable, $retirementDate);
 

--- a/app/Actions/Stables/RetireAction.php
+++ b/app/Actions/Stables/RetireAction.php
@@ -31,8 +31,8 @@ class RetireAction
      *
      * This handles the complete stable retirement workflow:
      * - Validates the stable can be retired (business rule compliance)
-     * - Retires eligible current wrestlers and tag teams
-     * - Ends current wrestler and tag team memberships
+     * - Ends current wrestler and tag team memberships at the operational date
+     * - Retires eligible former members and closes their remaining relationships at the retirement date
      * - Ends the activity period if currently active
      * - Creates the retirement record
      * - Makes the stable permanently unavailable for storylines
@@ -61,8 +61,6 @@ class RetireAction
             // Retire current members who are available
             $membersToRetire = $stable->getMembersToRetire();
 
-            // End stable memberships before member retirement workflows close
-            // their remaining current relationships at the retirement date.
             $this->removeStableMembersAction->handle($stable, $currentMembers, $operationalDate);
 
             if ($membersToRetire->wrestlers) {

--- a/app/Services/ManagerAssignmentService.php
+++ b/app/Services/ManagerAssignmentService.php
@@ -40,9 +40,10 @@ class ManagerAssignmentService
         $currentManagers = $manageable->currentManagers()->get();
 
         foreach ($currentManagers->diff($managers) as $manager) {
-            $manageable->managers()->updateExistingPivot($manager->getKey(), [
-                'fired_at' => $date,
-            ]);
+            $manageable->managers()
+                ->newPivotStatementForId($manager->getKey())
+                ->whereNull('fired_at')
+                ->update(['fired_at' => $date]);
         }
 
         $this->assign($manageable, $managers->diff($currentManagers), $date);

--- a/app/Services/StableMembershipService.php
+++ b/app/Services/StableMembershipService.php
@@ -75,9 +75,9 @@ class StableMembershipService
         }
 
         foreach ($members as $member) {
-            $relationship->updateExistingPivot($member->getKey(), [
-                'left_at' => $date,
-            ]);
+            $relationship->newPivotStatementForId($member->getKey())
+                ->whereNull('left_at')
+                ->update(['left_at' => $date]);
         }
     }
 

--- a/app/Services/TagTeamMembershipService.php
+++ b/app/Services/TagTeamMembershipService.php
@@ -86,9 +86,9 @@ class TagTeamMembershipService
         }
 
         foreach ($currentMembers->diff($desiredMembers) as $member) {
-            $relationship->updateExistingPivot($member->getKey(), [
-                $endedAtColumn => $date,
-            ]);
+            $relationship->newPivotStatementForId($member->getKey())
+                ->whereNull($endedAtColumn)
+                ->update([$endedAtColumn => $date]);
         }
 
         $this->addMembersToRelationship(

--- a/tests/Integration/Actions/Stables/RetireActionTest.php
+++ b/tests/Integration/Actions/Stables/RetireActionTest.php
@@ -63,6 +63,7 @@ test('it records a future retirement date while ending current operations now', 
         $membership = StableWrestler::query()
             ->whereBelongsTo($stable)
             ->whereBelongsTo($wrestler)
+            ->latest('id')
             ->firstOrFail();
 
         expect(requiredDate($membership->left_at)->toDateTimeString())
@@ -73,6 +74,7 @@ test('it records a future retirement date while ending current operations now', 
         $membership = StableTagTeam::query()
             ->whereBelongsTo($stable)
             ->whereBelongsTo($tagTeam, 'tagTeam')
+            ->latest('id')
             ->firstOrFail();
 
         expect(requiredDate($membership->left_at)->toDateTimeString())

--- a/tests/Unit/Services/ManagerAssignmentServiceTest.php
+++ b/tests/Unit/Services/ManagerAssignmentServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
+use App\Models\Wrestlers\WrestlerManager;
 use App\Services\ManagerAssignmentService;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -103,4 +104,36 @@ it('accepts an empty manager collection', function () {
     );
 
     expect($wrestler->managers()->exists())->toBeFalse();
+});
+
+it('preserves each manager assignment when a manager is reassigned', function () {
+    $wrestler = Wrestler::factory()->create();
+    $manager = Manager::factory()->create();
+    $managers = new Collection([$manager]);
+    $noManagers = new Collection();
+    $firstHiredAt = now()->subDays(4)->startOfSecond();
+    $firstFiredAt = now()->subDays(3)->startOfSecond();
+    $secondHiredAt = now()->subDays(2)->startOfSecond();
+    $secondFiredAt = now()->subDay()->startOfSecond();
+    $service = resolve(ManagerAssignmentService::class);
+
+    $service->assign($wrestler, $managers, $firstHiredAt);
+    $service->synchronize($wrestler, $noManagers, $firstFiredAt);
+    $service->assign($wrestler, $managers, $secondHiredAt);
+    $service->synchronize($wrestler, $noManagers, $secondFiredAt);
+
+    $assignments = WrestlerManager::query()
+        ->whereBelongsTo($wrestler)
+        ->whereBelongsTo($manager)
+        ->orderBy('hired_at')
+        ->get();
+    $firstAssignment = $assignments->firstOrFail();
+    $secondAssignment = $assignments->skip(1)->firstOrFail();
+
+    expect($assignments)->toHaveCount(2)
+        ->and($firstAssignment->hired_at->equalTo($firstHiredAt))->toBeTrue()
+        ->and($firstAssignment->fired_at?->equalTo($firstFiredAt))->toBeTrue()
+        ->and($secondAssignment->hired_at->equalTo($secondHiredAt))->toBeTrue()
+        ->and($secondAssignment->fired_at?->equalTo($secondFiredAt))->toBeTrue()
+        ->and($wrestler->currentManagers()->exists())->toBeFalse();
 });

--- a/tests/Unit/Services/StableMembershipServiceTest.php
+++ b/tests/Unit/Services/StableMembershipServiceTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use App\Data\Stables\StableMembershipData;
 use App\Models\Stables\Stable;
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use App\Services\StableMembershipService;
@@ -93,4 +95,50 @@ it('synchronizes changed groups while leaving omitted groups untouched', functio
         ->toEqualCanonicalizing([$retainedWrestler->id, $addedWrestler->id])
         ->and($this->stable->previousWrestlers()->whereKey($removedWrestler->id)->exists())->toBeTrue()
         ->and($this->stable->currentTagTeams()->whereKey($tagTeam->id)->exists())->toBeTrue();
+});
+
+it('preserves each membership period when members rejoin a stable', function () {
+    $wrestler = Wrestler::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+    $members = new StableMembershipData(
+        wrestlers: new Collection([$wrestler]),
+        tagTeams: new Collection([$tagTeam]),
+    );
+    $firstJoinedAt = now()->subDays(4)->startOfSecond();
+    $firstLeftAt = now()->subDays(3)->startOfSecond();
+    $secondJoinedAt = now()->subDays(2)->startOfSecond();
+    $secondLeftAt = now()->subDay()->startOfSecond();
+
+    $this->service->addMembers($this->stable, $members, $firstJoinedAt);
+    $this->service->removeMembers($this->stable, $members, $firstLeftAt);
+    $this->service->addMembers($this->stable, $members, $secondJoinedAt);
+    $this->service->removeMembers($this->stable, $members, $secondLeftAt);
+
+    $wrestlerMemberships = StableWrestler::query()
+        ->whereBelongsTo($this->stable)
+        ->whereBelongsTo($wrestler)
+        ->orderBy('joined_at')
+        ->get();
+    $tagTeamMemberships = StableTagTeam::query()
+        ->whereBelongsTo($this->stable)
+        ->whereBelongsTo($tagTeam, 'tagTeam')
+        ->orderBy('joined_at')
+        ->get();
+    $firstWrestlerMembership = $wrestlerMemberships->firstOrFail();
+    $secondWrestlerMembership = $wrestlerMemberships->skip(1)->firstOrFail();
+    $firstTagTeamMembership = $tagTeamMemberships->firstOrFail();
+    $secondTagTeamMembership = $tagTeamMemberships->skip(1)->firstOrFail();
+
+    expect($wrestlerMemberships)->toHaveCount(2)
+        ->and($firstWrestlerMembership->joined_at->equalTo($firstJoinedAt))->toBeTrue()
+        ->and($firstWrestlerMembership->left_at?->equalTo($firstLeftAt))->toBeTrue()
+        ->and($secondWrestlerMembership->joined_at->equalTo($secondJoinedAt))->toBeTrue()
+        ->and($secondWrestlerMembership->left_at?->equalTo($secondLeftAt))->toBeTrue()
+        ->and($tagTeamMemberships)->toHaveCount(2)
+        ->and($firstTagTeamMembership->joined_at->equalTo($firstJoinedAt))->toBeTrue()
+        ->and($firstTagTeamMembership->left_at?->equalTo($firstLeftAt))->toBeTrue()
+        ->and($secondTagTeamMembership->joined_at->equalTo($secondJoinedAt))->toBeTrue()
+        ->and($secondTagTeamMembership->left_at?->equalTo($secondLeftAt))->toBeTrue()
+        ->and($this->stable->currentWrestlers()->exists())->toBeFalse()
+        ->and($this->stable->currentTagTeams()->exists())->toBeFalse();
 });

--- a/tests/Unit/Services/TagTeamMembershipServiceTest.php
+++ b/tests/Unit/Services/TagTeamMembershipServiceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Data\TagTeams\TagTeamMembershipData;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
+use App\Models\TagTeams\TagTeamWrestler;
 use App\Models\Wrestlers\Wrestler;
 use App\Services\TagTeamMembershipService;
 use Illuminate\Database\Eloquent\Collection;
@@ -107,4 +108,50 @@ it('leaves an omitted membership group unchanged', function () {
     );
 
     expect($this->tagTeam->currentManagers()->whereKey($manager->id)->exists())->toBeTrue();
+});
+
+it('preserves each wrestler membership when a wrestler rejoins', function () {
+    $wrestler = Wrestler::factory()->create();
+    $wrestlers = new Collection([$wrestler]);
+    $noWrestlers = new Collection();
+    $firstJoinedAt = now()->subDays(4)->startOfSecond();
+    $firstLeftAt = now()->subDays(3)->startOfSecond();
+    $secondJoinedAt = now()->subDays(2)->startOfSecond();
+    $secondLeftAt = now()->subDay()->startOfSecond();
+
+    $this->service->establishMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData(wrestlers: $wrestlers),
+        $firstJoinedAt,
+    );
+    $this->service->updateMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData(wrestlers: $noWrestlers),
+        $firstLeftAt,
+    );
+    $this->service->establishMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData(wrestlers: $wrestlers),
+        $secondJoinedAt,
+    );
+    $this->service->updateMembership(
+        $this->tagTeam,
+        new TagTeamMembershipData(wrestlers: $noWrestlers),
+        $secondLeftAt,
+    );
+
+    $memberships = TagTeamWrestler::query()
+        ->whereBelongsTo($this->tagTeam, 'tagTeam')
+        ->whereBelongsTo($wrestler)
+        ->orderBy('joined_at')
+        ->get();
+    $firstMembership = $memberships->firstOrFail();
+    $secondMembership = $memberships->skip(1)->firstOrFail();
+
+    expect($memberships)->toHaveCount(2)
+        ->and($firstMembership->joined_at->equalTo($firstJoinedAt))->toBeTrue()
+        ->and($firstMembership->left_at?->equalTo($firstLeftAt))->toBeTrue()
+        ->and($secondMembership->joined_at->equalTo($secondJoinedAt))->toBeTrue()
+        ->and($secondMembership->left_at?->equalTo($secondLeftAt))->toBeTrue()
+        ->and($this->tagTeam->currentWrestlers()->exists())->toBeFalse();
 });


### PR DESCRIPTION
## Summary
- close only active manager and membership pivot rows
- preserve earlier history when a manager or member leaves, rejoins, and leaves again
- cover repeated manager, tag-team, and stable relationship periods

## Verification
- 14 focused tests passed with 59 assertions after rebasing onto development
- application and Pest PHPStan passed
- Pint with Blade formatting passed
- full composer test:push passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved retirement processing so stable memberships are ended consistently during wrestler and tag-team retirements.
  - Corrected manager assignment history to preserve separate records for each assignment period.
  - Fixed stable and tag-team membership updates to affect only active affiliations, preserving historical records.
  - Improved handling of members who leave and later rejoin, ensuring each membership period retains accurate start and end dates.

- **Tests**
  - Added coverage for repeated manager assignments, stable memberships, and tag-team departures and rejoinings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->