### PR TITLE
feat: prevent match assignment conflicts

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -16,6 +16,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | tests/Integration/** | .ai/rules/integration.md |
 | app/Livewire/** | .ai/rules/livewire.md |
 | app/{Actions/Matches,Exceptions/Matches,Exceptions/Scheduling}/** | .ai/rules/matches-exceptions-scheduling.md |
+| app/{Actions/Matches,Services,Exceptions/Scheduling}/** | .ai/rules/matches-services-exceptions-scheduling.md |
 | database/migrations/** | .ai/rules/migrations.md |
 | app/Models/** | .ai/rules/models.md |
 | app/{Livewire,Http/Requests,Actions,Services}/** | .ai/rules/requests-actions-services.md |

--- a/.ai/rules/matches-services-exceptions-scheduling.md
+++ b/.ai/rules/matches-services-exceptions-scheduling.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Actions/Matches,Services,Exceptions/Scheduling}/**'
+---
+
+# Matches Services Exceptions Scheduling
+
+## Prevent match assignment scheduling conflicts
+Wrestlers, tag teams, and titles may appear only once per event card and cannot be assigned to different events at the same exact date and time. Referees may officiate multiple matches on one card, but not different events at the same exact date and time. Unscheduled events conflict only within their own card. Enforce these rules transactionally through MatchAssignmentConflictService; keep current-state availability failures separate.

--- a/app/Actions/Matches/AddRefereesToMatchAction.php
+++ b/app/Actions/Matches/AddRefereesToMatchAction.php
@@ -7,11 +7,16 @@ namespace App\Actions\Matches;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
+use App\Services\MatchAssignmentConflictService;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Facades\DB;
 
 class AddRefereesToMatchAction
 {
+    public function __construct(
+        protected MatchAssignmentConflictService $conflictService,
+    ) {}
+
     /**
      * Add referees to an event match.
      *
@@ -53,6 +58,8 @@ class AddRefereesToMatchAction
         }
 
         DB::transaction(function () use ($eventMatch, $eligibleReferees): void {
+            $this->conflictService->ensureRefereesCanBeAssigned($eventMatch, $eligibleReferees);
+
             // Add each eligible referee to officiate the match
             $eligibleReferees->each(function (Referee $referee) use ($eventMatch) {
                 $eventMatch->referees()->attach($referee->id);

--- a/app/Actions/Matches/AddTagTeamsToMatchAction.php
+++ b/app/Actions/Matches/AddTagTeamsToMatchAction.php
@@ -8,11 +8,16 @@ use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
+use App\Services\MatchAssignmentConflictService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class AddTagTeamsToMatchAction
 {
+    public function __construct(
+        protected MatchAssignmentConflictService $conflictService,
+    ) {}
+
     /**
      * Add tag teams to an event match.
      *
@@ -60,10 +65,13 @@ class AddTagTeamsToMatchAction
         }
 
         DB::transaction(function () use ($eventMatch, $eligibleTagTeams, $sideNumber): void {
+            $this->conflictService->ensureTagTeamsCanBeAssigned($eventMatch, $eligibleTagTeams);
+
             // Add each eligible tag team to the specified side
             $eligibleTagTeams->each(function (TagTeam $tagTeam) use ($eventMatch, $sideNumber) {
                 $eventMatch->competitors()->create([
-                    'tag_team_id' => $tagTeam->id,
+                    'competitor_id' => $tagTeam->id,
+                    'competitor_type' => TagTeam::class,
                     'side_number' => $sideNumber,
                 ]);
             });

--- a/app/Actions/Matches/AddTitlesToMatchAction.php
+++ b/app/Actions/Matches/AddTitlesToMatchAction.php
@@ -7,11 +7,16 @@ namespace App\Actions\Matches;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\Titles\Title;
+use App\Services\MatchAssignmentConflictService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class AddTitlesToMatchAction
 {
+    public function __construct(
+        protected MatchAssignmentConflictService $conflictService,
+    ) {}
+
     /**
      * Add titles to an event match.
      *
@@ -53,6 +58,8 @@ class AddTitlesToMatchAction
         }
 
         DB::transaction(function () use ($eventMatch, $eligibleTitles): void {
+            $this->conflictService->ensureTitlesCanBeAssigned($eventMatch, $eligibleTitles);
+
             // Add each eligible title as championship stakes
             $eligibleTitles->each(function (Title $title) use ($eventMatch) {
                 $eventMatch->titles()->attach($title->id);

--- a/app/Actions/Matches/AddWrestlersToMatchAction.php
+++ b/app/Actions/Matches/AddWrestlersToMatchAction.php
@@ -8,11 +8,16 @@ use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
 use App\Models\Wrestlers\Wrestler;
+use App\Services\MatchAssignmentConflictService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class AddWrestlersToMatchAction
 {
+    public function __construct(
+        protected MatchAssignmentConflictService $conflictService,
+    ) {}
+
     /**
      * Add wrestlers to an event match.
      *
@@ -58,6 +63,8 @@ class AddWrestlersToMatchAction
         }
 
         DB::transaction(function () use ($eventMatch, $eligibleWrestlers, $sideNumber): void {
+            $this->conflictService->ensureWrestlersCanBeAssigned($eventMatch, $eligibleWrestlers);
+
             // Add each eligible wrestler to the specified side
             $eligibleWrestlers->each(function (Wrestler $wrestler) use ($eventMatch, $sideNumber) {
                 $eventMatch->competitors()->create([

--- a/app/Exceptions/Scheduling/SchedulingConflictException.php
+++ b/app/Exceptions/Scheduling/SchedulingConflictException.php
@@ -6,4 +6,20 @@ namespace App\Exceptions\Scheduling;
 
 use App\Exceptions\BaseBusinessException;
 
-final class SchedulingConflictException extends BaseBusinessException {}
+final class SchedulingConflictException extends BaseBusinessException
+{
+    public static function competitorAlreadyBooked(string $competitorType, string $competitorName): static
+    {
+        return new self("{$competitorType} [{$competitorName}] is already booked at this event time.");
+    }
+
+    public static function refereeAlreadyAssigned(string $refereeName): static
+    {
+        return new self("Referee [{$refereeName}] is already assigned to another event at this time.");
+    }
+
+    public static function titleAlreadyAssigned(string $titleName): static
+    {
+        return new self("Title [{$titleName}] is already assigned at this event time.");
+    }
+}

--- a/app/Models/Matches/MatchCompetitor.php
+++ b/app/Models/Matches/MatchCompetitor.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
@@ -44,6 +45,14 @@ class MatchCompetitor extends MorphPivot
 {
     /** @use HasFactory<MatchCompetitorFactory> */
     use HasFactory;
