### PR TITLE
refactor: enforce open employment periods

### DIFF
--- a/database/migrations/2026_08_11_024027_enforce_single_open_employment_for_wrestlers.php
+++ b/database/migrations/2026_08_11_024027_enforce_single_open_employment_for_wrestlers.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $connection = DB::connection();
+
+        match ($connection->getDriverName()) {
+            'sqlite', 'pgsql', 'sqlsrv' => $connection->statement(
+                'CREATE UNIQUE INDEX wrestlers_employments_one_open_period_unique '
+                .'ON wrestlers_employments (wrestler_id) WHERE ended_at IS NULL'
+            ),
+            'mysql', 'mariadb' => $connection->statement(
+                'ALTER TABLE wrestlers_employments '
+                .'ADD COLUMN current_wrestler_id BIGINT UNSIGNED '
+                .'GENERATED ALWAYS AS (CASE WHEN ended_at IS NULL THEN wrestler_id ELSE NULL END) STORED, '
+                .'ADD UNIQUE INDEX wrestlers_employments_one_open_period_unique (current_wrestler_id)'
+            ),
+            default => throw new LogicException('The database driver does not support open employment period constraints.'),
+        };
+    }
+};

--- a/database/migrations/2026_08_11_024028_enforce_single_open_employment_for_managers.php
+++ b/database/migrations/2026_08_11_024028_enforce_single_open_employment_for_managers.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $connection = DB::connection();
+
+        match ($connection->getDriverName()) {
+            'sqlite', 'pgsql', 'sqlsrv' => $connection->statement(
+                'CREATE UNIQUE INDEX managers_employments_one_open_period_unique '
+                .'ON managers_employments (manager_id) WHERE ended_at IS NULL'
+            ),
+            'mysql', 'mariadb' => $connection->statement(
+                'ALTER TABLE managers_employments '
+                .'ADD COLUMN current_manager_id BIGINT UNSIGNED '
+                .'GENERATED ALWAYS AS (CASE WHEN ended_at IS NULL THEN manager_id ELSE NULL END) STORED, '
+                .'ADD UNIQUE INDEX managers_employments_one_open_period_unique (current_manager_id)'
+            ),
+            default => throw new LogicException('The database driver does not support open employment period constraints.'),
+        };
+    }
+};

--- a/database/migrations/2026_08_11_024029_enforce_single_open_employment_for_referees.php
+++ b/database/migrations/2026_08_11_024029_enforce_single_open_employment_for_referees.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $connection = DB::connection();
+
+        match ($connection->getDriverName()) {
+            'sqlite', 'pgsql', 'sqlsrv' => $connection->statement(
+                'CREATE UNIQUE INDEX referees_employments_one_open_period_unique '
+                .'ON referees_employments (referee_id) WHERE ended_at IS NULL'
+            ),
+            'mysql', 'mariadb' => $connection->statement(
+                'ALTER TABLE referees_employments '
+                .'ADD COLUMN current_referee_id BIGINT UNSIGNED '
+                .'GENERATED ALWAYS AS (CASE WHEN ended_at IS NULL THEN referee_id ELSE NULL END) STORED, '
+                .'ADD UNIQUE INDEX referees_employments_one_open_period_unique (current_referee_id)'
+            ),
+            default => throw new LogicException('The database driver does not support open employment period constraints.'),
+        };
+    }
+};

--- a/database/migrations/2026_08_11_024030_enforce_single_open_employment_for_tag_teams.php
+++ b/database/migrations/2026_08_11_024030_enforce_single_open_employment_for_tag_teams.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $connection = DB::connection();
+
+        match ($connection->getDriverName()) {
+            'sqlite', 'pgsql', 'sqlsrv' => $connection->statement(
+                'CREATE UNIQUE INDEX tag_teams_employments_one_open_period_unique '
+                .'ON tag_teams_employments (tag_team_id) WHERE ended_at IS NULL'
+            ),
+            'mysql', 'mariadb' => $connection->statement(
+                'ALTER TABLE tag_teams_employments '
+                .'ADD COLUMN current_tag_team_id BIGINT UNSIGNED '
+                .'GENERATED ALWAYS AS (CASE WHEN ended_at IS NULL THEN tag_team_id ELSE NULL END) STORED, '
+                .'ADD UNIQUE INDEX tag_teams_employments_one_open_period_unique (current_tag_team_id)'
+            ),
+            default => throw new LogicException('The database driver does not support open employment period constraints.'),
+        };
+    }
+};

