### PR TITLE
fix: propagate unexpected Livewire action errors

### DIFF
--- a/.ai/rules/livewire.md
+++ b/.ai/rules/livewire.md
@@ -19,3 +19,6 @@ Build server-driven interactive UI with class-based Livewire components and Blad
 
 ## Class-based Livewire components
 Implement Livewire behavior in namespaced PHP classes using shared base classes where applicable. Do not introduce Volt or single-file components.
+
+## Translate only domain failures
+Catch and translate BaseBusinessException at Livewire user-interaction boundaries. Do not catch generic Exception or Throwable to produce business flash messages; let programmer, infrastructure, and framework failures propagate through Laravel's normal exception reporting.

--- a/app/Livewire/Concerns/ExecutesActionsWithContext.php
+++ b/app/Livewire/Concerns/ExecutesActionsWithContext.php
@@ -4,11 +4,11 @@ declare(strict_types=1);
 
 namespace App\Livewire\Concerns;
 
+use App\Exceptions\BaseBusinessException;
 use App\Services\ErrorMessageMappingService;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Log;
-use Throwable;
 
 /**
  * Trait for executing business actions with rich context and error handling.
@@ -66,7 +66,7 @@ trait ExecutesActionsWithContext
             $this->dispatch("{$entityType}-updated");
             session()->flash('success', __("{$entityType}s.actions.{$actionName}"));
 
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             // Log technical details for developers
@@ -134,10 +134,10 @@ trait ExecutesActionsWithContext
     /**
      * Map exception to user-friendly message based on entity type.
      *
-     * @param  Throwable  $exception  The exception to map
+     * @param  BaseBusinessException  $exception  The business exception to map
      * @param  string  $entityType  Entity type for mapping
      */