+
+    /**
+     * @return BelongsTo<EventMatch, $this>
+     */
+    public function eventMatch(): BelongsTo
+    {
+        return $this->belongsTo(EventMatch::class, 'match_id');
+    }
 
     /**
      * The table associated with the model.

--- a/app/Services/MatchAssignmentConflictService.php
+++ b/app/Services/MatchAssignmentConflictService.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use App\Exceptions\Scheduling\SchedulingConflictException;
+use App\Models\Events\Event;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Referees\Referee;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+final class MatchAssignmentConflictService
+{
+    /**
+     * @param  Collection<int, Wrestler>  $wrestlers
+     */
+    public function ensureWrestlersCanBeAssigned(EventMatch $eventMatch, Collection $wrestlers): void
+    {
+        $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
+        $conflictingWrestlerId = MatchCompetitor::query()
+            ->where('competitor_type', Wrestler::class)
+            ->whereIn('competitor_id', $wrestlers->pluck('id'))
+            ->whereHas('eventMatch', fn (Builder $query) => $query->whereIn('event_id', $conflictingEventIds))
+            ->value('competitor_id');
+
+        if ($conflictingWrestlerId === null) {
+            return;
+        }
+
+        $wrestler = $wrestlers->firstWhere('id', $conflictingWrestlerId);
+
+        throw SchedulingConflictException::competitorAlreadyBooked('Wrestler', $wrestler->name);
+    }
+
+    /**
+     * @param  Collection<int, TagTeam>  $tagTeams
+     */
+    public function ensureTagTeamsCanBeAssigned(EventMatch $eventMatch, Collection $tagTeams): void
+    {
+        $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
+        $conflictingTagTeamId = MatchCompetitor::query()
+            ->where('competitor_type', TagTeam::class)
+            ->whereIn('competitor_id', $tagTeams->pluck('id'))
+            ->whereHas('eventMatch', fn (Builder $query) => $query->whereIn('event_id', $conflictingEventIds))
+            ->value('competitor_id');
+
+        if ($conflictingTagTeamId === null) {
+            return;
+        }
+
+        $tagTeam = $tagTeams->firstWhere('id', $conflictingTagTeamId);
+
+        throw SchedulingConflictException::competitorAlreadyBooked('Tag team', $tagTeam->name);
+    }
+
+    /**
+     * @param  Collection<int, Referee>  $referees
+     */
+    public function ensureRefereesCanBeAssigned(EventMatch $eventMatch, Collection $referees): void
+    {
+        $conflictingEventIds = $this->lockConflictingEvents($eventMatch)
+            ->reject(fn (int $eventId): bool => $eventId === $eventMatch->event_id);
+
+        if ($conflictingEventIds->isEmpty()) {
+            return;
+        }
+
+        $conflictingRefereeId = EventMatch::query()
+            ->whereIn('event_id', $conflictingEventIds)
+            ->whereHas('referees', fn (Builder $query) => $query->whereKey($referees->pluck('id')))
+            ->with('referees:id,first_name,last_name')
+            ->get()
+            ->flatMap->referees
+            ->first(fn (Referee $referee): bool => $referees->contains('id', $referee->id))
+            ?->id;
+
+        if ($conflictingRefereeId === null) {
+            return;
+        }
+
+        $referee = $referees->firstWhere('id', $conflictingRefereeId);
+
+        throw SchedulingConflictException::refereeAlreadyAssigned($referee?->getDisplayName() ?? "ID: {$conflictingRefereeId}");
+    }
+
+    /**
+     * @param  Collection<int, Title>  $titles
+     */
+    public function ensureTitlesCanBeAssigned(EventMatch $eventMatch, Collection $titles): void
+    {
+        $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
+        $conflictingTitleId = EventMatch::query()
+            ->whereIn('event_id', $conflictingEventIds)
+            ->whereHas('titles', fn (Builder $query) => $query->whereKey($titles->pluck('id')))
+            ->with('titles:id,name')
+            ->get()
+            ->flatMap->titles
+            ->first(fn (Title $title): bool => $titles->contains('id', $title->id))
+            ?->id;
+
+        if ($conflictingTitleId === null) {
+            return;
+        }
+
+        $title = $titles->firstWhere('id', $conflictingTitleId);
+
+        throw SchedulingConflictException::titleAlreadyAssigned($title === null ? "ID: {$conflictingTitleId}" : (string) $title->name);
+    }
+
+    /**
+     * @return Collection<int, int>
+     */
+    private function lockConflictingEvents(EventMatch $eventMatch): Collection
+    {
+        $event = $eventMatch->event()->firstOrFail();
+
+        return Event::query()
+            ->where(function (Builder $query) use ($event): void {
+                $query->whereKey($event->id);
+
+                if ($event->date !== null) {
+                    $query->orWhere('date', $event->date);
+                }
+            })
+            ->orderBy('id')
+            ->lockForUpdate()
+            ->pluck('id');
+    }
+}

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -31,6 +31,17 @@ The match system handles complex wrestling match scenarios with flexible competi
 
 Match configuration and participant availability are separate failure boundaries. `InvalidMatchConfigurationException` describes an incomplete or structurally invalid match, such as missing referees, missing competitors, insufficient populated sides, or an invalid side number. `EntityNotAvailableException` describes a wrestler, tag team, referee, or title whose current state prevents assignment. `SchedulingConflictException` is reserved for an actual collision between bookings, times, or resources and must not substitute for either boundary.
 