--- a/docs/architecture/employment-status.md
+++ b/docs/architecture/employment-status.md
@@ -27,6 +27,7 @@ Employment status tracks the working relationship between entities and the promo
 - **Employment End**: Record employment end date when applicable
 - **Employment History**: Track all employment periods
 - **Current Employment**: Determine current employment status
+- **Database Enforcement**: Each employable entity may have only one open employment period while retaining unlimited ended periods
 
 ## Related Documentation
 - [Business Rules](business-rules.md)

--- a/tests/Integration/Actions/Managers/HealActionTest.php
+++ b/tests/Integration/Actions/Managers/HealActionTest.php
@@ -97,7 +97,7 @@ test('it handles database transactions correctly', function () {
 });
 
 test('it maintains employment status during healing', function () {
-    $manager = Manager::factory()->employed()->injured()->create();
+    $manager = Manager::factory()->injured()->create();
 
     expect($manager->isEmployed())->toBeTrue();
     expect($manager->isInjured())->toBeTrue();

--- a/tests/Integration/Actions/Managers/InjureActionTest.php
+++ b/tests/Integration/Actions/Managers/InjureActionTest.php
@@ -69,7 +69,7 @@ test('it persists the injury lifecycle', function () {
 });
 
 test('it prevents injuring already injured manager', function () {
-    $manager = Manager::factory()->employed()->injured()->create();
+    $manager = Manager::factory()->injured()->create();
 
     expect($manager->isInjured())->toBeTrue();
 
@@ -124,7 +124,7 @@ test('it maintains employment status during injury', function () {
 });
 
 test('it prevents injuring a suspended manager', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
 
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isInjured())->toBeFalse();

--- a/tests/Integration/Actions/Managers/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Managers/ReinstateActionTest.php
@@ -47,7 +47,7 @@ test('it prevents reinstating an injured manager', function () {
 });
 
 test('it reinstates manager with specific reinstatement date', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
     $reinstatementDate = now()->subDays(2);
 
     resolve(ReinstateAction::class)->handle($manager, $reinstatementDate);
@@ -63,7 +63,7 @@ test('it reinstates manager with specific reinstatement date', function () {
 });
 
 test('it persists the reinstatement lifecycle', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
 
     // Get current suspension to verify it gets ended
     $currentSuspension = $manager->currentSuspension()->firstOrFail();
@@ -93,7 +93,7 @@ test('it prevents reinstating non-suspended manager', function () {
 });
 
 test('it handles database transactions correctly', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
     $originalSuspensionId = $manager->currentSuspension()->firstOrFail()->id;
 
     resolve(ReinstateAction::class)->handle($manager);
@@ -115,7 +115,7 @@ test('it handles database transactions correctly', function () {
 });
 
 test('it maintains employment status during reinstatement', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
     $employmentId = $manager->currentEmployment()->firstOrFail()->id;
 
     expect($manager->isEmployed())->toBeTrue();
@@ -136,7 +136,7 @@ test('it maintains employment status during reinstatement', function () {
 });
 
 test('it uses DateHelper for consistent date handling', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
     $customReinstatementDate = now()->subDays(1)->startOfDay();
 
     resolve(ReinstateAction::class)->handle($manager, $customReinstatementDate);

--- a/tests/Integration/Actions/Managers/ReleaseActionTest.php
+++ b/tests/Integration/Actions/Managers/ReleaseActionTest.php
@@ -50,7 +50,7 @@ test('it releases manager with specific release date', function () {
 });
 
 test('it releases suspended manager and ends suspension', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
 
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isEmployed())->toBeTrue();
@@ -76,7 +76,7 @@ test('it releases suspended manager and ends suspension', function () {
 });
 
 test('it releases injured manager and ends injury', function () {
-    $manager = Manager::factory()->employed()->injured()->create();
+    $manager = Manager::factory()->injured()->create();
 
     expect($manager->isInjured())->toBeTrue();
     expect($manager->isEmployed())->toBeTrue();
@@ -176,7 +176,7 @@ test('it prevents releasing unemployed manager', function () {
 });
 
 test('it handles database transactions correctly', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
     $wrestler = Wrestler::factory()->employed()->create();
     $manager->wrestlers()->attach($wrestler->id, ['hired_at' => now()->subDay()]);
 
@@ -203,7 +203,7 @@ test('it handles database transactions correctly', function () {
 });
 
 test('it uses DateHelper for consistent date handling', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
     $customReleaseDate = now()->subDays(2)->startOfDay();
 
     resolve(ReleaseAction::class)->handle($manager, $customReleaseDate);

--- a/tests/Integration/Actions/Managers/RetireActionTest.php
+++ b/tests/Integration/Actions/Managers/RetireActionTest.php
@@ -63,7 +63,7 @@ test('it retires manager with specific retirement date', function () {
 });
 
 test('it retires suspended manager and ends suspension', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
 
     expect($manager->isSuspended())->toBeTrue();
     expect($manager->isEmployed())->toBeTrue();
@@ -90,7 +90,7 @@ test('it retires suspended manager and ends suspension', function () {
 });
 
 test('it retires injured manager and ends injury', function () {
-    $manager = Manager::factory()->employed()->injured()->create();
+    $manager = Manager::factory()->injured()->create();
 
     expect($manager->isInjured())->toBeTrue();
     expect($manager->isEmployed())->toBeTrue();

--- a/tests/Integration/Actions/Managers/SuspendActionTest.php
+++ b/tests/Integration/Actions/Managers/SuspendActionTest.php
@@ -69,7 +69,7 @@ test('it persists the suspension lifecycle', function () {
 });
 
 test('it prevents suspending already suspended manager', function () {
-    $manager = Manager::factory()->employed()->suspended()->create();
+    $manager = Manager::factory()->suspended()->create();
 
     expect($manager->isSuspended())->toBeTrue();
 
@@ -124,7 +124,7 @@ test('it maintains employment status during suspension', function () {
 });
 
 test('it prevents suspending an injured manager', function () {
-    $manager = Manager::factory()->employed()->injured()->create();
+    $manager = Manager::factory()->injured()->create();
 
     expect($manager->isInjured())->toBeTrue();
     expect($manager->isSuspended())->toBeFalse();

--- a/tests/Integration/Actions/Referees/DeleteActionTest.php
+++ b/tests/Integration/Actions/Referees/DeleteActionTest.php
@@ -70,7 +70,7 @@ test('it ends employment before deletion', function () {
 });
 
 test('it ends suspension before deletion', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $suspension = $referee->currentSuspension()->firstOrFail();
 
     expect($referee->isSuspended())->toBeTrue();
@@ -93,7 +93,7 @@ test('it ends suspension before deletion', function () {
 });
 
 test('it ends injury before deletion', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
     $injury = $referee->currentInjury()->firstOrFail();
 
     expect($referee->isInjured())->toBeTrue();
@@ -155,7 +155,7 @@ test('it handles DateHelper date resolution for deletion', function () {
 });
 
 test('it maintains transaction boundaries', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $employment = $referee->currentEmployment()->firstOrFail();
     $suspension = $referee->currentSuspension()->firstOrFail();
 

--- a/tests/Integration/Actions/Referees/HealActionTest.php
+++ b/tests/Integration/Actions/Referees/HealActionTest.php
@@ -13,7 +13,7 @@ beforeEach(function () {
 });
 
 test('it heals an injured referee', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
     $injury = $referee->currentInjury()->firstOrFail();
 
     expect($referee->isInjured())->toBeTrue();
@@ -34,7 +34,7 @@ test('it heals an injured referee', function () {
 });
 
 test('it heals referee with specific recovery date', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
     $injury = $referee->currentInjury()->firstOrFail();
     $recoveryDate = now()->subDays(2);
 
@@ -53,7 +53,7 @@ test('it heals referee with specific recovery date', function () {
 });
 
 test('it persists the healing lifecycle', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
 
     expect($referee->isInjured())->toBeTrue();
 
@@ -67,7 +67,7 @@ test('it persists the healing lifecycle', function () {
 });
 
 test('it handles DateHelper date resolution', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
     $recoveryDate = now()->subDays(5);
 
     resolve(HealAction::class)->handle($referee, $recoveryDate);
@@ -82,7 +82,7 @@ test('it handles DateHelper date resolution', function () {
 });
 
 test('it validates referee can be healed', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
 
     // Should succeed without throwing validation exception
     resolve(HealAction::class)->handle($referee);
@@ -101,7 +101,7 @@ test('it throws exception when referee cannot be healed', function () {
 });
 
 test('it maintains referee employment status after healing', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
     $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
@@ -119,7 +119,7 @@ test('it maintains referee employment status after healing', function () {
 });
 
 test('it preserves injury history', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
     $injury = $referee->currentInjury()->firstOrFail();
     $originalStartedAt = $injury->started_at;
 

--- a/tests/Integration/Actions/Referees/ReinstateActionTest.php
+++ b/tests/Integration/Actions/Referees/ReinstateActionTest.php
@@ -49,7 +49,7 @@ test('it prevents reinstating an injured referee', function () {
 });
 
 test('it reinstates referee with specific reinstatement date', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $suspension = $referee->currentSuspension()->firstOrFail();
     $reinstatementDate = now()->subDays(1);
 
@@ -68,7 +68,7 @@ test('it reinstates referee with specific reinstatement date', function () {
 });
 
 test('it handles DateHelper date resolution', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $reinstatementDate = now()->subDays(2);
 
     resolve(ReinstateAction::class)->handle($referee, $reinstatementDate);
@@ -83,7 +83,7 @@ test('it handles DateHelper date resolution', function () {
 });
 
 test('it validates referee can be reinstated', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
 
     // Should succeed without throwing validation exception
     resolve(ReinstateAction::class)->handle($referee);
@@ -102,7 +102,7 @@ test('it throws exception when referee cannot be reinstated', function () {
 });
 
 test('it maintains referee employment after reinstatement', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $employment = $referee->currentEmployment()->firstOrFail();
 
     expect($referee->isEmployed())->toBeTrue();
@@ -120,7 +120,7 @@ test('it maintains referee employment after reinstatement', function () {
 });
 
 test('it preserves suspension history', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $suspension = $referee->currentSuspension()->firstOrFail();
     $originalStartedAt = $suspension->started_at;
 

--- a/tests/Integration/Actions/Referees/ReleaseActionTest.php
+++ b/tests/Integration/Actions/Referees/ReleaseActionTest.php
@@ -87,7 +87,7 @@ test('it throws exception when referee cannot be released', function () {
 });
 
 test('it ends suspension before releasing', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $suspension = $referee->currentSuspension()->firstOrFail();
 
     expect($referee->isSuspended())->toBeTrue();
@@ -104,7 +104,7 @@ test('it ends suspension before releasing', function () {
 });
 
 test('it ends injury before releasing', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
     $injury = $referee->currentInjury()->firstOrFail();
 
     expect($referee->isInjured())->toBeTrue();
@@ -121,7 +121,7 @@ test('it ends injury before releasing', function () {
 });
 
 test('it maintains transaction boundaries', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $employment = $referee->currentEmployment()->firstOrFail();
     $suspension = $referee->currentSuspension()->firstOrFail();
 

--- a/tests/Integration/Actions/Referees/RetireActionTest.php
+++ b/tests/Integration/Actions/Referees/RetireActionTest.php
@@ -110,7 +110,7 @@ test('it ends employment when retiring', function () {
 });
 
 test('it ends suspension before retiring', function () {
-    $referee = Referee::factory()->employed()->suspended()->create();
+    $referee = Referee::factory()->suspended()->create();
     $suspension = $referee->currentSuspension()->firstOrFail();
 
     expect($referee->isSuspended())->toBeTrue();
@@ -127,7 +127,7 @@ test('it ends suspension before retiring', function () {
 });
 
 test('it ends injury before retiring', function () {
-    $referee = Referee::factory()->employed()->injured()->create();
+    $referee = Referee::factory()->injured()->create();
     $injury = $referee->currentInjury()->firstOrFail();
 
     expect($referee->isInjured())->toBeTrue();

--- a/tests/Integration/Database/EmploymentPeriodConstraintTest.php
+++ b/tests/Integration/Database/EmploymentPeriodConstraintTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Managers\Manager;
+use App\Models\Managers\ManagerEmployment;
+use App\Models\Referees\Referee;
+use App\Models\Referees\RefereeEmployment;
+use App\Models\TagTeams\TagTeam;
+use App\Models\TagTeams\TagTeamEmployment;
+use App\Models\Wrestlers\Wrestler;
+use App\Models\Wrestlers\WrestlerEmployment;
+use Illuminate\Database\QueryException;
+
+test('a wrestler has only one open employment period', function () {
+    $wrestler = Wrestler::factory()->create();
+
+    WrestlerEmployment::factory()->count(2)->create([
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => now(),
+    ]);
+    WrestlerEmployment::factory()->create([
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => null,
+    ]);
+
+    expect(fn () => WrestlerEmployment::factory()->create([
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => null,
+    ]))->toThrow(QueryException::class);
+});
+
+test('a manager has only one open employment period', function () {
+    $manager = Manager::factory()->create();
+
+    ManagerEmployment::factory()->count(2)->create([
+        'manager_id' => $manager->id,
+        'ended_at' => now(),
+    ]);
+    ManagerEmployment::factory()->create([
+        'manager_id' => $manager->id,
+        'ended_at' => null,
+    ]);
+
+    expect(fn () => ManagerEmployment::factory()->create([
+        'manager_id' => $manager->id,
+        'ended_at' => null,
+    ]))->toThrow(QueryException::class);
+});
+
+test('a referee has only one open employment period', function () {
+    $referee = Referee::factory()->create();
+
+    RefereeEmployment::factory()->count(2)->create([
+        'referee_id' => $referee->id,
+        'ended_at' => now(),
+    ]);
+    RefereeEmployment::factory()->create([
+        'referee_id' => $referee->id,
+        'ended_at' => null,
+    ]);
+
+    expect(fn () => RefereeEmployment::factory()->create([
+        'referee_id' => $referee->id,
+        'ended_at' => null,
+    ]))->toThrow(QueryException::class);
+});
+
+test('a tag team has only one open employment period', function () {
+    $tagTeam = TagTeam::factory()->create();
+
+    TagTeamEmployment::factory()->count(2)->create([
+        'tag_team_id' => $tagTeam->id,
+        'ended_at' => now(),
+    ]);
+    TagTeamEmployment::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'ended_at' => null,
+    ]);
+
+    expect(fn () => TagTeamEmployment::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'ended_at' => null,
+    ]))->toThrow(QueryException::class);
+});


### PR DESCRIPTION
## Summary
- enforce one open employment period per wrestler, manager, referee, and tag team at the database layer
- retain unlimited ended employment history across supported database drivers
- correct invalid manager and referee test fixtures that composed duplicate employed states
- document the employment-period database invariant

## Verification
- 155 focused Pest tests passed with 515 assertions
- PHPStan passed
- Rector passed
- Pest type coverage passed
- targeted Pint with Blade passed
- git diff --check passed

## Repository-wide note
- composer test:push reaches the existing unrelated Blade formatter drift and NO_COLOR/FORCE_COLOR Node warning; all formatter-created view changes were restored

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented wrestlers, managers, referees, and tag teams from having multiple open employment periods at the same time.
  * Existing closed employment periods remain supported without restriction.
  * Added consistent enforcement across supported database platforms.

* **Documentation**
  * Clarified employment lifecycle rules regarding open and ended employment periods.

* **Tests**
  * Added coverage confirming duplicate open employment periods are rejected.
  * Updated lifecycle tests to better reflect valid employment states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->