### PR TITLE
refactor: isolate tag team suspension validation

### DIFF
--- a/app/Models/Concerns/ValidatesTagTeamLifecycle.php
+++ b/app/Models/Concerns/ValidatesTagTeamLifecycle.php
@@ -5,11 +5,9 @@ declare(strict_types=1);
 namespace App\Models\Concerns;
 
 use App\Exceptions\Roster\TagTeams\CannotBeDeletedException;
-use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException;
 use App\Exceptions\Roster\TagTeams\CannotBeReleasedException;
 use App\Exceptions\Roster\TagTeams\CannotBeRestoredException;
 use App\Exceptions\Roster\TagTeams\CannotBeRetiredException;
-use App\Exceptions\Roster\TagTeams\CannotBeSuspendedException;
 use App\Exceptions\Roster\TagTeams\CannotBeUnretiredException;
 use App\Models\Wrestlers\Wrestler;
 use Exception;
@@ -118,106 +116,6 @@ trait ValidatesTagTeamLifecycle
         // if (! $this->hasRetirementAuthorization()) {
         //     throw CannotBeRetiredException::insufficientAuthorization($this, 'management');
         // }
-    }
-
-    /**
-     * Determine if the tag team can be suspended.
-     *
-     * Checks business rules for tag team suspension:
-     * - Must be currently employed
-     * - Must not already be suspended
-     * - Should validate disciplinary requirements
-     *
-     * @return bool True if the tag team can be suspended, false otherwise
-     */
-    public function canBeSuspended(): bool
-    {
-        if (! $this->isEmployed()) {
-            return false;
-        }
-
-        if ($this->isSuspended()) {
-            return false;
-        }
-
-        // Basic suspension is possible if employed and not already suspended
-        return true;
-    }
-
-    /**
-     * Ensure the tag team can be suspended, throwing an exception if not.
-     *
-     * Validates that the tag team is in a valid state for suspension while checking
-     * for business rule violations including employment status, existing suspensions,
-     * and administrative requirements.
-     *
-     * @throws CannotBeSuspendedException When suspension is not allowed
-     */
-    public function ensureCanBeSuspended(): void
-    {
-        if (! $this->isEmployed()) {
-            throw CannotBeSuspendedException::notEmployed($this);
-        }
-
-        if ($this->isSuspended()) {
-            throw CannotBeSuspendedException::alreadySuspended($this);
-        }
-
-        // Additional business rule validations could be added here:
-        // - Check for disciplinary authorization requirements
-        // - Check for active championship obligations
-        // - Check for scheduled match conflicts
-        // - Check for storyline impact considerations
-    }
-
-    /**
-     * Determine if the tag team can be reinstated.
-     *
-     * Checks business rules for tag team reinstatement:
-     * - Must be currently suspended
-     * - Must still be employed
-     * - Should validate reinstatement authorization
-     *
-     * @return bool True if the tag team can be reinstated, false otherwise
-     */
-    public function canBeReinstated(): bool
-    {
-        if (! $this->isSuspended()) {
-            return false;
-        }
-
-        if (! $this->isEmployed()) {
-            return false;
-        }
-
-        // Basic reinstatement is possible if suspended and employed
-        return true;
-    }
-
-    /**
-     * Ensure the tag team can be reinstated, throwing an exception if not.
-     *
-     * Validates that the tag team is in a valid state for reinstatement while checking
-     * for business rule violations including suspension status, employment status,
-     * and authorization requirements.
-     *
-     * @throws CannotBeReinstatedException When reinstatement is not allowed
-     */
-    public function ensureCanBeReinstated(): void
-    {
-        if (! $this->isSuspended()) {
-            throw CannotBeReinstatedException::notSuspended($this);
-        }
-
-        if (! $this->isEmployed()) {
-            throw CannotBeReinstatedException::notEmployed($this);
-        }
-
-        // Additional business rule validations could be added here:
-        // - Check for reinstatement authorization requirements
-        // - Check for disciplinary clearance
-        // - Check for administrative approval
-        // - Check for partner availability after suspension period
     }
 
     /**

--- a/app/Models/Concerns/ValidatesTagTeamSuspension.php
+++ b/app/Models/Concerns/ValidatesTagTeamSuspension.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException;
+use App\Exceptions\Roster\TagTeams\CannotBeSuspendedException;
+use App\Models\TagTeams\TagTeam;
+
+/** @mixin TagTeam */
+trait ValidatesTagTeamSuspension
+{
+    public function canBeSuspended(): bool
+    {
+        if (! $this->isEmployed()) {
+            return false;
+        }
+
+        return ! $this->isSuspended();
+    }
+
+    /** @throws CannotBeSuspendedException */
+    public function ensureCanBeSuspended(): void
+    {
+        if (! $this->isEmployed()) {
+            throw CannotBeSuspendedException::notEmployed($this);
+        }
+
+        if ($this->isSuspended()) {
+            throw CannotBeSuspendedException::alreadySuspended($this);
+        }
+    }
+
+    public function canBeReinstated(): bool
+    {
+        if (! $this->isSuspended()) {
+            return false;
+        }
+
+        return $this->isEmployed();
+    }
+
+    /** @throws CannotBeReinstatedException */
+    public function ensureCanBeReinstated(): void
+    {
+        if (! $this->isSuspended()) {
+            throw CannotBeReinstatedException::notSuspended($this);
+        }
+
+        if (! $this->isEmployed()) {
+            throw CannotBeReinstatedException::notEmployed($this);
+        }
+    }
+}

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -16,6 +16,7 @@ use App\Models\Concerns\IsSuspendable;
 use App\Models\Concerns\ProvidesTagTeamWrestlers;
 use App\Models\Concerns\ValidatesTagTeamEmployment;
 use App\Models\Concerns\ValidatesTagTeamLifecycle;
