### PR TITLE
refactor: simplify lifecycle contract documentation

### DIFF
--- a/app/Models/Contracts/Employable.php
+++ b/app/Models/Contracts/Employable.php
@@ -10,108 +10,24 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
- * Contract for models that can be employed.
- *
- * This interface defines the basic contract for any model that can have employment.
- * It provides a standard way to access employment relationships across different
- * model types while maintaining type safety through generics.
- *
- * Models implementing this interface should also use the IsEmployable trait
- * to get the complete employment functionality implementation.
- *
  * @template TEmployment of Model The employment model class
  * @template TModel of Model The model that can be employed
  *
  * @see IsEmployable For the trait implementation
- *
- * @example
- * ```php
- * class Wrestler extends Model implements Employable
- * {
- *     use IsEmployable;
- * }
- *
- * class Manager extends Model implements Employable
- * {
- *     use IsEmployable;
- * }
- * ```
  */
 interface Employable
 {
     /**
-     * Get all employments for the model.
-     *
-     * This method should return a HasMany relationship that provides access
-     * to all employment records associated with the model, regardless of status.
-     *
      * @return HasMany<TEmployment, TModel>
-     *                                      A relationship instance for accessing all employments
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $allEmployments = $model->employments;
-     * $activeEmployments = $model->employments()->whereNull('ended_at')->get();
-     * ```
      */
     public function employments(): HasMany;
 
     /**
-     * Get the current active employment for the model.
-     *
-     * This method should return a HasOne relationship that provides access
-     * to the currently active employment (where ended_at is null). Returns
-     * null if the model is not currently employed.
-     *
      * @return HasOne<TEmployment, TModel>
-     *                                     A relationship instance for accessing the current employment
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $currentEmployment = $model->currentEmployment;
-     *
-     * if ($currentEmployment) {
-     *     echo "Model is employed since: " . $currentEmployment->started_at;
-     * }
-     * ```
      */
     public function currentEmployment(): HasOne;
 
-    /**
-     * Check if the model is currently employed.
-     *
-     * This method should return true if there is an active employment record
-     * (where ended_at is null) for the model.
-     *
-     * @return bool True if currently employed, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * if ($wrestler->isEmployed()) {
-     *     echo "Wrestler is currently employed";
-     * }
-     * ```
-     */
     public function isEmployed(): bool;
 
-    /**
-     * Check if the model is currently released.
-     *
-     * This method should return true if the model has been released
-     * from employment (has released status).
-     *
-     * @return bool True if currently released, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * if ($wrestler->isReleased()) {
-     *     echo "Wrestler is currently released";
-     * }
-     * ```
-     */
     public function isReleased(): bool;
 }

--- a/app/Models/Contracts/Injurable.php
+++ b/app/Models/Contracts/Injurable.php
@@ -10,90 +10,22 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
- * Contract for models that can be injured.
- *
- * This interface defines the basic contract for any model that can have injuries.
- * It provides a standard way to access injury relationships across different
- * model types while maintaining type safety through generics.
- *
- * Models implementing this interface should also use the IsInjurable trait
- * to get the complete injury functionality implementation.
- *
  * @template TInjury of Model The injury model class
  * @template TModel of Model The model that can be injured
  *
  * @see IsInjurable For the trait implementation
- *
- * @example
- * ```php
- * class Wrestler extends Model implements Injurable
- * {
- *     use IsInjurable;
- * }
- *
- * class Manager extends Model implements Injurable
- * {
- *     use IsInjurable;
- * }
- * ```
  */
 interface Injurable
 {
     /**
-     * Get all injuries for the model.
-     *
-     * This method should return a HasMany relationship that provides access
-     * to all injury records associated with the model, regardless of status.
-     *
      * @return HasMany<TInjury, TModel>
-     *                                  A relationship instance for accessing all injuries
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $allInjuries = $model->injuries;
-     * $activeInjuries = $model->injuries()->whereNull('ended_at')->get();
-     * ```
      */
     public function injuries(): HasMany;
 
     /**
-     * Get the current active injury for the model.
-     *
-     * This method should return a HasOne relationship that provides access
-     * to the currently active injury (where ended_at is null). Returns
-     * null if the model is not currently injured.
-     *
      * @return HasOne<TInjury, TModel>
-     *                                 A relationship instance for accessing the current injury
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $currentInjury = $model->currentInjury;
-     *
-     * if ($currentInjury) {
-     *     echo "Model is injured since: " . $currentInjury->started_at;
-     * }
-     * ```
      */
     public function currentInjury(): HasOne;
 
-    /**
-     * Check if the model is currently injured.
-     *
-     * This method should return true if there is an active injury record
-     * (where ended_at is null) for the model.
-     *
-     * @return bool True if currently injured, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * if ($wrestler->isInjured()) {
-     *     echo "Wrestler is currently injured";
-     * }
-     * ```
-     */
     public function isInjured(): bool;
 }

