### PR TITLE
refactor: simplify stable exceptions

### DIFF
--- a/app/Exceptions/Roster/Stables/CannotBeDeletedException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeDeletedException.php
@@ -7,32 +7,6 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when a stable cannot be soft deleted due to business rule violations.
- *
- * This exception handles scenarios where stable soft deletion is prevented by current operational
- * state or business logic constraints. Since this is soft deletion, the focus is on current
- * operational constraints rather than data preservation concerns.
- *
- * BUSINESS CONTEXT:
- * Soft deletion allows stables to be removed from active operations while preserving all
- * historical data for future reference and potential restoration. This is typically used
- * for administrative cleanup, temporary removal, or when stables need to be archived
- * without losing their complete history and relationships.
- *
- * COMMON SCENARIOS:
- * - Attempting to delete currently active stables that should be disbanded first
- * - Trying to delete stables with current members who should be removed first
- * - Administrative validation to ensure proper stable lifecycle management
- * - Operational constraints during active storylines or championship reigns
- *
- * BUSINESS IMPACT:
- * - Maintains proper stable lifecycle procedures and operational integrity
- * - Ensures current members are properly handled before stable removal
- * - Protects against accidental deletion of operationally active stables
- * - Supports proper administrative workflows for stable management
- * - All historical data is preserved since this is soft deletion (recoverable)
- */
 final class CannotBeDeletedException extends BaseBusinessException
 {
     public static function alreadyDeleted(Stable $stable): static
@@ -42,11 +16,6 @@ final class CannotBeDeletedException extends BaseBusinessException
         return new self("{$context} cannot be deleted because it is already deleted.");
     }
 
-    /**
-     * Stable is currently active and should be disbanded before deletion.
-     *
-     * @param  Stable  $stable  The stable that cannot be deleted
-     */
     public static function currentlyActive(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -61,83 +30,11 @@ final class CannotBeDeletedException extends BaseBusinessException
         return new self("{$context} has a future establishment scheduled and cannot be deleted.");
     }
 
-    /**
-     * Stable has current members who must be removed before deletion.
-     *
-     * @param  Stable  $stable  The stable that cannot be deleted
-     * @param  int  $memberCount  Number of current members
-     */
     public static function hasCurrentMembers(Stable $stable, int $memberCount): static
     {
         $context = self::formatModelContext($stable);
         $memberText = $memberCount === 1 ? 'member' : 'members';
 
         return new self("{$context} has {$memberCount} current {$memberText} and cannot be deleted. Remove members first or use disband action.");
-    }
-
-    /**
-     * Stable cannot be deleted while members hold active championship titles.
-     *
-     * @param  Stable  $stable  The stable that cannot be deleted
-     * @param  array<string>  $championshipTitles  List of championship titles held by members
-     */
-    public static function membersHoldingTitles(Stable $stable, array $championshipTitles): static
-    {
-        $context = self::formatModelContext($stable);
-        $titles = implode(', ', $championshipTitles);
-
-        return new self("{$context} cannot be deleted while members hold championships: {$titles}. Complete championship storylines first.");
-    }
-
-    /**
-     * Stable cannot be deleted during active storyline participation.
-     *
-     * @param  Stable  $stable  The stable that cannot be deleted
-     * @param  string  $storylineDetails  Description of the active storyline
-     */
-    public static function activeStoryline(Stable $stable, string $storylineDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be deleted during active storyline: {$storylineDetails}. Complete storyline first.");
-    }
-
-    /**
-     * Stable cannot be deleted due to upcoming scheduled events.
-     *
-     * @param  Stable  $stable  The stable that cannot be deleted
-     * @param  string  $upcomingEvent  Description of the upcoming event
-     */
-    public static function upcomingScheduledEvent(Stable $stable, string $upcomingEvent): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be deleted due to upcoming scheduled event: {$upcomingEvent}.");
-    }
-
-    /**
-     * Stable cannot be deleted while involved in active feuds.
-     *
-     * @param  Stable  $stable  The stable that cannot be deleted
-     * @param  string  $feudDetails  Description of the active feud
-     */
-    public static function activeFeud(Stable $stable, string $feudDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be deleted during active feud: {$feudDetails}. Resolve feud first.");
-    }
-
-    /**
-     * Stable cannot be deleted without proper administrative authorization.
-     *
-     * @param  Stable  $stable  The stable that cannot be deleted
-     * @param  string  $authorizationLevel  Required authorization level for deletion
-     */
-    public static function insufficientAuthorization(Stable $stable, string $authorizationLevel): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be deleted without {$authorizationLevel} authorization.");
     }
 }

--- a/app/Exceptions/Roster/Stables/CannotBeDisbandedException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeDisbandedException.php
@@ -7,35 +7,6 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when a stable cannot be disbanded due to business rule violations.
- *
- * This exception handles scenarios where stable disbandment is prevented by current state
- * or business logic constraints in wrestling promotion stable management.
- *
- * BUSINESS CONTEXT:
- * Stable disbandment represents the formal dissolution of a wrestling faction, marking
- * the end of collective storylines and member alliances. This is a significant narrative
- * event that affects multiple roster members simultaneously and often serves as a
- * climactic conclusion to long-running feuds and storylines. Proper disbandment procedures
- * ensure narrative satisfaction while maintaining continuity for individual member careers.
- *
- * COMMON SCENARIOS:
- * - Attempting to disband an inactive, unactivated, or already disbanded stable
- * - Trying to disband stables that are permanently retired from competition
- * - Disbandment conflicts with active storylines, championship reigns, or ongoing feuds
- * - Missing activation prerequisites or improper stable lifecycle management
- * - Administrative errors involving stables not eligible for standard disbandment procedures
- * - Premature disbandment attempts during critical storyline developments or major events
- *
- * BUSINESS IMPACT:
- * - Maintains stable lifecycle integrity and member relationship consistency across storylines
- * - Protects ongoing narrative investments and multi-member storyline development
- * - Ensures proper member release and reallocation procedures for future booking flexibility
- * - Prevents disruption of active feuds, championship pursuits, and established alliances
- * - Supports accurate stable management records and faction history documentation
- * - Maintains fan investment in stable dynamics and long-term storytelling payoffs
- */
 final class CannotBeDisbandedException extends BaseBusinessException
 {
     public static function deleted(Stable $stable): static
@@ -45,11 +16,6 @@ final class CannotBeDisbandedException extends BaseBusinessException
         return new self("{$context} cannot be disbanded because it is deleted. Restore the stable first.");
     }
 