+## Event Card Scheduling
+
+Match assignments observe these collision rules:
+
+- A wrestler, tag team, or title may be assigned only once on an event card.
+- A wrestler, tag team, or title may not be assigned to different events scheduled for the same exact date and time.
+- A referee may officiate multiple matches on one event card, but may not officiate matches on different events scheduled for the same exact date and time.
+- An unscheduled event still prevents duplicate assignments within its own card. Its missing date does not conflict with other unscheduled events.
+
+Assignment actions lock the affected event rows and enforce these rules inside their database transactions. This serializes assignment commands that use the application boundary. The schema cannot enforce overlapping match windows because individual matches do not currently have their own start and end times.
+
 ## Winner/Loser System
 
 ### Multiple Winners and Losers

--- a/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use App\Actions\Matches\AddRefereesToMatchAction;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Exceptions\Scheduling\SchedulingConflictException;
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 
@@ -13,4 +15,33 @@ test('it rejects match assignment when no referee is available', function () {
 
     expect(fn () => resolve(AddRefereesToMatchAction::class)->handle($match, $referees))
         ->toThrow(EntityNotAvailableException::class, 'No eligible referees were provided for match assignment.');
+});
+
+test('it allows a referee to officiate multiple matches on one event card', function () {
+    $event = Event::factory()->scheduled()->create();
+    $existingMatch = EventMatch::factory()->forEvent($event)->create();
+    $targetMatch = EventMatch::factory()->forEvent($event)->create();
+    $referee = Referee::factory()->bookable()->create();
+
+    $existingMatch->referees()->attach($referee);
+
+    resolve(AddRefereesToMatchAction::class)->handle($targetMatch, $referee->newCollection([$referee]));
+
+    expect($targetMatch->referees()->whereKey($referee->id)->exists())->toBeTrue();
+});
+
+test('it rejects a referee assigned to another event at the same time', function () {
+    $eventDate = now()->addWeek();
+    $existingEvent = Event::factory()->create(['date' => $eventDate]);
+    $targetEvent = Event::factory()->create(['date' => $eventDate]);
+    $existingMatch = EventMatch::factory()->forEvent($existingEvent)->create();
+    $targetMatch = EventMatch::factory()->forEvent($targetEvent)->create();
+    $referee = Referee::factory()->bookable()->create();
+
+    $existingMatch->referees()->attach($referee);
+
+    expect(fn () => resolve(AddRefereesToMatchAction::class)->handle($targetMatch, $referee->newCollection([$referee])))
+        ->toThrow(SchedulingConflictException::class, "Referee [{$referee->getDisplayName()}] is already assigned to another event at this time.");
+
+    expect($targetMatch->referees()->count())->toBe(0);
 });

