### PR TITLE
refactor: remove unreachable reinstatement failure

### DIFF
--- a/app/Exceptions/Roster/Individuals/CannotBeReinstatedException.php
+++ b/app/Exceptions/Roster/Individuals/CannotBeReinstatedException.php
@@ -33,13 +33,6 @@ final class CannotBeReinstatedException extends BaseBusinessException
         return new static("{$context} has not been officially employed and cannot be reinstated.");
     }
 
-    public static function bookable(Wrestler|Manager|Referee $entity): static
-    {
-        $context = self::formatModelContext($entity);
-
-        return new static("{$context} is already bookable and does not need reinstatement.");
-    }
-
     public static function injured(Wrestler|Manager|Referee $entity, ?string $injuryDetails = null): static
     {
         $context = self::formatModelContext($entity);

--- a/app/Models/Concerns/ValidatesIndividualSuspension.php
+++ b/app/Models/Concerns/ValidatesIndividualSuspension.php
@@ -7,7 +7,6 @@ namespace App\Models\Concerns;
 use App\Enums\Shared\EmploymentStatus;
 use App\Exceptions\Roster\Individuals\CannotBeReinstatedException;
 use App\Exceptions\Roster\Individuals\CannotBeSuspendedException;
-use App\Models\Contracts\Bookable;
 use App\Models\Managers\Manager;
 use App\Models\Referees\Referee;
 use App\Models\Wrestlers\Wrestler;
@@ -92,9 +91,6 @@ trait ValidatesIndividualSuspension
             throw CannotBeReinstatedException::retired($entity);
         }
 
-        if ($entity instanceof Bookable && $entity->isBookable()) {
-            throw CannotBeReinstatedException::bookable($entity);
-        }
     }
 
     private function individualSuspensionEntity(): Wrestler|Manager|Referee

--- a/tests/Unit/Models/Concerns/ValidatesIndividualSuspensionTest.php
+++ b/tests/Unit/Models/Concerns/ValidatesIndividualSuspensionTest.php
@@ -3,7 +3,21 @@
 declare(strict_types=1);
 
 use App\Exceptions\Roster\Individuals\CannotBeReinstatedException;
+use App\Models\Referees\Referee;
 use App\Models\Wrestlers\Wrestler;
+
+test('reinstatement predicate matches its guard for suspended bookable individuals', function () {
+    $individuals = [
+        Wrestler::factory()->suspended()->create(),
+        Referee::factory()->suspended()->create(),
+    ];
+
+    foreach ($individuals as $individual) {
+        expect($individual->isBookable())->toBeFalse()
+            ->and($individual->canBeReinstated())->toBeTrue()
+            ->and(fn () => $individual->ensureCanBeReinstated())->not->toThrow(CannotBeReinstatedException::class);
+    }
+});
 
 test('reinstatement predicate matches its guard for an injured suspended wrestler', function () {
     $wrestler = Wrestler::factory()->suspended()->create();


### PR DESCRIPTION
## Summary
- remove the speculative bookable reinstatement exception factory
- remove the unreachable guard: suspended bookable individuals are necessarily not bookable
- cover guard/predicate parity for suspended wrestlers and referees

## Verification
- 20 focused tests passed with 70 assertions
- full application and Pest PHPStan passed
- Rector passed
- touched files passed Pint with Blade formatting
- git diff checks passed