-    /**
-     * Stable is not currently active and cannot be disbanded.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     */
     public static function unactivated(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -57,11 +23,6 @@ final class CannotBeDisbandedException extends BaseBusinessException
         return new self("{$context} is not active and cannot be disbanded.");
     }
 
-    /**
-     * Stable is already disbanded and cannot be disbanded again.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     */
     public static function disbanded(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -69,11 +30,6 @@ final class CannotBeDisbandedException extends BaseBusinessException
         return new static("{$context} is already disbanded.");
     }
 
-    /**
-     * Stable is permanently retired and cannot be disbanded.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     */
     public static function retired(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -81,107 +37,10 @@ final class CannotBeDisbandedException extends BaseBusinessException
         return new static("{$context} is retired and cannot be disbanded.");
     }
 
-    /**
-     * Stable has not been officially activated and cannot be disbanded.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     */
     public static function hasFutureActivation(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
 
         return new static("{$context} has not been officially activated and cannot be disbanded.");
-    }
-
-    /**
-     * Stable cannot be disbanded due to active storyline commitments.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     * @param  string  $storylineDetails  Description of the active storyline
-     */
-    public static function activeStoryline(Stable $stable, string $storylineDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be disbanded due to active storyline: {$storylineDetails}.");
-    }
-
-    /**
-     * Stable cannot be disbanded while members have active championship reigns.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     * @param  array<string>  $championshipTitles  List of championship titles held by members
-     */
-    public static function membersHoldingTitles(Stable $stable, array $championshipTitles): static
-    {
-        $context = self::formatModelContext($stable);
-        $titles = implode(', ', $championshipTitles);
-
-        return new static("{$context} cannot be disbanded while members hold championships: {$titles}.");
-    }
-
-    /**
-     * Stable cannot be disbanded due to upcoming major storyline events.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     * @param  string  $upcomingEvent  Description of the upcoming event
-     */
-    public static function upcomingMajorEvent(Stable $stable, string $upcomingEvent): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be disbanded due to upcoming major event: {$upcomingEvent}.");
-    }
-
-    /**
-     * Stable cannot be disbanded while involved in active feuds.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     * @param  string  $feudDetails  Description of the active feud
-     */
-    public static function activeFeud(Stable $stable, string $feudDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be disbanded during active feud: {$feudDetails}.");
-    }
-
-    /**
-     * Stable cannot be disbanded without proper authorization.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     * @param  string  $authorizationLevel  Required authorization level for disbandment
-     */
-    public static function unauthorizedDisbandment(Stable $stable, string $authorizationLevel): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be disbanded without {$authorizationLevel} authorization.");
-    }
-
-    /**
-     * Stable cannot be disbanded due to contractual member obligations.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     * @param  string  $memberObligations  Description of member contractual obligations
-     */
-    public static function memberContractualObligations(Stable $stable, string $memberObligations): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be disbanded due to member contractual obligations: {$memberObligations}.");
-    }
-
-    /**
-     * Stable cannot be disbanded during tournament or special event participation.
-     *
-     * @param  Stable  $stable  The stable that cannot be disbanded
-     * @param  string  $eventDetails  Description of the tournament or special event
-     */
-    public static function tournamentParticipation(Stable $stable, string $eventDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be disbanded during tournament participation: {$eventDetails}.");
     }
 }

--- a/app/Exceptions/Roster/Stables/CannotBeEstablishedException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeEstablishedException.php
@@ -7,35 +7,6 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when a stable cannot be established due to business rule violations.
- *
- * This exception handles scenarios where stable establishment is prevented by current state
- * or business logic constraints in wrestling promotion stable management.
- *
- * BUSINESS CONTEXT:
- * Stable establishment represents the formal creation and activation of a wrestling faction,
- * marking the beginning of collective storylines and member alliances. This is a significant
- * creative decision that affects multiple roster members simultaneously and establishes new
- * dynamics for feuds, championships, and character development. Proper establishment procedures
- * ensure narrative coherence while maximizing booking flexibility and storyline potential.
- *
- * COMMON SCENARIOS:
- * - Attempting to establish an already active or previously established stable
- * - Trying to establish stables with conflicting member commitments or availability issues
- * - Establishment conflicts with existing business rules, storylines, or member obligations
- * - Missing prerequisites for proper stable formation such as member availability or approval
- * - Administrative errors involving insufficient members or incompatible roster configurations
- * - Establishment attempts during periods of member instability or contractual complications
- *
- * BUSINESS IMPACT:
- * - Maintains stable lifecycle integrity and member relationship consistency across storylines
- * - Protects storyline planning investments and multi-member narrative development strategies
- * - Ensures proper member allocation and commitment procedures to prevent booking conflicts
- * - Prevents conflicts with active feuds, championship pursuits, and existing stable dynamics
- * - Supports accurate stable management records and faction formation documentation
- * - Maintains creative flexibility for future stable interactions and storyline developments
- */
 final class CannotBeEstablishedException extends BaseBusinessException
 {
     public static function deleted(Stable $stable): static
@@ -45,11 +16,6 @@ final class CannotBeEstablishedException extends BaseBusinessException
         return new self("{$context} cannot be established because it is deleted. Restore the stable first.");
     }
 
-    /**
-     * Stable is already established and cannot be re-established.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     */
     public static function established(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -57,186 +23,10 @@ final class CannotBeEstablishedException extends BaseBusinessException
         return new self("{$context} is already established and cannot be re-established.");
     }
 
