### PR TITLE
fix: type Livewire table action errors

### DIFF
--- a/app/Actions/Titles/PullAction.php
+++ b/app/Actions/Titles/PullAction.php
@@ -27,7 +27,7 @@ class PullAction
      * @param  Title  $title  The title to pull
      * @param  Carbon|null  $pullDate  The pull date (defaults to now)
      * @param  string|null  $notes  Optional notes about the pull
-     * @throws CannotBeDeactivatedException When title cannot be pulled due to business rules
+     * @throws CannotBePulledException When title cannot be pulled due to business rules
      */
     public function handle(Title $title, ?Carbon $pullDate = null, ?string $notes = null): void
     {

--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -15,7 +15,6 @@ use App\Livewire\Table\Filters\DateRangeFilter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Gate;
@@ -141,12 +140,8 @@ class Main extends BaseTable
 
         Gate::authorize('restore', $event);
 
-        try {
-            resolve(RestoreAction::class)->handle($event);
-            session()->flash('status', 'Event successfully restored.');
-            $this->redirect(route('events.index'));
-        } catch (Exception $e) {
-            session()->flash('status', $e->getMessage());
-        }
+        resolve(RestoreAction::class)->handle($event);
+        session()->flash('status', 'Event successfully restored.');
+        $this->redirect(route('events.index'));
     }
 }

--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -20,6 +20,7 @@ use App\Exceptions\Roster\Individuals\CannotBeEmployedException;
 use App\Exceptions\Roster\Individuals\CannotBeInjuredException;
 use App\Exceptions\Roster\Individuals\CannotBeReinstatedException;
 use App\Exceptions\Roster\Individuals\CannotBeReleasedException;
+use App\Exceptions\Roster\Individuals\CannotBeRestoredException;
 use App\Exceptions\Roster\Individuals\CannotBeRetiredException;
 use App\Exceptions\Roster\Individuals\CannotBeSuspendedException;
 use App\Exceptions\Roster\Individuals\CannotBeUnretiredException;
@@ -31,7 +32,6 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Managers\Manager;
-use Exception;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Facades\Gate;
 
@@ -209,7 +209,7 @@ class Main extends BaseTable
         try {
             resolve(RestoreAction::class)->handle($manager);
             $this->redirect(request()->header('Referer') ?: route('managers.index'));
-        } catch (Exception $e) {
+        } catch (CannotBeRestoredException $e) {
             session()->flash('error', $e->getMessage());
             $this->redirect(request()->header('Referer') ?: route('managers.index'));
         }

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -20,6 +20,7 @@ use App\Exceptions\Roster\Individuals\CannotBeEmployedException;
 use App\Exceptions\Roster\Individuals\CannotBeInjuredException;
 use App\Exceptions\Roster\Individuals\CannotBeReinstatedException;
 use App\Exceptions\Roster\Individuals\CannotBeReleasedException;
+use App\Exceptions\Roster\Individuals\CannotBeRestoredException;
 use App\Exceptions\Roster\Individuals\CannotBeRetiredException;
 use App\Exceptions\Roster\Individuals\CannotBeSuspendedException;
 use App\Exceptions\Roster\Individuals\CannotBeUnretiredException;
@@ -31,7 +32,6 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Referees\Referee;
-use Exception;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
@@ -226,7 +226,7 @@ class Main extends BaseTable
 
         try {
             resolve(RestoreAction::class)->handle($referee);
-        } catch (Exception $e) {
+        } catch (CannotBeRestoredException $e) {
             return redirect()->back()->with('error', $e->getMessage());
         }
 

--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -10,8 +10,10 @@ use App\Actions\Stables\RestoreAction;
 use App\Actions\Stables\RetireAction;
 use App\Actions\Stables\UnretireAction;
 use App\Builders\Roster\StableBuilder;
+use App\Exceptions\BaseBusinessException;
 use App\Exceptions\Roster\Stables\CannotBeDisbandedException;
 use App\Exceptions\Roster\Stables\CannotBeEstablishedException;
+use App\Exceptions\Roster\Stables\CannotBeRestoredException;
 use App\Exceptions\Roster\Stables\CannotBeRetiredException;
 use App\Exceptions\Roster\Stables\CannotBeUnretiredException;
 use App\Livewire\Base\Tables\BaseTable;
@@ -21,7 +23,6 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Stables\Stable;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 
@@ -144,7 +145,7 @@ class Main extends BaseTable
         try {
             resolve(RestoreAction::class)->handle($stable);
             $this->redirect(request()->header('Referer') ?: route('stables.index'));
-        } catch (Exception $e) {
+        } catch (CannotBeRestoredException $e) {
             session()->flash('error', $e->getMessage());
             $this->redirect(request()->header('Referer') ?: route('stables.index'));
         }
