### PR TITLE
refactor: narrow action exception contracts

### DIFF
--- a/app/Actions/Managers/EmployAction.php
+++ b/app/Actions/Managers/EmployAction.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\Managers;
 
+use App\Exceptions\Roster\Individuals\CannotBeEmployedException;
 use App\Lifecycle\EmploymentPeriodManager;
 use App\Models\Managers\Manager;
 use App\Support\DateHelper;
-use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -27,7 +27,7 @@ class EmployAction
      *
      * @param  Manager  $manager  The manager to employ
      * @param  Carbon|null  $startDate  The employment start date (defaults to now)
-     * @throws Exception When manager cannot be employed due to business rules
+     * @throws CannotBeEmployedException When the manager cannot be employed
      */
     public function handle(Manager $manager, ?Carbon $startDate = null): void
     {

--- a/app/Actions/Referees/EmployAction.php
+++ b/app/Actions/Referees/EmployAction.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\Referees;
 
+use App\Exceptions\Roster\Individuals\CannotBeEmployedException;
 use App\Lifecycle\EmploymentPeriodManager;
 use App\Models\Referees\Referee;
 use App\Support\DateHelper;
-use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -27,7 +27,7 @@ class EmployAction
      *
      * @param  Referee  $referee  The referee to employ
      * @param  Carbon|null  $employmentDate  The employment start date (defaults to now)
-     * @throws Exception When referee cannot be employed due to business rules
+     * @throws CannotBeEmployedException When the referee cannot be employed
      */
     public function handle(Referee $referee, ?Carbon $employmentDate = null): void
     {

--- a/app/Actions/TagTeams/EmployAction.php
+++ b/app/Actions/TagTeams/EmployAction.php
@@ -5,11 +5,11 @@ declare(strict_types=1);
 namespace App\Actions\TagTeams;
 
 use App\Actions\Managers\EmployCurrentManagersAction;
+use App\Exceptions\Roster\TagTeams\CannotBeEmployedException;
 use App\Lifecycle\EmploymentPeriodManager;
 use App\Lifecycle\RetirementPeriodManager;
 use App\Models\TagTeams\TagTeam;
 use App\Support\DateHelper;
-use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -35,7 +35,7 @@ class EmployAction
      *
      * @param  TagTeam  $tagTeam  The tag team to employ
      * @param  Carbon|null  $employmentDate  The employment start date (defaults to now)
-     * @throws Exception When tag team cannot be employed due to business rules
+     * @throws CannotBeEmployedException When the tag team cannot be employed
      */
     public function handle(TagTeam $tagTeam, ?Carbon $employmentDate = null): void
     {

--- a/app/Actions/TagTeams/UnretireCurrentMembersAction.php
+++ b/app/Actions/TagTeams/UnretireCurrentMembersAction.php
@@ -6,10 +6,10 @@ namespace App\Actions\TagTeams;
 
 use App\Actions\Managers\UnretireAction as UnretireManagerAction;
 use App\Actions\Wrestlers\UnretireAction as UnretireWrestlerAction;
+use App\Exceptions\Roster\Individuals\CannotBeUnretiredException;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
-use Exception;
 use Illuminate\Support\Carbon;
 
 class UnretireCurrentMembersAction
@@ -27,7 +27,7 @@ class UnretireCurrentMembersAction
         foreach ($wrestlers as $wrestler) {
             try {
                 $this->unretireWrestler->handle($wrestler, $unretirementDate, false);
-            } catch (Exception) {
+            } catch (CannotBeUnretiredException) {
                 continue;
             }
         }
@@ -38,7 +38,7 @@ class UnretireCurrentMembersAction
         foreach ($managers as $manager) {
             try {
                 $this->unretireManager->handle($manager, $unretirementDate, false);
-            } catch (Exception) {
+            } catch (CannotBeUnretiredException) {
                 continue;
             }
         }

--- a/app/Actions/Wrestlers/EmployAction.php
+++ b/app/Actions/Wrestlers/EmployAction.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 namespace App\Actions\Wrestlers;
 
 use App\Actions\Managers\EmployCurrentManagersAction;
+use App\Exceptions\Roster\Individuals\CannotBeEmployedException;
 use App\Lifecycle\EmploymentPeriodManager;
 use App\Models\Wrestlers\Wrestler;
 use App\Support\DateHelper;
-use Exception;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
@@ -31,7 +31,7 @@ class EmployAction
      *
      * @param  Wrestler  $wrestler  The wrestler to employ
      * @param  Carbon|null  $employmentDate  The employment start date (defaults to now)
-     * @throws Exception When wrestler cannot be employed due to business rules
+     * @throws CannotBeEmployedException When the wrestler cannot be employed
      */
     public function handle(Wrestler $wrestler, ?Carbon $employmentDate = null): void
     {

--- a/tests/Integration/Actions/TagTeams/UnretireCurrentMembersActionTest.php
+++ b/tests/Integration/Actions/TagTeams/UnretireCurrentMembersActionTest.php
@@ -2,9 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Actions\Managers\UnretireAction as UnretireManagerAction;
 use App\Actions\TagTeams\UnretireCurrentMembersAction;
+use App\Actions\Wrestlers\UnretireAction as UnretireWrestlerAction;
+use App\Exceptions\Roster\Individuals\CannotBeUnretiredException;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+use JMac\Testing\Double;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -44,4 +49,37 @@ test('it unretires retired current wrestlers and managers without employing them
         'manager_id' => $manager->id,
         'ended_at' => $unretirementDate->toDateTimeString(),
     ]);
+});
+
+test('it skips current members rejected by unretirement rules', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $wrestler = Wrestler::factory()->retired()->create();
+    $tagTeam->wrestlers()->attach($wrestler, ['joined_at' => now()->subMonth()]);
+    $unretireWrestler = Double::for(UnretireWrestlerAction::class);
+    $unretireManager = Double::for(UnretireManagerAction::class);
+    $unretireWrestler->expects('handle')
+        ->throws(CannotBeUnretiredException::notRetired($wrestler));
+
+    (new UnretireCurrentMembersAction($unretireWrestler, $unretireManager))
+        ->handle($tagTeam, now());
+
+    $unretireWrestler->verify();
+    $unretireManager->unused();
+});
+
+test('it does not swallow programmer errors while unretiring current members', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $wrestler = Wrestler::factory()->retired()->create();
+    $tagTeam->wrestlers()->attach($wrestler, ['joined_at' => now()->subMonth()]);
+    $unretireWrestler = Double::for(UnretireWrestlerAction::class);
+    $unretireManager = Double::for(UnretireManagerAction::class);
+    $unretireWrestler->expects('handle')
+        ->throws(new LogicException('Unexpected unretirement failure.'));
+    $action = new UnretireCurrentMembersAction($unretireWrestler, $unretireManager);
+
+    expect(fn () => $action->handle($tagTeam, now()))
+        ->toThrow(LogicException::class, 'Unexpected unretirement failure.');
+
+    $unretireWrestler->verify();
+    $unretireManager->unused();
 });


### PR DESCRIPTION
## Summary
- document exact employment business exceptions instead of generic Exception
- catch only expected unretirement domain rejections during best-effort member restoration
- allow programmer and infrastructure errors to propagate
- add focused coverage for both expected and unexpected failures

## Verification
- 3 focused tests passed with 15 assertions
- Rector and Pest type coverage passed
- touched files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push reached the existing repository-wide Blade formatter mismatch in unrelated view files; this PR does not modify those files.