+use App\Models\Concerns\ValidatesTagTeamSuspension;
 use App\Models\Contracts\Bookable;
 use App\Models\Contracts\CanBeAStableMember;
 use App\Models\Contracts\CanBeChampion;
@@ -151,6 +152,7 @@ class TagTeam extends Model implements Bookable, CanBeAStableMember, CanBeChampi
     use SoftDeletes;
     use ValidatesTagTeamEmployment;
     use ValidatesTagTeamLifecycle;
+    use ValidatesTagTeamSuspension;
 
     /**
      * The number of the wrestlers allowed on a tag team.

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -153,6 +153,8 @@ Tag-team lifecycle validation uses the concrete `Wrestler` models returned by it
 
 Tag-team employment eligibility is isolated in `ValidatesTagTeamEmployment`. The concern owns only the model-level `canBeEmployed()` and `ensureCanBeEmployed()` rules; the employment Action continues to own orchestration and persistence. Other tag-team lifecycle dimensions remain separate and will be extracted independently.
 
+Tag-team suspension eligibility is isolated in `ValidatesTagTeamSuspension`. Suspension and reinstatement remain paired as opposite transitions of one lifecycle dimension, while their Actions continue to own suspension-period persistence, dates, transactions, and member cascades.
+
 The following generalized classes were confirmed to have no production, configuration, container, console, route, or test consumers and were removed rather than retained as foundations for the target architecture:
 
 - `ActionPipeline`;


### PR DESCRIPTION
## Summary
- isolate tag-team suspension and reinstatement eligibility in a dedicated model concern
- keep persistence, transactions, dates, and member cascades in their existing Actions
- document the lifecycle boundary

## Verification
- 28 focused tests passed with 104 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- changed PHP files passed repository formatting
- git diff --check passed

## Local suite note
- composer test:push completed tests, PHPStan, Rector, and type coverage successfully, then reached the existing repository-wide Blade formatting mismatch in unrelated views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added suspension and reinstatement eligibility validation for tag teams.
  - Preserved existing retirement, release, deletion, restoration, and unretirement behavior.
- **Documentation**
  - Clarified lifecycle boundaries for suspension and reinstatement operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->