### PR TITLE
refactor: simplify individual restoration exception

### DIFF
--- a/app/Exceptions/Data/CannotBeRestoredException.php
+++ b/app/Exceptions/Data/CannotBeRestoredException.php
@@ -8,104 +8,12 @@ use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use Illuminate\Database\Eloquent\Model;
 
-/**
- * Exception thrown when an entity cannot be restored due to business rule violations.
- *
- * This exception handles scenarios where restoration from soft deletion is prevented
- * by current state or business logic constraints in wrestling promotion data management.
- *
- * BUSINESS CONTEXT:
- * Restoration represents recovering soft-deleted entities back to active status,
- * often for correcting administrative errors or reversing premature deletions.
- * Failed restorations can prevent data recovery and administrative corrections.
- *
- * COMMON SCENARIOS:
- * - Attempting to restore entities that are not currently deleted
- * - Trying to restore entities with dependency conflicts
- * - Restoration conflicts with replacement entities or updated business rules
- * - Missing prerequisites for proper data recovery workflow
- *
- * BUSINESS IMPACT:
- * - Maintains data integrity and administrative error correction capabilities
- * - Protects against restoration conflicts that could corrupt relationships
- * - Ensures proper audit trails for deletion and restoration activities
- * - Prevents unauthorized data recovery that could affect active operations
- */
 final class CannotBeRestoredException extends BaseBusinessException
 {
-    /**
-     * Entity is not currently deleted and cannot be restored.
-     *
-     * @param  Model  $entity  The entity that cannot be restored
-     */
     public static function notDeleted(Model $entity): static
     {
         $context = self::formatModelContext($entity);
 
         return self::forReason(BusinessRuleReason::NotDeleted, "{$context} is not deleted and cannot be restored.");
-    }
-
-    /**
-     * Entity cannot be restored due to dependency conflicts.
-     *
-     * @param  Model  $entity  The entity that cannot be restored
-     * @param  string  $conflictingDependency  Description of the conflicting dependency
-     */
-    public static function dependencyConflict(Model $entity, string $conflictingDependency): static
-    {
-        $context = self::formatModelContext($entity);
-
-        return new static("{$context} has dependency conflict ({$conflictingDependency}) and cannot be restored.");
-    }
-
-    /**
-     * Entity cannot be restored because a replacement exists.
-     *
-     * @param  Model  $entity  The entity that cannot be restored
-     * @param  string  $replacementEntity  Description of the replacement entity
-     */
-    public static function replacementExists(Model $entity, string $replacementEntity): static
-    {
-        $context = self::formatModelContext($entity);
-
-        return new static("{$context} cannot be restored because replacement exists ({$replacementEntity}).");
-    }
-
-    /**
-     * Entity cannot be restored due to hard deletion.
-     *
-     * @param  Model  $entity  The entity that cannot be restored
-     */
-    public static function hardDeleted(Model $entity): static
-    {
-        $context = self::formatModelContext($entity);
-
-        return new static("{$context} has been permanently deleted and cannot be restored.");
-    }
-
-    /**
-     * Entity cannot be restored without proper authorization.
-     *
-     * @param  Model  $entity  The entity that cannot be restored
-     * @param  string  $authorizationLevel  Required authorization level for restoration
-     */
-    public static function unauthorizedRestoration(Model $entity, string $authorizationLevel): static
-    {
-        $context = self::formatModelContext($entity);
-
-        return new static("{$context} cannot be restored without {$authorizationLevel} authorization.");
-    }
-
-    /**
-     * Generic restoration failure with custom message.
-     *
-     * @param  Model  $entity  The entity that cannot be restored
-     * @param  string  $reason  Specific reason why restoration failed
-     */
-    public static function withReason(Model $entity, string $reason): static
-    {
-        $context = self::formatModelContext($entity);
-
-        return new static("{$context} cannot be restored: {$reason}.");
     }
 }

--- a/tests/Unit/Services/ErrorMessageMappingServiceTest.php
+++ b/tests/Unit/Services/ErrorMessageMappingServiceTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\BusinessRuleReason;
+use App\Exceptions\Data\CannotBeRestoredException;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Roster\CannotBeClearedFromInjuryException;
 use App\Exceptions\Roster\CannotBeEmployedException;
@@ -38,6 +39,15 @@ test('it maps common lifecycle reasons for each roster presentation', function (
         ->toBe('referees.errors.cannot_injure_unemployed')
         ->and(ErrorMessageMappingService::mapWrestlerException(CannotBeClearedFromInjuryException::notInjured($wrestler)))
         ->toBe('wrestlers.errors.not_injured');
+});
+
+test('it maps restoration failures from the not-deleted reason', function () {
+    $wrestler = new Wrestler(['name' => 'Test Wrestler']);
+    $exception = CannotBeRestoredException::notDeleted($wrestler);
+
+    expect($exception->reason())->toBe(BusinessRuleReason::NotDeleted)
+        ->and(ErrorMessageMappingService::mapWrestlerException($exception))
+        ->toBe('wrestlers.errors.not_deleted');
 });
 
 test('it maps available roster reinstatement failures to suspension guidance', function () {


### PR DESCRIPTION
## Summary
- retain only the individual restoration failure that the application enforces
- remove speculative dependency, replacement, hard-deletion, authorization, and arbitrary-reason factories
- remove documentation for behavior that does not exist
- cover the stable not-deleted reason and presentation mapping

## Verification
- 15 focused tests passed with 35 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push passed its PHP, test, PHPStan, Rector, and type-coverage stages
- the final Blade lint stage reproduces the existing clean-development failure caused by unrelated Blade formatting differences and the local Node color warning; this PR changes no Blade files