### PR TITLE
refactor: isolate tag team employment validation

### DIFF
--- a/app/Models/Concerns/ValidatesTagTeamEmployment.php
+++ b/app/Models/Concerns/ValidatesTagTeamEmployment.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use App\Exceptions\Roster\TagTeams\CannotBeEmployedException;
+use App\Models\TagTeams\TagTeam;
+
+/** @mixin TagTeam */
+trait ValidatesTagTeamEmployment
+{
+    public function canBeEmployed(): bool
+    {
+        if ($this->isEmployed()) {
+            return false;
+        }
+
+        if ($this->isRetired()) {
+            return false;
+        }
+
+        return $this->currentWrestlers->isNotEmpty();
+    }
+
+    /** @throws CannotBeEmployedException */
+    public function ensureCanBeEmployed(): void
+    {
+        if ($this->isEmployed()) {
+            throw CannotBeEmployedException::alreadyEmployed($this);
+        }
+
+        if ($this->isRetired()) {
+            throw CannotBeEmployedException::retired($this);
+        }
+
+        if ($this->currentWrestlers->isEmpty()) {
+            throw CannotBeEmployedException::partnersUnavailable($this, 'No current partners available');
+        }
+    }
+}

--- a/app/Models/Concerns/ValidatesTagTeamLifecycle.php
+++ b/app/Models/Concerns/ValidatesTagTeamLifecycle.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Models\Concerns;
 
 use App\Exceptions\Roster\TagTeams\CannotBeDeletedException;
-use App\Exceptions\Roster\TagTeams\CannotBeEmployedException;
 use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException;
 use App\Exceptions\Roster\TagTeams\CannotBeReleasedException;
 use App\Exceptions\Roster\TagTeams\CannotBeRestoredException;
@@ -46,69 +45,6 @@ use Exception;
  */
 trait ValidatesTagTeamLifecycle
 {
-    /**
-     * Determine if the tag team can be employed.
-     *
-     * Checks business rules for tag team employment:
-     * - Must not already be employed
-     * - Must not be retired (requires unretirement first)
-     * - Partners must be available and employable
-     * - Must meet promotion standards
-     *
-     * @return bool True if the tag team can be employed, false otherwise
-     */
-    public function canBeEmployed(): bool
-    {
-        if ($this->isEmployed()) {
-            return false;
-        }
-
-        if ($this->isRetired()) {
-            return false;
-        }
-
-        // Check if current partners are available for employment
-        $currentPartners = $this->currentWrestlers;
-        if ($currentPartners->isEmpty()) {
-            return false;
-        }
-
-        // Basic employment is possible
-        return true;
-    }
-
-    /**
-     * Ensure the tag team can be employed, throwing an exception if not.
-     *
-     * Validates that the tag team is in a valid state for employment while checking
-     * for business rule violations including partner availability, standards compliance,
-     * and administrative requirements.
-     *
-     * @throws CannotBeEmployedException When employment is not allowed
-     */
-    public function ensureCanBeEmployed(): void
-    {
-        if ($this->isEmployed()) {
-            throw CannotBeEmployedException::alreadyEmployed($this);
-        }
-
-        if ($this->isRetired()) {
-            throw CannotBeEmployedException::retired($this);
-        }
-
-        // Check partner availability
-        $currentPartners = $this->currentWrestlers;
-        if ($currentPartners->isEmpty()) {
-            throw CannotBeEmployedException::partnersUnavailable($this, 'No current partners available');
-        }
-
-        // Additional business rule validations could be added here:
-        // - Check promotion employment standards
-        // - Check roster limits
-        // - Check authorization requirements
-        // - Check disciplinary issues
-    }
-
     /**
      * Determine if the tag team can be retired.
      *

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -14,6 +14,7 @@ use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsRetirable;
 use App\Models\Concerns\IsSuspendable;
 use App\Models\Concerns\ProvidesTagTeamWrestlers;
+use App\Models\Concerns\ValidatesTagTeamEmployment;
 use App\Models\Concerns\ValidatesTagTeamLifecycle;
 use App\Models\Contracts\Bookable;
 use App\Models\Contracts\CanBeAStableMember;
@@ -148,6 +149,7 @@ class TagTeam extends Model implements Bookable, CanBeAStableMember, CanBeChampi
     use ProvidesTagTeamWrestlers;
 
     use SoftDeletes;
+    use ValidatesTagTeamEmployment;
     use ValidatesTagTeamLifecycle;
 
     /**

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -151,6 +151,8 @@ Suspension eligibility follows the same typed boundary. Shared individual valida
 
 Tag-team lifecycle validation uses the concrete `Wrestler` models returned by its current-wrestler relationship. It must not probe for speculative capabilities with `method_exists()`. Current wrestler employment remains valid when employing the team, while an injured current wrestler remains unavailable for tag-team unretirement. Any future exclusivity rule must be introduced as an explicit reviewed domain rule with real model behavior and tests.
 
+Tag-team employment eligibility is isolated in `ValidatesTagTeamEmployment`. The concern owns only the model-level `canBeEmployed()` and `ensureCanBeEmployed()` rules; the employment Action continues to own orchestration and persistence. Other tag-team lifecycle dimensions remain separate and will be extracted independently.
+
 The following generalized classes were confirmed to have no production, configuration, container, console, route, or test consumers and were removed rather than retained as foundations for the target architecture:
 
 - `ActionPipeline`;


### PR DESCRIPTION
## Summary
- extract tag-team employment eligibility into a focused model concern
- keep the existing public validation API and behavior unchanged
- leave employment orchestration and persistence in the typed Action
- document the incremental lifecycle-validation boundary

## Verification
- 21 focused employment tests passed with 72 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector and Pest type coverage passed
- changed files passed Pint with Blade formatting
- git diff --check passed

## Existing repository issue
- composer test:push reaches the existing Blade formatter mismatch in unrelated views, which is also reproducible on clean development