-    /**
-     * Stable cannot be established because it has been permanently retired.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     */
     public static function retired(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
 
         return new static("{$context} is retired and cannot be established.");
-    }
-
-    /**
-     * Stable cannot be established due to member availability conflicts.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $conflict  Description of the member availability conflict
-     */
-    public static function memberConflict(Stable $stable, string $conflict): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established due to member conflict: {$conflict}.");
-    }
-
-    /**
-     * Stable cannot be established due to missing required members.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  int  $required  Number of members required
-     * @param  int  $available  Number of members currently available
-     */
-    public static function insufficientMembers(Stable $stable, int $required, int $available): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established: requires {$required} members but only {$available} available.");
-    }
-
-    /**
-     * Stable cannot be established due to business rule conflicts.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $conflict  Description of the business rule conflict
-     */
-    public static function businessRuleConflict(Stable $stable, string $conflict): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established due to conflict: {$conflict}.");
-    }
-
-    /**
-     * Stable cannot be established without proper authorization.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $authorizationLevel  Required authorization level for establishment
-     */
-    public static function unauthorizedEstablishment(Stable $stable, string $authorizationLevel): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established without {$authorizationLevel} authorization.");
-    }
-
-    /**
-     * Stable cannot be established due to scheduling conflicts.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $conflictDetails  Description of the scheduling conflict
-     */
-    public static function schedulingConflict(Stable $stable, string $conflictDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established due to scheduling conflict: {$conflictDetails}.");
-    }
-
-    /**
-     * Stable cannot be established due to conflicting existing stable memberships.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $existingStableConflicts  Description of existing stable conflicts
-     */
-    public static function existingStableConflicts(Stable $stable, string $existingStableConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established due to existing stable conflicts: {$existingStableConflicts}.");
-    }
-
-    /**
-     * Stable cannot be established due to member contractual restrictions.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $contractualRestrictions  Description of contractual restrictions
-     */
-    public static function memberContractualRestrictions(Stable $stable, string $contractualRestrictions): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established due to member contractual restrictions: {$contractualRestrictions}.");
-    }
-
-    /**
-     * Stable cannot be established during member injury or medical absence.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $memberMedicalIssues  Description of member medical issues
-     */
-    public static function memberMedicalIssues(Stable $stable, string $memberMedicalIssues): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established due to member medical issues: {$memberMedicalIssues}.");
-    }
-
-    /**
-     * Stable cannot be established due to ongoing disciplinary actions against members.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $disciplinaryIssues  Description of disciplinary issues
-     */
-    public static function memberDisciplinaryIssues(Stable $stable, string $disciplinaryIssues): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established due to member disciplinary issues: {$disciplinaryIssues}.");
-    }
-
-    /**
-     * Stable cannot be established due to incompatible member character alignments.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $alignmentConflicts  Description of character alignment conflicts
-     */
-    public static function characterAlignmentConflicts(Stable $stable, string $alignmentConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established due to character alignment conflicts: {$alignmentConflicts}.");
-    }
-
-    /**
-     * Stable cannot be established during active tournament or special event periods.
-     *
-     * @param  Stable  $stable  The stable that cannot be established
-     * @param  string  $eventDetails  Description of the active event
-     */
-    public static function activeEventPeriod(Stable $stable, string $eventDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be established during active event period: {$eventDetails}.");
-    }
-
-    /**
-     * Stable cannot be reunited due to insufficient available former members.
-     *
-     * @param  Stable  $stable  The stable that cannot be reunited
-     * @param  int  $required  Number of members required for reunion
-     * @param  int  $available  Number of former members currently available
-     */
-    public static function insufficientFormerMembers(Stable $stable, int $required, int $available): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be reunited: requires {$required} members but only {$available} former members are available.");
-    }
-
-    /**
-     * Stable cannot be reunited because key former members are unavailable.
-     *
-     * @param  Stable  $stable  The stable that cannot be reunited
-     * @param  string  $unavailableMembers  Description of unavailable key members
-     */
-    public static function keyFormerMembersUnavailable(Stable $stable, string $unavailableMembers): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new static("{$context} cannot be reunited because key former members are unavailable: {$unavailableMembers}.");
     }
 }

