### PR TITLE
test: remove generic exception catches

### DIFF
--- a/tests/Browser/LoginTest.php
+++ b/tests/Browser/LoginTest.php
@@ -80,7 +80,7 @@ test('login form keyboard navigation works', function () {
         ->assertScript('document.activeElement.getAttribute("data-test") === "password"');
 });
 
-test('remember me functionality works if present', function () {
+test('remember me can be selected during login', function (): void {
     // Create administrator user for testing
     $admin = User::factory()->administrator()->create([
         'email' => 'administrator@example.com',
@@ -90,16 +90,11 @@ test('remember me functionality works if present', function () {
     $page = visit(route('login'));
 
     $page->type('@email', $admin->email)
-        ->type('@password', 'password');
-
-    // Check if remember me checkbox exists and check it
-    try {
-        $page->check('@remember');
-    } catch (Exception $e) {
-        // Checkbox might not be present, skip
-    }
-
-    $page->press('@sign-in')
+        ->type('@password', 'password')
+        ->assertPresent('@remember')
+        ->check('@remember')
+        ->assertChecked('@remember')
+        ->press('@sign-in')
         ->assertScript('window.location.pathname === "/dashboard"')
         ->assertSee('Dashboard');
 });

--- a/tests/Feature/Architecture/ExceptionArchitectureTest.php
+++ b/tests/Feature/Architecture/ExceptionArchitectureTest.php
@@ -71,7 +71,7 @@ test('application code does not directly construct generic exceptions', function
     expect($violations)->toBeEmpty();
 });
 
-test('Livewire components do not catch generic exception types', function () {
+test('application and test code do not catch generic exception types', function () {
     $genericCatchTypes = function (string $contents): array {
         $statements = (new ParserFactory())->createForNewestSupportedVersion()->parse($contents);
         $resolvedStatements = (new NodeTraverser(new NameResolver()))->traverse($statements ?? []);
@@ -97,20 +97,27 @@ test('Livewire components do not catch generic exception types', function () {
         }
         PHP))->toBe([Exception::class]);
 
-    $files = new RecursiveIteratorIterator(
-        new RecursiveDirectoryIterator(app_path('Livewire'), FilesystemIterator::SKIP_DOTS)
-    );
     $violations = [];
 
-    foreach ($files as $file) {
-        if (! $file instanceof SplFileInfo || ! $file->isFile() || $file->getExtension() !== 'php') {
-            continue;
-        }
+    foreach ([app_path(), base_path('tests')] as $directory) {
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+        );
 
-        $contents = file_get_contents($file->getPathname());
+        foreach ($files as $file) {
+            if (! $file instanceof SplFileInfo || ! $file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
 
-        if ($contents !== false && $genericCatchTypes($contents) !== []) {
-            $violations[] = str($file->getPathname())->after(app_path().DIRECTORY_SEPARATOR)->toString();
+            if ($file->getRealPath() === __FILE__) {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+
+            if ($contents !== false && $genericCatchTypes($contents) !== []) {
+                $violations[] = str($file->getPathname())->after(base_path().DIRECTORY_SEPARATOR)->toString();
+            }
         }
     }
 

--- a/tests/Integration/Actions/Stables/SplitStableActionTest.php
+++ b/tests/Integration/Actions/Stables/SplitStableActionTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Actions\Stables\CreateAction;
 use App\Actions\Stables\SplitStableAction;
 use App\Data\Stables\StableMembershipData;
 use App\Enums\Shared\EmploymentStatus;
@@ -11,7 +12,9 @@ use App\Models\Stables\StableTagTeam;
 use App\Models\Stables\StableWrestler;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
+use App\Services\StableMembershipService;
 use Illuminate\Support\Carbon;
+use JMac\Testing\Double;
 
 /**
  * Integration tests for SplitStableAction.
@@ -441,28 +444,46 @@ describe('SplitStableAction Integration Tests', function () {
             expect(freshModel($this->originalStable)->currentWrestlers()->count())->toBeGreaterThanOrEqual(0);
         });
 
-        test('split handles transaction rollback on constraint violation', function () {
+        test('split rolls back membership changes when stable creation fails', function () {
             $splitDate = Carbon::now();
-
-            // Get initial counts
             $initialStableCount = Stable::count();
+            $originalMembershipIds = StableWrestler::query()
+                ->whereBelongsTo($this->originalStable)
+                ->whereNull('left_at')
+                ->pluck('id');
+            $originalTagTeamMembershipIds = StableTagTeam::query()
+                ->whereBelongsTo($this->originalStable)
+                ->whereNull('left_at')
+                ->pluck('id');
+            $createAction = Double::for(CreateAction::class);
+            $createAction->expects('handle')
+                ->throws(new LogicException('Stable creation failed.'));
+            $action = new SplitStableAction(
+                $createAction,
+                resolve(StableMembershipService::class),
+            );
 
-            // For now, verify that normal split doesn't affect counts negatively
-            try {
-                $newStable = resolve(SplitStableAction::class)->handle(
-                    $this->originalStable,
-                    $this->newStableName,
-                    $this->membersForNewStable,
-                    $splitDate
-                );
+            expect(fn () => $action->handle(
+                $this->originalStable,
+                $this->newStableName,
+                $this->membersForNewStable,
+                $splitDate
+            ))
+                ->toThrow(LogicException::class, 'Stable creation failed.');
 
-                // Verify operation completed successfully
-                expect(Stable::count())->toBe($initialStableCount + 1);
+            expect(Stable::count())->toBe($initialStableCount)
+                ->and(StableWrestler::query()
+                    ->whereKey($originalMembershipIds)
+                    ->whereNull('left_at')
+                    ->count())
+                ->toBe($originalMembershipIds->count())
+                ->and(StableTagTeam::query()
+                    ->whereKey($originalTagTeamMembershipIds)
+                    ->whereNull('left_at')
+                    ->count())
+                ->toBe($originalTagTeamMembershipIds->count());
 
-            } catch (Exception $e) {
-                // If transaction fails, verify no partial changes occurred
-                expect(Stable::count())->toBe($initialStableCount);
-            }
+            $createAction->verify();
         });
     });
 


### PR DESCRIPTION
## Summary
- require and verify the rendered remember-me checkbox instead of swallowing browser failures
- replace the non-deterministic stable split rollback test with an injected creation failure
- prove the transaction restores both wrestler and tag-team membership periods
- enforce that application and test code do not catch generic Exception or Throwable types

## Verification
- 30 focused tests passed with 80 assertions
- browser login test passed
- Pest PHPStan passed for all changed test files
- touched files passed Pint with Blade formatting
- git diff --check passed