### PR TITLE
refactor: isolate tag team release validation

### DIFF
--- a/app/Models/Concerns/ValidatesTagTeamLifecycle.php
+++ b/app/Models/Concerns/ValidatesTagTeamLifecycle.php
@@ -5,68 +5,12 @@ declare(strict_types=1);
 namespace App\Models\Concerns;
 
 use App\Exceptions\Roster\TagTeams\CannotBeDeletedException;
-use App\Exceptions\Roster\TagTeams\CannotBeReleasedException;
 use App\Exceptions\Roster\TagTeams\CannotBeRestoredException;
 use Exception;
 
 /** Provides validation for the remaining tag-team lifecycle operations. */
 trait ValidatesTagTeamLifecycle
 {
-    /**
-     * Determine if the tag team can be released.
-     *
-     * Checks business rules for tag team release:
-     * - Must be currently employed
-     * - Should validate contractual obligations
-     * - Should check for championship commitments
-     *
-     * @return bool True if the tag team can be released, false otherwise
-     */
-    public function canBeReleased(): bool
-    {
-        if (! $this->isEmployed()) {
-            return false;
-        }
-
-        // Basic release is possible if employed
-        return true;
-    }
-
-    /**
-     * Ensure the tag team can be released, throwing an exception if not.
-     *
-     * Validates that the tag team is in a valid state for release while checking
-     * for business rule violations including employment status, contractual obligations,
-     * and championship commitments.
-     *
-     * @throws CannotBeReleasedException When release is not allowed
-     */
-    public function ensureCanBeReleased(): void
-    {
-        if (! $this->isEmployed()) {
-            throw CannotBeReleasedException::notEmployed($this);
-        }
-
-        // Additional business rule validations could be added here:
-        // - Check for championship obligations
-        // if ($this->hasCurrentChampionshipObligations()) {
-        //     $championships = $this->getCurrentChampionshipDetails();
-        //     throw CannotBeReleasedException::hasChampionshipObligations($this, $championships);
-        // }
-
-        // - Check for contractual obligations
-        // if ($this->hasUnfulfilledContractualObligations()) {
-        //     $obligations = $this->getContractualObligationDetails();
-        //     throw CannotBeReleasedException::contractualObligations($this, $obligations);
-        // }
-
-        // - Check for scheduled match commitments
-        // if ($this->hasScheduledMatches()) {
-        //     $matches = $this->getScheduledMatchDetails();
-        //     throw CannotBeReleasedException::hasScheduledMatches($this, $matches);
-        // }
-    }
-
     /**
      * Determine if the tag team can be deleted (soft deleted).
      *

--- a/app/Models/Concerns/ValidatesTagTeamRelease.php
+++ b/app/Models/Concerns/ValidatesTagTeamRelease.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models\Concerns;
+
+use App\Exceptions\Roster\TagTeams\CannotBeReleasedException;
+use App\Models\TagTeams\TagTeam;
+
+/** @mixin TagTeam */
+trait ValidatesTagTeamRelease
+{
+    public function canBeReleased(): bool
+    {
+        return $this->isEmployed();
+    }
+
+    /** @throws CannotBeReleasedException */
+    public function ensureCanBeReleased(): void
+    {
+        if (! $this->isEmployed()) {
+            throw CannotBeReleasedException::notEmployed($this);
+        }
+    }
+}

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -16,6 +16,7 @@ use App\Models\Concerns\IsSuspendable;
 use App\Models\Concerns\ProvidesTagTeamWrestlers;
 use App\Models\Concerns\ValidatesTagTeamEmployment;
 use App\Models\Concerns\ValidatesTagTeamLifecycle;
+use App\Models\Concerns\ValidatesTagTeamRelease;
 use App\Models\Concerns\ValidatesTagTeamRetirement;
 use App\Models\Concerns\ValidatesTagTeamSuspension;
 use App\Models\Contracts\Bookable;
@@ -153,6 +154,7 @@ class TagTeam extends Model implements Bookable, CanBeAStableMember, CanBeChampi
     use SoftDeletes;
     use ValidatesTagTeamEmployment;
     use ValidatesTagTeamLifecycle;
+    use ValidatesTagTeamRelease;
     use ValidatesTagTeamRetirement;
     use ValidatesTagTeamSuspension;
 

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -157,6 +157,8 @@ Tag-team suspension eligibility is isolated in `ValidatesTagTeamSuspension`. Sus
 
 Tag-team retirement eligibility is isolated in `ValidatesTagTeamRetirement`. Retirement and unretirement remain paired as opposite transitions of one lifecycle dimension. The concern owns employment, name-conflict, partner-count, and partner-availability rules; the Actions continue to own retirement-period persistence, dates, transactions, and member cascades.
 
+Tag-team release eligibility is isolated in `ValidatesTagTeamRelease`. The concern owns the requirement that a team be employed before release; the Action continues to own employment and suspension period closure, dates, transactions, and relationship cleanup.
+
 The following generalized classes were confirmed to have no production, configuration, container, console, route, or test consumers and were removed rather than retained as foundations for the target architecture:
 
 - `ActionPipeline`;

--- a/tests/Integration/Actions/TagTeams/ReleaseActionTest.php
+++ b/tests/Integration/Actions/TagTeams/ReleaseActionTest.php
@@ -14,12 +14,14 @@ beforeEach(function () {
 test('it releases an employed tag team', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
 
-    expect($tagTeam->isEmployed())->toBeTrue();
+    expect($tagTeam->isEmployed())->toBeTrue()
+        ->and($tagTeam->canBeReleased())->toBeTrue();
 
     resolve(ReleaseAction::class)->handle($tagTeam);
 
     $tagTeam->refresh();
-    expect($tagTeam->isEmployed())->toBeFalse();
+    expect($tagTeam->isEmployed())->toBeFalse()
+        ->and($tagTeam->canBeReleased())->toBeFalse();
 
     // Verify employment record was ended
     $this->assertDatabaseHas('tag_teams_employments', [


### PR DESCRIPTION
## Summary
- isolate tag-team release eligibility in a dedicated model concern
- keep employment and suspension period closure, transactions, dates, and relationship cleanup in the release Action
- add direct eligibility assertions and document the lifecycle boundary

## Verification
- 12 focused tests passed with 37 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- changed files passed repository formatting
- git diff --check passed

## Local suite note
- composer test:push completed tests, PHPStan, Rector, and type coverage successfully, then reached the existing repository-wide Blade formatting mismatch in unrelated views