--- a/app/Exceptions/Roster/Stables/CannotBeMergedException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeMergedException.php
@@ -7,39 +7,8 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when stables cannot be merged due to business rule violations.
- *
- * This exception handles scenarios where stable merging is prevented by current state
- * or business logic constraints in wrestling promotion stable management.
- *
- * BUSINESS CONTEXT:
- * Stable merging represents the consolidation of two separate factions into a single
- * unified entity, typically due to alliance formation, leadership changes, or strategic
- * roster management. This is a significant narrative event that affects multiple
- * storylines and member relationships while creating new competitive opportunities.
- *
- * COMMON SCENARIOS:
- * - Attempting to merge inactive, retired, or disbanded stables
- * - Trying to merge incompatible stables with conflicting storylines
- * - Member compatibility issues or contractual conflicts
- * - Administrative errors involving invalid stable combinations
- * - Merge conflicts during active championship reigns or major events
- *
- * BUSINESS IMPACT:
- * - Maintains stable compatibility and storyline continuity
- * - Protects ongoing narrative investments and faction dynamics
- * - Ensures merged stable remains competitively viable
- * - Prevents disruption of active storylines and member relationships
- * - Supports proper faction management and booking flexibility
- */
 final class CannotBeMergedException extends BaseBusinessException
 {
-    /**
-     * Cannot merge a stable with itself.
-     *
-     * @param  Stable  $stable  The stable attempting self-merge
-     */
     public static function selfMerge(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -47,11 +16,6 @@ final class CannotBeMergedException extends BaseBusinessException
         return new self("{$context} cannot be merged with itself.");
     }
 
-    /**
-     * Primary stable is retired and cannot receive merged members.
-     *
-     * @param  Stable  $primaryStable  The primary stable that is retired
-     */
     public static function primaryRetired(Stable $primaryStable): static
     {
         $context = self::formatModelContext($primaryStable);
@@ -59,11 +23,6 @@ final class CannotBeMergedException extends BaseBusinessException
         return new self("{$context} is retired and cannot receive merged members.");
     }
 
-    /**
-     * Secondary stable is retired and cannot be merged.
-     *
-     * @param  Stable  $secondaryStable  The secondary stable that is retired
-     */
     public static function secondaryRetired(Stable $secondaryStable): static
     {
         $context = self::formatModelContext($secondaryStable);
@@ -71,11 +30,6 @@ final class CannotBeMergedException extends BaseBusinessException
         return new self("{$context} is retired and cannot be merged.");
     }
 
-    /**
-     * Primary stable is not active and cannot receive merged members.
-     *
-     * @param  Stable  $primaryStable  The primary stable that is not active
-     */
     public static function primaryNotActive(Stable $primaryStable): static
     {
         $context = self::formatModelContext($primaryStable);
@@ -83,11 +37,6 @@ final class CannotBeMergedException extends BaseBusinessException
         return new self("{$context} is not currently active and cannot receive merged members.");
     }
 
-    /**
-     * Secondary stable is not active and cannot be merged.
-     *
-     * @param  Stable  $secondaryStable  The secondary stable that is not active
-     */
     public static function secondaryNotActive(Stable $secondaryStable): static
     {
         $context = self::formatModelContext($secondaryStable);
@@ -95,89 +44,9 @@ final class CannotBeMergedException extends BaseBusinessException
         return new self("{$context} is not currently active and cannot be merged.");
     }
 
-    /**
-     * One or more secondary members are unavailable for the primary stable.
-     *
-     * @param  array<int, string>  $memberNames
-     */
+    /** @param array<int, string> $memberNames */
     public static function membersUnavailable(array $memberNames): static
     {
         return new self('Cannot merge stables: these secondary stable members are unavailable: '.implode(', ', $memberNames).'.');
-    }
-
-    /**
-     * Stables cannot be merged due to conflicting storylines.
-     *
-     * @param  Stable  $primaryStable  The primary stable
-     * @param  Stable  $secondaryStable  The secondary stable
-     * @param  string  $conflictDetails  Description of the storyline conflict
-     */
-    public static function conflictingStorylines(Stable $primaryStable, Stable $secondaryStable, string $conflictDetails): static
-    {
-        $primaryContext = self::formatModelContext($primaryStable);
-        $secondaryContext = self::formatModelContext($secondaryStable);
-
-        return new self("{$primaryContext} and {$secondaryContext} cannot be merged due to conflicting storylines: {$conflictDetails}.");
-    }
-
-    /**
-     * Stables cannot be merged due to incompatible member relationships.
-     *
-     * @param  Stable  $primaryStable  The primary stable
-     * @param  Stable  $secondaryStable  The secondary stable
-     * @param  string  $incompatibilityDetails  Description of member incompatibilities
-     */
-    public static function incompatibleMembers(Stable $primaryStable, Stable $secondaryStable, string $incompatibilityDetails): static
-    {
-        $primaryContext = self::formatModelContext($primaryStable);
-        $secondaryContext = self::formatModelContext($secondaryStable);
-
-        return new self("{$primaryContext} and {$secondaryContext} cannot be merged due to incompatible members: {$incompatibilityDetails}.");
-    }
-
-    /**
-     * Stables cannot be merged while members hold conflicting championships.
-     *
-     * @param  Stable  $primaryStable  The primary stable
-     * @param  Stable  $secondaryStable  The secondary stable
-     * @param  array<string>  $conflictingTitles  List of conflicting championship titles
-     */
-    public static function conflictingChampionships(Stable $primaryStable, Stable $secondaryStable, array $conflictingTitles): static
-    {
-        $primaryContext = self::formatModelContext($primaryStable);
-        $secondaryContext = self::formatModelContext($secondaryStable);
-        $titles = implode(', ', $conflictingTitles);
-
-        return new self("{$primaryContext} and {$secondaryContext} cannot be merged due to conflicting championships: {$titles}.");
-    }
-
-    /**
-     * Stables cannot be merged during active feuds between them.
-     *
-     * @param  Stable  $primaryStable  The primary stable
-     * @param  Stable  $secondaryStable  The secondary stable
-     * @param  string  $feudDetails  Description of the active feud
-     */
-    public static function activeFeudBetween(Stable $primaryStable, Stable $secondaryStable, string $feudDetails): static
-    {
-        $primaryContext = self::formatModelContext($primaryStable);
-        $secondaryContext = self::formatModelContext($secondaryStable);
-
-        return new self("{$primaryContext} and {$secondaryContext} cannot be merged during active feud: {$feudDetails}.");
-    }
-
-    /**
-     * Stables cannot be merged due to upcoming major events.
-     *
-     * @param  Stable  $primaryStable  The primary stable
-     * @param  Stable  $secondaryStable  The secondary stable
-     * @param  string  $upcomingEvent  Description of the upcoming event
-     */
-    public static function upcomingMajorEvent(Stable $primaryStable, Stable $secondaryStable, string $upcomingEvent): static
-    {
-        $primaryContext = self::formatModelContext($primaryStable);
-        $secondaryContext = self::formatModelContext($secondaryStable);
-
-        return new self("{$primaryContext} and {$secondaryContext} cannot be merged due to upcoming major event: {$upcomingEvent}.");
     }
 }

