### PR TITLE
docs: align related model error contracts

### DIFF
--- a/app/Models/Concerns/HasActivityPeriods.php
+++ b/app/Models/Concerns/HasActivityPeriods.php
@@ -11,7 +11,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
-use RuntimeException;
+use LogicException;
 
 /**
  * @template TActivityPeriod of Model The activity period model class (e.g., TitleActivityPeriod)
@@ -204,7 +204,7 @@ trait HasActivityPeriods
     }
 
     /**
-     * @throws RuntimeException
+     * @throws LogicException
      * @return class-string<TActivityPeriod>
      */
     protected function resolveActivityPeriodModelClass(): string

--- a/app/Models/Concerns/HasStatusHistory.php
+++ b/app/Models/Concerns/HasStatusHistory.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
-use RuntimeException;
+use LogicException;
 
 /**
  * @template TStatusChange of Model The status change model class (e.g., TitleStatusChange)
@@ -102,7 +102,7 @@ trait HasStatusHistory
     }
 
     /**
-     * @throws RuntimeException
+     * @throws LogicException
      * @return class-string<TStatusChange>
      */
     protected function resolveStatusChangeModelClass(): string

--- a/app/Models/Concerns/IsEmployable.php
+++ b/app/Models/Concerns/IsEmployable.php
@@ -10,7 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Support\Carbon;
-use RuntimeException;
+use LogicException;
 
 /**
  * Adds employment-related behavior to a model.
@@ -418,7 +418,7 @@ trait IsEmployable
      * conventions. For example, if the parent model is 'Wrestler', it will look for
      * a 'WrestlerEmployment' model class.
      *
-     * @throws RuntimeException If the resolved model class doesn't exist
+     * @throws LogicException If the resolved model class doesn't exist
      * @return class-string<TEmployment> The fully qualified class name of the employment model
      *
      * @example

--- a/app/Models/Concerns/IsInjurable.php
+++ b/app/Models/Concerns/IsInjurable.php
@@ -8,7 +8,7 @@ use App\Models\Contracts\Injurable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use RuntimeException;
+use LogicException;
 
 /**
  * Adds injury-related behavior to a model.
@@ -198,7 +198,7 @@ trait IsInjurable
      * conventions. For example, if the parent model is 'Wrestler', it will look for
      * a 'WrestlerInjury' model class.
      *
-     * @throws RuntimeException If the resolved model class doesn't exist
+     * @throws LogicException If the resolved model class doesn't exist
      * @return class-string<TInjury> The fully qualified class name of the injury model
      *
      * @example

--- a/app/Models/Concerns/IsRetirable.php
+++ b/app/Models/Concerns/IsRetirable.php
@@ -8,7 +8,7 @@ use App\Models\Contracts\Retirable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use RuntimeException;
+use LogicException;
 
 /**
  * Adds retirement-related behavior to a model.
@@ -198,7 +198,7 @@ trait IsRetirable
      * conventions. For example, if the parent model is 'Wrestler', it will look for
      * a 'WrestlerRetirement' model class.
      *
-     * @throws RuntimeException If the resolved model class doesn't exist
+     * @throws LogicException If the resolved model class doesn't exist
      * @return class-string<TRetirement> The fully qualified class name of the retirement model
      *
      * @example

--- a/app/Models/Concerns/IsSuspendable.php
+++ b/app/Models/Concerns/IsSuspendable.php
@@ -8,7 +8,7 @@ use App\Models\Contracts\Suspendable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
-use RuntimeException;
+use LogicException;
 
 /**
  * Adds suspension-related behavior to a model.
@@ -198,7 +198,7 @@ trait IsSuspendable
      * conventions. For example, if the parent model is 'Wrestler', it will look for
      * a 'WrestlerSuspension' model class.
      *
-     * @throws RuntimeException If the resolved model class doesn't exist
+     * @throws LogicException If the resolved model class doesn't exist
      * @return class-string<TSuspension> The fully qualified class name of the suspension model
      *
      * @example


### PR DESCRIPTION
## Summary
- document LogicException as the convention-resolution failure for activity and status relationship models
- align employment, injury, retirement, and suspension relation contracts with ResolvesRelatedModels
- remove stale RuntimeException imports from the six model concerns

## Verification
- 63 focused tests passed with 81 assertions
- full application and Pest PHPStan passed
- touched files passed Pint with Blade formatting
- git diff checks passed