### PR TITLE
refactor: expose dummy data configuration errors

### DIFF
--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Concerns;
 
 use DateTime;
-use Throwable;
+use LogicException;
 
 /**
  * Trait for generating dummy data in Livewire forms and modals.
@@ -83,88 +83,19 @@ trait GeneratesDummyData
      */
     private function populateField(string $field, mixed $value): void
     {
-        // Strategy 1: Try modelForm property (for some form patterns)
-        if ($this->tryPopulateModelForm($field, $value)) {
+        if (isset($this->form) && property_exists($this->form, $field)) {
+            $this->form->{$field} = $value;
+
             return;
         }
 
-        // Strategy 2: Try direct property assignment
-        if ($this->tryPopulateDirectProperty($field, $value)) {
+        if (property_exists($this, $field)) {
+            $this->{$field} = $value;
+
             return;
         }
 
-        // Strategy 3: Try form property (for BaseFormModal pattern)
-        if ($this->tryPopulateFormProperty($field, $value)) {
-            return;
-        }
-
-        // If none work, silently skip (graceful degradation)
-    }
-
-    /**
-     * Try to populate via modelForm property.
-     *
-     * @param  string  $field  Field name
-     * @param  mixed  $value  Value to set
-     * @return bool True if successful
-     */
-    private function tryPopulateModelForm(string $field, mixed $value): bool
-    {
-        try {
-            if (isset($this->modelForm)) {
-                $this->modelForm->{$field} = $value;
-
-                return true;
-            }
-        } catch (Throwable) {
-            // Ignore and try next strategy
-        }
-
-        return false;
-    }
-
-    /**
-     * Try to populate via direct property.
-     *
-     * @param  string  $field  Field name
-     * @param  mixed  $value  Value to set
-     * @return bool True if successful
-     */
-    private function tryPopulateDirectProperty(string $field, mixed $value): bool
-    {
-        try {
-            if (property_exists($this, $field)) {
-                $this->{$field} = $value;
-
-                return true;
-            }
-        } catch (Throwable) {
-            // Ignore and try next strategy
-        }
-
-        return false;
-    }
-
-    /**
-     * Try to populate via form property (BaseFormModal pattern).
-     *
-     * @param  string  $field  Field name
-     * @param  mixed  $value  Value to set
-     * @return bool True if successful
-     */
-    private function tryPopulateFormProperty(string $field, mixed $value): bool
-    {
-        try {
-            if (isset($this->form)) {
-                $this->form->{$field} = $value;
-
-                return true;
-            }
-        } catch (Throwable) {
-            // Ignore - no more strategies
-        }
-
-        return false;
+        throw new LogicException("Dummy data field [{$field}] is not defined on the form or component.");
     }
 
     /**
@@ -408,7 +339,7 @@ trait GeneratesDummyData
      * ```php
      * // Common usage in FormModal getDummyDataFields()
      * 'start_date' => fn () => $this->generateOptionalStartDate(),
-     * 'employment_date' => fn () => $this->generateOptionalStartDate('Y-m-d', 0.7),
+     * 'employment_date' => fn () => $this->generateOptionalEmploymentDate(0.7),
      * ```
      */
     protected function generateOptionalStartDate(
@@ -423,5 +354,13 @@ trait GeneratesDummyData
         }
 
         return null;
+    }
+
+    /**
+     * Generate an optional date for an employment field.
+     */
+    protected function generateOptionalEmploymentDate(float $probability = 0.8): ?string
+    {
+        return $this->generateOptionalStartDate('Y-m-d', $probability);
     }
 }

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -48,7 +48,7 @@ class FormModal extends BaseFormModal
         return [
             'first_name' => fn () => fake()->firstName(),
             'last_name' => fn () => fake()->lastName(),
-            'start_date' => fn () => $this->generateOptionalStartDate(),
+            'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
         ];
     }
 

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -46,7 +46,7 @@ class FormModal extends BaseFormModal
         return [
             'first_name' => fn () => fake()->firstName(),
             'last_name' => fn () => fake()->lastName(),
-            'employment_date' => fn () => $this->generateOptionalStartDate(),
+            'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
         ];
     }
 

