### PR TITLE
refactor: separate activity state from status history

### DIFF
--- a/app/Models/Concerns/HasActivityPeriods.php
+++ b/app/Models/Concerns/HasActivityPeriods.php
@@ -14,33 +14,12 @@ use Illuminate\Support\Carbon;
 use RuntimeException;
 
 /**
- * Adds activity period behavior to a model.
- *
- * This trait provides a complete activity period system for Eloquent models, including
- * methods to manage current activity periods, historical activity periods, and activity status.
- * Perfect for entities like titles and stables that can be active/inactive over multiple periods.
- *
  * @template TActivityPeriod of Model The activity period model class (e.g., TitleActivityPeriod)
  * @template TModel of Model The parent model class that can have activity periods (e.g., Title)
  *
  * @phpstan-require-implements HasActivityPeriodsContract<TActivityPeriod, TModel>
  *
  * @see HasActivityPeriodsContract
- *
- * @example
- * ```php
- * // In your model:
- * class Title extends Model implements HasActivityPeriods
- * {
- *     use HasActivityPeriods;
- * }
- *
- * // Usage:
- * $title = Title::find(1);
- * $title->isCurrentlyActive();         // Check if currently active
- * $title->currentActivityPeriod();     // Get active period
- * $title->previousActivityPeriods();   // Get completed periods
- * ```
  */
 trait HasActivityPeriods
 {
@@ -49,21 +28,7 @@ trait HasActivityPeriods
 
     use ResolvesRelatedModels;
 
-    /**
-     * Get all activity periods for the model.
-     *
-     * This method returns a HasMany relationship that includes all activity period records
-     * for the model, regardless of their status (active, completed, etc.).
-     *
-     * @return HasMany<TActivityPeriod, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $allPeriods = $title->activityPeriods;
-     * $periodCount = $title->activityPeriods()->count();
-     * ```
-     */
+    /** @return HasMany<TActivityPeriod, TModel> */
     public function activityPeriods(): HasMany
     {
         /** @var HasMany<TActivityPeriod, TModel> $relation */
@@ -83,22 +48,9 @@ trait HasActivityPeriods
     }
 
     /**
-     * Get the current (active) activity period.
+     * Get the current activity period, which has started and has not ended.
      *
-     * Returns a HasOne relationship for the currently active period.
-     * An active period is one where the 'ended_at' field is null.
-     *
-     * @return HasOne<TActivityPeriod, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $currentPeriod = $title->currentActivityPeriod;
-     *
-     * if ($title->currentActivityPeriod()->exists()) {
-     *     echo "Title is currently active";
-     * }
-     * ```
+     * @return HasOne<TActivityPeriod, TModel>
      */
     public function currentActivityPeriod(): HasOne
     {
@@ -111,22 +63,9 @@ trait HasActivityPeriods
     }
 
     /**
-     * Get a future activity period that hasn't started yet.
+     * Get a future activity period that has not started or ended.
      *
-     * Returns a HasOne relationship for a period that is scheduled for the future.
-     * A future period has a 'started_at' date greater than now and 'ended_at' is null.
-     *
-     * @return HasOne<TActivityPeriod, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $futurePeriod = $title->futureActivityPeriod;
-     *
-     * if ($title->futureActivityPeriod()->exists()) {
-     *     echo "Title has a scheduled activation";
-     * }
-     * ```
+     * @return HasOne<TActivityPeriod, TModel>
      */
     public function futureActivityPeriod(): HasOne
     {
@@ -139,19 +78,9 @@ trait HasActivityPeriods
     }
 
     /**
-     * Get all completed activity periods.
+     * Get activity periods that have ended.
      *
-     * Returns a HasMany relationship for periods that have ended.
-     * A completed period is one where the 'ended_at' field is not null.
-     *
-     * @return HasMany<TActivityPeriod, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $completedPeriods = $title->previousActivityPeriods;
-     * $periodHistory = $title->previousActivityPeriods()->orderBy('ended_at', 'desc')->get();
-     * ```
+     * @return HasMany<TActivityPeriod, TModel>
      */
     public function previousActivityPeriods(): HasMany
     {
@@ -163,22 +92,9 @@ trait HasActivityPeriods
     }
 
     /**
-     * Get the most recent completed activity period.
+     * Get the most recently ended activity period.
      *
-     * Returns a HasOne relationship for the most recently completed period,
-     * determined by the highest 'ended_at' value.
-     *
-     * @return HasOne<TActivityPeriod, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $lastPeriod = $title->previousActivityPeriod;
-     *
-     * if ($title->previousActivityPeriod()->exists()) {
-     *     $endDate = $title->previousActivityPeriod->ended_at;
-     * }
-     * ```
+     * @return HasOne<TActivityPeriod, TModel>
      */
     public function previousActivityPeriod(): HasOne
     {
@@ -191,21 +107,9 @@ trait HasActivityPeriods
     }
 
     /**
-     * Get the first activity period record.
+     * Get the earliest activity period by start date.
      *
-     * Returns a HasOne relationship for the earliest period based on 'started_at'.
-     *
-     * @return HasOne<TActivityPeriod, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $firstPeriod = $title->firstActivityPeriod;
-     *
-     * if ($title->firstActivityPeriod()->exists()) {
-     *     $startDate = $title->firstActivityPeriod->started_at;
-     * }
-     * ```
+     * @return HasOne<TActivityPeriod, TModel>
      */
     public function firstActivityPeriod(): HasOne
     {
@@ -216,89 +120,21 @@ trait HasActivityPeriods
         return $relation;
     }
 
-    /**
-     * Determine if the model has any activity periods at all.
-     *
-     * Checks if there are any activity period records associated with this model,
-     * regardless of their status (active or completed).
-     *
-     * @return bool True if the model has any activity periods, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->hasActivityPeriods()) {
-     *     echo "This title has an activity history";
-     * }
-     * ```
-     */
     public function hasActivityPeriods(): bool
     {
         return $this->activityPeriods()->exists();
     }
 
-    /**
-     * Determine if the model is currently active.
-     *
-     * Checks if there is an active period (one with a null 'ended_at' field).
-     * This is a convenience method that's more efficient than loading the full
-     * relationship just to check existence.
-     *
-     * @return bool True if the model is currently active, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->isCurrentlyActive()) {
-     *     echo "This title is currently active";
-     * }
-     * ```
-     */
     public function isCurrentlyActive(): bool
     {
         return $this->currentActivityPeriod()->exists();
     }
 
-    /**
-     * Determine if the model has a future activity period scheduled.
-     *
-     * Checks if there is a scheduled period that hasn't started yet.
-     *
-     * @return bool True if the model has a future period, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->hasFutureActivity()) {
-     *     echo "This title has a scheduled activation";
-     * }
-     * ```
-     */
     public function hasFutureActivity(): bool
     {
         return $this->futureActivityPeriod()->exists();
     }
 
-    /**
-     * Check if the model is not currently active.
-     *
-     * Considers the model not active if it is inactive, scheduled for the future,
-     * or retired (if the model supports retirement).
-     *
-     * @return bool True if the model is not currently active, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->isNotCurrentlyActive()) {
-     *     echo "Title is not currently available";
-     * }
-     * ```
-     */
     public function isNotCurrentlyActive(): bool
     {
         if ($this->isInactive()) {
@@ -309,43 +145,14 @@ trait HasActivityPeriods
             return true;
         }
 
-        // Check if the model is retired (assuming it implements IsRetirable)
         return $this instanceof Retirable && $this->isRetired();
     }
 
-    /**
-     * Check if the model's status is Unactivated.
-     *
-     * @return bool True if the status is Unactivated, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->isUnactivated()) {
-     *     echo "This title has never been activated";
-     * }
-     * ```
-     */
     public function isUnactivated(): bool
     {
         return ! $this->hasActivityPeriods();
     }
 
-    /**
-     * Check if the model's status is Inactive.
-     *
-     * @return bool True if the status is Inactive, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->isInactive()) {
-     *     echo "This title is currently inactive";
-     * }
-     * ```
-     */
     public function isInactive(): bool
     {
         return ! $this->isCurrentlyActive();
@@ -355,17 +162,6 @@ trait HasActivityPeriods
      * Check if the current activity period started on a specific date.
      *
      * @param  Carbon  $activityDate  The date to check against
-     * @return bool True if activity started on the specified date, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $targetDate = Carbon::parse('2024-01-15');
-     *
-     * if ($title->wasActiveOn($targetDate)) {
-     *     echo "Title became active on January 15, 2024";
-     * }
-     * ```
      */
     public function wasActiveOn(Carbon $activityDate): bool
     {
@@ -378,17 +174,6 @@ trait HasActivityPeriods
      * Check if the current activity period started on or before a specific date.
      *
      * @param  Carbon  $activityDate  The date to check against
-     * @return bool True if activity started before or on the specified date, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $targetDate = Carbon::parse('2024-01-15');
-     *
-     * if ($title->wasActiveBefore($targetDate)) {
-     *     echo "Title was active before January 15, 2024";
-     * }
-     * ```
      */
     public function wasActiveBefore(Carbon $activityDate): bool
     {
@@ -397,22 +182,6 @@ trait HasActivityPeriods
         return $currentPeriod ? $currentPeriod->started_at->lte($activityDate) : false;
     }
 
-    /**
-     * Check if the model has a future activation scheduled.
-     *
-     * A future activation is an activity period that is scheduled to start
-     * in the future (started_at > now) and has not ended (ended_at is null).
-     *
-     * @return bool True if has future activation, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * if ($title->hasFutureActivation()) {
-     *     echo "Title has a scheduled activation";
-     * }
-     * ```
-     */
     public function hasFutureActivation(): bool
     {
         return $this->futureActivityPeriod()->exists();
@@ -422,14 +191,6 @@ trait HasActivityPeriods
      * Get the formatted start date of the first activity period.
      *
      * Returns 'TBD' if no activity periods exist or the date is unavailable.
-     *
-     * @return string The formatted date (Y-m-d) or 'TBD'
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * echo $title->getFormattedFirstActivity(); // "2024-01-15" or "TBD"
-     * ```
      */
     public function getFormattedFirstActivity(): string
     {
@@ -443,32 +204,14 @@ trait HasActivityPeriods
     }
 
     /**
-     * Resolve the model class for the activity period relation.
-     *
-     * This method automatically determines the activity period model class based on naming
-     * conventions. For example, if the parent model is 'Title', it will look for
-     * a 'TitleActivityPeriod' model class.
-     *
-     *
-     * @throws RuntimeException If the resolved model class doesn't exist
-     * @return class-string<TActivityPeriod> The fully qualified class name of the activity period model
-     *
-     * @example
-     * For a 'Title' model, this will resolve to 'App\\Models\\Titles\\TitleActivityPeriod'
+     * @throws RuntimeException
+     * @return class-string<TActivityPeriod>
      */
     protected function resolveActivityPeriodModelClass(): string
     {
         return $this->resolveRelatedModelClass('ActivityPeriod');
     }
 
-    /**
-     * Get the table name for activity periods.
-     *
-     * This method can be overridden in models to specify a custom table name
-     * for activity periods. By default, it uses the resolved model's table name.
-     *
-     * @return string The table name for activity periods
-     */
     protected function getActivityPeriodTableName(): string
     {
         $modelClass = $this->resolveActivityPeriodModelClass();

--- a/app/Models/Concerns/HasStatusHistory.php
+++ b/app/Models/Concerns/HasStatusHistory.php
@@ -6,7 +6,6 @@ namespace App\Models\Concerns;
 
 use App\Enums\Shared\ActivationStatus;
 use App\Models\Contracts\Debutable;
-use App\Models\Contracts\Retirable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
@@ -14,34 +13,12 @@ use Illuminate\Support\Carbon;
 use RuntimeException;
 
 /**
- * Adds status history behavior to a model.
- *
- * This trait provides a complete status change tracking system for Eloquent models, including
- * methods to manage status changes over time, debut tracking, and current status determination.
- * Perfect for entities like titles and stables that debut and have their status tracked historically.
- *
  * @template TStatusChange of Model The status change model class (e.g., TitleStatusChange)
  * @template TModel of Model The parent model class that can have status changes (e.g., Title)
  *
  * @phpstan-require-implements Debutable<TStatusChange, TModel>
  *
  * @see Debutable
- *
- * @example
- * ```php
- * // In your model:
- * class Title extends Model implements Debutable
- * {
- *     use HasStatusHistory;
- * }
- *
- * // Usage:
- * $title = Title::find(1);
- * $title->hasDebuted();              // Check if ever debuted
- * $title->debutedAt();               // Get debut date
- * $title->statusChanges;             // Get all status changes
- * $title->latestStatusChange;        // Get current status change
- * ```
  */
 trait HasStatusHistory
 {
@@ -50,22 +27,7 @@ trait HasStatusHistory
 
     use ResolvesRelatedModels;
 
-    /**
-     * Get all status changes for the model.
-     *
-     * This method returns a HasMany relationship that includes all status change records
-     * for the model, ordered chronologically by when they occurred.
-     *
-     * @return HasMany<TStatusChange, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $allChanges = $title->statusChanges;
-     * $changeCount = $title->statusChanges()->count();
-     * $recentChanges = $title->statusChanges()->latest('changed_at')->take(5)->get();
-     * ```
-     */
+    /** @return HasMany<TStatusChange, TModel> */
     public function statusChanges(): HasMany
     {
         /** @var HasMany<TStatusChange, TModel> $relation */
@@ -76,22 +38,9 @@ trait HasStatusHistory
     }
 
     /**
-     * Get the debut (first) status change record.
+     * Get the earliest status change.
      *
-     * Returns a HasOne relationship for the first status change record,
-     * which represents when the entity debuted (was first introduced).
-     *
-     * @return HasOne<TStatusChange, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $debutRecord = $title->debutStatusChange;
-     *
-     * if ($title->debutStatusChange()->exists()) {
-     *     echo "Title debuted on: " . $title->debutStatusChange->changed_at;
-     * }
-     * ```
+     * @return HasOne<TStatusChange, TModel>
      */
     public function debutStatusChange(): HasOne
     {
@@ -105,17 +54,7 @@ trait HasStatusHistory
     /**
      * Get the most recent status change.
      *
-     * Returns a HasOne relationship for the most recent status change record,
-     * which determines the current status of the entity.
-     *
-     * @return HasOne<TStatusChange, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $latestChange = $title->latestStatusChange;
-     * $currentStatus = $title->latestStatusChange->status;
-     * ```
+     * @return HasOne<TStatusChange, TModel>
      */
     public function latestStatusChange(): HasOne
     {
@@ -126,142 +65,14 @@ trait HasStatusHistory
         return $relation;
     }
 
-    /**
-     * Determine if the model has debuted (has any status changes).
-     *
-     * Checks if there are any status change records associated with this model,
-     * indicating the entity has been introduced/debuted.
-     *
-     * @return bool True if the model has debuted, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->hasDebuted()) {
-     *     echo "This title has been introduced";
-     * }
-     * ```
-     */
     public function hasDebuted(): bool
     {
         return $this->statusChanges()->exists();
     }
 
-    /**
-     * Get the debut date of the entity.
-     *
-     * Returns the date when the entity first debuted, or null if it hasn't debuted yet.
-     *
-     * @return Carbon|null The debut date, or null if not debuted
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $debutDate = $title->debutedAt();
-     *
-     * if ($debutDate) {
-     *     echo "Title debuted on: " . $debutDate->format('Y-m-d');
-     * }
-     * ```
-     */
     public function debutedAt(): ?Carbon
     {
         return $this->debutStatusChange?->changed_at;
-    }
-
-    /**
-     * Determine if the model is currently active.
-     *
-     * Checks the latest status change to determine if the entity is currently active.
-     * If there are no status changes, falls back to the model's status attribute.
-     *
-     * @return bool True if the model is currently active, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->isCurrentlyActive()) {
-     *     echo "This title is currently active";
-     * }
-     * ```
-     */
-    public function isCurrentlyActive(): bool
-    {
-        $latestStatusChange = $this->latestStatusChange;
-
-        if ($latestStatusChange) {
-            return $latestStatusChange->status === ActivationStatus::Active;
-        }
-
-        // Fall back to the model's current status if no history exists
-        return $this->hasStatus(ActivationStatus::Active);
-    }
-
-    /**
-     * Check if the model is not currently active.
-     *
-     * Considers the model not active if its latest status is inactive, unactivated,
-     * or if it's retired (if the model supports retirement).
-     *
-     * @return bool True if the model is not currently active, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->isNotCurrentlyActive()) {
-     *     echo "Title is not currently available";
-     * }
-     * ```
-     */
-    public function isNotCurrentlyActive(): bool
-    {
-        if (! $this->isCurrentlyActive()) {
-            return true;
-        }
-
-        // Check if the model is retired (assuming it implements IsRetirable)
-        return $this instanceof Retirable && $this->isRetired();
-    }
-
-    /**
-     * Check if the model's status is Unactivated.
-     *
-     * @return bool True if the status is Unactivated, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->isUnactivated()) {
-     *     echo "This title has never been activated";
-     * }
-     * ```
-     */
-    public function isUnactivated(): bool
-    {
-        return $this->hasStatus(ActivationStatus::Unactivated);
-    }
-
-    /**
-     * Check if the model's status is Inactive.
-     *
-     * @return bool True if the status is Inactive, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     *
-     * if ($title->isInactive()) {
-     *     echo "This title is currently inactive";
-     * }
-     * ```
-     */
-    public function isInactive(): bool
-    {
-        return $this->hasStatus(ActivationStatus::Inactive);
     }
 
     /**
@@ -269,17 +80,6 @@ trait HasStatusHistory
      *
      * @param  ActivationStatus  $status  The status to check for
      * @param  Carbon  $date  The date to check against
-     * @return bool True if status changed to the specified value on the date, false otherwise
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * $targetDate = Carbon::parse('2024-01-15');
-     *
-     * if ($title->statusChangedTo(ActivationStatus::Active, $targetDate)) {
-     *     echo "Title became active on January 15, 2024";
-     * }
-     * ```
      */
     public function statusChangedTo(ActivationStatus $status, Carbon $date): bool
     {
@@ -293,14 +93,6 @@ trait HasStatusHistory
      * Get the formatted debut date.
      *
      * Returns 'TBD' if the entity hasn't debuted yet.
-     *
-     * @return string The formatted date (Y-m-d) or 'TBD'
-     *
-     * @example
-     * ```php
-     * $title = Title::find(1);
-     * echo $title->getFormattedDebutDate(); // "2024-01-15" or "TBD"
-     * ```
      */
     public function getFormattedDebutDate(): string
     {
@@ -310,18 +102,8 @@ trait HasStatusHistory
     }
 
     /**
-     * Resolve the model class for the status change relation.
-     *
-     * This method automatically determines the status change model class based on naming
-     * conventions. For example, if the parent model is 'Title', it will look for
-     * a 'TitleStatusChange' model class.
-     *
-     *
-     * @throws RuntimeException If the resolved model class doesn't exist
-     * @return class-string<TStatusChange> The fully qualified class name of the status change model
-     *
-     * @example
-     * For a 'Title' model, this will resolve to 'App\\Models\\Titles\\TitleStatusChange'
+     * @throws RuntimeException
+     * @return class-string<TStatusChange>
      */
     protected function resolveStatusChangeModelClass(): string
     {

--- a/app/Models/Stables/Stable.php
+++ b/app/Models/Stables/Stable.php
@@ -110,12 +110,7 @@ use Tests\Unit\Models\Stables\StableTest;
 class Stable extends Model implements Debutable, HasActivityPeriodsContract, Retirable
 {
     /** @use HasActivityPeriods<StableActivityPeriod, static> */
-    use HasActivityPeriods {
-        HasActivityPeriods::isCurrentlyActive insteadof HasStatusHistory;
-        HasActivityPeriods::isNotCurrentlyActive insteadof HasStatusHistory;
-        HasActivityPeriods::isUnactivated insteadof HasStatusHistory;
-        HasActivityPeriods::isInactive insteadof HasStatusHistory;
-    }
+    use HasActivityPeriods;
 
     /** @use HasFactory<StableFactory> */
     use HasFactory;

--- a/app/Models/Titles/Title.php
+++ b/app/Models/Titles/Title.php
@@ -105,12 +105,7 @@ use Illuminate\Support\Carbon;
 class Title extends Model implements Debutable, HasActivityPeriodsContract, HasDisplayName, Retirable
 {
     /** @use HasActivityPeriods<TitleActivityPeriod, static> */
-    use HasActivityPeriods {
-        HasActivityPeriods::isCurrentlyActive insteadof HasStatusHistory;
-        HasActivityPeriods::isNotCurrentlyActive insteadof HasStatusHistory;
-        HasActivityPeriods::isUnactivated insteadof HasStatusHistory;
-        HasActivityPeriods::isInactive insteadof HasStatusHistory;
-    }
+    use HasActivityPeriods;
 
     use HasChampionships;
 


### PR DESCRIPTION
## Summary
- make `HasActivityPeriods` the sole owner of activity-state behavior
- remove duplicate activity methods from `HasStatusHistory`
- remove trait conflict resolution from the `Title` and `Stable` models
- trim redundant examples and narration while preserving static-analysis annotations and non-obvious semantics

## Verification
- `composer test:push`
- 54 focused tests passed with 84 assertions
- application PHPStan passed
- Pest PHPStan passed
- `composer lint` passed
- `git diff --check` passed