### PR TITLE
refactor: tighten exception model boundaries

### DIFF
--- a/app/Exceptions/BaseBusinessException.php
+++ b/app/Exceptions/BaseBusinessException.php
@@ -7,7 +7,6 @@ namespace App\Exceptions;
 use App\Enums\BusinessRuleReason;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Carbon;
 use Throwable;
 
 abstract class BaseBusinessException extends Exception
@@ -31,25 +30,10 @@ abstract class BaseBusinessException extends Exception
         return new static($message, reason: $reason);
     }
 
-    /** @return array{name: mixed, type: string, id: mixed} */
-    protected static function extractModelInfo(Model $model): array
-    {
-        return [
-            'name' => $model->getAttribute('name') ?? "ID: {$model->getKey()}",
-            'type' => class_basename($model),
-            'id' => $model->getKey(),
-        ];
-    }
-
     protected static function formatModelContext(Model $model): string
     {
-        $info = self::extractModelInfo($model);
+        $name = $model->getAttribute('name') ?? "ID: {$model->getKey()}";
 
-        return "{$info['type']} '{$info['name']}'";
-    }
-
-    protected static function formatDateContext(?Carbon $date, string $format = 'Y-m-d'): string
-    {
-        return $date?->format($format) ?? '';
+        return class_basename($model)." '{$name}'";
     }
 }

--- a/app/Exceptions/Roster/Individuals/CannotBeRestoredException.php
+++ b/app/Exceptions/Roster/Individuals/CannotBeRestoredException.php
@@ -6,11 +6,13 @@ namespace App\Exceptions\Roster\Individuals;
 
 use App\Enums\BusinessRuleReason;
 use App\Exceptions\BaseBusinessException;
-use Illuminate\Database\Eloquent\Model;
+use App\Models\Managers\Manager;
+use App\Models\Referees\Referee;
+use App\Models\Wrestlers\Wrestler;
 
 final class CannotBeRestoredException extends BaseBusinessException
 {
-    public static function notDeleted(Model $entity): static
+    public static function notDeleted(Wrestler|Manager|Referee $entity): static
     {
         $context = self::formatModelContext($entity);
 

--- a/tests/Feature/Architecture/ExceptionArchitectureTest.php
+++ b/tests/Feature/Architecture/ExceptionArchitectureTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Exceptions\BaseBusinessException;
+use Illuminate\Database\Eloquent\Model;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
@@ -25,6 +26,12 @@ arch('business exceptions use the exception suffix')
     ->expect('App\Exceptions')
     ->classes()
     ->toHaveSuffix('Exception');
+
+arch('concrete business exceptions expose domain-specific inputs')
+    ->expect('App\Exceptions')
+    ->classes()
+    ->not->toUse(Model::class)
+    ->ignoring(BaseBusinessException::class);
 
 test('the business exception foundation is abstract', function () {
     $reflection = new ReflectionClass(BaseBusinessException::class);

--- a/tests/Feature/Architecture/ExceptionArchitectureTest.php
+++ b/tests/Feature/Architecture/ExceptionArchitectureTest.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 use App\Exceptions\BaseBusinessException;
 use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Name;
 use PhpParser\Node\Stmt\Catch_;
 use PhpParser\NodeFinder;
 use PhpParser\NodeTraverser;
@@ -129,4 +132,67 @@ test('application and test code do not catch generic exception types', function 
     }
 
     expect($violations)->toBeEmpty();
+});
+
+test('every concrete exception factory has an enforced caller', function () {
+    $calledFactories = collect([app_path(), base_path('tests')])
+        ->flatMap(function (string $directory): array {
+            $files = new RecursiveIteratorIterator(
+                new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+            );
+
+            return iterator_to_array($files);
+        })
+        ->filter(fn (SplFileInfo $file): bool => $file->isFile() && $file->getExtension() === 'php')
+        ->flatMap(function (SplFileInfo $file): array {
+            $contents = file_get_contents($file->getPathname());
+
+            if ($contents === false) {
+                return [];
+            }
+
+            $statements = (new ParserFactory())->createForNewestSupportedVersion()->parse($contents);
+            $resolvedStatements = (new NodeTraverser(new NameResolver()))->traverse($statements ?? []);
+            $calledFactories = [];
+
+            foreach ((new NodeFinder())->findInstanceOf($resolvedStatements, StaticCall::class) as $call) {
+                if (! $call->class instanceof Name || ! $call->name instanceof Identifier) {
+                    continue;
+                }
+
+                $calledFactories[] = $call->class->toString().'::'.$call->name->toString();
+            }
+
+            return $calledFactories;
+        })
+        ->unique();
+
+    $exceptionFiles = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator(app_path('Exceptions'), FilesystemIterator::SKIP_DOTS)
+    );
+    $exceptionClasses = [];
+
+    foreach ($exceptionFiles as $file) {
+        if (! $file instanceof SplFileInfo || ! $file->isFile() || $file->getExtension() !== 'php') {
+            continue;
+        }
+
+        $exceptionClasses[] = 'App\\Exceptions\\'.str($file->getPathname())
+            ->after(app_path('Exceptions').DIRECTORY_SEPARATOR)
+            ->beforeLast('.php')
+            ->replace(DIRECTORY_SEPARATOR, '\\');
+    }
+
+    $orphanedFactories = collect($exceptionClasses)
+        ->filter(fn (string $class): bool => class_exists($class) && $class !== BaseBusinessException::class)
+        ->flatMap(function (string $class): array {
+            return collect((new ReflectionClass($class))->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_STATIC))
+                ->filter(fn (ReflectionMethod $method): bool => $method->getDeclaringClass()->getName() === $class)
+                ->map(fn (ReflectionMethod $method): string => $class.'::'.$method->getName())
+                ->all();
+        })
+        ->reject(fn (string $factory): bool => $calledFactories->contains($factory))
+        ->values();
+
+    expect($orphanedFactories)->toBeEmpty();
 });