--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -61,7 +61,7 @@ class FormModal extends BaseFormModal
         return [
             'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
             'signature_move' => fn () => Str::of(fake()->optional(0.8)->sentence(3))->title()->value(),
-            'start_date' => fn () => $this->generateOptionalStartDate(),
+            'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
             'wrestlerA' => fn () => $wrestlerA->id,
             'wrestlerB' => fn () => $wrestlerB->id,
         ];

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -41,8 +41,7 @@ class FormModal extends BaseFormModal
         return [
             'name' => fn () => Str::of(fake()->words(2, true))->title()->append(' Title')->value(),
             'type' => fn () => fake()->randomElement(['singles', 'tag-team']),
-            'introduction' => fn () => fake()->optional(0.8)->paragraphs(2, true),
-            'active_at' => fn () => $this->generateOptionalStartDate('Y-m-d H:i:s', 0.6, '-1 year', 'now'),
+            'start_date' => fn () => $this->generateOptionalStartDate('Y-m-d', 0.6, '-1 year', 'now'),
         ];
     }
 

--- a/app/Livewire/Wrestlers/Modals/FormModal.php
+++ b/app/Livewire/Wrestlers/Modals/FormModal.php
@@ -44,7 +44,7 @@ class FormModal extends BaseFormModal
             'height_inches' => fn () => fake()->numberBetween(0, 11),
             'weight' => fn () => fake()->numberBetween(180, 350),
             'signature_move' => fn () => Str::of(fake()->optional(0.8)->sentence(3))->title()->value(),
-            'employment_date' => fn () => $this->generateOptionalStartDate(),
+            'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
         ];
     }
 

--- a/tests/Feature/Architecture/ExceptionArchitectureTest.php
+++ b/tests/Feature/Architecture/ExceptionArchitectureTest.php
@@ -71,7 +71,7 @@ test('application code does not directly construct generic exceptions', function
     expect($violations)->toBeEmpty();
 });
 
-test('Livewire table actions do not catch generic exception types', function () {
+test('Livewire components do not catch generic exception types', function () {
     $genericCatchTypes = function (string $contents): array {
         $statements = (new ParserFactory())->createForNewestSupportedVersion()->parse($contents);
         $resolvedStatements = (new NodeTraverser(new NameResolver()))->traverse($statements ?? []);
@@ -97,15 +97,22 @@ test('Livewire table actions do not catch generic exception types', function () 
         }
         PHP))->toBe([Exception::class]);
 
-    $violations = collect(glob(app_path('Livewire/*/Tables/Main.php')) ?: [])
-        ->filter(function (string $filename) use ($genericCatchTypes): bool {
-            $contents = file_get_contents($filename);
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator(app_path('Livewire'), FilesystemIterator::SKIP_DOTS)
+    );
+    $violations = [];
 
-            return $contents !== false && $genericCatchTypes($contents) !== [];
-        })
-        ->map(fn (string $filename): string => str($filename)->after(app_path().DIRECTORY_SEPARATOR)->toString())
-        ->values()
-        ->all();
+    foreach ($files as $file) {
+        if (! $file instanceof SplFileInfo || ! $file->isFile() || $file->getExtension() !== 'php') {
+            continue;
+        }
+
+        $contents = file_get_contents($file->getPathname());
+
+        if ($contents !== false && $genericCatchTypes($contents) !== []) {
+            $violations[] = str($file->getPathname())->after(app_path().DIRECTORY_SEPARATOR)->toString();
+        }
+    }
 
     expect($violations)->toBeEmpty();
 });

--- a/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
+++ b/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
@@ -72,30 +72,6 @@ describe('GeneratesDummyData Unit Tests', function () {
             expect(reflectionTypeName($parameters[1]))->toBe('mixed');
         });
 
