### PR TITLE
fix: map tag team business errors

### DIFF
--- a/app/Exceptions/Roster/TagTeams/CannotBeEmployedException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeEmployedException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
 
@@ -13,14 +14,14 @@ final class CannotBeEmployedException extends BaseBusinessException
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} is already employed.");
+        return self::forReason(BusinessRuleReason::AlreadyEmployed, "{$context} is already employed.");
     }
 
     public static function retired(TagTeam $tagTeam): static
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} is retired and cannot be employed. Consider unretirement first.");
+        return self::forReason(BusinessRuleReason::Retired, "{$context} is retired and cannot be employed. Consider unretirement first.");
     }
 
     public static function partnersUnavailable(TagTeam $tagTeam, string $unavailablePartners): static

--- a/app/Exceptions/Roster/TagTeams/CannotBeReleasedException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeReleasedException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
 
@@ -13,6 +14,6 @@ final class CannotBeReleasedException extends BaseBusinessException
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} cannot be released because it is not currently employed. Only employed tag teams can be released from their contracts.");
+        return self::forReason(BusinessRuleReason::Unemployed, "{$context} cannot be released because it is not currently employed. Only employed tag teams can be released from their contracts.");
     }
 }

--- a/app/Exceptions/Roster/TagTeams/CannotBeRestoredException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeRestoredException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
 
@@ -13,7 +14,7 @@ final class CannotBeRestoredException extends BaseBusinessException
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} cannot be restored because it is not deleted. Only soft-deleted tag teams can be restored to active status.");
+        return self::forReason(BusinessRuleReason::NotDeleted, "{$context} cannot be restored because it is not deleted. Only soft-deleted tag teams can be restored to active status.");
     }
 
     public static function nameConflict(TagTeam $tagTeam, string $conflictingName): static

--- a/app/Exceptions/Roster/TagTeams/CannotBeRetiredException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeRetiredException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
 
@@ -13,13 +14,13 @@ final class CannotBeRetiredException extends BaseBusinessException
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} is not currently employed and cannot be retired.");
+        return self::forReason(BusinessRuleReason::Unemployed, "{$context} is not currently employed and cannot be retired.");
     }
 
     public static function alreadyRetired(TagTeam $tagTeam): static
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} is already retired.");
+        return self::forReason(BusinessRuleReason::AlreadyRetired, "{$context} is already retired.");
     }
 }

--- a/app/Exceptions/Roster/TagTeams/CannotBeSuspendedException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeSuspendedException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
 
@@ -13,13 +14,13 @@ final class CannotBeSuspendedException extends BaseBusinessException
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} cannot be suspended because it is not currently employed. Only employed tag teams can be suspended from active competition.");
+        return self::forReason(BusinessRuleReason::Unemployed, "{$context} cannot be suspended because it is not currently employed. Only employed tag teams can be suspended from active competition.");
     }
 
     public static function alreadySuspended(TagTeam $tagTeam): static
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new static("{$context} cannot be suspended because it is already suspended. Review current suspension status or consider reinstatement before applying new disciplinary measures.");
+        return self::forReason(BusinessRuleReason::AlreadySuspended, "{$context} cannot be suspended because it is already suspended. Review current suspension status or consider reinstatement before applying new disciplinary measures.");
     }
 }

--- a/app/Exceptions/Roster/TagTeams/CannotBeUnretiredException.php
+++ b/app/Exceptions/Roster/TagTeams/CannotBeUnretiredException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Roster\TagTeams;
 
+use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
 use App\Models\TagTeams\TagTeam;
 
@@ -13,7 +14,7 @@ final class CannotBeUnretiredException extends BaseBusinessException
     {
         $context = self::formatModelContext($tagTeam);
 
-        return new self("{$context} is not retired and cannot be unretired.");
+        return self::forReason(BusinessRuleReason::NotRetired, "{$context} is not retired and cannot be unretired.");
     }
 
     public static function nameConflict(TagTeam $tagTeam, string $conflictingTeamName): static

--- a/app/Services/ErrorMessageMappingService.php
+++ b/app/Services/ErrorMessageMappingService.php
@@ -15,7 +15,13 @@ use App\Exceptions\Roster\Individuals\CannotBeRestoredException;
 use App\Exceptions\Roster\Individuals\CannotBeRetiredException;
 use App\Exceptions\Roster\Individuals\CannotBeSuspendedException;
 use App\Exceptions\Roster\Individuals\CannotBeUnretiredException;
+use App\Exceptions\Roster\TagTeams\CannotBeEmployedException as TagTeamCannotBeEmployedException;
 use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException as TagTeamCannotBeReinstatedException;
+use App\Exceptions\Roster\TagTeams\CannotBeReleasedException as TagTeamCannotBeReleasedException;
+use App\Exceptions\Roster\TagTeams\CannotBeRestoredException as TagTeamCannotBeRestoredException;
+use App\Exceptions\Roster\TagTeams\CannotBeRetiredException as TagTeamCannotBeRetiredException;
+use App\Exceptions\Roster\TagTeams\CannotBeSuspendedException as TagTeamCannotBeSuspendedException;
+use App\Exceptions\Roster\TagTeams\CannotBeUnretiredException as TagTeamCannotBeUnretiredException;
 use Throwable;
 
 final class ErrorMessageMappingService