-    protected function mapExceptionToUserMessage(Throwable $exception, string $entityType): string
+    protected function mapExceptionToUserMessage(BaseBusinessException $exception, string $entityType): string
     {
         return match ($entityType) {
             'wrestler' => ErrorMessageMappingService::mapWrestlerException($exception),

--- a/app/Livewire/Referees/Components/Actions.php
+++ b/app/Livewire/Referees/Components/Actions.php
@@ -13,6 +13,7 @@ use App\Actions\Referees\RestoreAction;
 use App\Actions\Referees\RetireAction;
 use App\Actions\Referees\SuspendAction;
 use App\Actions\Referees\UnretireAction;
+use App\Exceptions\BaseBusinessException;
 use App\Models\Referees\Referee;
 use App\Services\ErrorMessageMappingService;
 use Illuminate\Contracts\View\View;
@@ -20,7 +21,6 @@ use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Livewire\Component;
-use Throwable;
 
 /**
  * Referee Actions Component
@@ -62,7 +62,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.employed'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             // Log technical details for developers
@@ -101,7 +101,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.released'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Referee release failed', [
@@ -140,7 +140,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.retired'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Referee retirement failed', [
@@ -179,7 +179,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.unretired'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Referee unretirement failed', [
@@ -217,7 +217,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.suspended'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Referee suspension failed', [
@@ -255,7 +255,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.reinstated'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Referee reinstatement failed', [
@@ -293,7 +293,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.injured'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Referee injury recording failed', [
@@ -331,7 +331,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.healed'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Referee healing failed', [
@@ -369,7 +369,7 @@ class Actions extends Component
 
             $this->dispatch('referee-updated');
             session()->flash('success', __('referees.actions.restored'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Referee restoration failed', [

--- a/app/Livewire/Wrestlers/Components/Actions.php
+++ b/app/Livewire/Wrestlers/Components/Actions.php
@@ -13,6 +13,7 @@ use App\Actions\Wrestlers\RestoreAction;
 use App\Actions\Wrestlers\RetireAction;
 use App\Actions\Wrestlers\SuspendAction;
 use App\Actions\Wrestlers\UnretireAction;
+use App\Exceptions\BaseBusinessException;
 use App\Models\Wrestlers\Wrestler;
 use App\Services\ErrorMessageMappingService;
 use Illuminate\Contracts\View\View;
@@ -20,7 +21,6 @@ use Illuminate\Support\Facades\Context;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\Log;
 use Livewire\Component;
-use Throwable;
 
 /**
  * Wrestler Actions Component
@@ -62,7 +62,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.employed'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             // Log technical details for developers
@@ -101,7 +101,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.released'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Wrestler release failed', [
@@ -139,7 +139,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.retired'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Wrestler retirement failed', [
@@ -177,7 +177,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.unretired'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Wrestler unretirement failed', [
@@ -214,7 +214,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.suspended'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Wrestler suspension failed', [
@@ -252,7 +252,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.reinstated'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Wrestler reinstatement failed', [
@@ -291,7 +291,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.injured'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Wrestler injury recording failed', [
@@ -328,7 +328,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.healed'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Wrestler healing failed', [
@@ -365,7 +365,7 @@ class Actions extends Component
 
             $this->dispatch('wrestler-updated');
             session()->flash('success', __('wrestlers.actions.restored'));
-        } catch (Throwable $e) {
+        } catch (BaseBusinessException $e) {
             Context::push('action_breadcrumbs', 'action_failed_with_exception');
 
             Log::warning('Wrestler restoration failed', [

--- a/tests/Feature/Livewire/Wrestlers/Components/ActionsTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Components/ActionsTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Actions\Wrestlers\EmployAction;
 use App\Livewire\Wrestlers\Components\Actions;
 use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
+use JMac\Testing\Double;
 
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
@@ -30,5 +32,18 @@ describe('Actions Basic Functionality', function () {
         $component = testLivewire(Actions::class, ['wrestler' => $this->wrestler]);
 
         $component->assertSuccessful();
+    });
+
+    it('does not translate unexpected action failures into business errors', function () {
+        $employAction = Double::for(EmployAction::class);
+        $employAction->expects('handle')
+            ->throws(new LogicException('Unexpected employment failure.'));
+        app()->instance(EmployAction::class, $employAction);
+        $component = testLivewire(Actions::class, ['wrestler' => $this->wrestler]);
+
+        expect(fn () => $component->call('employ'))
+            ->toThrow(LogicException::class, 'Unexpected employment failure.');
+
+        $employAction->verify();
     });
 });

--- a/tests/Integration/Livewire/Managers/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Managers/Components/ActionsTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Actions\Managers\EmployAction;
 use App\Livewire\Managers\Components\Actions;
 use App\Models\Managers\Manager;
 use App\Models\Users\User;
+use JMac\Testing\Double;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
@@ -57,6 +59,20 @@ describe('ManagersActions Integration Tests', function () {
             livewire(Actions::class, ['manager' => $this->manager])
                 ->assertOk();
             expect(true)->toBeTrue();
+        });
+
+        test('unexpected action failures propagate to Laravel', function () {
+            actingAs($this->admin);
+            $employAction = Double::for(EmployAction::class);
+            $employAction->expects('handle')
+                ->throws(new LogicException('Unexpected employment failure.'));
+            app()->instance(EmployAction::class, $employAction);
+            $component = livewire(Actions::class, ['manager' => $this->manager]);
+
+            expect(fn () => $component->call('employ'))
+                ->toThrow(LogicException::class, 'Unexpected employment failure.');
+
+            $employAction->verify();
         });
     });
 

--- a/tests/Integration/Livewire/Referees/Components/ActionsTest.php
+++ b/tests/Integration/Livewire/Referees/Components/ActionsTest.php
@@ -2,9 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Actions\Referees\EmployAction;
 use App\Livewire\Referees\Components\Actions;
 use App\Models\Referees\Referee;
 use App\Models\Users\User;
+use JMac\Testing\Double;
 use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
@@ -57,6 +59,20 @@ describe('RefereesActions Integration Tests', function () {
             livewire(Actions::class, ['referee' => $this->referee])
                 ->assertOk();
             expect(true)->toBeTrue();
+        });
+
+        test('unexpected action failures propagate to Laravel', function () {
+            actingAs($this->admin);
+            $employAction = Double::for(EmployAction::class);
+            $employAction->expects('handle')
+                ->throws(new LogicException('Unexpected employment failure.'));
+            app()->instance(EmployAction::class, $employAction);
+            $component = livewire(Actions::class, ['referee' => $this->referee]);
+
+            expect(fn () => $component->call('employ'))
+                ->toThrow(LogicException::class, 'Unexpected employment failure.');
+
+            $employAction->verify();
         });
     });
 


### PR DESCRIPTION
## Summary
- translate only typed business exceptions into Livewire flash messages
- allow programmer, framework, and infrastructure failures to reach Laravel reporting
- cover shared manager/tag-team handling and wrestler/referee action components
- record the exception boundary in shared Livewire AI rules

## Verification
- 67 focused tests passed with 204 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push reached the existing repository-wide Blade formatter mismatch in unrelated view files; this PR does not modify those files.