### PR TITLE
refactor: route table deletions through actions

### DIFF
--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Events\Tables;
 
+use App\Actions\Events\DeleteAction;
 use App\Actions\Events\RestoreAction;
 use App\Builders\Events\EventBuilder;
 use App\Livewire\Base\Tables\BaseTable;
@@ -128,7 +129,10 @@ class Main extends BaseTable
 
     public function delete(Event $event): void
     {
-        $this->deleteModel($event);
+        Gate::authorize('delete', $event);
+
+        resolve(DeleteAction::class)->handle($event);
+        session()->flash('status', 'Event successfully deleted.');
     }
 
     /**

--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Managers\Tables;
 
+use App\Actions\Managers\DeleteAction;
 use App\Actions\Managers\EmployAction;
 use App\Actions\Managers\HealAction;
 use App\Actions\Managers\InjureAction;
@@ -114,7 +115,10 @@ class Main extends BaseTable
 
     public function delete(Manager $manager): void
     {
-        $this->deleteModel($manager);
+        Gate::authorize('delete', $manager);
+
+        resolve(DeleteAction::class)->handle($manager);
+        session()->flash('status', 'Manager successfully deleted.');
     }
 
     /**

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Referees\Tables;
 
+use App\Actions\Referees\DeleteAction;
 use App\Actions\Referees\EmployAction;
 use App\Actions\Referees\HealAction;
 use App\Actions\Referees\InjureAction;
@@ -116,7 +117,10 @@ class Main extends BaseTable
 
     public function delete(Referee $referee): void
     {
-        $this->deleteModel($referee);
+        Gate::authorize('delete', $referee);
+
+        resolve(DeleteAction::class)->handle($referee);
+        session()->flash('status', 'Referee successfully deleted.');
     }
 
     /**

--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Stables\Tables;
 
+use App\Actions\Stables\DeleteAction;
 use App\Actions\Stables\DisbandAction;
 use App\Actions\Stables\EstablishAction;
 use App\Actions\Stables\RestoreAction;
@@ -98,7 +99,10 @@ class Main extends BaseTable
 
     public function delete(Stable $stable): void
     {
-        $this->deleteModel($stable);
+        Gate::authorize('delete', $stable);
+
+        resolve(DeleteAction::class)->handle($stable);
+        session()->flash('status', 'Stable successfully deleted.');
     }
 
     /**

--- a/app/Livewire/TagTeams/Tables/Main.php
+++ b/app/Livewire/TagTeams/Tables/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\TagTeams\Tables;
 
+use App\Actions\TagTeams\DeleteAction;
 use App\Actions\TagTeams\EmployAction;
 use App\Actions\TagTeams\ReinstateAction;
 use App\Actions\TagTeams\ReleaseAction;
@@ -106,7 +107,10 @@ class Main extends BaseTable
 
     public function delete(TagTeam $tagTeam): void
     {
-        $this->deleteModel($tagTeam);
+        Gate::authorize('delete', $tagTeam);
+
+        resolve(DeleteAction::class)->handle($tagTeam);
+        session()->flash('status', 'Tag team successfully deleted.');
     }
 
     /**

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Titles\Tables;
 
 use App\Actions\Titles\DebutAction;
+use App\Actions\Titles\DeleteAction;
 use App\Actions\Titles\PullAction;
 use App\Actions\Titles\RestoreAction;
 use App\Actions\Titles\RetireAction;
@@ -197,7 +198,10 @@ class Main extends BaseTable
      */
     public function delete(Title $title): void
     {
-        $this->deleteModel($title);
+        Gate::authorize('delete', $title);
+
+        resolve(DeleteAction::class)->handle($title);
+        session()->flash('status', 'Title successfully deleted.');
     }
 
     /**

--- a/app/Livewire/Venues/Tables/Main.php
+++ b/app/Livewire/Venues/Tables/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Venues\Tables;
 
+use App\Actions\Venues\DeleteAction;
 use App\Actions\Venues\RestoreAction;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Table\Column;
@@ -56,9 +57,12 @@ class Main extends BaseTable
         ];
     }
 
-    public function delete(Venue $Venue): void
+    public function delete(Venue $venue): void
     {
-        $this->deleteModel($Venue);
+        Gate::authorize('delete', $venue);
+
+        resolve(DeleteAction::class)->handle($venue);
+        session()->flash('status', 'Venue successfully deleted.');
     }
 
     /**

--- a/app/Livewire/Wrestlers/Tables/Main.php
+++ b/app/Livewire/Wrestlers/Tables/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Wrestlers\Tables;
 
+use App\Actions\Wrestlers\DeleteAction;
 use App\Actions\Wrestlers\RestoreAction;
 use App\Builders\Roster\WrestlerBuilder;
 use App\Enums\Shared\EmploymentStatus;
@@ -90,7 +91,10 @@ class Main extends BaseTable
 
     public function delete(Wrestler $wrestler): void
     {
-        $this->deleteModel($wrestler);
+        Gate::authorize('delete', $wrestler);
+
+        resolve(DeleteAction::class)->handle($wrestler);
+        session()->flash('status', 'Wrestler successfully deleted.');
     }
 
     /**

--- a/tests/Integration/Livewire/DeletionActionsTest.php
+++ b/tests/Integration/Livewire/DeletionActionsTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Lifecycle\LifecycleDimension;
+use App\Enums\Lifecycle\LifecycleOwnerType;
+use App\Enums\Lifecycle\LifecycleTransitionType;
+use App\Livewire\Events\Tables\Main as EventsTable;
+use App\Livewire\Managers\Tables\Main as ManagersTable;
+use App\Livewire\Referees\Tables\Main as RefereesTable;
+use App\Livewire\Stables\Tables\Main as StablesTable;
+use App\Livewire\TagTeams\Tables\Main as TagTeamsTable;
+use App\Livewire\Titles\Tables\Main as TitlesTable;
+use App\Livewire\Venues\Tables\Main as VenuesTable;
+use App\Livewire\Wrestlers\Tables\Main as WrestlersTable;
+use App\Models\Events\Event;
+use App\Models\Events\Venue;
+use App\Models\Lifecycle\LifecycleTransition;
+use App\Models\Managers\Manager;
+use App\Models\Referees\Referee;
+use App\Models\Stables\Stable;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Wrestlers\Wrestler;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+test('table deletions use the typed lifecycle action', function (LifecycleOwnerType $ownerType) {
+    $owner = match ($ownerType) {
+        LifecycleOwnerType::Event => Event::factory()->create(),
+        LifecycleOwnerType::Manager => Manager::factory()->create(),
+        LifecycleOwnerType::Referee => Referee::factory()->create(),
+        LifecycleOwnerType::Stable => Stable::factory()->inactive()->create(),
+        LifecycleOwnerType::TagTeam => TagTeam::factory()->create(),
+        LifecycleOwnerType::Title => Title::factory()->create(),
+        LifecycleOwnerType::Venue => Venue::factory()->create(),
+        LifecycleOwnerType::Wrestler => Wrestler::factory()->create(),
+    };
+    $component = match ($ownerType) {
+        LifecycleOwnerType::Event => EventsTable::class,
+        LifecycleOwnerType::Manager => ManagersTable::class,
+        LifecycleOwnerType::Referee => RefereesTable::class,
+        LifecycleOwnerType::Stable => StablesTable::class,
+        LifecycleOwnerType::TagTeam => TagTeamsTable::class,
+        LifecycleOwnerType::Title => TitlesTable::class,
+        LifecycleOwnerType::Venue => VenuesTable::class,
+        LifecycleOwnerType::Wrestler => WrestlersTable::class,
+    };
+
+    actingAs(administrator());
+
+    livewire($component)
+        ->call('delete', $owner)
+        ->assertHasNoErrors();
+
+    $transition = LifecycleTransition::query()
+        ->where('subject_type', $ownerType->morphAlias())
+        ->where('subject_id', $owner->getKey())
+        ->sole();
+    $owner->refresh();
+
+    expect($owner->trashed())->toBeTrue()
+        ->and($transition->dimension)->toBe(LifecycleDimension::Deletion)
+        ->and($transition->transition)->toBe(LifecycleTransitionType::Deleted);
+})->with(LifecycleOwnerType::cases());


### PR DESCRIPTION
## Summary
- route aggregate table deletions through their typed DeleteAction classes
- preserve authorization immediately before each deletion operation
- verify all eight lifecycle aggregate tables record deletion transitions

## Verification
- focused Livewire deletion coverage: 8 tests, 32 assertions
- pre-rebase affected table suites: 211 tests, 536 assertions
- application PHPStan passed
- Pest PHPStan passed
- Pest type coverage passed at 100%
- Rector passed with no changes
- targeted Blade-aware formatting passed
- git diff check passed

## Local suite note
- composer test:push reaches the existing repository-wide Blade formatting backlog after type coverage and Rector pass; this branch does not modify any of the reported Blade files. GitHub's isolated checks will validate the PR.