@@ -47,16 +53,22 @@ final class ErrorMessageMappingService
             : BusinessRuleReason::General;
 
         $key = match ($exception::class) {
-            CannotBeEmployedException::class => self::employmentKey($reason, $entity),
-            CannotBeReleasedException::class => self::releaseKey($reason, $entity),
-            CannotBeRetiredException::class => self::retirementKey($reason, $entity),
-            CannotBeUnretiredException::class => self::unretirementKey($reason),
-            CannotBeSuspendedException::class => self::suspensionKey($reason, $entity),
+            CannotBeEmployedException::class,
+            TagTeamCannotBeEmployedException::class => self::employmentKey($reason, $entity),
+            CannotBeReleasedException::class,
+            TagTeamCannotBeReleasedException::class => self::releaseKey($reason, $entity),
+            CannotBeRetiredException::class,
+            TagTeamCannotBeRetiredException::class => self::retirementKey($reason, $entity),
+            CannotBeUnretiredException::class,
+            TagTeamCannotBeUnretiredException::class => self::unretirementKey($reason),
+            CannotBeSuspendedException::class,
+            TagTeamCannotBeSuspendedException::class => self::suspensionKey($reason, $entity),
             CannotBeReinstatedException::class,
             TagTeamCannotBeReinstatedException::class => self::reinstatementKey($reason),
             CannotBeInjuredException::class => self::injuryKey($reason, $entity),
             CannotBeClearedFromInjuryException::class => self::healingKey($reason),
-            CannotBeRestoredException::class => self::restorationKey($reason),
+            CannotBeRestoredException::class,
+            TagTeamCannotBeRestoredException::class => self::restorationKey($reason),
             default => 'general_error',
         };
 

--- a/tests/Unit/Services/ErrorMessageMappingServiceTest.php
+++ b/tests/Unit/Services/ErrorMessageMappingServiceTest.php
@@ -9,7 +9,13 @@ use App\Exceptions\Roster\Individuals\CannotBeInjuredException;
 use App\Exceptions\Roster\Individuals\CannotBeReinstatedException;
 use App\Exceptions\Roster\Individuals\CannotBeRestoredException;
 use App\Exceptions\Roster\Individuals\CannotBeSuspendedException;
+use App\Exceptions\Roster\TagTeams\CannotBeEmployedException as TagTeamCannotBeEmployedException;
 use App\Exceptions\Roster\TagTeams\CannotBeReinstatedException as TagTeamCannotBeReinstatedException;
+use App\Exceptions\Roster\TagTeams\CannotBeReleasedException as TagTeamCannotBeReleasedException;
+use App\Exceptions\Roster\TagTeams\CannotBeRestoredException as TagTeamCannotBeRestoredException;
+use App\Exceptions\Roster\TagTeams\CannotBeRetiredException as TagTeamCannotBeRetiredException;
+use App\Exceptions\Roster\TagTeams\CannotBeSuspendedException as TagTeamCannotBeSuspendedException;
+use App\Exceptions\Roster\TagTeams\CannotBeUnretiredException as TagTeamCannotBeUnretiredException;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use App\Services\ErrorMessageMappingService;
@@ -69,6 +75,29 @@ test('it maps tag team reinstatement failures from a stable reason', function ()
     expect($exception->reason())->toBe(BusinessRuleReason::NotSuspended)
         ->and(ErrorMessageMappingService::mapTagTeamException($exception))
         ->toBe('tag-teams.errors.not_suspended');
+});
+
+test('it maps tag team lifecycle failures from stable reasons', function () {
+    $tagTeam = new TagTeam(['name' => 'Test Team']);
+
+    expect(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeEmployedException::alreadyEmployed($tagTeam)))
+        ->toBe('tag-teams.errors.already_employed')
+        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeEmployedException::retired($tagTeam)))
+        ->toBe('tag-teams.errors.cannot_employ_retired')
+        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeReleasedException::notEmployed($tagTeam)))
+        ->toBe('tag-teams.errors.not_employed')
+        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeRetiredException::notEmployed($tagTeam)))
+        ->toBe('tag-teams.errors.cannot_retire_unemployed')
+        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeRetiredException::alreadyRetired($tagTeam)))
+        ->toBe('tag-teams.errors.already_retired')
+        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeUnretiredException::notRetired($tagTeam)))
+        ->toBe('tag-teams.errors.not_retired')
+        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeSuspendedException::notEmployed($tagTeam)))
+        ->toBe('tag-teams.errors.not_employed_suspend')
+        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeSuspendedException::alreadySuspended($tagTeam)))
+        ->toBe('tag-teams.errors.already_suspended')
+        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeRestoredException::notDeleted($tagTeam)))
+        ->toBe('tag-teams.errors.not_deleted');
 });
 
 test('it uses a general message for unknown exceptions', function () {


### PR DESCRIPTION
## Summary
- map every tag-team lifecycle exception class to its existing localized presentation key
- attach stable business-rule reasons to tag-team failures whose UI treatment differs
- cover tag-team employment, release, retirement, suspension, and restoration mappings

## Verification
- 7 focused tests passed with 26 assertions
- full application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff checks passed

## Repository-wide note
- composer test:push reached the existing unrelated Blade formatting backlog after type coverage and Rector passed
- the standalone full parallel Pest run was stopped after producing no output for more than three minutes; the PR application-test workflow remains the bounded full-suite gate