### PR TITLE
refactor: classify programmer exceptions

### DIFF
--- a/app/Livewire/Managers/Tables/PreviousStables.php
+++ b/app/Livewire/Managers/Tables/PreviousStables.php
@@ -7,8 +7,8 @@ namespace App\Livewire\Managers\Tables;
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
 use App\Livewire\Table\Column;
 use App\Models\Stables\Stable;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousStables extends BasePreviousStablesTable
 {
@@ -29,7 +29,7 @@ class PreviousStables extends BasePreviousStablesTable
     public function builder(): Builder
     {
         if (! isset($this->managerId)) {
-            throw new Exception("You didn't specify a manager");
+            throw new LogicException('A manager was not provided.');
         }
 
         // Simplified query - just return all stables for now to fix the test

--- a/app/Livewire/Managers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeams.php
@@ -9,8 +9,8 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\TagTeams\TagTeamManager;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousTagTeams extends DataTableComponent
 {
@@ -31,7 +31,7 @@ class PreviousTagTeams extends DataTableComponent
     public function builder(): Builder
     {
         if (! isset($this->managerId)) {
-            throw new Exception("You didn't specify a manager");
+            throw new LogicException('A manager was not provided.');
         }
 
         return TagTeamManager::query()

--- a/app/Livewire/Managers/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlers.php
@@ -9,8 +9,8 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\Wrestlers\WrestlerManager;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousWrestlers extends DataTableComponent
 {
@@ -28,7 +28,7 @@ class PreviousWrestlers extends DataTableComponent
     public function builder(): Builder
     {
         if (! isset($this->managerId)) {
-            throw new Exception("You didn't specify a manager");
+            throw new LogicException('A manager was not provided.');
         }
 
         return WrestlerManager::query()

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -12,9 +12,9 @@ use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Referees\Referee;
 use App\Models\Titles\Title;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
+use LogicException;
 
 class MatchesTable extends DataTableComponent
 {
@@ -35,7 +35,7 @@ class MatchesTable extends DataTableComponent
     public function builder(): Builder
     {
         if ($this->eventId === null) {
-            throw new Exception("You didn't specify a event");
+            throw new LogicException('An event was not provided.');
         }
 
         return EventMatch::query()

--- a/app/Livewire/Referees/Tables/PreviousMatches.php
+++ b/app/Livewire/Referees/Tables/PreviousMatches.php
@@ -6,8 +6,8 @@ namespace App\Livewire\Referees\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousMatchesTable;
 use App\Models\Matches\EventMatch;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousMatches extends BasePreviousMatchesTable
 {
@@ -26,7 +26,7 @@ class PreviousMatches extends BasePreviousMatchesTable
     public function builder(): Builder
     {
         if (! isset($this->refereeId)) {
-            throw new Exception("You didn't specify a referee");
+            throw new LogicException('A referee was not provided.');
         }
 
         return EventMatch::query()

--- a/app/Livewire/Stables/Tables/PreviousManagers.php
+++ b/app/Livewire/Stables/Tables/PreviousManagers.php
@@ -8,8 +8,8 @@ use App\Livewire\Base\Tables\BasePreviousManagersTable;
 use App\Livewire\Table\Column;
 use App\Models\Managers\Manager;
 use App\Models\Stables\Stable;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousManagers extends BasePreviousManagersTable
 {
@@ -23,7 +23,7 @@ class PreviousManagers extends BasePreviousManagersTable
     public function builder(): Builder
     {
         if (! isset($this->stableId)) {
-            throw new Exception("You didn't specify a stable");
+            throw new LogicException('A stable was not provided.');
         }
 
         // Note: Stables do not directly have managers.

--- a/app/Livewire/Stables/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Stables/Tables/PreviousTagTeams.php
@@ -10,9 +10,9 @@ use App\Livewire\Table\DataTableComponent;
 use App\Models\Stables\StableTagTeam;
 use App\Models\TagTeams\TagTeam;
 use Carbon\Carbon;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use LogicException;
 
 class PreviousTagTeams extends DataTableComponent
 {
@@ -28,7 +28,7 @@ class PreviousTagTeams extends DataTableComponent
     public function builder(): Builder
     {
         if (! isset($this->stableId)) {
-            throw new Exception("You didn't specify a stable");
+            throw new LogicException('A stable was not provided.');
         }
 
         return TagTeam::query()

--- a/app/Livewire/Stables/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Stables/Tables/PreviousWrestlers.php
@@ -10,9 +10,9 @@ use App\Livewire\Table\DataTableComponent;
 use App\Models\Stables\StableWrestler;
 use App\Models\Wrestlers\Wrestler;
 use Carbon\Carbon;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use LogicException;
 
 class PreviousWrestlers extends DataTableComponent
 {
@@ -28,7 +28,7 @@ class PreviousWrestlers extends DataTableComponent
     public function builder(): Builder
     {
         if (! isset($this->stableId)) {
-            throw new Exception("You didn't specify a stable");
+            throw new LogicException('A stable was not provided.');
         }
 
         return Wrestler::query()

--- a/app/Livewire/TagTeams/Tables/PreviousManagers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousManagers.php
@@ -6,8 +6,8 @@ namespace App\Livewire\TagTeams\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousManagersTable;
 use App\Models\TagTeams\TagTeamManager;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousManagers extends BasePreviousManagersTable
 {
@@ -24,7 +24,7 @@ class PreviousManagers extends BasePreviousManagersTable
     public function builder(): Builder
     {
         if (! isset($this->tagTeamId)) {
-            throw new Exception("You didn't specify a tag team");
+            throw new LogicException('A tag team was not provided.');
         }
 
         return TagTeamManager::query()

--- a/app/Livewire/TagTeams/Tables/PreviousMatches.php
+++ b/app/Livewire/TagTeams/Tables/PreviousMatches.php
@@ -7,8 +7,8 @@ namespace App\Livewire\TagTeams\Tables;
 use App\Livewire\Base\Tables\BasePreviousMatchesTable;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousMatches extends BasePreviousMatchesTable
 {
@@ -27,7 +27,7 @@ class PreviousMatches extends BasePreviousMatchesTable
     public function builder(): Builder
     {
         if (! isset($this->tagTeamId)) {
-            throw new Exception("You didn't specify a tag team");
+            throw new LogicException('A tag team was not provided.');
         }
 
         $tagTeam = TagTeam::find($this->tagTeamId);

--- a/app/Livewire/TagTeams/Tables/PreviousStables.php
+++ b/app/Livewire/TagTeams/Tables/PreviousStables.php
@@ -6,9 +6,9 @@ namespace App\Livewire\TagTeams\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
 use App\Models\Stables\Stable;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
+use LogicException;
 
 class PreviousStables extends BasePreviousStablesTable
 {
@@ -22,7 +22,7 @@ class PreviousStables extends BasePreviousStablesTable
     public function builder(): Builder
     {
         if (! isset($this->tagTeamId)) {
-            throw new Exception("You didn't specify a tag team");
+            throw new LogicException('A tag team was not provided.');
         }
 
         return Stable::query()

--- a/app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
@@ -7,8 +7,8 @@ namespace App\Livewire\TagTeams\Tables;
 use App\Livewire\Base\Tables\BasePreviousTitleChampionshipsTable;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\TitleChampionship;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
 {
@@ -23,7 +23,7 @@ class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
     public function builder(): Builder
     {
         if (! isset($this->tagTeamId)) {
-            throw new Exception("You didn't specify a tag team");
+            throw new LogicException('A tag team was not provided.');
         }
 
         return TitleChampionship::query()

--- a/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
@@ -10,8 +10,8 @@ use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\TagTeams\TagTeamWrestler;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousWrestlers extends DataTableComponent
 {
@@ -29,7 +29,7 @@ class PreviousWrestlers extends DataTableComponent
     public function builder(): Builder
     {
         if (! isset($this->tagTeamId)) {
-            throw new Exception("You didn't specify a tag team");
+            throw new LogicException('A tag team was not provided.');
         }
 
         return TagTeamWrestler::query()

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -9,9 +9,9 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
+use LogicException;
 
 class PreviousTitleChampionships extends DataTableComponent
 {
@@ -37,7 +37,7 @@ class PreviousTitleChampionships extends DataTableComponent
     public function builder(): Builder
     {
         if (! isset($this->titleId)) {
-            throw new Exception("You didn't specify a title");
+            throw new LogicException('A title was not provided.');
         }
 
         return TitleChampionship::query()

--- a/app/Livewire/Venues/Tables/PreviousEvents.php
+++ b/app/Livewire/Venues/Tables/PreviousEvents.php
@@ -11,7 +11,7 @@ use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\Events\Event;
-use Exception;
+use LogicException;
 
 class PreviousEvents extends DataTableComponent
 {
@@ -29,7 +29,7 @@ class PreviousEvents extends DataTableComponent
     public function builder(): EventBuilder
     {
         if (! isset($this->venueId)) {
-            throw new Exception("You didn't specify a venue");
+            throw new LogicException('A venue was not provided.');
         }
 
         return Event::query()

--- a/app/Livewire/Wrestlers/Tables/PreviousManagers.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousManagers.php
@@ -6,8 +6,8 @@ namespace App\Livewire\Wrestlers\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousManagersTable;
 use App\Models\Wrestlers\WrestlerManager;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousManagers extends BasePreviousManagersTable
 {
@@ -24,7 +24,7 @@ class PreviousManagers extends BasePreviousManagersTable
     public function builder(): Builder
     {
         if (! isset($this->wrestlerId)) {
-            throw new Exception("You didn't specify a wrestler");
+            throw new LogicException('A wrestler was not provided.');
         }
 
         return WrestlerManager::query()

--- a/app/Livewire/Wrestlers/Tables/PreviousMatches.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousMatches.php
@@ -7,8 +7,8 @@ namespace App\Livewire\Wrestlers\Tables;
 use App\Livewire\Base\Tables\BasePreviousMatchesTable;
 use App\Models\Matches\EventMatch;
 use App\Models\Wrestlers\Wrestler;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousMatches extends BasePreviousMatchesTable
 {
@@ -25,7 +25,7 @@ class PreviousMatches extends BasePreviousMatchesTable
     public function builder(): Builder
     {
         if (! isset($this->wrestlerId)) {
-            throw new Exception("You didn't specify a wrestler");
+            throw new LogicException('A wrestler was not provided.');
         }
 
         $wrestler = Wrestler::find($this->wrestlerId);

--- a/app/Livewire/Wrestlers/Tables/PreviousStables.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousStables.php
@@ -6,9 +6,9 @@ namespace App\Livewire\Wrestlers\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
 use App\Models\Stables\Stable;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
+use LogicException;
 
 class PreviousStables extends BasePreviousStablesTable
 {
@@ -25,7 +25,7 @@ class PreviousStables extends BasePreviousStablesTable
     public function builder(): Builder
     {
         if (! isset($this->wrestlerId)) {
-            throw new Exception("You didn't specify a wrestler");
+            throw new LogicException('A wrestler was not provided.');
         }
 
         return Stable::query()

--- a/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
@@ -7,8 +7,8 @@ namespace App\Livewire\Wrestlers\Tables;
 use App\Livewire\Base\Tables\BasePreviousTagTeamsTable;
 use App\Models\TagTeams\TagTeamWrestler;
 use App\Models\Wrestlers\Wrestler;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 /**
  * Livewire table component for displaying a wrestler's previous tag team memberships.
@@ -62,7 +62,7 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
      * most recent previous memberships first.
      *
      *
-     * @throws Exception If wrestlerId is not set
+     * @throws LogicException If wrestlerId is not set
      * @return Builder<TagTeamWrestler> Query builder for tag team wrestler pivot records
      *
      * @example
@@ -76,7 +76,7 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
     public function builder(): Builder
     {
         if (! isset($this->wrestlerId)) {
-            throw new Exception("You didn't specify a wrestler");
+            throw new LogicException('A wrestler was not provided.');
         }
 
         return TagTeamWrestler::query()

--- a/app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php
@@ -7,8 +7,8 @@ namespace App\Livewire\Wrestlers\Tables;
 use App\Livewire\Base\Tables\BasePreviousTitleChampionshipsTable;
 use App\Models\Titles\TitleChampionship;
 use App\Models\Wrestlers\Wrestler;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use LogicException;
 
 class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
 {
@@ -27,7 +27,7 @@ class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
     public function builder(): Builder
     {
         if (! isset($this->wrestlerId)) {
-            throw new Exception("You didn't specify a wrestler");
+            throw new LogicException('A wrestler was not provided.');
         }
 
         // dd(TitleChampionship::query()

--- a/app/Models/Matches/MatchLoser.php
+++ b/app/Models/Matches/MatchLoser.php
@@ -7,7 +7,6 @@ namespace App\Models\Matches;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Database\Factories\Matches\MatchLoserFactory;
-use Exception;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
@@ -15,6 +14,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use LogicException;
 
 /**
  * Event match loser model for tracking match losers.
@@ -80,7 +80,7 @@ class MatchLoser extends Model
     /**
      * Get the loser entity with type safety.
      *
-     * @throws Exception
+     * @throws LogicException
      */
     public function getLoser(): Wrestler|TagTeam
     {
@@ -89,7 +89,7 @@ class MatchLoser extends Model
         return match ($loser::class) {
             Wrestler::class,
             TagTeam::class => $loser,
-            default => throw new Exception('Unexpected loser type: '.$loser::class),
+            default => throw new LogicException('Unexpected loser type: '.$loser::class),
         };
     }
 

--- a/app/Models/Matches/MatchWinner.php
+++ b/app/Models/Matches/MatchWinner.php
@@ -7,7 +7,6 @@ namespace App\Models\Matches;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Database\Factories\Matches\MatchWinnerFactory;
-use Exception;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
@@ -15,6 +14,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
+use LogicException;
 
 /**
  * Match winner model for tracking match winners.
@@ -80,7 +80,7 @@ class MatchWinner extends Model
     /**
      * Get the winner entity with type safety.
      *
-     * @throws Exception
+     * @throws LogicException
      */
     public function getWinner(): Wrestler|TagTeam
     {
@@ -89,7 +89,7 @@ class MatchWinner extends Model
         return match ($winner::class) {
             Wrestler::class,
             TagTeam::class => $winner,
-            default => throw new Exception('Unexpected winner type: '.$winner::class),
+            default => throw new LogicException('Unexpected winner type: '.$winner::class),
         };
     }
 

--- a/tests/Feature/Architecture/ExceptionArchitectureTest.php
+++ b/tests/Feature/Architecture/ExceptionArchitectureTest.php
@@ -35,3 +35,33 @@ test('exceptions do not use technical catch-all directories', function () {
     expect(glob(app_path('Exceptions/Data/*.php')) ?: [])->toBeEmpty()
         ->and(glob(app_path('Exceptions/BusinessRules/*.php')) ?: [])->toBeEmpty();
 });
+
+test('application code does not directly construct generic exceptions', function () {
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator(app_path(), FilesystemIterator::SKIP_DOTS)
+    );
+
+    $violations = [];
+
+    foreach ($files as $file) {
+        if (! $file instanceof SplFileInfo) {
+            continue;
+        }
+
+        if (! $file->isFile() || $file->getExtension() !== 'php') {
+            continue;
+        }
+
+        if ($file->getPathname() === app_path('Exceptions/BaseBusinessException.php')) {
+            continue;
+        }
+
+        $contents = file_get_contents($file->getPathname());
+
+        if ($contents !== false && preg_match('/throw\s+new\s+\\?Exception\s*\(/', $contents) === 1) {
+            $violations[] = str($file->getPathname())->after(app_path().DIRECTORY_SEPARATOR)->toString();
+        }
+    }
+
+    expect($violations)->toBeEmpty();
+});

--- a/tests/Feature/Livewire/Wrestlers/Tables/PreviousManagersTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/PreviousManagersTest.php
@@ -17,10 +17,8 @@ beforeEach(function () {
 
 describe('PreviousManagers Configuration', function () {
     it('requires wrestler id to be set', function () {
-        expect(function () {
-            testLivewire(PreviousManagers::class)
-                ->call('builder');
-        })->toThrow(Exception::class, "You didn't specify a wrestler");
+        expect(fn () => (new PreviousManagers())->builder())
+            ->toThrow(LogicException::class, 'A wrestler was not provided.');
     });
 
     it('can set wrestler id', function () {

--- a/tests/Feature/Livewire/Wrestlers/Tables/PreviousMatchesTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/PreviousMatchesTest.php
@@ -15,10 +15,8 @@ beforeEach(function () {
 
 describe('PreviousMatchesTable Configuration', function () {
     it('requires wrestler id to be set', function () {
-        expect(function () {
-            testLivewire(PreviousMatches::class)
-                ->call('builder');
-        })->toThrow(Exception::class, "You didn't specify a wrestler");
+        expect(fn () => (new PreviousMatches())->builder())
+            ->toThrow(LogicException::class, 'A wrestler was not provided.');
     });
 
     it('can set wrestler id', function () {

--- a/tests/Feature/Livewire/Wrestlers/Tables/PreviousStablesTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/PreviousStablesTest.php
@@ -15,10 +15,8 @@ beforeEach(function () {
 
 describe('PreviousStablesTable Configuration', function () {
     it('requires wrestler id to be set', function () {
-        expect(function () {
-            testLivewire(PreviousStables::class)
-                ->call('builder');
-        })->toThrow(Exception::class, "You didn't specify a wrestler");
+        expect(fn () => (new PreviousStables())->builder())
+            ->toThrow(LogicException::class, 'A wrestler was not provided.');
     });
 
     it('can set wrestler id', function () {

--- a/tests/Feature/Livewire/Wrestlers/Tables/PreviousTagTeamsTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/PreviousTagTeamsTest.php
@@ -15,10 +15,8 @@ beforeEach(function () {
 
 describe('PreviousTagTeamsTable Configuration', function () {
     it('requires wrestler id to be set', function () {
-        expect(function () {
-            testLivewire(PreviousTagTeams::class)
-                ->call('builder');
-        })->toThrow(Exception::class, "You didn't specify a wrestler");
+        expect(fn () => (new PreviousTagTeams())->builder())
+            ->toThrow(LogicException::class, 'A wrestler was not provided.');
     });
 
     it('can set wrestler id', function () {

--- a/tests/Feature/Livewire/Wrestlers/Tables/PreviousTitleChampionshipsTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/PreviousTitleChampionshipsTest.php
@@ -15,10 +15,8 @@ beforeEach(function () {
 
 describe('PreviousTitleChampionshipsTable Configuration', function () {
     it('requires wrestler id to be set', function () {
-        expect(function () {
-            testLivewire(PreviousTitleChampionships::class)
-                ->call('builder');
-        })->toThrow(Exception::class, "You didn't specify a wrestler");
+        expect(fn () => (new PreviousTitleChampionships())->builder())
+            ->toThrow(LogicException::class, 'A wrestler was not provided.');
     });
 
     it('can set wrestler id', function () {

--- a/tests/Integration/Livewire/TagTeams/Tables/PreviousWrestlersTest.php
+++ b/tests/Integration/Livewire/TagTeams/Tables/PreviousWrestlersTest.php
@@ -33,9 +33,8 @@ describe('Previous Wrestlers Table Component', function () {
     });
 
     it('throws exception when tag team ID not specified', function () {
-        expect(function () {
-            livewire(PreviousWrestlers::class);
-        })->toThrow(Exception::class, "You didn't specify a tag team");
+        expect(fn () => (new PreviousWrestlers())->builder())
+            ->toThrow(LogicException::class, 'A tag team was not provided.');
     });
 
     it('displays only previous wrestlers with left dates', function () {

--- a/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/PreviousEventsTest.php
@@ -76,11 +76,8 @@ describe('PreviousEventsTable Integration Tests', function () {
         });
 
         test('throws exception when venue ID is not provided', function () {
-            expect(function () {
-                \Pest\Laravel\actingAs($this->admin);
-
-                \Pest\Livewire\livewire(PreviousEvents::class);
-            })->toThrow(Exception::class, "You didn't specify a venue");
+            expect(fn () => (new PreviousEvents())->builder())
+                ->toThrow(LogicException::class, 'A venue was not provided.');
         });
 
         test('filters events by specific venue only', function () {
@@ -260,7 +257,7 @@ describe('PreviousEventsTable Integration Tests', function () {
             expect(function () {
                 $table = new PreviousEvents();
                 $table->builder();
-            })->toThrow(Exception::class, "You didn't specify a venue");
+            })->toThrow(LogicException::class, 'A venue was not provided.');
         });
 
         test('handles invalid venue ID gracefully', function () {

--- a/tests/Integration/Livewire/Wrestlers/Tables/PreviousManagersTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Tables/PreviousManagersTest.php
@@ -33,9 +33,8 @@ describe('Previous Managers Table Component', function () {
     })->group('wrestlers', 'integration', 'livewire', 'tables', 'rendering');
 
     it('throws exception when wrestler ID not specified', function () {
-        expect(function () {
-            testLivewire(PreviousManagers::class);
-        })->toThrow(Exception::class, "You didn't specify a wrestler");
+        expect(fn () => (new PreviousManagers())->builder())
+            ->toThrow(LogicException::class, 'A wrestler was not provided.');
         expect(true)->toBeTrue();
     })->group('wrestlers', 'integration', 'livewire', 'tables', 'configuration');
 


### PR DESCRIPTION
## Summary
- classify missing Livewire component inputs as programmer errors with `LogicException`
- classify impossible match winner and loser model states as programmer errors
- prohibit direct construction of generic `Exception` instances through architecture coverage

## Verification
- `composer test:push` passed the application suite, PHPStan, Rector, and Pest type coverage
- focused exception architecture tests passed
- touched PHP and Blade-aware Pint formatting passed
- `git diff --check` passed

## Existing local formatting note
- the final full-tree Blade formatting check still reports the known unrelated Blade mismatches on clean `development`; GitHub clean-checkout code style remains authoritative