### PR TITLE
docs: complete action exception contracts

### DIFF
--- a/app/Actions/Matches/AddMatchForEventAction.php
+++ b/app/Actions/Matches/AddMatchForEventAction.php
@@ -6,6 +6,7 @@ namespace App\Actions\Matches;
 
 use App\Data\Matches\EventMatchData;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
@@ -54,6 +55,8 @@ class AddMatchForEventAction
      *
      * @param  Event  $event  The event to add the match to
      * @param  EventMatchData  $eventMatchData  Complete match data including all participants
+     * @throws EntityNotAvailableException When an assigned referee or title is unavailable
+     * @throws InvalidMatchConfigurationException When required match data or side assignments are invalid
      * @return EventMatch The newly created match with all components properly assigned
      */
     public function handle(Event $event, EventMatchData $eventMatchData): EventMatch

--- a/app/Actions/Stables/EstablishAction.php
+++ b/app/Actions/Stables/EstablishAction.php
@@ -30,6 +30,7 @@ class EstablishAction
      * @param  Carbon|null  $activationDate  The establishment date (defaults to now)
      * @param  Carbon|null  $endDate  The date the stable stopped being active
      * @throws CannotBeEstablishedException When stable cannot be established due to business rules
+     * @throws InvalidDateRangeException When the end date precedes the activation date
      */
     public function handle(
         Stable $stable,

--- a/app/Actions/Stables/SplitStableAction.php
+++ b/app/Actions/Stables/SplitStableAction.php
@@ -32,6 +32,7 @@ class SplitStableAction
      * @param  string  $newStableName  Name for the new stable
      * @param  StableMembershipData  $membersForNewStable  Members to move to new stable
      * @param  Carbon  $date  The date when the split operation occurs
+     * @throws CannotBeSplitException When the stable or selected members cannot be split
      * @return Stable The newly created stable
      */
     public function handle(


### PR DESCRIPTION
## Summary
- document invalid stable establishment date ranges on the public Action contract
- document typed stable split failures on the public Action contract
- document match configuration and entity availability failures propagated by match creation

## Verification
- 48 focused tests passed with 137 assertions
- PHPStan passed for all touched Actions
- touched files passed Pint with Blade formatting
- git diff --check passed