### PR TITLE
refactor: simplify relationship contract documentation

### DIFF
--- a/app/Models/Contracts/CanBeAStableMember.php
+++ b/app/Models/Contracts/CanBeAStableMember.php
@@ -11,66 +11,17 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
- * Contract for models that can be members of stables.
- *
- * This interface defines the basic contract for any model that can be a member
- * of stables. It provides a standard way to access stable relationships
- * across different model types while maintaining type safety through generics.
- *
- * Models implementing this interface should also use the CanJoinStables trait
- * to get the complete stable membership functionality implementation.
- *
  * @template TPivotModel of Pivot The pivot model for the stable relationship
  * @template TModel of Model The model that can be a stable member
  *
  * @see CanJoinStables For the trait implementation
- *
- * @example
- * ```php
- * class Wrestler extends Model implements CanBeAStableMember
- * {
- *     use CanJoinStables;
- * }
- * ```
  */
 interface CanBeAStableMember
 {
     /**
-     * Get all stables this model has been a part of.
-     *
-     * This method should return a BelongsToMany relationship that provides access
-     * to all stable records associated with the model, regardless of status.
-     *
      * @return BelongsToMany<Stable, TModel, TPivotModel>
-     *                                                    A relationship instance for accessing all stables
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $allStables = $wrestler->stables;
-     * $stableCount = $wrestler->stables()->count();
-     * ```
      */
     public function stables(): BelongsToMany;
 
-    /**
-     * Get the stable the model currently belongs to.
-     *
-     * This method should return a BelongsToOne relationship for the currently
-     * active stable membership.
-     *
-     * @return BelongsToOne
-     *                      A relationship instance for accessing the current stable
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $currentStable = $wrestler->currentStable;
-     *
-     * if ($wrestler->currentStable()->exists()) {
-     *     echo "Wrestler is currently in a stable";
-     * }
-     * ```
-     */
     public function currentStable(): BelongsToOne;
 }

--- a/app/Models/Contracts/CanBeATagTeamMember.php
+++ b/app/Models/Contracts/CanBeATagTeamMember.php
@@ -11,123 +11,26 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
- * Contract for models that can be members of tag teams.
- *
- * This interface defines the basic contract for any model that can be a member
- * of tag teams. It provides a standard way to access tag team relationships
- * across different model types while maintaining type safety through generics.
- *
- * Models implementing this interface should also use the CanJoinTagTeams trait
- * to get the complete tag team membership functionality implementation.
- *
  * @template TPivotModel of Pivot The pivot model for the tag team relationship
  * @template TModel of Model The model that can be a tag team member
  *
  * @see CanJoinTagTeams For the trait implementation
- *
- * @example
- * ```php
- * class Wrestler extends Model implements CanBeATagTeamMember
- * {
- *     use CanJoinTagTeams;
- * }
- * ```
  */
 interface CanBeATagTeamMember
 {
     /**
-     * Get all tag teams this model has been a part of.
-     *
-     * This method should return a BelongsToMany relationship that provides access
-     * to all tag team records associated with the model, regardless of status.
-     *
      * @return BelongsToMany<TagTeam, TModel, TPivotModel>
-     *                                                     A relationship instance for accessing all tag teams
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $allTagTeams = $wrestler->tagTeams;
-     * $teamCount = $wrestler->tagTeams()->count();
-     * ```
      */
     public function tagTeams(): BelongsToMany;
 
-    /**
-     * Get the tag team the model currently belongs to.
-     *
-     * This method should return a BelongsToOne relationship for the currently
-     * active tag team membership.
-     *
-     * @return BelongsToOne
-     *                      A relationship instance for accessing the current tag team
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $currentTeam = $wrestler->currentTagTeam;
-     *
-     * if ($wrestler->currentTagTeam()->exists()) {
-     *     echo "Wrestler is currently in a tag team";
-     * }
-     * ```
-     */
     public function currentTagTeam(): BelongsToOne;
 
-    /**
-     * Get the most recent previous tag team (if any).
-     *
-     * This method should return a BelongsToOne relationship for the most
-     * recently left tag team.
-     *
-     * @return BelongsToOne
-     *                      A relationship instance for accessing the previous tag team
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $previousTeam = $wrestler->previousTagTeam;
-     *
-     * if ($wrestler->previousTagTeam()->exists()) {
-     *     echo "Wrestler was previously in: " . $wrestler->previousTagTeam->name;
-     * }
-     * ```
-     */
     public function previousTagTeam(): BelongsToOne;
 
     /**
-     * Get all tag teams the model has previously been a part of.
-     *
-     * This method should return a BelongsToMany relationship that provides access
-     * to all completed tag team memberships.
-     *
      * @return BelongsToMany<TagTeam, TModel, TPivotModel>
-     *                                                     A relationship instance for accessing previous tag teams
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $formerTeams = $wrestler->previousTagTeams;
-     * $teamHistory = $wrestler->previousTagTeams()->orderBy('ended_at', 'desc')->get();
-     * ```
      */
     public function previousTagTeams(): BelongsToMany;
 
-    /**
-     * Determine whether the model is currently part of an active tag team.
-     *
-     * This method should check if there is an active tag team membership.
-     *
-     * @return bool True if the model is currently in a tag team, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     *
-     * if ($wrestler->isAMemberOfCurrentTagTeam()) {
-     *     echo "Wrestler is currently in a tag team";
-     * }
-     * ```
-     */
     public function isAMemberOfCurrentTagTeam(): bool;
 }

