### PR TITLE
refactor: enforce current stable membership

### DIFF
--- a/database/migrations/2026_08_11_022704_enforce_single_current_stable_membership_for_wrestlers.php
+++ b/database/migrations/2026_08_11_022704_enforce_single_current_stable_membership_for_wrestlers.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $connection = DB::connection();
+
+        match ($connection->getDriverName()) {
+            'sqlite', 'pgsql', 'sqlsrv' => $connection->statement(
+                'CREATE UNIQUE INDEX stables_wrestlers_one_current_membership_unique '
+                .'ON stables_wrestlers (wrestler_id) WHERE left_at IS NULL'
+            ),
+            'mysql', 'mariadb' => $connection->statement(
+                'ALTER TABLE stables_wrestlers '
+                .'ADD COLUMN current_wrestler_id BIGINT UNSIGNED '
+                .'GENERATED ALWAYS AS (CASE WHEN left_at IS NULL THEN wrestler_id ELSE NULL END) STORED, '
+                .'ADD UNIQUE INDEX stables_wrestlers_one_current_membership_unique (current_wrestler_id)'
+            ),
+            default => throw new LogicException('The database driver does not support current stable membership constraints.'),
+        };
+    }
+};

--- a/database/migrations/2026_08_11_022715_enforce_single_current_stable_membership_for_tag_teams.php
+++ b/database/migrations/2026_08_11_022715_enforce_single_current_stable_membership_for_tag_teams.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $connection = DB::connection();
+
+        match ($connection->getDriverName()) {
+            'sqlite', 'pgsql', 'sqlsrv' => $connection->statement(
+                'CREATE UNIQUE INDEX stables_tag_teams_one_current_membership_unique '
+                .'ON stables_tag_teams (tag_team_id) WHERE left_at IS NULL'
+            ),
+            'mysql', 'mariadb' => $connection->statement(
+                'ALTER TABLE stables_tag_teams '
+                .'ADD COLUMN current_tag_team_id BIGINT UNSIGNED '
+                .'GENERATED ALWAYS AS (CASE WHEN left_at IS NULL THEN tag_team_id ELSE NULL END) STORED, '
+                .'ADD UNIQUE INDEX stables_tag_teams_one_current_membership_unique (current_tag_team_id)'
+            ),
+            default => throw new LogicException('The database driver does not support current stable membership constraints.'),
+        };
+    }
+};

--- a/docs/architecture/stable-membership.md
+++ b/docs/architecture/stable-membership.md
@@ -13,6 +13,7 @@ Stable membership defines how wrestlers and tag teams can belong to stables.
 - **Tag Team Membership**: Tag teams can belong to stables
 - **Manager Exclusion**: Managers do NOT belong to stables directly (they manage individual wrestlers/tag teams)
 - **Single Current Stable**: Wrestlers and tag teams can belong to only one stable at a time
+- **Database Enforcement**: Membership history tables enforce one open membership per wrestler or tag team while allowing unlimited ended memberships
 - **Membership History**: Wrestlers and tag teams can belong to multiple stables across non-overlapping historical periods
 - **Stable Leadership**: Stables can have designated leaders
 - **Member Availability**: New memberships require employed members who are not suspended; injured wrestlers cannot join

--- a/tests/Integration/Database/StableMembershipConstraintTest.php
+++ b/tests/Integration/Database/StableMembershipConstraintTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Stables\Stable;
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\QueryException;
+
+test('a wrestler may have multiple ended stable memberships', function () {
+    $wrestler = Wrestler::factory()->create();
+
+    Stable::factory()->count(2)->create()->each(
+        fn (Stable $stable) => StableWrestler::query()->create([
+            'stable_id' => $stable->id,
+            'wrestler_id' => $wrestler->id,
+            'joined_at' => now()->subMonth(),
+            'left_at' => now()->subDay(),
+        ])
+    );
+
+    expect(StableWrestler::query()->where('wrestler_id', $wrestler->id)->count())->toBe(2);
+});
+
+test('a wrestler cannot have multiple current stable memberships', function () {
+    $wrestler = Wrestler::factory()->create();
+    $firstStable = Stable::factory()->create();
+    $secondStable = Stable::factory()->create();
+
+    StableWrestler::query()->create([
+        'stable_id' => $firstStable->id,
+        'wrestler_id' => $wrestler->id,
+        'joined_at' => now(),
+    ]);
+
+    expect(fn () => StableWrestler::query()->create([
+        'stable_id' => $secondStable->id,
+        'wrestler_id' => $wrestler->id,
+        'joined_at' => now(),
+    ]))->toThrow(QueryException::class);
+});
+
+test('a tag team may have multiple ended stable memberships', function () {
+    $tagTeam = TagTeam::factory()->create();
+
+    Stable::factory()->count(2)->create()->each(
+        fn (Stable $stable) => StableTagTeam::query()->create([
+            'stable_id' => $stable->id,
+            'tag_team_id' => $tagTeam->id,
+            'joined_at' => now()->subMonth(),
+            'left_at' => now()->subDay(),
+        ])
+    );
+
+    expect(StableTagTeam::query()->where('tag_team_id', $tagTeam->id)->count())->toBe(2);
+});
+
+test('a tag team cannot have multiple current stable memberships', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $firstStable = Stable::factory()->create();
+    $secondStable = Stable::factory()->create();
+
+    StableTagTeam::query()->create([
+        'stable_id' => $firstStable->id,
+        'tag_team_id' => $tagTeam->id,
+        'joined_at' => now(),
+    ]);
+
+    expect(fn () => StableTagTeam::query()->create([
+        'stable_id' => $secondStable->id,
+        'tag_team_id' => $tagTeam->id,
+        'joined_at' => now(),
+    ]))->toThrow(QueryException::class);
+});


### PR DESCRIPTION
## Summary
- enforce one current stable membership per wrestler at the database boundary
- enforce one current stable membership per tag team at the database boundary
- preserve unlimited ended membership history
- use independently deployable migrations for each membership table
- document the storage invariant in the stable membership architecture

## Verification
- 40 affected membership tests passed with 140 assertions
- split migration verification: 32 tests passed with 108 assertions
- PHPStan passed for application and Pest tests
- Rector and 100% type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push reaches the existing repository-wide Blade formatter drift and stops at test:lint; this PR does not modify those Blade views