@@ -197,7 +198,7 @@ class Main extends BaseTable
                 'unretire' => resolve(UnretireAction::class)->handle($stable),
                 default => null,
             };
-        } catch (Exception $e) {
+        } catch (BaseBusinessException $e) {
             session()->flash('error', $e->getMessage());
         }
     }

--- a/app/Livewire/TagTeams/Tables/Main.php
+++ b/app/Livewire/TagTeams/Tables/Main.php
@@ -13,12 +13,14 @@ use App\Actions\TagTeams\SuspendAction;
 use App\Actions\TagTeams\UnretireAction;
 use App\Builders\Roster\TagTeamBuilder;
 use App\Enums\Shared\EmploymentStatus;
-use App\Exceptions\Roster\Individuals\CannotBeEmployedException;
-use App\Exceptions\Roster\Individuals\CannotBeReleasedException;
-use App\Exceptions\Roster\Individuals\CannotBeRetiredException;
-use App\Exceptions\Roster\Individuals\CannotBeSuspendedException;
-use App\Exceptions\Roster\Individuals\CannotBeUnretiredException;
+use App\Exceptions\BaseBusinessException;
+use App\Exceptions\Roster\TagTeams\CannotBeEmployedException;
 use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException;
+use App\Exceptions\Roster\TagTeams\CannotBeReleasedException;
+use App\Exceptions\Roster\TagTeams\CannotBeRestoredException;
+use App\Exceptions\Roster\TagTeams\CannotBeRetiredException;
+use App\Exceptions\Roster\TagTeams\CannotBeSuspendedException;
+use App\Exceptions\Roster\TagTeams\CannotBeUnretiredException;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
@@ -26,7 +28,6 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\TagTeams\TagTeam;
-use Exception;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
@@ -167,7 +168,7 @@ class Main extends BaseTable
 
         try {
             resolve(RestoreAction::class)->handle($tagTeam);
-        } catch (Exception $e) {
+        } catch (CannotBeRestoredException $e) {
             return redirect()->back()->with('error', $e->getMessage());
         }
 
@@ -239,7 +240,7 @@ class Main extends BaseTable
                 'unretire' => resolve(UnretireAction::class)->handle($tagTeam),
                 default => null,
             };
-        } catch (Exception $e) {
+        } catch (BaseBusinessException $e) {
             session()->flash('error', $e->getMessage());
         }
     }

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -10,6 +10,10 @@ use App\Actions\Titles\RestoreAction;
 use App\Actions\Titles\RetireAction;
 use App\Actions\Titles\UnretireAction;
 use App\Builders\Titles\TitleBuilder;
+use App\Exceptions\Titles\CannotBeDebutedException;
+use App\Exceptions\Titles\CannotBePulledException;
+use App\Exceptions\Titles\CannotBeRetiredException;
+use App\Exceptions\Titles\CannotBeUnretiredException;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstActivityPeriodColumn;
 use App\Livewire\Components\Tables\Filters\FirstActivityPeriodFilter;
@@ -18,7 +22,6 @@ use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Livewire\Titles\Components\Actions;
 use App\Models\Titles\Title;
-use Exception;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
@@ -209,7 +212,7 @@ class Main extends BaseTable
 
         try {
             resolve(DebutAction::class)->handle($title);
-        } catch (Exception $e) {
+        } catch (CannotBeDebutedException $e) {
             return redirect()->back()->with('error', $e->getMessage());
         }
 
@@ -228,7 +231,7 @@ class Main extends BaseTable
 
         try {
             resolve(PullAction::class)->handle($title);
-        } catch (Exception $e) {
+        } catch (CannotBePulledException $e) {
             return redirect()->back()->with('error', $e->getMessage());
         }
 
@@ -264,7 +267,7 @@ class Main extends BaseTable
 
         try {
             resolve(RetireAction::class)->handle($title);
-        } catch (Exception $e) {
+        } catch (CannotBeRetiredException $e) {
             return redirect()->back()->with('error', $e->getMessage());
         }
 
@@ -283,7 +286,7 @@ class Main extends BaseTable
 
         try {
             resolve(UnretireAction::class)->handle($title);
-        } catch (Exception $e) {
+        } catch (CannotBeUnretiredException $e) {
             return redirect()->back()->with('error', $e->getMessage());
         }
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -7,12 +7,6 @@ parameters:
 			path: app/Actions/Matches/AddMatchForEventAction.php
 
 		-