--- a/app/Exceptions/Roster/Stables/CannotBeRestoredException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeRestoredException.php
@@ -7,39 +7,8 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when a stable cannot be restored from soft deletion due to business rule violations.
- *
- * This exception handles scenarios where stable restoration is prevented by current state
- * or business logic constraints in wrestling promotion stable management.
- *
- * BUSINESS CONTEXT:
- * Stable restoration allows previously soft-deleted stables to be brought back into
- * active operations, typically for reunion storylines, nostalgia acts, or correcting
- * administrative errors. This is a significant narrative opportunity that can create
- * compelling storylines while maintaining historical continuity and member relationships.
- *
- * COMMON SCENARIOS:
- * - Attempting to restore stables when original members are unavailable
- * - Trying to restore stables with conflicting current member commitments
- * - Restoration conflicts with active storylines or championship reigns
- * - Administrative constraints preventing restoration without proper authorization
- * - Member compatibility issues or contractual conflicts preventing reunion
- *
- * BUSINESS IMPACT:
- * - Maintains roster stability and prevents member commitment conflicts
- * - Protects ongoing storylines and current stable dynamics
- * - Ensures restored stables have viable member bases for compelling storylines
- * - Prevents administrative errors and unauthorized stable resurrections
- * - Supports proper storyline continuity and fan investment management
- */
 final class CannotBeRestoredException extends BaseBusinessException
 {
-    /**
-     * Stable is not soft deleted and cannot be restored.
-     *
-     * @param  Stable  $stable  The stable that is not deleted
-     */
     public static function notDeleted(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -47,119 +16,10 @@ final class CannotBeRestoredException extends BaseBusinessException
         return new self("{$context} is not deleted and cannot be restored.");
     }
 
-    /**
-     * Stable name conflicts with an existing active stable.
-     *
-     * @param  Stable  $stable  The stable being restored
-     * @param  string  $conflictingStableName  Name of the conflicting stable
-     */
     public static function nameConflict(Stable $stable, string $conflictingStableName): static
     {
         $context = self::formatModelContext($stable);
 
         return new self("{$context} cannot be restored: name conflicts with existing stable '{$conflictingStableName}'.");
-    }
-
-    /**
-     * No former members are available for restoration.
-     *
-     * @param  Stable  $stable  The stable being restored
-     */
-    public static function noAvailableFormerMembers(Stable $stable): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be restored: no former members are currently available.");
-    }
-
-    /**
-     * Insufficient former members available for viable restoration.
-     *
-     * @param  Stable  $stable  The stable being restored
-     * @param  int  $availableCount  Number of available former members
-     * @param  int  $minimumRequired  Minimum members required
-     */
-    public static function insufficientFormerMembers(Stable $stable, int $availableCount, int $minimumRequired): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be restored: only {$availableCount} former members available, but {$minimumRequired} required.");
-    }
-
-    /**
-     * Key former members are unavailable for restoration.
-     *
-     * @param  Stable  $stable  The stable being restored
-     * @param  string  $unavailableMembers  Names of unavailable key members
-     */
-    public static function keyMembersUnavailable(Stable $stable, string $unavailableMembers): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be restored: key former members unavailable: {$unavailableMembers}.");
-    }
-
-    /**
-     * Former members have conflicting current stable commitments.
-     *
-     * @param  Stable  $stable  The stable being restored
-     * @param  string  $conflictingCommitments  Description of member conflicts
-     */
-    public static function memberCommitmentConflicts(Stable $stable, string $conflictingCommitments): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be restored due to member commitment conflicts: {$conflictingCommitments}.");
-    }
-
-    /**
-     * Restoration would conflict with active storylines.
-     *
-     * @param  Stable  $stable  The stable being restored
-     * @param  string  $storylineConflicts  Description of storyline conflicts
-     */
-    public static function storylineConflicts(Stable $stable, string $storylineConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be restored due to storyline conflicts: {$storylineConflicts}.");
-    }
-
-    /**
-     * Restoration requires proper administrative authorization.
-     *
-     * @param  Stable  $stable  The stable being restored
-     * @param  string  $authorizationLevel  Required authorization level
-     */
-    public static function insufficientAuthorization(Stable $stable, string $authorizationLevel): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be restored without {$authorizationLevel} authorization.");
-    }
-
-    /**
-     * Stable was permanently disbanded and cannot be restored.
-     *
-     * @param  Stable  $stable  The stable that was permanently disbanded
-     */
-    public static function permanentlyDisbanded(Stable $stable): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} was permanently disbanded and cannot be restored.");
-    }
-
-    /**
-     * Restoration timing conflicts with scheduled events.
-     *
-     * @param  Stable  $stable  The stable being restored
-     * @param  string  $eventConflicts  Description of event timing conflicts
-     */
-    public static function eventTimingConflicts(Stable $stable, string $eventConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be restored due to event timing conflicts: {$eventConflicts}.");
     }
 }

--- a/app/Exceptions/Roster/Stables/CannotBeRetiredException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeRetiredException.php
@@ -7,32 +7,6 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when a stable cannot be retired due to business rule violations.
- *
- * This exception handles scenarios where stable retirement is prevented by current state
- * or business logic constraints in wrestling promotion stable management.
- *
- * BUSINESS CONTEXT:
- * Stable retirement marks the formal end of a stable's existence, typically due to
- * internal conflicts, member departures, storyline conclusions, or administrative
- * decisions. Unlike disbandment (which can be temporary), retirement is considered
- * permanent and involves comprehensive member status transitions.
- *
- * COMMON SCENARIOS:
- * - Attempting to retire inactive or already disbanded stables
- * - Retiring stables with active championship obligations
- * - Retirement conflicts with ongoing storylines or major events
- * - Member contractual obligations preventing retirement
- * - Administrative constraints requiring proper authorization
- *
- * BUSINESS IMPACT:
- * - Maintains roster stability and prevents premature stable endings
- * - Protects ongoing storylines and championship lineages
- * - Ensures member transitions are properly handled
- * - Supports proper administrative oversight of stable operations
- * - Preserves fan investment and storyline continuity
- */
 final class CannotBeRetiredException extends BaseBusinessException
 {
     public static function deleted(Stable $stable): static
@@ -42,11 +16,6 @@ final class CannotBeRetiredException extends BaseBusinessException
         return new self("{$context} cannot be retired because it is deleted. Restore the stable first.");
     }
 
-    /**
-     * Stable is not currently active and cannot be retired.
-     *
-     * @param  Stable  $stable  The inactive stable
-     */
     public static function notActive(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -54,119 +23,10 @@ final class CannotBeRetiredException extends BaseBusinessException
         return new self("{$context} is not currently active and cannot be retired.");
     }
 
-    /**
-     * Stable is already retired.
-     *
-     * @param  Stable  $stable  The already retired stable
-     */
     public static function alreadyRetired(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
 
         return new self("{$context} is already retired.");
-    }
-
-    /**
-     * Stable has current members holding championships.
-     *
-     * @param  Stable  $stable  The stable with championship obligations
-     * @param  string  $championshipDetails  Details of current championships
-     */
-    public static function hasChampionshipObligations(Stable $stable, string $championshipDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be retired due to championship obligations: {$championshipDetails}.");
-    }
-
-    /**
-     * Stable retirement conflicts with active storylines.
-     *
-     * @param  Stable  $stable  The stable with storyline conflicts
-     * @param  string  $storylineConflicts  Details of conflicting storylines
-     */
-    public static function storylineConflicts(Stable $stable, string $storylineConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be retired due to active storylines: {$storylineConflicts}.");
-    }
-
-    /**
-     * Stable has upcoming scheduled events.
-     *
-     * @param  Stable  $stable  The stable with scheduled events
-     * @param  string  $eventDetails  Details of upcoming events
-     */
-    public static function hasScheduledEvents(Stable $stable, string $eventDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be retired due to scheduled events: {$eventDetails}.");
-    }
-
-    /**
-     * Members have contractual obligations preventing retirement.
-     *
-     * @param  Stable  $stable  The stable with member contract conflicts
-     * @param  string  $contractConflicts  Details of contract conflicts
-     */
-    public static function memberContractConflicts(Stable $stable, string $contractConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be retired due to member contract conflicts: {$contractConflicts}.");
-    }
-
-    /**
-     * Retirement requires proper administrative authorization.
-     *
-     * @param  Stable  $stable  The stable requiring authorization
-     * @param  string  $authorizationLevel  Required authorization level
-     */
-    public static function insufficientAuthorization(Stable $stable, string $authorizationLevel): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be retired without {$authorizationLevel} authorization.");
-    }
-
-    /**
-     * Stable has unresolved member disciplinary issues.
-     *
-     * @param  Stable  $stable  The stable with disciplinary issues
-     * @param  string  $disciplinaryIssues  Details of unresolved issues
-     */
-    public static function unresolvedDisciplinaryIssues(Stable $stable, string $disciplinaryIssues): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be retired due to unresolved disciplinary issues: {$disciplinaryIssues}.");
-    }
-
-    /**
-     * Retirement timing conflicts with major events.
-     *
-     * @param  Stable  $stable  The stable with timing conflicts
-     * @param  string  $majorEventConflicts  Details of major event conflicts
-     */
-    public static function majorEventConflicts(Stable $stable, string $majorEventConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be retired due to major event conflicts: {$majorEventConflicts}.");
-    }
-
-    /**
-     * Stable members are involved in active feuds.
-     *
-     * @param  Stable  $stable  The stable with active feuds
-     * @param  string  $feudDetails  Details of active feuds
-     */
-    public static function activeFeudInvolvement(Stable $stable, string $feudDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be retired due to active feud involvement: {$feudDetails}.");
     }
 }