--- a/app/Models/Contracts/Retirable.php
+++ b/app/Models/Contracts/Retirable.php
@@ -10,90 +10,22 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
- * Contract for models that can be retired.
- *
- * This interface defines the basic contract for any model that can have retirements.
- * It provides a standard way to access retirement relationships across different
- * model types while maintaining type safety through generics.
- *
- * Models implementing this interface should also use the IsRetirable trait
- * to get the complete retirement functionality implementation.
- *
  * @template TRetirement of Model The retirement model class
  * @template TModel of Model The model that can be retired
  *
  * @see IsRetirable For the trait implementation
- *
- * @example
- * ```php
- * class Wrestler extends Model implements Retirable
- * {
- *     use IsRetirable;
- * }
- *
- * class Manager extends Model implements Retirable
- * {
- *     use IsRetirable;
- * }
- * ```
  */
 interface Retirable
 {
     /**
-     * Get all retirements for the model.
-     *
-     * This method should return a HasMany relationship that provides access
-     * to all retirement records associated with the model, regardless of status.
-     *
      * @return HasMany<TRetirement, TModel>
-     *                                      A relationship instance for accessing all retirements
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $allRetirements = $model->retirements;
-     * $activeRetirements = $model->retirements()->whereNull('ended_at')->get();
-     * ```
      */
     public function retirements(): HasMany;
 
     /**
-     * Get the current active retirement for the model.
-     *
-     * This method should return a HasOne relationship that provides access
-     * to the currently active retirement (where ended_at is null). Returns
-     * null if the model is not currently retired.
-     *
      * @return HasOne<TRetirement, TModel>
-     *                                     A relationship instance for accessing the current retirement
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $currentRetirement = $model->currentRetirement;
-     *
-     * if ($currentRetirement) {
-     *     echo "Model is retired since: " . $currentRetirement->started_at;
-     * }
-     * ```
      */
     public function currentRetirement(): HasOne;
 
-    /**
-     * Check if the model is currently retired.
-     *
-     * This method should return true if there is an active retirement record
-     * (where ended_at is null) for the model.
-     *
-     * @return bool True if currently retired, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * if ($wrestler->isRetired()) {
-     *     echo "Wrestler is currently retired";
-     * }
-     * ```
-     */
     public function isRetired(): bool;
 }

--- a/app/Models/Contracts/Suspendable.php
+++ b/app/Models/Contracts/Suspendable.php
@@ -10,90 +10,22 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
- * Contract for models that can be suspended.
- *
- * This interface defines the basic contract for any model that can have suspensions.
- * It provides a standard way to access suspension relationships across different
- * model types while maintaining type safety through generics.
- *
- * Models implementing this interface should also use the IsSuspendable trait
- * to get the complete suspension functionality implementation.
- *
  * @template TSuspension of Model The suspension model class
  * @template TModel of Model The model that can be suspended
  *
  * @see IsSuspendable For the trait implementation
- *
- * @example
- * ```php
- * class Wrestler extends Model implements Suspendable
- * {
- *     use IsSuspendable;
- * }
- *
- * class Manager extends Model implements Suspendable
- * {
- *     use IsSuspendable;
- * }
- * ```
  */
 interface Suspendable
 {
     /**
-     * Get all suspensions for the model.
-     *
-     * This method should return a HasMany relationship that provides access
-     * to all suspension records associated with the model, regardless of status.
-     *
      * @return HasMany<TSuspension, TModel>
-     *                                      A relationship instance for accessing all suspensions
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $allSuspensions = $model->suspensions;
-     * $activeSuspensions = $model->suspensions()->whereNull('ended_at')->get();
-     * ```
      */
     public function suspensions(): HasMany;
 
     /**
-     * Get the current active suspension for the model.
-     *
-     * This method should return a HasOne relationship that provides access
-     * to the currently active suspension (where ended_at is null). Returns
-     * null if the model is not currently suspended.
-     *
      * @return HasOne<TSuspension, TModel>
-     *                                     A relationship instance for accessing the current suspension
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $currentSuspension = $model->currentSuspension;
-     *
-     * if ($currentSuspension) {
-     *     echo "Model is suspended since: " . $currentSuspension->started_at;
-     * }
-     * ```
      */
     public function currentSuspension(): HasOne;
 
-    /**
-     * Check if the model is currently suspended.
-     *
-     * This method should return true if there is an active suspension record
-     * (where ended_at is null) for the model.
-     *
-     * @return bool True if currently suspended, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * if ($wrestler->isSuspended()) {
-     *     echo "Wrestler is currently suspended";
-     * }
-     * ```
-     */
     public function isSuspended(): bool;
 }


### PR DESCRIPTION
## Summary
- remove redundant lifecycle contract prose and example blocks
- retain generic model and relationship types required by static analysis
- keep the contracts focused on their executable API

## Verification
- application PHPStan passed
- Pest PHPStan passed
- Blade-aware Pint passed
- git diff check passed