--- a/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
@@ -4,8 +4,24 @@ declare(strict_types=1);
 
 use App\Actions\Matches\AddTagTeamsToMatchAction;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Exceptions\Scheduling\SchedulingConflictException;
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
+
+test('it adds a tag team to a match as a polymorphic competitor', function () {
+    $match = EventMatch::factory()->create();
+    $tagTeam = TagTeam::factory()->bookable()->create();
+
+    resolve(AddTagTeamsToMatchAction::class)->handle($match, collect([$tagTeam]), 1);
+
+    $this->assertDatabaseHas('events_matches_competitors', [
+        'match_id' => $match->id,
+        'competitor_id' => $tagTeam->id,
+        'competitor_type' => TagTeam::class,
+        'side_number' => 1,
+    ]);
+});
 
 test('it rejects match assignment when no tag team is available', function () {
     $match = EventMatch::factory()->create();
@@ -13,4 +29,22 @@ test('it rejects match assignment when no tag team is available', function () {
 
     expect(fn () => resolve(AddTagTeamsToMatchAction::class)->handle($match, $tagTeams, 1))
         ->toThrow(EntityNotAvailableException::class, 'No eligible tag teams were provided for match assignment.');
+});
+
+test('it rejects a tag team already booked on the event card', function () {
+    $event = Event::factory()->scheduled()->create();
+    $existingMatch = EventMatch::factory()->forEvent($event)->create();
+    $targetMatch = EventMatch::factory()->forEvent($event)->create();
+    $tagTeam = TagTeam::factory()->bookable()->create();
+
+    $existingMatch->competitors()->create([
+        'competitor_id' => $tagTeam->id,
+        'competitor_type' => TagTeam::class,
+        'side_number' => 1,
+    ]);
+
+    expect(fn () => resolve(AddTagTeamsToMatchAction::class)->handle($targetMatch, collect([$tagTeam]), 1))
+        ->toThrow(SchedulingConflictException::class, "Tag team [{$tagTeam->name}] is already booked at this event time.");
+
+    expect($targetMatch->competitors()->count())->toBe(0);
 });

--- a/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 use App\Actions\Matches\AddTitlesToMatchAction;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Exceptions\Scheduling\SchedulingConflictException;
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Titles\Title;
 
@@ -135,4 +137,18 @@ test('it handles transaction consistency', function () {
 
     // Verify both database records exist
     $this->assertDatabaseCount('events_matches_titles', 2);
+});
+
+test('it rejects a title already assigned on the event card', function () {
+    $event = Event::factory()->scheduled()->create();
+    $existingMatch = EventMatch::factory()->forEvent($event)->create();
+    $targetMatch = EventMatch::factory()->forEvent($event)->create();
+    $title = Title::factory()->active()->create();
+
+    $existingMatch->titles()->attach($title);
+
+    expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($targetMatch, collect([$title])))
+        ->toThrow(SchedulingConflictException::class, "Title [{$title->name}] is already assigned at this event time.");
+
+    expect($targetMatch->titles()->count())->toBe(0);
 });

--- a/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 use App\Actions\Matches\AddWrestlersToMatchAction;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Exceptions\Scheduling\SchedulingConflictException;
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Wrestlers\Wrestler;
 
@@ -156,4 +158,42 @@ test('it handles transaction rollback on failure', function () {
 
     // No competitors should be added due to transaction rollback
     expect($match->refresh()->competitors()->count())->toBe(0);
+});
+
+test('it rejects a wrestler booked on another event at the same time', function () {
+    $eventDate = now()->addWeek();
+    $existingEvent = Event::factory()->create(['date' => $eventDate]);
+    $targetEvent = Event::factory()->create(['date' => $eventDate]);
+    $existingMatch = EventMatch::factory()->forEvent($existingEvent)->create();
+    $targetMatch = EventMatch::factory()->forEvent($targetEvent)->create();
+    $wrestler = Wrestler::factory()->bookable()->create();
+
+    $existingMatch->competitors()->create([
+        'competitor_id' => $wrestler->id,
+        'competitor_type' => Wrestler::class,
+        'side_number' => 1,
+    ]);
+
+    expect(fn () => resolve(AddWrestlersToMatchAction::class)->handle($targetMatch, collect([$wrestler]), 1))
+        ->toThrow(SchedulingConflictException::class, "Wrestler [{$wrestler->name}] is already booked at this event time.");
+
+    expect($targetMatch->competitors()->count())->toBe(0);
+});
+
+test('it allows a wrestler booked at a different event time', function () {
+    $existingEvent = Event::factory()->create(['date' => now()->addWeek()]);
+    $targetEvent = Event::factory()->create(['date' => now()->addWeek()->addHour()]);
+    $existingMatch = EventMatch::factory()->forEvent($existingEvent)->create();
+    $targetMatch = EventMatch::factory()->forEvent($targetEvent)->create();
+    $wrestler = Wrestler::factory()->bookable()->create();
+
+    $existingMatch->competitors()->create([
+        'competitor_id' => $wrestler->id,
+        'competitor_type' => Wrestler::class,
+        'side_number' => 1,
+    ]);
+
+    resolve(AddWrestlersToMatchAction::class)->handle($targetMatch, collect([$wrestler]), 1);
+
+    expect($targetMatch->competitors()->count())->toBe(1);
 });


### PR DESCRIPTION
## Summary
- prevent wrestlers, tag teams, and titles from being assigned more than once per event card or across simultaneous events
- allow referees to officiate multiple matches on one card while preventing simultaneous cross-event assignments
- serialize assignment checks with transactional event locks and fix tag-team polymorphic competitor persistence
- document and record the scheduling boundary

## Verification
- 30 Match Action tests passed with 72 assertions
- application and Pest PHPStan passed
- type coverage and Rector passed
- touched files passed Pint with Blade formatting
- git diff checks passed

## Repository-wide suite note
- composer test:push reached the existing Blade-formatting backlog in untouched view files; this branch does not modify those files
- the full parallel Pest command was stopped after three minutes without output; the complete bounded Match Action suite passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added scheduling conflict prevention when assigning wrestlers, tag teams, referees, and titles to matches.
  - Prevented duplicate assignments within event cards and conflicts across events occurring at the same time.
  - Added clear conflict messages for affected assignments.
  - Supported polymorphic competitor assignments for tag teams.

- **Bug Fixes**
  - Failed assignments now leave the target match unchanged.

- **Documentation**
  - Documented event-card scheduling and assignment rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->