### PR TITLE
refactor: propagate Livewire base errors

### DIFF
--- a/app/Livewire/Base/BaseForm.php
+++ b/app/Livewire/Base/BaseForm.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Livewire\Base;
 
-use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
 use Livewire\Form;
@@ -300,15 +299,9 @@ abstract class BaseForm extends Form
             return 'Unknown';
         }
 
-        // Try to access the field (handles both properties and accessors)
-        try {
-            $value = $this->formModel->{$fieldName};
+        $value = $this->formModel->{$fieldName};
 
-            return (string) ($value ?? 'Unknown');
-        } catch (Exception) {
-            // Fallback for non-existent fields or other errors
-            return 'Unknown';
-        }
+        return (string) ($value ?? 'Unknown');
     }
 
     /**
@@ -499,7 +492,6 @@ abstract class BaseForm extends Form
      * - Maintains the existing model reference
      *
      *
-     * @throws Exception If model creation or update fails
      * @return bool True if the model was successfully saved, false otherwise
      *
      * @see getModelData() For data transformation requirements

--- a/app/Livewire/Base/BaseForm.php
+++ b/app/Livewire/Base/BaseForm.php
@@ -259,12 +259,12 @@ abstract class BaseForm extends Form
      *
      * The method provides several layers of safety:
      * 1. Checks if the model exists (handles creation mode gracefully)
-     * 2. Verifies the requested field exists on the model
+     * 2. Accesses the requested field directly so field access failures propagate
      * 3. Handles null field values with appropriate fallbacks
      * 4. Converts values to strings for display purposes
      *
      * @param  string  $fieldName  The name of the model field to extract
-     * @return string The field value as a string, or 'Unknown' if unavailable
+     * @return string The field value as a string, or 'Unknown' when the model or value is null
      *
      * @example
      * ```php

--- a/app/Livewire/Base/BaseModal.php
+++ b/app/Livewire/Base/BaseModal.php
@@ -4,9 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Base;
 
-use Exception;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Log;
 use Illuminate\View\View;
 use LivewireUI\Modal\ModalComponent;
 
@@ -71,13 +69,9 @@ abstract class BaseModal extends ModalComponent
     public function mount(int|string|null $modelId = null): void
     {
         if ($modelId !== null) {
-            try {
-                $id = is_numeric($modelId) ? (int) $modelId : $modelId;
-                $this->model = $this->modelType::findOrFail($id);
-                $this->modelForm->setModel($this->model);
-            } catch (Exception $e) {
-                Log::error($e->getMessage());
-            }
+            $id = is_numeric($modelId) ? (int) $modelId : $modelId;
+            $this->model = $this->modelType::findOrFail($id);
+            $this->modelForm->setModel($this->model);
         } else {
             // Reset to create mode
             $this->model = null;

--- a/tests/Integration/Livewire/Venues/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Venues/Modals/FormModalTest.php
@@ -2,10 +2,14 @@
 
 declare(strict_types=1);
 
+use App\Livewire\Venues\Forms\CreateEditForm;
 use App\Livewire\Venues\Modals\FormModal;
 use App\Models\Events\Venue;
 use App\Models\Shared\State;
 use App\Models\Users\User;
+use Illuminate\Database\Eloquent\MissingAttributeException;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 use function Pest\Livewire\livewire;
 
@@ -70,6 +74,25 @@ describe('Form Modal Initialization', function () {
 });
 
 describe('Form Modal Editing', function () {
+    it('propagates a missing model failure', function () {
+        expect(fn () => livewire(FormModal::class)->call('openModal', PHP_INT_MAX))
+            ->toThrow(ModelNotFoundException::class);
+    });
+
+    it('propagates a misconfigured model title field', function () {
+        $venue = Venue::factory()->create();
+        $form = new CreateEditForm(livewire(FormModal::class)->instance(), 'form');
+        $form->setModel(Venue::query()->findOrFail($venue->id));
+        Model::preventAccessingMissingAttributes();
+
+        try {
+            expect(fn () => $form->generateModelEditName('missing_title_field'))
+                ->toThrow(MissingAttributeException::class);
+        } finally {
+            Model::preventAccessingMissingAttributes(false);
+        }
+    });
+
     it('can load existing venue for editing', function () {
         $venue = Venue::factory()->create([
             'name' => 'Madison Square Garden',

--- a/tests/Unit/Livewire/Concerns/BaseModalTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseModalTest.php
@@ -183,11 +183,10 @@ describe('BaseModal Unit Tests', function () {
             $source = reflectionSource($reflection);
 
             // Check for actual imports in BaseModal
-            expect($source)->toContain('use Exception;');
             expect($source)->toContain('use Illuminate\\Database\\Eloquent\\Model;');
-            expect($source)->toContain('use Illuminate\\Support\\Facades\\Log;');
             expect($source)->toContain('use Illuminate\\View\\View;');
             expect($source)->toContain('use LivewireUI\\Modal\\ModalComponent;');
+            expect($source)->not->toContain('catch (Exception');
         });
     });
 

--- a/tests/Unit/Livewire/Concerns/BaseModalTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseModalTest.php
@@ -186,7 +186,6 @@ describe('BaseModal Unit Tests', function () {
             expect($source)->toContain('use Illuminate\\Database\\Eloquent\\Model;');
             expect($source)->toContain('use Illuminate\\View\\View;');
             expect($source)->toContain('use LivewireUI\\Modal\\ModalComponent;');
-            expect($source)->not->toContain('catch (Exception');
         });
     });
 


### PR DESCRIPTION
## Summary
- let missing modal models propagate through Laravel instead of logging and continuing with partial state
- let invalid or failing model title accessors surface as configuration/programmer failures
- remove the stale generic exception contract from BaseForm persistence
- cover missing records and misconfigured title fields with Livewire regression tests

## Verification
- 55 focused tests passed with 185 assertions
- full application and Pest PHPStan passed
- Rector passed
- touched files passed Pint with Blade formatting
- git diff checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Errors encountered while loading models or accessing missing fields are now surfaced directly instead of being silently converted or logged.
  * Improved error transparency when editing records that no longer exist or have unavailable attributes.

* **Tests**
  * Added coverage for missing-record and missing-attribute scenarios.
  * Updated validation to reflect the improved error-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->