--- a/tests/Feature/Architecture/ExceptionArchitectureTest.php
+++ b/tests/Feature/Architecture/ExceptionArchitectureTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Exceptions\BaseBusinessException;
 use Illuminate\Database\Eloquent\Model;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\StaticCall;
 use PhpParser\Node\Identifier;
 use PhpParser\Node\Name;
@@ -75,6 +76,52 @@ test('application code does not directly construct generic exceptions', function
 
         if ($contents !== false && preg_match('/throw\s+new\s+\\?Exception\s*\(/', $contents) === 1) {
             $violations[] = str($file->getPathname())->after(app_path().DIRECTORY_SEPARATOR)->toString();
+        }
+    }
+
+    expect($violations)->toBeEmpty();
+});
+
+test('application and test code construct business exceptions through factories', function () {
+    $violations = [];
+
+    foreach ([app_path(), base_path('tests')] as $directory) {
+        $files = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($directory, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($files as $file) {
+            if (! $file instanceof SplFileInfo || ! $file->isFile() || $file->getExtension() !== 'php') {
+                continue;
+            }
+
+            if (str_starts_with($file->getPathname(), app_path('Exceptions').DIRECTORY_SEPARATOR)) {
+                continue;
+            }
+
+            $contents = file_get_contents($file->getPathname());
+
+            if ($contents === false) {
+                continue;
+            }
+
+            $statements = (new ParserFactory())->createForNewestSupportedVersion()->parse($contents);
+            $resolvedStatements = (new NodeTraverser(new NameResolver()))->traverse($statements ?? []);
+
+            foreach ((new NodeFinder())->findInstanceOf($resolvedStatements, New_::class) as $construction) {
+                if (! $construction->class instanceof Name) {
+                    continue;
+                }
+
+                $class = $construction->class->toString();
+
+                if (class_exists($class) && is_subclass_of($class, BaseBusinessException::class)) {
+                    $relativePath = str($file->getPathname())
+                        ->after(base_path().DIRECTORY_SEPARATOR)
+                        ->toString();
+                    $violations[] = "{$relativePath}:{$construction->getStartLine()} constructs {$class}";
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- restrict the individual restoration exception to supported wrestler, manager, and referee models
- remove unused context extraction and date-formatting helpers from the business exception foundation
- reject generic Eloquent model dependencies in concrete exceptions
- require every exception factory to have an enforced caller and prevent callers from bypassing factories

## Verification
- 36 focused restoration and architecture tests passed with 107 assertions before the enforcement additions
- final exception architecture suite passed: 11 tests, 14 assertions
- deliberate orphan-factory mutation failed as expected, then was removed
- application PHPStan passed for app/Exceptions
- Pest PHPStan passed for the exception architecture suite
- Pint with Blade formatting passed
- git diff --check passed