-			message: '#^PHPDoc tag @throws with type App\\Actions\\Titles\\CannotBeDeactivatedException is not subtype of Throwable$#'
-			identifier: throws.notThrowable
-			count: 1
-			path: app/Actions/Titles/PullAction.php
-
-		-
 			message: '#^Parameter \#1 \$callback of method Illuminate\\Database\\Eloquent\\Collection\<int,App\\Models\\Matches\\MatchCompetitor\>\:\:map\(\) expects callable\(App\\Models\\Matches\\MatchCompetitor, int\)\: Illuminate\\Support\\Collection\<int, App\\Models\\TagTeams\\TagTeam\|App\\Models\\Wrestlers\\Wrestler\>, Closure\(App\\Collections\\MatchCompetitorsCollection\)\: Illuminate\\Support\\Collection\<int, App\\Models\\TagTeams\\TagTeam\|App\\Models\\Wrestlers\\Wrestler\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/Feature/Architecture/ExceptionArchitectureTest.php
+++ b/tests/Feature/Architecture/ExceptionArchitectureTest.php
@@ -3,6 +3,11 @@
 declare(strict_types=1);
 
 use App\Exceptions\BaseBusinessException;
+use PhpParser\Node\Stmt\Catch_;
+use PhpParser\NodeFinder;
+use PhpParser\NodeTraverser;
+use PhpParser\NodeVisitor\NameResolver;
+use PhpParser\ParserFactory;
 
 arch('business exceptions use the shared exception foundation')
     ->expect('App\Exceptions')
@@ -67,12 +72,36 @@ test('application code does not directly construct generic exceptions', function
 });
 
 test('Livewire table actions do not catch generic exception types', function () {
+    $genericCatchTypes = function (string $contents): array {
+        $statements = (new ParserFactory())->createForNewestSupportedVersion()->parse($contents);
+        $resolvedStatements = (new NodeTraverser(new NameResolver()))->traverse($statements ?? []);
+        $catchClauses = (new NodeFinder())->findInstanceOf($resolvedStatements, Catch_::class);
+
+        return collect($catchClauses)
+            ->flatMap(fn (Catch_ $catchClause): array => $catchClause->types)
+            ->map(fn ($type): string => $type->toString())
+            ->intersect([Exception::class, Throwable::class])
+            ->values()
+            ->all();
+    };
+
+    expect($genericCatchTypes(<<<'PHP'
+        <?php
+
+        use Exception as GenericException;
+
+        try {
+            // Execute an operation.
+        } catch (GenericException) {
+            // Handle the exception.
+        }
+        PHP))->toBe([Exception::class]);
+
     $violations = collect(glob(app_path('Livewire/*/Tables/Main.php')) ?: [])
-        ->filter(function (string $filename): bool {
+        ->filter(function (string $filename) use ($genericCatchTypes): bool {
             $contents = file_get_contents($filename);
 
-            return $contents !== false
-                && preg_match('/catch\s*\(\s*(?:\\\\?Exception|\\\\?Throwable)\b/', $contents) === 1;
+            return $contents !== false && $genericCatchTypes($contents) !== [];
         })
         ->map(fn (string $filename): string => str($filename)->after(app_path().DIRECTORY_SEPARATOR)->toString())
         ->values()

--- a/tests/Feature/Architecture/ExceptionArchitectureTest.php
+++ b/tests/Feature/Architecture/ExceptionArchitectureTest.php
@@ -65,3 +65,18 @@ test('application code does not directly construct generic exceptions', function
 
     expect($violations)->toBeEmpty();
 });
+
+test('Livewire table actions do not catch generic exception types', function () {
+    $violations = collect(glob(app_path('Livewire/*/Tables/Main.php')) ?: [])
+        ->filter(function (string $filename): bool {
+            $contents = file_get_contents($filename);
+
+            return $contents !== false
+                && preg_match('/catch\s*\(\s*(?:\\\\?Exception|\\\\?Throwable)\b/', $contents) === 1;
+        })
+        ->map(fn (string $filename): string => str($filename)->after(app_path().DIRECTORY_SEPARATOR)->toString())
+        ->values()
+        ->all();
+
+    expect($violations)->toBeEmpty();
+});


### PR DESCRIPTION
## Summary
- catch exact domain exceptions for fixed Livewire table actions
- use the shared business-exception boundary only for dynamic action dispatchers
- correct tag-team tables to catch tag-team exceptions rather than individual exceptions
- let event restoration infrastructure failures propagate normally
- fix the title pull @throws contract and remove its obsolete PHPStan baseline entry
- add architecture enforcement against generic catches in table action components

## Verification
- 162 focused tests passed with 403 assertions
- full application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push reached the existing repository-wide Blade formatter mismatch in unrelated view files; this PR does not modify those files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for restore and other table actions by using more specific business errors.
  * Preserved clear error messages and redirects where applicable.
  * Unhandled restoration errors now propagate correctly in event tables.

* **Tests**
  * Added automated checks to prevent overly broad exception handling in table actions.

* **Maintenance**
  * Updated error documentation and removed an obsolete static-analysis exception.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->