-        test('has strategy methods', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            $strategyMethods = [
-                'tryPopulateModelForm',
-                'tryPopulateDirectProperty',
-                'tryPopulateFormProperty',
-            ];
-
-            foreach ($strategyMethods as $methodName) {
-                expect($reflection->hasMethod($methodName))->toBeTrue();
-
-                $method = $reflection->getMethod($methodName);
-                expect($method->isPrivate())->toBeTrue();
-                expect(reflectionReturnTypeName($method))->toBe('bool');
-                expect($method->getNumberOfParameters())->toBe(2);
-
-                $parameters = $method->getParameters();
-                expect($parameters[0]->getName())->toBe('field');
-                expect(reflectionTypeName($parameters[0]))->toBe('string');
-                expect($parameters[1]->getName())->toBe('value');
-                expect(reflectionTypeName($parameters[1]))->toBe('mixed');
-            }
-        });
     });
 
     describe('protected generator method signatures', function () {
@@ -179,11 +155,11 @@ describe('GeneratesDummyData Unit Tests', function () {
     });
 
     describe('dependency imports', function () {
-        test('imports Throwable', function () {
+        test('imports LogicException', function () {
             $reflection = new ReflectionClass(GeneratesDummyData::class);
             $source = reflectionSource($reflection);
 
-            expect($source)->toContain('use Throwable;');
+            expect($source)->toContain('use LogicException;');
         });
     });
 
@@ -246,7 +222,7 @@ describe('GeneratesDummyData Unit Tests', function () {
 
             expect($publicMethods)->toHaveCount(1); // fillDummyFields
             expect(count($protectedMethods))->toBeGreaterThan(5); // generators + abstract
-            expect(count($privateMethods))->toBeGreaterThan(3); // population strategies
+            expect($privateMethods)->toHaveCount(1); // populateField
         });
 
         test('has no properties', function () {
@@ -260,24 +236,76 @@ describe('GeneratesDummyData Unit Tests', function () {
         });
     });
 
-    describe('population strategy pattern', function () {
-        test('implements multiple population strategies', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $source = reflectionSource($reflection);
+    describe('field population', function () {
+        test('populates fields directly on a form', function () {
+            $form = new class
+            {
+                use GeneratesDummyData;
 
-            // Check for strategy pattern implementation
-            expect($source)->toContain('tryPopulateModelForm');
-            expect($source)->toContain('tryPopulateDirectProperty');
-            expect($source)->toContain('tryPopulateFormProperty');
+                public string $name = '';
+
+                protected function getDummyDataFields(): array
+                {
+                    return ['name' => 'Test Name'];
+                }
+            };
+
+            $form->fillDummyFields();
+
+            expect($form->name)->toBe('Test Name');
         });
 
-        test('uses graceful degradation', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $source = reflectionSource($reflection);
+        test('populates fields on a nested form object', function () {
+            $nestedForm = new class
+            {
+                public string $name = '';
+            };
+            $component = new class($nestedForm)
+            {
+                use GeneratesDummyData;
 
-            // Check for graceful failure handling
-            expect($source)->toContain('// If none work, silently skip');
-            expect($source)->toContain('catch (Throwable)');
+                public function __construct(public object $form) {}
+
+                protected function getDummyDataFields(): array
+                {
+                    return ['name' => 'Test Name'];
+                }
+            };
+
+            $component->fillDummyFields();
+
+            expect($nestedForm->name)->toBe('Test Name');
+        });
+
+        test('propagates invalid field configuration', function () {
+            $form = new class
+            {
+                use GeneratesDummyData;
+
+                protected function getDummyDataFields(): array
+                {
+                    return ['missing' => 'Test Name'];
+                }
+            };
+
+            expect(fn () => $form->fillDummyFields())
+                ->toThrow(LogicException::class, 'Dummy data field [missing] is not defined');
+        });
+
+        test('propagates invalid generated value types', function () {
+            $form = new class
+            {
+                use GeneratesDummyData;
+
+                public int $count = 0;
+
+                protected function getDummyDataFields(): array
+                {
+                    return ['count' => 'invalid'];
+                }
+            };
+
+            expect(fn () => $form->fillDummyFields())->toThrow(TypeError::class);
         });
     });
 


### PR DESCRIPTION
## Summary
- replace catch-and-fallback dummy field assignment with explicit form/component field resolution
- surface misspelled dummy fields as LogicException and preserve type errors instead of silently skipping them
- add generateOptionalEmploymentDate and correct Manager/TagTeam dummy keys to employment_date
- enforce parser-based generic-catch prohibition across the entire Livewire layer

## Verification
- 167 focused tests passed with 514 assertions
- full application and Pest PHPStan passed
- Rector passed
- touched files passed Pint with Blade formatting
- git diff checks passed