--- a/app/Exceptions/Roster/Stables/CannotBeReunitedException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeReunitedException.php
@@ -7,33 +7,6 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when a stable cannot be reunited due to business rule violations.
- *
- * This exception handles scenarios where stable reunion is prevented by current state
- * or business logic constraints in wrestling promotion stable management.
- *
- * BUSINESS CONTEXT:
- * Stable reunion allows previously disbanded stables to return to active competition,
- * typically for comeback storylines, nostalgia acts, or member reconciliation narratives.
- * This represents significant storyline opportunities that require careful validation
- * to ensure compelling and realistic reunion scenarios.
- *
- * COMMON SCENARIOS:
- * - Attempting to reunite stables that were never active before
- * - Trying to reunite already active or retired stables
- * - Reunion when key former members are unavailable or committed elsewhere
- * - Conflicting storylines that prevent meaningful reunion
- * - Administrative constraints requiring proper authorization
- * - Member compatibility issues preventing effective reunion
- *
- * BUSINESS IMPACT:
- * - Maintains roster stability and prevents member commitment conflicts
- * - Protects ongoing storylines and current stable dynamics
- * - Ensures reunited stables have viable member bases for compelling storylines
- * - Prevents administrative errors and unauthorized stable resurrections
- * - Supports proper storyline continuity and fan investment management
- */
 final class CannotBeReunitedException extends BaseBusinessException
 {
     public static function deleted(Stable $stable): static
@@ -43,11 +16,6 @@ final class CannotBeReunitedException extends BaseBusinessException
         return new self("{$context} cannot be reunited because it is deleted. Restore the stable first.");
     }
 
-    /**
-     * Stable has never been active and cannot be reunited.
-     *
-     * @param  Stable  $stable  The stable that was never active
-     */
     public static function neverActive(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -55,11 +23,6 @@ final class CannotBeReunitedException extends BaseBusinessException
         return new self("{$context} has never been active and cannot be reunited. Use establishment instead.");
     }
 
-    /**
-     * Stable is currently active and doesn't need reunion.
-     *
-     * @param  Stable  $stable  The stable that is already active
-     */
     public static function currentlyActive(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -67,11 +30,6 @@ final class CannotBeReunitedException extends BaseBusinessException
         return new self("{$context} is currently active and doesn't need reunion.");
     }
 
-    /**
-     * Stable is retired and cannot be reunited.
-     *
-     * @param  Stable  $stable  The retired stable
-     */
     public static function retired(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -79,13 +37,6 @@ final class CannotBeReunitedException extends BaseBusinessException
         return new self("{$context} is retired and cannot be reunited. Consider unretirement instead.");
     }
 
-    /**
-     * Insufficient former members available for viable reunion.
-     *
-     * @param  Stable  $stable  The stable being reunited
-     * @param  int  $availableCount  Number of available former members
-     * @param  int  $minimumRequired  Minimum members required
-     */
     public static function insufficientFormerMembers(Stable $stable, int $availableCount, int $minimumRequired): static
     {
         $context = self::formatModelContext($stable);
@@ -93,82 +44,10 @@ final class CannotBeReunitedException extends BaseBusinessException
         return new self("{$context} cannot be reunited: only {$availableCount} former members available, but {$minimumRequired} required.");
     }
 
-    /**
-     * Key former members are unavailable for reunion.
-     *
-     * @param  Stable  $stable  The stable being reunited
-     * @param  string  $unavailableMembers  Names of unavailable key members
-     */
     public static function keyMembersUnavailable(Stable $stable, string $unavailableMembers): static
     {
         $context = self::formatModelContext($stable);
 
         return new self("{$context} cannot be reunited: key former members unavailable: {$unavailableMembers}.");
-    }
-
-    /**
-     * Former members have conflicting current commitments.
-     *
-     * @param  Stable  $stable  The stable being reunited
-     * @param  string  $conflictingCommitments  Description of member conflicts
-     */
-    public static function memberCommitmentConflicts(Stable $stable, string $conflictingCommitments): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be reunited due to member commitment conflicts: {$conflictingCommitments}.");
-    }
-
-    /**
-     * Reunion would conflict with active storylines.
-     *
-     * @param  Stable  $stable  The stable being reunited
-     * @param  string  $storylineConflicts  Description of storyline conflicts
-     */
-    public static function storylineConflicts(Stable $stable, string $storylineConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be reunited due to storyline conflicts: {$storylineConflicts}.");
-    }
-
-    /**
-     * Reunion requires proper administrative authorization.
-     *
-     * @param  Stable  $stable  The stable being reunited
-     * @param  string  $authorizationLevel  Required authorization level
-     */
-    public static function insufficientAuthorization(Stable $stable, string $authorizationLevel): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be reunited without {$authorizationLevel} authorization.");
-    }
-
-    /**
-     * Too soon since disbandment for credible reunion.
-     *
-     * @param  Stable  $stable  The stable being reunited
-     * @param  int  $daysSinceDisbandment  Days since disbandment
-     * @param  int  $minimumDays  Minimum days required
-     */
-    public static function tooSoonSinceDisbandment(Stable $stable, int $daysSinceDisbandment, int $minimumDays): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be reunited: only {$daysSinceDisbandment} days since disbandment, but {$minimumDays} days required for credible reunion.");
-    }
-
-    /**
-     * Reunion timing conflicts with scheduled events.
-     *
-     * @param  Stable  $stable  The stable being reunited
-     * @param  string  $eventConflicts  Description of event timing conflicts
-     */
-    public static function eventTimingConflicts(Stable $stable, string $eventConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be reunited due to event timing conflicts: {$eventConflicts}.");
     }
 }

