### PR TITLE
refactor: remove speculative tag team validation

### DIFF
--- a/app/Models/Concerns/ValidatesTagTeamLifecycle.php
+++ b/app/Models/Concerns/ValidatesTagTeamLifecycle.php
@@ -12,6 +12,7 @@ use App\Exceptions\Roster\TagTeams\CannotBeRestoredException;
 use App\Exceptions\Roster\TagTeams\CannotBeRetiredException;
 use App\Exceptions\Roster\TagTeams\CannotBeSuspendedException;
 use App\Exceptions\Roster\TagTeams\CannotBeUnretiredException;
+use App\Models\Wrestlers\Wrestler;
 use Exception;
 
 /**
@@ -72,15 +73,6 @@ trait ValidatesTagTeamLifecycle
             return false;
         }
 
-        // Check if any partner has conflicting employment
-        $conflictedPartners = $currentPartners->filter(function ($wrestler) {
-            return $wrestler->isEmployed() && method_exists($wrestler, 'hasExclusivityConflicts') && $wrestler->hasExclusivityConflicts();
-        });
-
-        if ($conflictedPartners->isNotEmpty()) {
-            return false;
-        }
-
         // Basic employment is possible
         return true;
     }
@@ -108,16 +100,6 @@ trait ValidatesTagTeamLifecycle
         $currentPartners = $this->currentWrestlers;
         if ($currentPartners->isEmpty()) {
             throw CannotBeEmployedException::partnersUnavailable($this, 'No current partners available');
-        }
-
-        // Check for partner employment conflicts
-        $conflictedPartners = $currentPartners->filter(function ($wrestler) {
-            return $wrestler->isEmployed() && method_exists($wrestler, 'hasExclusivityConflicts') && $wrestler->hasExclusivityConflicts();
-        });
-
-        if ($conflictedPartners->isNotEmpty()) {
-            $partnerNames = $conflictedPartners->pluck('name')->join(', ');
-            throw CannotBeEmployedException::partnerEmploymentConflicts($this, $partnerNames);
         }
 
         // Additional business rule validations could be added here:
@@ -590,9 +572,9 @@ trait ValidatesTagTeamLifecycle
             }
 
             // Check if key partners are available
-            $unavailablePartners = $currentPartners->filter(function ($wrestler) {
-                return (method_exists($wrestler, 'hasExclusivityConflicts') && $wrestler->hasExclusivityConflicts()) || $wrestler->isInjured();
-            });
+            $unavailablePartners = $currentPartners->filter(
+                fn (Wrestler $wrestler): bool => $wrestler->isInjured()
+            );
 
             if ($unavailablePartners->isNotEmpty()) {
                 $partnerNames = $unavailablePartners->pluck('name')->join(', ');

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -149,6 +149,8 @@ Retirement eligibility no longer uses an operation-name string or a generic `Mod
 
 Suspension eligibility follows the same typed boundary. Shared individual validation accepts only wrestlers, managers, and referees. Tag teams retain their established lifecycle validation, while stables and titles do not support suspension. The unused generic suspension contract and tag-team and stable strategy classes were removed rather than preserving unreachable dispatch paths.
 
+Tag-team lifecycle validation uses the concrete `Wrestler` models returned by its current-wrestler relationship. It must not probe for speculative capabilities with `method_exists()`. Current wrestler employment remains valid when employing the team, while an injured current wrestler remains unavailable for tag-team unretirement. Any future exclusivity rule must be introduced as an explicit reviewed domain rule with real model behavior and tests.
+
 The following generalized classes were confirmed to have no production, configuration, container, console, route, or test consumers and were removed rather than retained as foundations for the target architecture:
 
 - `ActionPipeline`;

--- a/tests/Integration/Actions/TagTeams/EmployActionTest.php
+++ b/tests/Integration/Actions/TagTeams/EmployActionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Actions\TagTeams\EmployAction;
 use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -27,6 +28,17 @@ test('it employs an unemployed tag team', function () {
         'started_at' => now()->toDateTimeString(),
         'ended_at' => null,
     ]);
+});
+
+test('it employs a tag team whose current wrestlers are already employed', function () {
+    $wrestlers = Wrestler::factory()->employed()->count(2)->create();
+    $tagTeam = TagTeam::factory()
+        ->withCurrentWrestlers($wrestlers)
+        ->create();
+
+    resolve(EmployAction::class)->handle($tagTeam);
+
+    expect($tagTeam->refresh()->isEmployed())->toBeTrue();
 });
 
 test('it employs tag team with specific employment date', function () {

--- a/tests/Integration/Actions/TagTeams/UnretireActionTest.php
+++ b/tests/Integration/Actions/TagTeams/UnretireActionTest.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use App\Actions\TagTeams\UnretireAction;
+use App\Exceptions\Roster\TagTeams\CannotBeUnretiredException;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -36,6 +38,24 @@ test('it unretires a retired tag team', function () {
         'started_at' => now()->toDateTimeString(),
         'ended_at' => null,
     ]);
+});
+
+test('it prevents unretiring a tag team with an injured current wrestler', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $wrestlers = Wrestler::factory()->employed()->count(1)->create();
+    $injuredWrestler = Wrestler::factory()->injured()->create();
+
+    $tagTeam->retirements()->create([
+        'started_at' => now()->subDay(),
+        'ended_at' => null,
+    ]);
+    $tagTeam->wrestlers()->attach(
+        $wrestlers->push($injuredWrestler),
+        ['joined_at' => now()->subDays(2), 'left_at' => null],
+    );
+
+    expect(fn () => resolve(UnretireAction::class)->handle($tagTeam))
+        ->toThrow(CannotBeUnretiredException::class);
 });
 
 test('it unretires and employs current members by default', function () {


### PR DESCRIPTION
## Summary
- remove dormant tag-team checks for a wrestler exclusivity capability that does not exist
- keep current wrestler employment valid when employing a tag team
- retain typed injury validation for tag-team unretirement
- document the concrete tag-team lifecycle validation boundary

## Verification
- 29 focused tests passed with 115 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector and Pest type coverage passed
- changed files passed Pint with Blade formatting
- git diff --check passed

## Existing repository issue
- composer test:push reaches the existing Blade formatter mismatch in unrelated views, which is also reproducible on clean development

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tag teams can now be employed even when their current wrestlers are already employed elsewhere.
  * Tag-team unretirement continues to be blocked when a current wrestler is injured.
  * Exclusivity conflicts no longer prevent tag-team employment or unretirement.

* **Documentation**
  * Clarified tag-team lifecycle validation rules and wrestler availability requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->