### PR TITLE
refactor: classify related model resolution errors

### DIFF
--- a/.ai/rules/app.md
+++ b/.ai/rules/app.md
@@ -16,3 +16,6 @@ Organize application code by technical responsibility at the top level, then by 
 
 ## Use date helpers for the current date
 Use now() and today() for the current timestamp or date. Use Carbon constructors for parsing or constructing explicit date values.
+
+## Classify exception boundaries by failure source
+Use typed BaseBusinessException subclasses for domain-rule rejections. Use LogicException for impossible programmer or configuration states, including missing convention-derived model classes and invalid trait hosts. Reserve InvalidArgumentException for invalid values supplied by a caller; do not directly construct generic Exception.

--- a/app/Models/Concerns/CanBeManaged.php
+++ b/app/Models/Concerns/CanBeManaged.php
@@ -9,7 +9,7 @@ use App\Models\Managers\Manager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use RuntimeException;
+use LogicException;
 
 /**
  * Provides manager relationship support for models that can be managed by `Manager` instances.
@@ -160,7 +160,7 @@ trait CanBeManaged
      * a 'WrestlerManager' pivot model class.
      *
      *
-     * @throws RuntimeException If the resolved model class doesn't exist
+     * @throws LogicException If the resolved model class doesn't exist
      * @return class-string<TPivotModel> The fully qualified class name of the pivot model
      *
      * @example
@@ -191,7 +191,7 @@ trait CanBeManaged
         $resolved = $namespace.'\\'.$relatedModelName;
 
         if (! class_exists($resolved)) {
-            throw new RuntimeException("Related pivot model [{$resolved}] not found for [{$declaring}]. Override the resolution method or ensure the class exists.");
+            throw new LogicException("Related pivot model [{$resolved}] not found for [{$declaring}]. Override the resolution method or ensure the class exists.");
         }
 
         /** @var class-string<TPivotModel> */

--- a/app/Models/Concerns/CanJoinStables.php
+++ b/app/Models/Concerns/CanJoinStables.php
@@ -15,7 +15,7 @@ use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use InvalidArgumentException;
+use LogicException;
 
 /**
  * @template TPivotModel of Pivot
@@ -43,7 +43,7 @@ trait CanJoinStables
                 'foreignKey' => 'tag_team_id',
                 'pivot' => StableTagTeam::class,
             ],
-            default => throw new InvalidArgumentException('Unsupported stable member type: '.static::class),
+            default => throw new LogicException('Unsupported stable member type: '.static::class),
         };
     }
 

--- a/app/Models/Concerns/CanJoinTagTeams.php
+++ b/app/Models/Concerns/CanJoinTagTeams.php
@@ -11,7 +11,7 @@ use App\Models\TagTeams\TagTeam;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use RuntimeException;
+use LogicException;
 
 /**
  * Provides functionality for models (e.g., Wrestlers) to join and manage relationships with tag teams.
@@ -211,7 +211,7 @@ trait CanJoinTagTeams
      * a 'TagTeamWrestler' pivot model class.
      *
      *
-     * @throws RuntimeException If the resolved model class doesn't exist
+     * @throws LogicException If the resolved model class doesn't exist
      * @return class-string<TPivotModel> The fully qualified class name of the pivot model
      *
      * @example
@@ -241,7 +241,7 @@ trait CanJoinTagTeams
         $resolved = 'App\\Models\\TagTeams\\'.$relatedModelName;
 
         if (! class_exists($resolved)) {
-            throw new RuntimeException("Related pivot model [{$resolved}] not found for [{$declaring}]. Override the resolution method or ensure the class exists.");
+            throw new LogicException("Related pivot model [{$resolved}] not found for [{$declaring}]. Override the resolution method or ensure the class exists.");
         }
 
         /** @var class-string<TPivotModel> */

--- a/app/Models/Concerns/ResolvesRelatedModels.php
+++ b/app/Models/Concerns/ResolvesRelatedModels.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Concerns;
 