--- a/app/Models/Contracts/Debutable.php
+++ b/app/Models/Contracts/Debutable.php
@@ -10,113 +10,27 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 
 /**
- * Contract for models that can debut and have status changes tracked over time.
- *
- * This interface defines the basic contract for any model that can debut (be introduced)
- * and then have their status changes tracked historically. It provides a standard way to
- * access status change relationships across different model types while maintaining type safety
- * through generics.
- *
- * Perfect for entities like titles and stables that debut at a specific time and then
- * have their status (Active, Inactive, Retired) tracked through status change records.
- *
- * Models implementing this interface should also use the HasActivityPeriods trait
- * to get the complete status change functionality implementation.
- *
  * @template TStatusChange of Model The status change model class
  * @template TModel of Model The model that can debut
  *
  * @see HasActivityPeriods For the trait implementation
- *
- * @example
- * ```php
- * class Title extends Model implements Debutable
- * {
- *     use HasActivityPeriods;
- * }
- *
- * class Stable extends Model implements Debutable
- * {
- *     use HasActivityPeriods;
- * }
- * ```
  */
 interface Debutable
 {
     /**
-     * Get all status changes for the model.
-     *
-     * This method should return a HasMany relationship that provides access
-     * to all status change records associated with the model, ordered chronologically.
-     * Each record represents when the entity's status changed.
-     *
      * @return HasMany<TStatusChange, TModel>
-     *                                        A relationship instance for accessing all status changes
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $allChanges = $model->statusChanges;
-     * $recentChanges = $model->statusChanges()->latest('changed_at')->get();
-     * ```
      */
     public function statusChanges(): HasMany;
 
     /**
-     * Get the debut status change record.
-     *
-     * This method should return a HasOne relationship for the first status change
-     * (the debut), which represents when the entity was first introduced.
-     *
      * @return HasOne<TStatusChange, TModel>
-     *                                       A relationship instance for accessing the debut record
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $debutRecord = $model->debutStatusChange;
-     *
-     * if ($model->debutStatusChange()->exists()) {
-     *     echo "Entity debuted on: " . $model->debutStatusChange->changed_at;
-     * }
-     * ```
      */
     public function debutStatusChange(): HasOne;
 
     /**
-     * Get the most recent status change.
-     *
-     * This method should return a HasOne relationship for the most recent
-     * status change, which determines the current status.
-     *
      * @return HasOne<TStatusChange, TModel>
-     *                                       A relationship instance for accessing the latest status change
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     * $latestChange = $model->latestStatusChange;
-     * $currentStatus = $model->latestStatusChange->status;
-     * ```
      */
     public function latestStatusChange(): HasOne;
 
-    /**
-     * Determine if the model has debuted.
-     *
-     * This method should check if there are any status change records,
-     * indicating the entity has been introduced.
-     *
-     * @return bool True if the model has debuted, false otherwise
-     *
-     * @example
-     * ```php
-     * $model = SomeModel::find(1);
-     *
-     * if ($model->hasDebuted()) {
-     *     echo "Entity has been introduced";
-     * }
-     * ```
-     */
     public function hasDebuted(): bool;
 }

--- a/app/Models/Contracts/Manageable.php
+++ b/app/Models/Contracts/Manageable.php
@@ -11,87 +11,25 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
 /**
- * Contract for models that can be managed.
- *
- * This interface defines the basic contract for any model that can have managers.
- * It provides a standard way to access manager relationships across different
- * model types while maintaining type safety through generics.
- *
- * Models implementing this interface should also use the CanBeManaged trait
- * to get the complete management functionality implementation.
- *
  * @template TPivotModel of Pivot The pivot model for the manager relationship
  * @template TModel of Model The model that can be managed
  *
  * @see CanBeManaged For the trait implementation
- *
- * @example
- * ```php
- * class Wrestler extends Model implements Manageable
- * {
- *     use CanBeManaged;
- * }
- * ```
  */
 interface Manageable
 {
     /**
-     * Get all managers that have ever been associated with the model.
-     *
-     * This method should return a BelongsToMany relationship that provides access
-     * to all manager records associated with the model, including both current
-     * and former managers. This represents the full historical record of all
-     * manager relationships.
-     *
      * @return BelongsToMany<Manager, TModel, TPivotModel>
-     *                                                     A relationship instance for accessing all managers
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $allManagers = $wrestler->managers;
-     * $managerCount = $wrestler->managers()->count();
-     * ```
      */
     public function managers(): BelongsToMany;
 
     /**
-     * Get managers currently hired.
-     *
-     * This method should return a BelongsToMany relationship for managers
-     * who are actively associated with the model (i.e., without a 'fired_at' date).
-     *
      * @return BelongsToMany<Manager, TModel, TPivotModel>
-     *                                                     A relationship instance for accessing current managers
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $currentManagers = $wrestler->currentManagers;
-     *
-     * if ($wrestler->currentManagers()->exists()) {
-     *     echo "Wrestler has active managers";
-     * }
-     * ```
      */
     public function currentManagers(): BelongsToMany;
 
     /**
-     * Get previously hired managers who have since been removed.
-     *
-     * This method should return a BelongsToMany relationship for managers
-     * who were once associated with the model but are no longer hired
-     * (i.e., have a 'fired_at' date).
-     *
      * @return BelongsToMany<Manager, TModel, TPivotModel>
-     *                                                     A relationship instance for accessing previous managers
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $formerManagers = $wrestler->previousManagers;
-     * $managerHistory = $wrestler->previousManagers()->orderBy('fired_at', 'desc')->get();
-     * ```
      */
     public function previousManagers(): BelongsToMany;
 }


### PR DESCRIPTION
## Summary
- remove redundant prose from four active relationship contracts
- remove embedded usage examples that duplicate the executable API
- preserve PHPStan generic relationship types and trait references

## Verification
- application PHPStan passed
- Pest PHPStan passed
- Blade-aware Pint passed
- git diff check passed