--- a/app/Exceptions/Roster/Stables/CannotBeSplitException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeSplitException.php
@@ -7,39 +7,8 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when a stable cannot be split due to business rule violations.
- *
- * This exception handles scenarios where stable splitting is prevented by current state
- * or business logic constraints in wrestling promotion stable management.
- *
- * BUSINESS CONTEXT:
- * Stable splitting represents the division of an existing faction into two separate
- * entities, typically due to internal conflicts, storyline developments, or strategic
- * roster changes. This is a significant narrative event that affects member relationships
- * and ongoing storylines while creating new faction dynamics and competitive opportunities.
- *
- * COMMON SCENARIOS:
- * - Attempting to split inactive, retired, or disbanded stables
- * - Trying to split stables with insufficient members for viable division
- * - Split conflicts with active storylines, championships, or ongoing feuds
- * - Member distribution that would leave one faction non-viable
- * - Administrative errors involving stables not eligible for splitting
- *
- * BUSINESS IMPACT:
- * - Maintains stable viability and member distribution integrity
- * - Protects ongoing narrative investments and faction dynamics
- * - Ensures both resulting stables remain competitively viable
- * - Prevents disruption of active storylines and championship pursuits
- * - Supports proper faction management and booking flexibility
- */
 final class CannotBeSplitException extends BaseBusinessException
 {
-    /**
-     * Stable is retired and cannot be split.
-     *
-     * @param  Stable  $stable  The stable that cannot be split
-     */
     public static function retired(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -47,11 +16,6 @@ final class CannotBeSplitException extends BaseBusinessException
         return new self("{$context} is retired and cannot be split.");
     }
 
-    /**
-     * Stable is not currently active and cannot be split.
-     *
-     * @param  Stable  $stable  The stable that cannot be split
-     */
     public static function notActive(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -59,13 +23,6 @@ final class CannotBeSplitException extends BaseBusinessException
         return new self("{$context} is not currently active and cannot be split.");
     }
 
-    /**
-     * Stable has insufficient members for splitting.
-     *
-     * @param  Stable  $stable  The stable that cannot be split
-     * @param  int  $currentMembers  Number of current members
-     * @param  int  $minimumRequired  Minimum members required for split
-     */
     public static function insufficientMembers(Stable $stable, int $currentMembers, int $minimumRequired): static
     {
         $context = self::formatModelContext($stable);
@@ -73,37 +30,23 @@ final class CannotBeSplitException extends BaseBusinessException
         return new self("{$context} has only {$currentMembers} members but requires at least {$minimumRequired} members to split.");
     }
 
-    /**
-     * No members specified to move to new stable.
-     */
     public static function noMembersToMove(): static
     {
         return new self('Cannot split stable: at least one member must be moved to the new stable.');
     }
 
-    /**
-     * All members would be moved, leaving original stable empty.
-     */
     public static function allMembersMoving(): static
     {
         return new self('Cannot split stable: at least one member must remain in the original stable.');
     }
 
-    /**
-     * One or more selected members do not belong to the original stable.
-     *
-     * @param  array<int, string>  $memberNames
-     */
+    /** @param array<int, string> $memberNames */
     public static function membersDoNotBelongToStable(array $memberNames): static
     {
         return new self('Cannot split stable: these selected members do not belong to the original stable: '.implode(', ', $memberNames).'.');
     }
 
-    /**
-     * One or more selected members are unavailable for the new stable.
-     *
-     * @param  array<int, string>  $memberNames
-     */
+    /** @param array<int, string> $memberNames */
     public static function membersUnavailable(array $memberNames): static
     {
         return new self('Cannot split stable: these selected members are unavailable: '.implode(', ', $memberNames).'.');
@@ -112,58 +55,5 @@ final class CannotBeSplitException extends BaseBusinessException
     public static function resultingStableBelowMinimum(string $stable, int $memberCount, int $minimumRequired): static
     {
         return new self("Cannot split stable: the {$stable} stable would have {$memberCount} members but requires at least {$minimumRequired}.");
-    }
-
-    /**
-     * Stable cannot be split during active championship reigns.
-     *
-     * @param  Stable  $stable  The stable that cannot be split
-     * @param  array<string>  $championshipTitles  List of championship titles held by members
-     */
-    public static function membersHoldingTitles(Stable $stable, array $championshipTitles): static
-    {
-        $context = self::formatModelContext($stable);
-        $titles = implode(', ', $championshipTitles);
-
-        return new self("{$context} cannot be split while members hold championships: {$titles}.");
-    }
-
-    /**
-     * Stable cannot be split during active storyline participation.
-     *
-     * @param  Stable  $stable  The stable that cannot be split
-     * @param  string  $storylineDetails  Description of the active storyline
-     */
-    public static function activeStoryline(Stable $stable, string $storylineDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be split during active storyline: {$storylineDetails}.");
-    }
-
-    /**
-     * Stable cannot be split during active feud participation.
-     *
-     * @param  Stable  $stable  The stable that cannot be split
-     * @param  string  $feudDetails  Description of the active feud
-     */
-    public static function activeFeud(Stable $stable, string $feudDetails): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be split during active feud: {$feudDetails}.");
-    }
-
-    /**
-     * Stable cannot be split due to upcoming major events.
-     *
-     * @param  Stable  $stable  The stable that cannot be split
-     * @param  string  $upcomingEvent  Description of the upcoming event
-     */
-    public static function upcomingMajorEvent(Stable $stable, string $upcomingEvent): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be split due to upcoming major event: {$upcomingEvent}.");
     }
 }

--- a/app/Exceptions/Roster/Stables/CannotBeUnretiredException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeUnretiredException.php
@@ -7,33 +7,6 @@ namespace App\Exceptions\Roster\Stables;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Stables\Stable;
 