-use RuntimeException;
+use LogicException;
 
 /**
  * Provides generic model class resolution functionality for Eloquent model relationships.
@@ -47,7 +47,7 @@ trait ResolvesRelatedModels
      * it will resolve to 'WrestlerEmployment' in the same namespace.
      *
      * @param  string  $suffix  The suffix to append to the base model name (e.g., 'Employment', 'Retirement')
-     * @throws RuntimeException If the resolved model class doesn't exist
+     * @throws LogicException If the resolved model class doesn't exist
      * @return string The fully qualified class name of the resolved model
      *
      * @example
@@ -70,7 +70,7 @@ trait ResolvesRelatedModels
      * Perform the actual model class resolution.
      *
      * @param  string  $suffix  The suffix to append to the base model name
-     * @throws RuntimeException If the resolved model class doesn't exist
+     * @throws LogicException If the resolved model class doesn't exist
      * @return string The fully qualified class name of the resolved model
      */
     private function performModelResolution(string $suffix): string
@@ -97,7 +97,7 @@ trait ResolvesRelatedModels
 
         // Validate that the resolved class exists
         if (! class_exists($resolvedClass)) {
-            throw new RuntimeException(
+            throw new LogicException(
                 "Related model [{$resolvedClass}] not found for [{$declaringClass}] with suffix [{$suffix}]. ".
                 'Ensure the class exists or override the domain-specific resolver method.'
             );
@@ -118,7 +118,7 @@ trait ResolvesRelatedModels
             $this->resolveRelatedModelClass($suffix);
 
             return true;
-        } catch (RuntimeException) {
+        } catch (LogicException) {
             return false;
         }
     }

--- a/tests/Unit/Models/Concerns/CanBeManagedTest.php
+++ b/tests/Unit/Models/Concerns/CanBeManagedTest.php
@@ -25,6 +25,7 @@ use App\Models\Concerns\CanBeManaged;
 use App\Models\Contracts\Manageable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use LogicException;
 use Tests\Unit\Models\Concerns\Support\FakeManageableModel;
 use Tests\Unit\Models\Concerns\Support\FakeManagerPivotModel;
 
