### PR TITLE
refactor: serialize wrestler availability transitions

### DIFF
--- a/app/Actions/Wrestlers/InjureAction.php
+++ b/app/Actions/Wrestlers/InjureAction.php
@@ -9,6 +9,7 @@ use App\Lifecycle\InjuryPeriodManager;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class InjureAction
 {
@@ -29,10 +30,17 @@ class InjureAction
      */
     public function handle(Wrestler $wrestler, ?Carbon $injuryDate = null): void
     {
-        $wrestler->ensureCanBeInjured();
-
         $injuryDate = DateHelper::resolveDate($injuryDate);
 
-        $this->injuryPeriods->start($wrestler, $injuryDate);
+        DB::transaction(function () use ($wrestler, $injuryDate): void {
+            $lockedWrestler = Wrestler::query()
+                ->withTrashed()
+                ->lockForUpdate()
+                ->findOrFail($wrestler->getKey());
+
+            $lockedWrestler->ensureCanBeInjured();
+
+            $this->injuryPeriods->start($lockedWrestler, $injuryDate);
+        });
     }
 }

--- a/app/Actions/Wrestlers/SuspendAction.php
+++ b/app/Actions/Wrestlers/SuspendAction.php
@@ -9,6 +9,7 @@ use App\Lifecycle\SuspensionPeriodManager;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class SuspendAction
 {
@@ -29,10 +30,17 @@ class SuspendAction
      */
     public function handle(Wrestler $wrestler, ?Carbon $suspensionDate = null): void
     {
-        $wrestler->ensureCanBeSuspended();
-
         $suspensionDate = DateHelper::resolveDate($suspensionDate);
 
-        $this->suspensionPeriods->start($wrestler, $suspensionDate);
+        DB::transaction(function () use ($wrestler, $suspensionDate): void {
+            $lockedWrestler = Wrestler::query()
+                ->withTrashed()
+                ->lockForUpdate()
+                ->findOrFail($wrestler->getKey());
+
+            $lockedWrestler->ensureCanBeSuspended();
+
+            $this->suspensionPeriods->start($lockedWrestler, $suspensionDate);
+        });
     }
 }

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -153,6 +153,8 @@ Retirement eligibility no longer uses an operation-name string or a generic `Mod
 
 Suspension eligibility follows the same typed boundary. Shared individual validation accepts only wrestlers, managers, and referees. Tag teams retain their established lifecycle validation, while stables and titles do not support suspension. The unused generic suspension contract and tag-team and stable strategy classes were removed rather than preserving unreachable dispatch paths.
 
+Wrestler injury and suspension are mutually exclusive availability states. Both transition Actions acquire a lock on the wrestler and evaluate their opposing-state guard inside the same transaction that opens the new period. Concurrent injury and suspension requests therefore serialize on the wrestler instead of both validating stale state before either period is written.
+
 Tag-team lifecycle validation uses the concrete `Wrestler` models returned by its current-wrestler relationship. It must not probe for speculative capabilities with `method_exists()`. Current wrestler employment remains valid when employing the team, while an injured current wrestler remains unavailable for tag-team unretirement. Any future exclusivity rule must be introduced as an explicit reviewed domain rule with real model behavior and tests.
 
 Tag-team employment eligibility is isolated in `ValidatesTagTeamEmployment`. The concern owns only the model-level `canBeEmployed()` and `ensureCanBeEmployed()` rules; the employment Action continues to own orchestration and persistence. Other tag-team lifecycle dimensions remain separate and will be extracted independently.


### PR DESCRIPTION
## Summary
- acquire a wrestler row lock before validating injury and suspension transitions
- evaluate opposing-state guards inside the same transaction that opens the lifecycle period
- prevent concurrent injury and suspension requests from both validating stale availability state
- document wrestler availability-state exclusivity

## Verification
- 21 focused Pest tests passed with 73 assertions
- PHPStan passed
- Rector passed
- Pest type coverage passed
- targeted Pint with Blade passed
- git diff --check passed

## Repository-wide note
- composer test:push reaches the existing unrelated Blade formatter drift and NO_COLOR/FORCE_COLOR Node warning; all formatter-created view changes were restored