-/**
- * Exception thrown when a stable cannot be unretired due to business rule violations.
- *
- * This exception handles scenarios where stable unretirement is prevented by current state
- * or business logic constraints in wrestling promotion stable management.
- *
- * BUSINESS CONTEXT:
- * Stable unretirement allows previously retired stables to return to active competition,
- * typically for reunion storylines, nostalgia acts, or special events. This represents
- * significant storyline opportunities but must be carefully managed to maintain roster
- * stability and storyline continuity.
- *
- * COMMON SCENARIOS:
- * - Attempting to unretire stables that aren't currently retired
- * - Trying to unretire when key former members are unavailable
- * - Unretirement conflicts with current storylines or roster commitments
- * - Name conflicts with existing active stables
- * - Administrative constraints preventing unauthorized unretirement
- * - Member contractual conflicts preventing reunion
- *
- * BUSINESS IMPACT:
- * - Maintains roster stability and prevents member commitment conflicts
- * - Protects ongoing storylines and current stable dynamics
- * - Ensures unretired stables have viable member bases for compelling storylines
- * - Prevents administrative errors and unauthorized stable resurrections
- * - Supports proper storyline continuity and fan investment management
- */
 final class CannotBeUnretiredException extends BaseBusinessException
 {
     public static function deleted(Stable $stable): static
@@ -43,11 +16,6 @@ final class CannotBeUnretiredException extends BaseBusinessException
         return new self("{$context} cannot be unretired because it is deleted. Restore the stable first.");
     }
 
-    /**
-     * Stable is not currently retired and cannot be unretired.
-     *
-     * @param  Stable  $stable  The stable that is not retired
-     */
     public static function notRetired(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -55,12 +23,6 @@ final class CannotBeUnretiredException extends BaseBusinessException
         return new self("{$context} is not retired and cannot be unretired.");
     }
 
-    /**
-     * Stable name conflicts with an existing active stable.
-     *
-     * @param  Stable  $stable  The stable being unretired
-     * @param  string  $conflictingStableName  Name of the conflicting stable
-     */
     public static function nameConflict(Stable $stable, string $conflictingStableName): static
     {
         $context = self::formatModelContext($stable);
@@ -68,11 +30,6 @@ final class CannotBeUnretiredException extends BaseBusinessException
         return new self("{$context} cannot be unretired: name conflicts with existing stable '{$conflictingStableName}'.");
     }
 
-    /**
-     * No former members are available for unretirement.
-     *
-     * @param  Stable  $stable  The stable being unretired
-     */
     public static function noAvailableFormerMembers(Stable $stable): static
     {
         $context = self::formatModelContext($stable);
@@ -80,13 +37,6 @@ final class CannotBeUnretiredException extends BaseBusinessException
         return new self("{$context} cannot be unretired: no former members are currently available.");
     }
 
-    /**
-     * Insufficient former members available for viable unretirement.
-     *
-     * @param  Stable  $stable  The stable being unretired
-     * @param  int  $availableCount  Number of available former members
-     * @param  int  $minimumRequired  Minimum members required
-     */
     public static function insufficientFormerMembers(Stable $stable, int $availableCount, int $minimumRequired): static
     {
         $context = self::formatModelContext($stable);
@@ -94,80 +44,10 @@ final class CannotBeUnretiredException extends BaseBusinessException
         return new self("{$context} cannot be unretired: only {$availableCount} former members available, but {$minimumRequired} required.");
     }
 
-    /**
-     * Key former members are unavailable for unretirement.
-     *
-     * @param  Stable  $stable  The stable being unretired
-     * @param  string  $unavailableMembers  Names of unavailable key members
-     */
     public static function keyMembersUnavailable(Stable $stable, string $unavailableMembers): static
     {
         $context = self::formatModelContext($stable);
 
         return new self("{$context} cannot be unretired: key former members unavailable: {$unavailableMembers}.");
-    }
-
-    /**
-     * Former members have conflicting current commitments.
-     *
-     * @param  Stable  $stable  The stable being unretired
-     * @param  string  $conflictingCommitments  Description of member conflicts
-     */
-    public static function memberCommitmentConflicts(Stable $stable, string $conflictingCommitments): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be unretired due to member commitment conflicts: {$conflictingCommitments}.");
-    }
-
-    /**
-     * Unretirement would conflict with active storylines.
-     *
-     * @param  Stable  $stable  The stable being unretired
-     * @param  string  $storylineConflicts  Description of storyline conflicts
-     */
-    public static function storylineConflicts(Stable $stable, string $storylineConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be unretired due to storyline conflicts: {$storylineConflicts}.");
-    }
-
-    /**
-     * Unretirement requires proper administrative authorization.
-     *
-     * @param  Stable  $stable  The stable being unretired
-     * @param  string  $authorizationLevel  Required authorization level
-     */
-    public static function insufficientAuthorization(Stable $stable, string $authorizationLevel): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be unretired without {$authorizationLevel} authorization.");
-    }
-
-    /**
-     * Stable was permanently retired and cannot be unretired.
-     *
-     * @param  Stable  $stable  The stable that was permanently retired
-     */
-    public static function permanentlyRetired(Stable $stable): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} was permanently retired and cannot be unretired.");
-    }
-
-    /**
-     * Unretirement timing conflicts with scheduled events.
-     *
-     * @param  Stable  $stable  The stable being unretired
-     * @param  string  $eventConflicts  Description of event timing conflicts
-     */
-    public static function eventTimingConflicts(Stable $stable, string $eventConflicts): static
-    {
-        $context = self::formatModelContext($stable);
-
-        return new self("{$context} cannot be unretired due to event timing conflicts: {$eventConflicts}.");
     }
 }


### PR DESCRIPTION
## Summary
- remove unused Stable exception factories and speculative documentation
- retain only failure constructors enforced by current Stable lifecycle callers
- keep Stable business failures focused on the behavior they represent

## Verification
- 3,663 Pest tests passed with 11,621 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- changed Stable exception files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push reached pre-existing Blade formatting mismatches in files unchanged by this branch; all remaining branch-relevant checks were run directly and passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined stable lifecycle error handling across establishment, merging, restoration, retirement, reunion, splitting, and related actions.
  - Removed several specialized conflict and authorization error messages.
  - Core lifecycle-state and member-availability validations remain supported.
  - Simplified supporting documentation for these error conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->