### PR TITLE
fix: deduplicate match assignments

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -15,8 +15,8 @@ Before planning or editing, find the row whose globs match the file's path and r
 | tests/Feature/** | .ai/rules/feature.md |
 | tests/Integration/** | .ai/rules/integration.md |
 | app/Livewire/** | .ai/rules/livewire.md |
-| app/{Actions/Matches,Exceptions/Matches,Exceptions/Scheduling}/** | .ai/rules/matches-exceptions-scheduling.md |
-| app/{Actions/Matches,Services,Exceptions/Scheduling}/** | .ai/rules/matches-services-exceptions-scheduling.md |
+| app/Exceptions/{Matches,Scheduling}/** | .ai/rules/matches-scheduling.md |
+| app/{Actions/Matches,Services}/** | .ai/rules/matches-services.md |
 | database/migrations/** | .ai/rules/migrations.md |
 | app/Models/** | .ai/rules/models.md |
 | app/{Livewire,Http/Requests,Actions,Services}/** | .ai/rules/requests-actions-services.md |

--- a/.ai/rules/matches-scheduling.md
+++ b/.ai/rules/matches-scheduling.md
@@ -1,9 +1,9 @@
 ---
 paths:
-  - 'app/{Actions/Matches,Exceptions/Matches,Exceptions/Scheduling}/**'
+  - 'app/Exceptions/{Matches,Scheduling}/**'
 ---
 
-# Matches Exceptions Scheduling
+# Matches Scheduling
 
 ## Separate match configuration, availability, and scheduling failures
 Use InvalidMatchConfigurationException for incomplete or structurally invalid match assignments. Use EntityNotAvailableException when a selected participant or title's own state prevents assignment. Reserve SchedulingConflictException for actual collisions between bookings, times, or resources.

--- a/.ai/rules/matches-services.md
+++ b/.ai/rules/matches-services.md
@@ -1,9 +1,9 @@
 ---
 paths:
-  - 'app/{Actions/Matches,Services,Exceptions/Scheduling}/**'
+  - 'app/{Actions/Matches,Services}/**'
 ---
 
-# Matches Services Exceptions Scheduling
+# Matches Services
 
 ## Prevent match assignment scheduling conflicts
 Wrestlers, tag teams, and titles may appear only once per event card and cannot be assigned to different events at the same exact date and time. Referees may officiate multiple matches on one card, but not different events at the same exact date and time. Unscheduled events conflict only within their own card. Enforce these rules transactionally through MatchAssignmentConflictService; keep current-state availability failures separate.

--- a/app/Actions/Matches/AddRefereesToMatchAction.php
+++ b/app/Actions/Matches/AddRefereesToMatchAction.php
@@ -50,7 +50,7 @@ class AddRefereesToMatchAction
         // Pre-filter referees to ensure only eligible officials are processed
         $eligibleReferees = $referees->filter(
             fn (Referee $referee) => $this->isRefereeEligibleForMatch($referee, $eventMatch)
-        );
+        )->unique('id')->values();
 
         // Validate we have referees to add after filtering
         if ($eligibleReferees->isEmpty()) {

--- a/app/Actions/Matches/AddTagTeamsToMatchAction.php
+++ b/app/Actions/Matches/AddTagTeamsToMatchAction.php
@@ -52,7 +52,7 @@ class AddTagTeamsToMatchAction
         // Pre-filter tag teams to ensure only eligible teams are processed
         $eligibleTagTeams = $tagTeams->filter(
             fn (TagTeam $tagTeam) => $this->isTagTeamEligibleForMatch($tagTeam, $eventMatch)
-        );
+        )->unique('id')->values();
 
         // Validate we have tag teams to add after filtering
         if ($eligibleTagTeams->isEmpty()) {

--- a/app/Actions/Matches/AddTitlesToMatchAction.php
+++ b/app/Actions/Matches/AddTitlesToMatchAction.php
@@ -50,7 +50,7 @@ class AddTitlesToMatchAction
         // Pre-filter titles to ensure only eligible championships are processed
         $eligibleTitles = $titles->filter(
             fn (Title $title) => $this->isTitleEligibleForMatch($title, $eventMatch)
-        );
+        )->unique('id')->values();
 
         // Validate we have titles to add after filtering
         if ($eligibleTitles->isEmpty()) {

--- a/app/Actions/Matches/AddWrestlersToMatchAction.php
+++ b/app/Actions/Matches/AddWrestlersToMatchAction.php
@@ -50,7 +50,7 @@ class AddWrestlersToMatchAction
         // Pre-filter wrestlers to ensure only eligible competitors are processed
         $eligibleWrestlers = $wrestlers->filter(
             fn (Wrestler $wrestler) => $this->isWrestlerEligibleForMatch($wrestler, $eventMatch)
-        );
+        )->unique('id')->values();
 
         // Validate we have wrestlers to add after filtering
         if ($eligibleWrestlers->isEmpty()) {

--- a/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
@@ -45,3 +45,12 @@ test('it rejects a referee assigned to another event at the same time', function
 
     expect($targetMatch->referees()->count())->toBe(0);
 });
+
+test('it assigns a repeated referee only once', function () {
+    $match = EventMatch::factory()->create();
+    $referee = Referee::factory()->bookable()->create();
+
+    resolve(AddRefereesToMatchAction::class)->handle($match, $referee->newCollection([$referee, $referee]));
+
+    expect($match->referees()->count())->toBe(1);
+});

--- a/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
@@ -48,3 +48,12 @@ test('it rejects a tag team already booked on the event card', function () {
 
     expect($targetMatch->competitors()->count())->toBe(0);
 });
+
+test('it assigns a repeated tag team only once', function () {
+    $match = EventMatch::factory()->create();
+    $tagTeam = TagTeam::factory()->bookable()->create();
+
+    resolve(AddTagTeamsToMatchAction::class)->handle($match, collect([$tagTeam, $tagTeam]), 1);
+
+    expect($match->competitors()->count())->toBe(1);
+});

--- a/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
@@ -152,3 +152,12 @@ test('it rejects a title already assigned on the event card', function () {
 
     expect($targetMatch->titles()->count())->toBe(0);
 });
+
+test('it assigns a repeated title only once', function () {
+    $match = EventMatch::factory()->create();
+    $title = Title::factory()->active()->create();
+
+    resolve(AddTitlesToMatchAction::class)->handle($match, collect([$title, $title]));
+
+    expect($match->titles()->count())->toBe(1);
+});

--- a/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
@@ -197,3 +197,12 @@ test('it allows a wrestler booked at a different event time', function () {
 
     expect($targetMatch->competitors()->count())->toBe(1);
 });
+
+test('it assigns a repeated wrestler only once', function () {
+    $match = EventMatch::factory()->create();
+    $wrestler = Wrestler::factory()->bookable()->create();
+
+    resolve(AddWrestlersToMatchAction::class)->handle($match, collect([$wrestler, $wrestler]), 1);
+
+    expect($match->competitors()->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary
- normalize eligible wrestler, tag-team, referee, and title collections by model ID before conflict checks and persistence
- add regression coverage proving duplicate inputs create only one assignment
- regenerate specialized match scheduling rules with non-overlapping scopes

## CodeRabbit follow-up
Addresses the actionable findings from #766:
- duplicate resources in one assignment command
- overlapping specialized scheduling-rule mappings

## Verification
- 34 Match Action tests passed with 76 assertions
- application and Pest PHPStan passed
- type coverage and Rector passed
- touched files passed Pint with Blade formatting
- git diff checks passed

## Repository-wide suite note
- composer test:push reached the existing Blade-formatting backlog in untouched view files; this PR does not modify those files