@@ -74,6 +75,22 @@ describe('CanBeManaged Trait Unit Tests', function () {
     });
 
     describe('manager pivot model resolution', function () {
+        test('reports missing convention-based pivot models as logic errors', function () {
+            $model = new class extends Model implements Manageable
+            {
+                /** @use CanBeManaged<FakeManagerPivotModel, self> */
+                use CanBeManaged;
+
+                public function resolvePivotModel(): string
+                {
+                    return $this->resolveManagersPivotModel();
+                }
+            };
+
+            expect(fn () => $model->resolvePivotModel())
+                ->toThrow(LogicException::class, 'Related pivot model');
+        });
+
         test('can fake manager pivot model class', function () {
             FakeManageableModel::fakeManagerPivotModel(FakeManagerPivotModel::class);
             $model = new FakeManageableModel();

--- a/tests/Unit/Models/Concerns/CanJoinStablesTest.php
+++ b/tests/Unit/Models/Concerns/CanJoinStablesTest.php
@@ -12,6 +12,8 @@ use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use LogicException;
+use Tests\Unit\Models\Concerns\Support\UnsupportedStableMemberModel;
 
 dataset('stable members', [
     'wrestler' => [fn (): Wrestler => Wrestler::factory()->make()],
@@ -22,6 +24,13 @@ dataset('stable relationship configurations', [
     'wrestler' => [fn (): Wrestler => Wrestler::factory()->make(), 'stables_wrestlers', 'wrestler_id', StableWrestler::class],
     'tag team' => [fn (): TagTeam => TagTeam::factory()->make(), 'stables_tag_teams', 'tag_team_id', StableTagTeam::class],
 ]);
+
+it('reports unsupported trait hosts as logic errors', function () {
+    $member = new UnsupportedStableMemberModel();
+
+    expect(fn () => $member->stables())
+        ->toThrow(LogicException::class, 'Unsupported stable member type');
+});
 
 it('defines all stable relationships', function (Wrestler|TagTeam $member) {
     $stables = $member->stables();

--- a/tests/Unit/Models/Concerns/CanJoinTagTeamsTest.php
+++ b/tests/Unit/Models/Concerns/CanJoinTagTeamsTest.php
@@ -18,6 +18,7 @@ use App\Models\Concerns\CanJoinTagTeams;
 use App\Models\Contracts\CanBeATagTeamMember;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use LogicException;
 use Tests\Unit\Models\Concerns\Support\FakeTagTeamMemberModel;
 use Tests\Unit\Models\Concerns\Support\FakeTagTeamPivotModel;
 
@@ -81,6 +82,22 @@ describe('CanJoinTagTeams Trait Unit Tests', function () {
     });
 
     describe('tag team pivot model resolution', function () {
+        test('reports missing convention-based pivot models as logic errors', function () {
+            $model = new class extends Model implements CanBeATagTeamMember
+            {
+                /** @use CanJoinTagTeams<FakeTagTeamPivotModel, self> */
+                use CanJoinTagTeams;
+
+                public function resolvePivotModel(): string
+                {
+                    return $this->resolveTagTeamPivotModel();
+                }
+            };
+
+            expect(fn () => $model->resolvePivotModel())
+                ->toThrow(LogicException::class, 'Related pivot model');
+        });
+
         test('can fake tag team pivot model class', function () {
             FakeTagTeamMemberModel::fakeTagTeamPivotModel(FakeTagTeamPivotModel::class);
             $model = new FakeTagTeamMemberModel();

--- a/tests/Unit/Models/Concerns/IsInjurableTest.php
+++ b/tests/Unit/Models/Concerns/IsInjurableTest.php
@@ -21,7 +21,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Query\Builder as QueryBuilder;
 use JMac\Testing\Double;
-use RuntimeException;
+use LogicException;
 use Tests\Unit\Models\Concerns\Support\FakeInjuryModel;
 
 /** @extends EloquentBuilder<FakeInjuryModel> */
@@ -211,7 +211,7 @@ describe('IsInjurable Trait Unit Tests', function () {
                 use IsInjurable;
             };
 
-            expect(fn () => $model->injuries())->toThrow(RuntimeException::class);
+            expect(fn () => $model->injuries())->toThrow(LogicException::class);
         });
     });
 

--- a/tests/Unit/Models/Concerns/ResolvesRelatedModelsTest.php
+++ b/tests/Unit/Models/Concerns/ResolvesRelatedModelsTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Concerns\ResolvesRelatedModels;
+
+test('it reports a missing convention-based related model as a logic error', function () {
+    $model = new class
+    {
+        use ResolvesRelatedModels;
+
+        public function resolve(string $suffix): string
+        {
+            return $this->resolveRelatedModelClass($suffix);
+        }
+    };
+
+    expect(fn () => $model->resolve('MissingRelationship'))
+        ->toThrow(LogicException::class, 'Related model');
+});
+
+test('it reports whether a convention-based related model exists', function () {
+    $model = new class
+    {
+        use ResolvesRelatedModels;
+
+        public function relatedModelIsAvailable(string $suffix): bool
+        {
+            return $this->relatedModelExists($suffix);
+        }
+    };
+
+    expect($model->relatedModelIsAvailable('MissingRelationship'))->toBeFalse();
+});

--- a/tests/Unit/Models/Concerns/Support/UnsupportedStableMemberModel.php
+++ b/tests/Unit/Models/Concerns/Support/UnsupportedStableMemberModel.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Models\Concerns\Support;
+
+use App\Models\Concerns\CanJoinStables;
+use App\Models\Contracts\CanBeAStableMember;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @implements CanBeAStableMember<Pivot, self>
+ */
+class UnsupportedStableMemberModel extends Model implements CanBeAStableMember
+{
+    /** @use CanJoinStables<Pivot, self> */
+    use CanJoinStables;
+}


### PR DESCRIPTION
## Summary
- classify missing convention-derived related and pivot model classes as `LogicException` programmer/configuration failures
- classify unsupported stable-membership trait hosts as logic errors
- add focused resolver, tag-team pivot, manager pivot, and stable-member host coverage
- record the durable distinction between domain, logic, and caller-argument exceptions with Laravel Boost

## Verification
- 39 focused Pest tests passed with 77 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched files passed Pint with Blade formatting
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling when related, pivot, or stable-member models cannot be resolved.
  * Invalid model configurations now consistently report logic errors with clearer messages.

* **Tests**
  * Added coverage for missing related models, unavailable pivot models, and unsupported stable-member models.
  * Verified availability checks correctly report unresolved models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->