### PR TITLE
refactor: type stable removal date failures

### DIFF
--- a/app/Actions/Stables/RemoveStableMembersAction.php
+++ b/app/Actions/Stables/RemoveStableMembersAction.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Actions\Stables;
 
 use App\Data\Stables\StableMembershipData;
+use App\Exceptions\Lifecycle\InvalidDateRangeException;
 use App\Models\Stables\Stable;
 use App\Services\StableMembershipService;
 use Illuminate\Support\Carbon;
-use InvalidArgumentException;
 
 /**
  * Remove members from a stable.
@@ -29,13 +29,12 @@ class RemoveStableMembersAction
      * @param  Stable  $stable  The stable to remove members from
      * @param  StableMembershipData  $members  The members to remove
      * @param  Carbon  $removalDate  The date they left
-     * @throws InvalidArgumentException When parameters are invalid
+     * @throws InvalidDateRangeException When the removal date is in the future
      */
     public function handle(Stable $stable, StableMembershipData $members, Carbon $removalDate): void
     {
-        // Validate parameters
         if ($removalDate->isFuture()) {
-            throw new InvalidArgumentException('Cannot remove members with future date.');
+            throw InvalidDateRangeException::futureNotAllowed($removalDate, 'Stable membership removal');
         }
 
         if ($members->isNotEmpty()) {

--- a/tests/Integration/Actions/Stables/RemoveStableMembersActionTest.php
+++ b/tests/Integration/Actions/Stables/RemoveStableMembersActionTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Stables\RemoveStableMembersAction;
+use App\Data\Stables\StableMembershipData;
+use App\Exceptions\Lifecycle\InvalidDateRangeException;
+use App\Models\Stables\Stable;
+use App\Models\Stables\StableWrestler;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
+
+test('it rejects a future membership removal date', function () {
+    $stable = Stable::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+    $stable->wrestlers()->attach($wrestler, ['joined_at' => today()]);
+    $members = new StableMembershipData(wrestlers: new Collection([$wrestler]));
+
+    expect(fn () => resolve(RemoveStableMembersAction::class)->handle(
+        $stable,
+        $members,
+        now()->addDay(),
+    ))->toThrow(InvalidDateRangeException::class);
+
+    expect(StableWrestler::query()
+        ->whereBelongsTo($stable)
+        ->whereBelongsTo($wrestler)
+        ->whereNull('left_at')
+        ->exists())->toBeTrue();
+});
+
+test('it ends current stable memberships on the removal date', function () {
+    $stable = Stable::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+    $stable->wrestlers()->attach($wrestler, ['joined_at' => today()->subDay()]);
+    $members = new StableMembershipData(wrestlers: new Collection([$wrestler]));
+    $removalDate = now()->startOfSecond();
+
+    resolve(RemoveStableMembersAction::class)->handle(
+        $stable,
+        $members,
+        $removalDate,
+    );
+
+    $membership = StableWrestler::query()
+        ->whereBelongsTo($stable)
+        ->whereBelongsTo($wrestler)
+        ->firstOrFail();
+
+    expect($membership->left_at)->not->toBeNull()
+        ->and($membership->left_at?->equalTo($removalDate))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- replace the generic invalid-argument failure for future stable membership removals with `InvalidDateRangeException`
- add focused integration coverage for rejection without mutation and successful membership closure
- align the action PHPDoc with the typed lifecycle failure

## Verification
- focused action and exception architecture tests passed
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched files passed Pint with Blade formatting
- `git diff --check` passed

## Existing local formatting note
- `composer test:push` reaches the known unrelated full-tree Blade formatting mismatch on clean `development`; GitHub clean-checkout code style remains authoritative