### PR TITLE
fix: require explicit unretirement before employment

### DIFF
--- a/app/Actions/Managers/EmployAction.php
+++ b/app/Actions/Managers/EmployAction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Actions\Managers;
 
 use App\Lifecycle\EmploymentPeriodManager;
-use App\Lifecycle\RetirementPeriodManager;
 use App\Models\Managers\Manager;
 use App\Support\DateHelper;
 use Exception;
@@ -16,7 +15,6 @@ class EmployAction
 {
     public function __construct(
         private readonly EmploymentPeriodManager $employmentPeriods,
-        private readonly RetirementPeriodManager $retirementPeriods,
     ) {}
 
     /**
@@ -24,7 +22,6 @@ class EmployAction
      *
      * This handles the complete manager employment workflow:
      * - Validates the manager can be employed (not retired, not already employed)
-     * - Ends retirement if currently retired
      * - Creates the employment record through the shared lifecycle component
      * - Makes the manager available for talent management assignments
      *
@@ -39,10 +36,6 @@ class EmployAction
         $startDate = DateHelper::resolveDate($startDate);
 
         DB::transaction(function () use ($manager, $startDate): void {
-            if ($manager->isRetired()) {
-                $this->retirementPeriods->end($manager, $startDate);
-            }
-
             $this->employmentPeriods->start($manager, $startDate);
         });
     }

--- a/app/Actions/Referees/EmployAction.php
+++ b/app/Actions/Referees/EmployAction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Actions\Referees;
 
 use App\Lifecycle\EmploymentPeriodManager;
-use App\Lifecycle\RetirementPeriodManager;
 use App\Models\Referees\Referee;
 use App\Support\DateHelper;
 use Exception;
@@ -16,7 +15,6 @@ class EmployAction
 {
     public function __construct(
         private readonly EmploymentPeriodManager $employmentPeriods,
-        private readonly RetirementPeriodManager $retirementPeriods,
     ) {}
 
     /**
@@ -24,7 +22,6 @@ class EmployAction
      *
      * This handles the complete referee employment workflow:
      * - Validates the referee can be employed (not retired, not already employed)
-     * - Ends retirement if currently retired
      * - Creates the employment record through the shared lifecycle component
      * - Makes the referee available for match officiating assignments
      *
@@ -39,10 +36,6 @@ class EmployAction
         $employmentDate = DateHelper::resolveDate($employmentDate);
 
         DB::transaction(function () use ($referee, $employmentDate): void {
-            if ($referee->isRetired()) {
-                $this->retirementPeriods->end($referee, $employmentDate);
-            }
-
             $this->employmentPeriods->start($referee, $employmentDate);
         });
     }

--- a/app/Actions/Wrestlers/EmployAction.php
+++ b/app/Actions/Wrestlers/EmployAction.php
@@ -6,7 +6,6 @@ namespace App\Actions\Wrestlers;
 
 use App\Actions\Managers\EmployCurrentManagersAction;
 use App\Lifecycle\EmploymentPeriodManager;
-use App\Lifecycle\RetirementPeriodManager;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
 use Exception;
@@ -17,7 +16,6 @@ class EmployAction
 {
     public function __construct(
         private readonly EmploymentPeriodManager $employmentPeriods,
-        private readonly RetirementPeriodManager $retirementPeriods,
         private readonly EmployCurrentManagersAction $employCurrentManagers,
     ) {}
 
@@ -42,10 +40,6 @@ class EmployAction
         $employmentDate = DateHelper::resolveDate($employmentDate);
 
         DB::transaction(function () use ($wrestler, $employmentDate): void {
-            if ($wrestler->isRetired()) {
-                $this->retirementPeriods->end($wrestler, $employmentDate);
-            }
-
             $this->employmentPeriods->start($wrestler, $employmentDate);
             $this->employCurrentManagers->handle($wrestler, $employmentDate);
         });

--- a/app/Exceptions/Roster/CannotBeEmployedException.php
+++ b/app/Exceptions/Roster/CannotBeEmployedException.php
@@ -7,6 +7,9 @@ namespace App\Exceptions\Roster;
 use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Contracts\Employable;
+use App\Models\Managers\Manager;
+use App\Models\Referees\Referee;
+use App\Models\Wrestlers\Wrestler;
 
 /**
  * Exception thrown when a roster member cannot be employed due to business rule violations.
@@ -55,6 +58,13 @@ final class CannotBeEmployedException extends BaseBusinessException
         $context = self::formatModelContext($entity);
 
         return self::forReason(BusinessRuleReason::Retired, "{$context} is retired and cannot be employed.");
+    }
+
+    public static function hasFutureEmployment(Wrestler|Manager|Referee $entity): static
+    {
+        $context = self::formatModelContext($entity);
+
+        return new self("{$context} already has future employment scheduled and cannot be employed again.");
     }
 
     /**

--- a/app/Models/Concerns/ValidatesEmployment.php
+++ b/app/Models/Concerns/ValidatesEmployment.php
@@ -61,17 +61,13 @@ trait ValidatesEmployment
      */
     public function canBeEmployed(): bool
     {
-        // Cannot employ if already employed
-        if ($this->isEmployed()) {
+        try {
+            $this->ensureCanBeEmployed();
+
+            return true;
+        } catch (CannotBeEmployedException) {
             return false;
         }
-
-        // Cannot employ if currently retired (need to end retirement first)
-        if ($this->isRetired()) {
-            return false;
-        }
-
-        return true;
     }
 
     /**
@@ -94,8 +90,13 @@ trait ValidatesEmployment
         if ($this->isEmployed()) {
             throw CannotBeEmployedException::employed($this);
         }
+
         if ($this->hasFutureEmployment()) {
-            throw CannotBeEmployedException::employed($this);
+            throw CannotBeEmployedException::hasFutureEmployment($this);
+        }
+
+        if ($this->isRetired()) {
+            throw CannotBeEmployedException::retired($this);
         }
     }
 

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -80,6 +80,8 @@ Tag-team unretirement follows the same boundary through `UnretireCurrentMembersA
 
 Wrestler unretirement does not require a cascade collaborator merely to choose whether employment follows. The wrestler action owns that explicit option and calls its typed employment action directly when requested.
 
+Employment does not implicitly end retirement. Wrestlers, managers, and referees must first pass through their explicit unretirement action before they can be employed. Individual employment predicates delegate to the same typed guards used by their actions, including current employment, future employment, and retirement checks.
+
 Employment cascades use explicit capability and domain collaborators. Both tag teams and wrestlers delegate current-manager employment to `Managers\EmployCurrentManagersAction`, which accepts the existing `Manageable` contract. Tag teams separately delegate current-wrestler employment to `TagTeams\EmployCurrentWrestlersAction`. Each collaborator invokes complete typed employment actions only for currently unemployed related entities.
 
 Membership persistence remains separate from employment orchestration. `ManagerAssignmentService` establishes and synchronizes manager relationships for any model implementing `Manageable`, dates assignments that have ended, and preserves their historical pivot rows. `TagTeamMembershipService` owns the corresponding tag-team wrestler relationships and delegates manager persistence to that shared service. Eligibility is validated before the Action receives its data, while wrestler and tag-team Actions coordinate typed employment cascades when an employment date is supplied.

--- a/tests/Integration/Actions/Managers/EmployActionTest.php
+++ b/tests/Integration/Actions/Managers/EmployActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Managers\EmployAction;
+use App\Exceptions\Roster\CannotBeEmployedException;
 use App\Models\Managers\Manager;
 
 use function Spatie\PestPluginTestTime\testTime;
@@ -44,28 +45,25 @@ test('it employs manager with specific employment date', function () {
     ]);
 });
 
-test('it employs retired manager and ends retirement', function () {
+test('it rejects employing a retired manager without changing retirement', function () {
     $manager = Manager::factory()->retired()->create();
+    $retirement = $manager->currentRetirement()->firstOrFail();
 
     expect($manager->isRetired())->toBeTrue();
     expect($manager->isEmployed())->toBeFalse();
 
-    resolve(EmployAction::class)->handle($manager);
+    expect(fn () => resolve(EmployAction::class)->handle($manager))
+        ->toThrow(CannotBeEmployedException::class);
 
     $manager->refresh();
-    expect($manager->isEmployed())->toBeTrue();
-    expect($manager->isRetired())->toBeFalse();
+    $retirement->refresh();
 
-    // Retirement should be ended
-    $this->assertDatabaseHas('managers_retirements', [
-        'manager_id' => $manager->id,
-        'ended_at' => now()->toDateTimeString(),
-    ]);
+    expect($manager->isEmployed())->toBeFalse()
+        ->and($manager->isRetired())->toBeTrue()
+        ->and($retirement->ended_at)->toBeNull();
 
-    // Employment should be created
-    $this->assertDatabaseHas('managers_employments', [
+    $this->assertDatabaseMissing('managers_employments', [
         'manager_id' => $manager->id,
-        'started_at' => now()->toDateTimeString(),
         'ended_at' => null,
     ]);
 });

--- a/tests/Integration/Actions/Referees/EmployActionTest.php
+++ b/tests/Integration/Actions/Referees/EmployActionTest.php
@@ -66,31 +66,26 @@ test('it prevents re-employing injured referee', function () {
         ->toThrow(CannotBeEmployedException::class);
 });
 
-test('it employs retired referee and ends retirement', function () {
+test('it rejects employing a retired referee without changing retirement', function () {
     $referee = Referee::factory()->retired()->create();
     $retirement = $referee->currentRetirement()->firstOrFail();
 
     expect($referee->isRetired())->toBeTrue();
     expect($referee->isEmployed())->toBeFalse();
 
-    resolve(EmployAction::class)->handle($referee);
+    expect(fn () => resolve(EmployAction::class)->handle($referee))
+        ->toThrow(CannotBeEmployedException::class);
 
     $referee->refresh();
     $retirement->refresh();
 
-    expect($referee->isEmployed())->toBeTrue();
-    expect($referee->isRetired())->toBeFalse();
+    expect($referee->isEmployed())->toBeFalse()
+        ->and($referee->isRetired())->toBeTrue()
+        ->and($retirement->ended_at)->toBeNull();
 
-    // Retirement should be ended
-    $this->assertDatabaseHas('referees_retirements', [
-        'id' => $retirement->id,
-        'ended_at' => now()->toDateTimeString(),
-    ]);
-
-    // Employment should be created
-    $this->assertDatabaseHas('referees_employments', [
+    $this->assertDatabaseMissing('referees_employments', [
         'referee_id' => $referee->id,
-        'started_at' => now()->toDateTimeString(),
+        'ended_at' => null,
     ]);
 });
 

--- a/tests/Integration/Actions/Wrestlers/EmployActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/EmployActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Wrestlers\EmployAction;
+use App\Exceptions\Roster\CannotBeEmployedException;
 use App\Models\Managers\Manager;
 use App\Models\Wrestlers\Wrestler;
 
@@ -107,4 +108,24 @@ test('it prevents employing already employed wrestler', function () {
 
     expect(fn () => resolve(EmployAction::class)->handle($wrestler))
         ->toThrow(Exception::class);
+});
+
+test('it rejects employing a retired wrestler without changing retirement', function () {
+    $wrestler = Wrestler::factory()->retired()->create();
+    $retirement = $wrestler->currentRetirement()->firstOrFail();
+
+    expect(fn () => resolve(EmployAction::class)->handle($wrestler))
+        ->toThrow(CannotBeEmployedException::class);
+
+    $wrestler->refresh();
+    $retirement->refresh();
+
+    expect($wrestler->isEmployed())->toBeFalse()
+        ->and($wrestler->isRetired())->toBeTrue()
+        ->and($retirement->ended_at)->toBeNull();
+
+    $this->assertDatabaseMissing('wrestlers_employments', [
+        'wrestler_id' => $wrestler->id,
+        'ended_at' => null,
+    ]);
 });

--- a/tests/Integration/Models/Concerns/ValidatesEmploymentTest.php
+++ b/tests/Integration/Models/Concerns/ValidatesEmploymentTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Exceptions\Roster\CannotBeEmployedException;
+use App\Models\Wrestlers\Wrestler;
+
+test('keeps the employment predicate aligned with its guard', function (string $factoryState, bool $canBeEmployed) {
+    $wrestler = Wrestler::factory()->{$factoryState}()->create();
+
+    expect($wrestler->canBeEmployed())->toBe($canBeEmployed);
+
+    if ($canBeEmployed) {
+        expect(fn () => $wrestler->ensureCanBeEmployed())
+            ->not->toThrow(CannotBeEmployedException::class);
+
+        return;
+    }
+
+    expect(fn () => $wrestler->ensureCanBeEmployed())
+        ->toThrow(CannotBeEmployedException::class);
+})->with([
+    'unemployed' => ['unemployed', true],
+    'released' => ['released', true],
+    'employed' => ['employed', false],
+    'future employment' => ['withFutureEmployment', false],
+    'retired' => ['retired', false],
+]);

--- a/tests/Integration/Workflows/Managers/EmploymentTest.php
+++ b/tests/Integration/Workflows/Managers/EmploymentTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\Managers\EmployAction;
 use App\Actions\Managers\ReleaseAction;
 use App\Actions\Managers\SuspendAction;
+use App\Actions\Managers\UnretireAction;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Managers\Manager;
 use Illuminate\Support\Carbon;
@@ -136,8 +137,8 @@ describe('Manager Employment Workflows', function () {
         test('complex multi-action management workflows maintain data consistency', function () {
             $manager = Manager::factory()->retired()->create();
 
-            // Retire -> Employ -> Suspend -> Release workflow
-            resolve(EmployAction::class)->handle($manager, Carbon::now());
+            // Retire -> Unretire -> Suspend -> Release workflow
+            resolve(UnretireAction::class)->handle($manager, Carbon::now());
             $employed = freshModel($manager);
             expect($employed->isEmployed())->toBeTrue();
 

--- a/tests/Integration/Workflows/Referees/EmploymentTest.php
+++ b/tests/Integration/Workflows/Referees/EmploymentTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\Referees\EmployAction;
 use App\Actions\Referees\ReleaseAction;
 use App\Actions\Referees\SuspendAction;
+use App\Actions\Referees\UnretireAction;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Referees\Referee;
 use Illuminate\Support\Carbon;
@@ -135,8 +136,8 @@ describe('Referee Employment Workflows', function () {
         test('complex multi-action employment workflows maintain data consistency', function () {
             $referee = Referee::factory()->retired()->create();
 
-            // Retire -> Employ -> Suspend -> Release workflow
-            resolve(EmployAction::class)->handle($referee, Carbon::now());
+            // Retire -> Unretire -> Suspend -> Release workflow
+            resolve(UnretireAction::class)->handle($referee, Carbon::now());
             $employed = freshModel($referee);
             expect($employed->isEmployed())->toBeTrue();
 


### PR DESCRIPTION
## Summary
- align individual employment predicates with their typed guards
- reject future employment and retirement consistently
- remove implicit unretirement from wrestler, manager, and referee employment actions
- preserve retirement and employment history when an invalid employment attempt is rejected
- document explicit unretirement as the lifecycle boundary

## Verification
- 61 focused tests passed with 226 assertions
- application and Pest PHPStan passed
- full composer test:types passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff checks passed

## Local suite note
- composer test:push passed type coverage and Rector, then reached the existing unrelated Blade formatter baseline and Node color warning; this branch does not modify those views