### PR TITLE
refactor: type match assignment failures

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -15,6 +15,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | tests/Feature/** | .ai/rules/feature.md |
 | tests/Integration/** | .ai/rules/integration.md |
 | app/Livewire/** | .ai/rules/livewire.md |
+| app/{Actions/Matches,Exceptions/Matches,Exceptions/Scheduling}/** | .ai/rules/matches-exceptions-scheduling.md |
 | database/migrations/** | .ai/rules/migrations.md |
 | app/Models/** | .ai/rules/models.md |
 | app/{Livewire,Http/Requests,Actions,Services}/** | .ai/rules/requests-actions-services.md |

--- a/.ai/rules/matches-exceptions-scheduling.md
+++ b/.ai/rules/matches-exceptions-scheduling.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Actions/Matches,Exceptions/Matches,Exceptions/Scheduling}/**'
+---
+
+# Matches Exceptions Scheduling
+
+## Separate match configuration, availability, and scheduling failures
+Use InvalidMatchConfigurationException for incomplete or structurally invalid match assignments. Use EntityNotAvailableException when a selected participant or title's own state prevents assignment. Reserve SchedulingConflictException for actual collisions between bookings, times, or resources.

--- a/app/Actions/Matches/AddCompetitorsToMatchAction.php
+++ b/app/Actions/Matches/AddCompetitorsToMatchAction.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
 
 class AddCompetitorsToMatchAction
 {
@@ -44,7 +44,7 @@ class AddCompetitorsToMatchAction
         // Validate competitor distribution before processing
         $competitorArray = $competitors->toArray();
         if (! $this->validateCompetitorDistribution($competitorArray)) {
-            throw new InvalidArgumentException('Match must have at least 2 sides with competitors');
+            throw InvalidMatchConfigurationException::insufficientSides(2);
         }
 
         DB::transaction(function () use ($eventMatch, $competitors): void {

--- a/app/Actions/Matches/AddMatchForEventAction.php
+++ b/app/Actions/Matches/AddMatchForEventAction.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace App\Actions\Matches;
 
 use App\Data\Matches\EventMatchData;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
 
 class AddMatchForEventAction
 {
@@ -58,11 +58,6 @@ class AddMatchForEventAction
      */
     public function handle(Event $event, EventMatchData $eventMatchData): EventMatch
     {
-        // Validate event can accept new matches
-        if (! $this->isEventEligibleForMatches($event)) {
-            throw new InvalidArgumentException('Event cannot accept new matches at this time');
-        }
-
         // Validate match data completeness
         $this->validateMatchData($eventMatchData);
 
@@ -98,7 +93,7 @@ class AddMatchForEventAction
     /**
      * Transform competitors from type-grouped to side-grouped structure.
      *
-     * @param  Collection<"wrestlers"|"tag_teams", array<int, Wrestler|TagTeam>>  $competitors
+     * @param  Collection<string, covariant array<int, Wrestler|TagTeam>>  $competitors
      * @return Collection<int, array<string, array<int, Wrestler|TagTeam>>>
      */
     private function transformCompetitorsStructure(Collection $competitors): Collection
@@ -119,35 +114,21 @@ class AddMatchForEventAction
     }
 
     /**
-     * Validate that an event can accept new matches.
-     *
-     * @param  Event  $event  The event to validate
-     * @return bool True if the event can accept matches
-     */
-    private function isEventEligibleForMatches(Event $event): bool
-    {
-        // Basic checks - event should be scheduled and not completed
-        // More complex validation would check event status, date constraints, etc.
-        // Could validate $event->status and $event->date for eligibility
-        return true;
-    }
-
-    /**
      * Validate match data for completeness and business rules.
      *
      * @param  EventMatchData  $eventMatchData  The match data to validate
-     * @throws InvalidArgumentException When validation fails
+     * @throws InvalidMatchConfigurationException When validation fails
      */
     private function validateMatchData(EventMatchData $eventMatchData): void
     {
         // Ensure we have competitors for the match
         if ($eventMatchData->competitors->isEmpty()) {
-            throw new InvalidArgumentException('Match must have competitors assigned');
+            throw InvalidMatchConfigurationException::missingCompetitors();
         }
 
         // Ensure we have at least one referee
         if ($eventMatchData->referees->isEmpty()) {
-            throw new InvalidArgumentException('Match must have at least one referee assigned');
+            throw InvalidMatchConfigurationException::missingReferees();
         }
 
         // Additional validation could include:

--- a/app/Actions/Matches/AddRefereesToMatchAction.php
+++ b/app/Actions/Matches/AddRefereesToMatchAction.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
+use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
 
 class AddRefereesToMatchAction
 {
@@ -49,7 +49,7 @@ class AddRefereesToMatchAction
 
         // Validate we have referees to add after filtering
         if ($eligibleReferees->isEmpty()) {
-            throw new InvalidArgumentException('No eligible referees provided for match assignment');
+            throw EntityNotAvailableException::forMatchAssignment('referees');
         }
 
         DB::transaction(function () use ($eventMatch, $eligibleReferees): void {

--- a/app/Actions/Matches/AddTagTeamsToMatchAction.php
+++ b/app/Actions/Matches/AddTagTeamsToMatchAction.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
 
 class AddTagTeamsToMatchAction
 {
@@ -50,12 +51,12 @@ class AddTagTeamsToMatchAction
 
         // Validate we have tag teams to add after filtering
         if ($eligibleTagTeams->isEmpty()) {
-            throw new InvalidArgumentException('No eligible tag teams provided for match assignment');
+            throw EntityNotAvailableException::forMatchAssignment('tag teams');
         }
 
         // Validate side number is reasonable for match structure
         if ($sideNumber < 1) {
-            throw new InvalidArgumentException('Side number must be positive');
+            throw InvalidMatchConfigurationException::invalidSideNumber($sideNumber);
         }
 
         DB::transaction(function () use ($eventMatch, $eligibleTagTeams, $sideNumber): void {

--- a/app/Actions/Matches/AddTitlesToMatchAction.php
+++ b/app/Actions/Matches/AddTitlesToMatchAction.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
+use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\Titles\Title;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
 
 class AddTitlesToMatchAction
 {
@@ -49,7 +49,7 @@ class AddTitlesToMatchAction
 
         // Validate we have titles to add after filtering
         if ($eligibleTitles->isEmpty()) {
-            throw new InvalidArgumentException('No eligible titles provided for championship match');
+            throw EntityNotAvailableException::forMatchAssignment('titles');
         }
 
         DB::transaction(function () use ($eventMatch, $eligibleTitles): void {

--- a/app/Actions/Matches/AddWrestlersToMatchAction.php
+++ b/app/Actions/Matches/AddWrestlersToMatchAction.php
@@ -4,11 +4,12 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
-use InvalidArgumentException;
 
 class AddWrestlersToMatchAction
 {
@@ -48,12 +49,12 @@ class AddWrestlersToMatchAction
 
         // Validate we have wrestlers to add after filtering
         if ($eligibleWrestlers->isEmpty()) {
-            throw new InvalidArgumentException('No eligible wrestlers provided for match assignment');
+            throw EntityNotAvailableException::forMatchAssignment('wrestlers');
         }
 
         // Validate side number is reasonable for match structure
         if ($sideNumber < 1) {
-            throw new InvalidArgumentException('Side number must be positive');
+            throw InvalidMatchConfigurationException::invalidSideNumber($sideNumber);
         }
 
         DB::transaction(function () use ($eventMatch, $eligibleWrestlers, $sideNumber): void {

--- a/app/Data/Matches/EventMatchData.php
+++ b/app/Data/Matches/EventMatchData.php
@@ -19,7 +19,7 @@ readonly class EventMatchData
      *
      * @param  EloquentCollection<int, Referee>  $referees
      * @param  EloquentCollection<int, Title>  $titles
-     * @param  Collection<"wrestlers"|"tag_teams", array<int, Wrestler|TagTeam>>  $competitors
+     * @param  Collection<string, covariant array<int, Wrestler|TagTeam>>  $competitors
      */
     public function __construct(
         public MatchType $matchType,

--- a/app/Exceptions/Matches/InvalidMatchConfigurationException.php
+++ b/app/Exceptions/Matches/InvalidMatchConfigurationException.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Matches;
+
+use App\Exceptions\BaseBusinessException;
+
+final class InvalidMatchConfigurationException extends BaseBusinessException
+{
+    public static function insufficientSides(int $minimumSides): static
+    {
+        return new self("A match must have competitors assigned to at least {$minimumSides} sides.");
+    }
+
+    public static function invalidSideNumber(int $sideNumber): static
+    {
+        return new self("Match side number [{$sideNumber}] must be positive.");
+    }
+
+    public static function missingCompetitors(): static
+    {
+        return new self('A match must have competitors assigned.');
+    }
+
+    public static function missingReferees(): static
+    {
+        return new self('A match must have at least one referee assigned.');
+    }
+}

--- a/app/Exceptions/Scheduling/EntityNotAvailableException.php
+++ b/app/Exceptions/Scheduling/EntityNotAvailableException.php
@@ -6,4 +6,10 @@ namespace App\Exceptions\Scheduling;
 
 use App\Exceptions\BaseBusinessException;
 
-final class EntityNotAvailableException extends BaseBusinessException {}
+final class EntityNotAvailableException extends BaseBusinessException
+{
+    public static function forMatchAssignment(string $entityType): static
+    {
+        return new self("No eligible {$entityType} were provided for match assignment.");
+    }
+}

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -27,6 +27,10 @@ The match system handles complex wrestling match scenarios with flexible competi
 - **Gauntlet**: Can be wrestlers, tag teams, or mixed
 - **Rationale**: These match types support flexible competitor configurations
 
+## Match Assignment Failures
+
+Match configuration and participant availability are separate failure boundaries. `InvalidMatchConfigurationException` describes an incomplete or structurally invalid match, such as missing referees, missing competitors, insufficient populated sides, or an invalid side number. `EntityNotAvailableException` describes a wrestler, tag team, referee, or title whose current state prevents assignment. `SchedulingConflictException` is reserved for an actual collision between bookings, times, or resources and must not substitute for either boundary.
+
 ## Winner/Loser System
 
 ### Multiple Winners and Losers

--- a/tests/Integration/Actions/Matches/AddCompetitorsToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddCompetitorsToMatchActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\Matches\AddCompetitorsToMatchAction;
 use App\Actions\Matches\AddTagTeamsToMatchAction;
 use App\Actions\Matches\AddWrestlersToMatchAction;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
@@ -60,4 +61,17 @@ test('it adds tag team competitors to a match', function () {
 
     $addTagTeamsAction->verify();
     $addWrestlersAction->unused();
+});
+
+test('it rejects competitor assignments with fewer than two populated sides', function () {
+    $eventMatch = EventMatch::factory()->create();
+    $wrestler = Wrestler::factory()->bookable()->create();
+    $competitors = collect([
+        1 => [
+            'wrestlers' => [$wrestler],
+        ],
+    ]);
+
+    expect(fn () => resolve(AddCompetitorsToMatchAction::class)->handle($eventMatch, $competitors))
+        ->toThrow(InvalidMatchConfigurationException::class, 'A match must have competitors assigned to at least 2 sides.');
 });

--- a/tests/Integration/Actions/Matches/AddMatchForEventActionTest.php
+++ b/tests/Integration/Actions/Matches/AddMatchForEventActionTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Matches\AddMatchForEventAction;
+use App\Data\Matches\EventMatchData;
+use App\Enums\MatchType;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Models\Events\Event;
+use App\Models\Referees\Referee;
+use App\Models\Titles\Title;
+use App\Models\Wrestlers\Wrestler;
+
+test('it rejects a match without competitors', function () {
+    $event = Event::factory()->create();
+    $matchData = new EventMatchData(
+        MatchType::Singles,
+        Referee::factory()->bookable()->count(1)->create(),
+        Title::query()->whereKey([])->get(),
+        collect(),
+        null,
+    );
+
+    expect(fn () => resolve(AddMatchForEventAction::class)->handle($event, $matchData))
+        ->toThrow(InvalidMatchConfigurationException::class, 'A match must have competitors assigned.');
+});
+
+test('it rejects a match without referees', function () {
+    $event = Event::factory()->create();
+    $wrestlers = [
+        Wrestler::factory()->bookable()->create(),
+        Wrestler::factory()->bookable()->create(),
+    ];
+    $matchData = new EventMatchData(
+        MatchType::Singles,
+        Referee::query()->whereKey([])->get(),
+        Title::query()->whereKey([])->get(),
+        collect(['wrestlers' => $wrestlers]),
+        null,
+    );
+
+    expect(fn () => resolve(AddMatchForEventAction::class)->handle($event, $matchData))
+        ->toThrow(InvalidMatchConfigurationException::class, 'A match must have at least one referee assigned.');
+});

--- a/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Matches\AddRefereesToMatchAction;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Models\Matches\EventMatch;
+use App\Models\Referees\Referee;
+
+test('it rejects match assignment when no referee is available', function () {
+    $match = EventMatch::factory()->create();
+    $referees = Referee::factory()->retired()->count(2)->create();
+
+    expect(fn () => resolve(AddRefereesToMatchAction::class)->handle($match, $referees))
+        ->toThrow(EntityNotAvailableException::class, 'No eligible referees were provided for match assignment.');
+});

--- a/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Matches\AddTagTeamsToMatchAction;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Models\Matches\EventMatch;
+use App\Models\TagTeams\TagTeam;
+
+test('it rejects match assignment when no tag team is available', function () {
+    $match = EventMatch::factory()->create();
+    $tagTeams = TagTeam::factory()->retired()->count(2)->create();
+
+    expect(fn () => resolve(AddTagTeamsToMatchAction::class)->handle($match, $tagTeams, 1))
+        ->toThrow(EntityNotAvailableException::class, 'No eligible tag teams were provided for match assignment.');
+});

--- a/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Actions\Matches\AddTitlesToMatchAction;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\Titles\Title;
 
@@ -87,7 +88,7 @@ test('it throws exception when no eligible titles provided', function () {
     $titles = collect([$inactiveTitle]);
 
     expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($match, $titles))
-        ->toThrow(InvalidArgumentException::class, 'No eligible titles provided for championship match');
+        ->toThrow(EntityNotAvailableException::class, 'No eligible titles were provided for match assignment.');
 });
 
 test('it handles empty collection', function () {
@@ -95,7 +96,7 @@ test('it handles empty collection', function () {
     $titles = Title::query()->whereKey([])->get();
 
     expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($match, $titles))
-        ->toThrow(InvalidArgumentException::class, 'No eligible titles provided for championship match');
+        ->toThrow(EntityNotAvailableException::class, 'No eligible titles were provided for match assignment.');
 });
 
 test('it creates championship match correctly', function () {

--- a/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Actions\Matches\AddWrestlersToMatchAction;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\Wrestlers\Wrestler;
 
@@ -127,7 +129,7 @@ test('it throws exception when no eligible wrestlers provided', function () {
     $sideNumber = 1;
 
     expect(fn () => resolve(AddWrestlersToMatchAction::class)->handle($match, $wrestlers, $sideNumber))
-        ->toThrow(InvalidArgumentException::class, 'No eligible wrestlers provided for match assignment');
+        ->toThrow(EntityNotAvailableException::class, 'No eligible wrestlers were provided for match assignment.');
 });
 
 test('it throws exception when side number is invalid', function () {
@@ -138,7 +140,7 @@ test('it throws exception when side number is invalid', function () {
     $invalidSideNumber = 0;
 
     expect(fn () => resolve(AddWrestlersToMatchAction::class)->handle($match, $wrestlers, $invalidSideNumber))
-        ->toThrow(InvalidArgumentException::class, 'Side number must be positive');
+        ->toThrow(InvalidMatchConfigurationException::class, 'Match side number [0] must be positive.');
 });
 
 test('it handles transaction rollback on failure', function () {
@@ -150,7 +152,7 @@ test('it handles transaction rollback on failure', function () {
     $invalidSideNumber = -1;
 
     expect(fn () => resolve(AddWrestlersToMatchAction::class)->handle($match, $wrestlers, $invalidSideNumber))
-        ->toThrow(InvalidArgumentException::class);
+        ->toThrow(InvalidMatchConfigurationException::class);
 
     // No competitors should be added due to transaction rollback
     expect($match->refresh()->competitors()->count())->toBe(0);


### PR DESCRIPTION
## Summary
- distinguish invalid match structure from unavailable participants and future scheduling collisions
- replace generic InvalidArgumentException throws across Match assignment actions with typed business exceptions
- remove the unreachable hypothetical event-eligibility failure
- add focused caller coverage, architecture documentation, and a durable Boost rule

## Verification
- 3,676 Pest tests passed with 11,640 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push reached the existing unrelated full-tree Blade formatter mismatch; GitHub clean-checkout Code Style remains the authoritative formatting gate.