### PR TITLE
refactor: isolate soft-deleted match history

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -18,6 +18,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/Livewire/** | .ai/rules/livewire.md |
 | app/Exceptions/{Matches,Scheduling}/** | .ai/rules/matches-scheduling.md |
 | app/{Actions/Matches,Services}/** | .ai/rules/matches-services.md |
+| app/{Actions,Models}/Matches/** | .ai/rules/matches.md |
 | database/migrations/** | .ai/rules/migrations.md |
 | app/{Models,ValueObjects,Casts}/** | .ai/rules/models-value-objects-casts.md |
 | app/Models/** | .ai/rules/models.md |

--- a/.ai/rules/matches.md
+++ b/.ai/rules/matches.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Actions,Models}/Matches/**'
+---
+
+# Matches
+
+## Preserve match history with soft deletion
+Delete matches by soft deleting only the EventMatch through DeletionStateManager. Preserve competitors, referee and title assignments, results, winners, losers, and championship references as historical records. Default queries exclude deleted matches; use withTrashed() only for explicit historical access.

--- a/app/Actions/Matches/DeleteAction.php
+++ b/app/Actions/Matches/DeleteAction.php
@@ -4,12 +4,21 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
+use App\Lifecycle\DeletionStateManager;
 use App\Models\Matches\EventMatch;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class DeleteAction
 {
-    public function handle(EventMatch $eventMatch): void
+    public function __construct(private readonly DeletionStateManager $deletionState) {}
+
+    public function handle(EventMatch $eventMatch, ?Carbon $deletedAt = null): void
     {
-        $eventMatch->delete();
+        DB::transaction(function () use ($eventMatch, $deletedAt): void {
+            $lockedMatch = EventMatch::query()->lockForUpdate()->findOrFail($eventMatch->getKey());
+
+            $this->deletionState->delete($lockedMatch, $deletedAt ?? now());
+        });
     }
 }

--- a/app/Actions/Matches/DeleteAction.php
+++ b/app/Actions/Matches/DeleteAction.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Matches;
+
+use App\Models\Matches\EventMatch;
+
+class DeleteAction
+{
+    public function handle(EventMatch $eventMatch): void
+    {
+        $eventMatch->delete();
+    }
+}

--- a/app/Enums/Lifecycle/LifecycleOwnerType.php
+++ b/app/Enums/Lifecycle/LifecycleOwnerType.php
@@ -7,6 +7,7 @@ namespace App\Enums\Lifecycle;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Managers\Manager;
+use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
@@ -19,6 +20,7 @@ enum LifecycleOwnerType: string
 {
     case Event = 'event';
     case Manager = 'manager';
+    case Match = 'match';
     case Referee = 'referee';
     case Stable = 'stable';
     case TagTeam = 'tag_team';
@@ -31,6 +33,7 @@ enum LifecycleOwnerType: string
         return match (true) {
             $model instanceof Event => self::Event,
             $model instanceof Manager => self::Manager,
+            $model instanceof EventMatch => self::Match,
             $model instanceof Referee => self::Referee,
             $model instanceof Stable => self::Stable,
             $model instanceof TagTeam => self::TagTeam,
@@ -46,6 +49,7 @@ enum LifecycleOwnerType: string
         return match ($this) {
             self::Event => (new Event())->getMorphClass(),
             self::Manager => (new Manager())->getMorphClass(),
+            self::Match => (new EventMatch())->getMorphClass(),
             self::Referee => (new Referee())->getMorphClass(),
             self::Stable => (new Stable())->getMorphClass(),
             self::TagTeam => (new TagTeam())->getMorphClass(),

--- a/app/Livewire/Base/Tables/BaseTable.php
+++ b/app/Livewire/Base/Tables/BaseTable.php
@@ -7,8 +7,6 @@ namespace App\Livewire\Base\Tables;
 use App\Livewire\Concerns\BaseTableTrait;
 use App\Livewire\Concerns\Columns\HasActionColumn;
 use App\Livewire\Table\DataTableComponent;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Support\Facades\Gate;
 
 abstract class BaseTable extends DataTableComponent
 {
@@ -17,21 +15,4 @@ abstract class BaseTable extends DataTableComponent
 
     /** @var array<string, bool> */
     protected array $actionLinksToDisplay = ['view' => true, 'edit' => true, 'delete' => true];
-
-    /**
-     * Delete a model with proper authorization checking.
-     *
-     * @param  Model  $model  The model to delete
-     */
-    protected function deleteModel(Model $model): void
-    {
-        $canDelete = Gate::inspect('delete', $model);
-
-        if ($canDelete->allowed()) {
-            $model->delete();
-            session()->flash('status', 'Model successfully updated.');
-        } else {
-            session()->flash('status', 'You cannot delete this Model.');
-        }
-    }
 }

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Matches\Tables;
 
+use App\Actions\Matches\DeleteAction;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\LinkColumn;
@@ -73,6 +74,10 @@ class Main extends BaseTable
 
     public function delete(EventMatch $eventMatch): void
     {
-        $this->deleteModel($eventMatch);
+        Gate::authorize('delete', $eventMatch);
+
+        resolve(DeleteAction::class)->handle($eventMatch);
+
+        session()->flash('status', 'Match successfully deleted.');
     }
 }

--- a/app/Models/Matches/EventMatch.php
+++ b/app/Models/Matches/EventMatch.php
@@ -6,6 +6,8 @@ namespace App\Models\Matches;
 
 use App\Collections\MatchCompetitorsCollection;
 use App\Enums\MatchType;
+use App\Models\Concerns\HasLifecycleTransitions;
+use App\Models\Contracts\SoftDeletable;
 use App\Models\Events\Event;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
@@ -24,6 +26,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
 /**
@@ -35,6 +38,7 @@ use Illuminate\Support\Carbon;
  * @property string|null $preview
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
+ * @property Carbon|null $deleted_at
  *
  * @property-read MatchCompetitor|null $pivot
  * @property-read MatchCompetitorsCollection<int, MatchCompetitor> $competitors
@@ -51,17 +55,23 @@ use Illuminate\Support\Carbon;
  * @method static \Database\Factories\Matches\MatchFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch newModelQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch onlyTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch withoutTrashed()
  *
  * @mixin \Eloquent
  */
 #[Table('events_matches')]
 #[Fillable('event_id', 'match_number', 'match_type', 'match_stipulation_id', 'preview')]
 #[UseFactory(MatchFactory::class)]
-class EventMatch extends Model
+class EventMatch extends Model implements SoftDeletable
 {
     /** @use HasFactory<MatchFactory> */
     use HasFactory;
+
+    use HasLifecycleTransitions;
+    use SoftDeletes;
 
     /**
      * Get the attributes that should be cast.

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,6 +8,7 @@ use App\Console\Commands\EnhancedTestMakeCommand;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Managers\Manager;
+use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
@@ -63,6 +64,7 @@ class AppServiceProvider extends ServiceProvider
         Relation::morphMap([
             'wrestler' => Wrestler::class,
             'manager' => Manager::class,
+            'match' => EventMatch::class,
             'title' => Title::class,
             'tagTeam' => TagTeam::class,
             'referee' => Referee::class,

--- a/database/migrations/2026_08_13_135841_add_deleted_at_to_events_matches_table.php
+++ b/database/migrations/2026_08_13_135841_add_deleted_at_to_events_matches_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events_matches', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+};

--- a/docs/architecture/lifecycle-operation-boundaries.md
+++ b/docs/architecture/lifecycle-operation-boundaries.md
@@ -155,6 +155,8 @@ Retirement eligibility uses explicit typed collaborators rather than an operatio
 
 Individual soft-deletion eligibility is shared by wrestlers, managers, and referees. `ValidatesIndividualDeletion` rejects repeated deletion through a typed business exception, while `ValidatesIndividualRestoration` requires an existing soft-deleted record. Their boolean predicates delegate to the same typed guards used by the deletion and restoration Actions. Restoring an individual does not infer or recreate employment or other historical relationships; those transitions remain explicit operations.
 
+Match deletion soft deletes only the `EventMatch` record through `DeletionStateManager`. Competitors, referee and title assignments, results, winners, losers, and championship references remain intact as historical records. Default match queries exclude deleted matches, while explicit historical queries may include them with `withTrashed()`.
+
 Suspension eligibility follows the same typed boundary. `IndividualSuspensionEligibility` accepts only wrestlers, managers, and referees and keeps each boolean predicate aligned with its throwing guard. Each typed Action reloads and locks the individual inside its transaction before changing the suspension period. Tag teams retain their established lifecycle validation, while stables and titles do not support suspension.
 
 Wrestler injury and suspension are mutually exclusive availability states. Both transition Actions acquire a lock on the wrestler and evaluate their opposing-state guard inside the same transaction that opens the new period. Concurrent injury and suspension requests therefore serialize on the wrestler instead of both validating stale state before either period is written.

--- a/tests/Integration/Actions/Matches/DeleteActionTest.php
+++ b/tests/Integration/Actions/Matches/DeleteActionTest.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Matches\DeleteAction;
+use App\Models\Matches\EventMatch;
+
+test('it deletes a match', function () {
+    $eventMatch = EventMatch::factory()->create();
+
+    resolve(DeleteAction::class)->handle($eventMatch);
+
+    $this->assertModelMissing($eventMatch);
+});

--- a/tests/Integration/Actions/Matches/DeleteActionTest.php
+++ b/tests/Integration/Actions/Matches/DeleteActionTest.php
@@ -3,12 +3,26 @@
 declare(strict_types=1);
 
 use App\Actions\Matches\DeleteAction;
+use App\Enums\Lifecycle\LifecycleTransitionType;
 use App\Models\Matches\EventMatch;
+use App\Models\Referees\Referee;
 
-test('it deletes a match', function () {
-    $eventMatch = EventMatch::factory()->create();
+test('it soft deletes a match while preserving its historical records', function () {
+    $eventMatch = EventMatch::factory()->complete()->withReferees()->create();
+    $competitorIds = $eventMatch->competitors()->pluck('id');
+    $refereeIds = $eventMatch->referees()->pluck('referees.id');
+    $resultId = $eventMatch->result()->sole()->id;
 
     resolve(DeleteAction::class)->handle($eventMatch);
 
-    $this->assertModelMissing($eventMatch);
+    $this->assertSoftDeleted($eventMatch);
+
+    expect(EventMatch::query()->find($eventMatch->id))->toBeNull()
+        ->and(EventMatch::withTrashed()->find($eventMatch->id))->not->toBeNull()
+        ->and($eventMatch->competitors()->pluck('id'))->toEqual($competitorIds)
+        ->and($eventMatch->referees()->pluck('referees.id'))->toEqual($refereeIds)
+        ->and($eventMatch->result()->sole()->id)->toBe($resultId)
+        ->and($eventMatch->lifecycleTransitions()->sole()->transition)->toBe(LifecycleTransitionType::Deleted);
+
+    expect(Referee::query()->whereKey($refereeIds)->count())->toBe($refereeIds->count());
 });

--- a/tests/Integration/Lifecycle/DeletionStateManagerTest.php
+++ b/tests/Integration/Lifecycle/DeletionStateManagerTest.php
@@ -9,6 +9,7 @@ use App\Lifecycle\DeletionStateManager;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Managers\Manager;
+use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
@@ -25,6 +26,7 @@ test('it records deletion and restoration for every soft-deletable owner', funct
     $owner = match ($ownerType) {
         LifecycleOwnerType::Event => Event::factory()->create(),
         LifecycleOwnerType::Manager => Manager::factory()->create(),
+        LifecycleOwnerType::Match => EventMatch::factory()->create(),
         LifecycleOwnerType::Referee => Referee::factory()->create(),
         LifecycleOwnerType::Stable => Stable::factory()->create(),
         LifecycleOwnerType::TagTeam => TagTeam::factory()->create(),

--- a/tests/Integration/Livewire/DeletionActionsTest.php
+++ b/tests/Integration/Livewire/DeletionActionsTest.php
@@ -7,6 +7,7 @@ use App\Enums\Lifecycle\LifecycleOwnerType;
 use App\Enums\Lifecycle\LifecycleTransitionType;
 use App\Livewire\Events\Tables\Main as EventsTable;
 use App\Livewire\Managers\Tables\Main as ManagersTable;
+use App\Livewire\Matches\Tables\Main as MatchesTable;
 use App\Livewire\Referees\Tables\Main as RefereesTable;
 use App\Livewire\Stables\Tables\Main as StablesTable;
 use App\Livewire\TagTeams\Tables\Main as TagTeamsTable;
@@ -17,6 +18,7 @@ use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Lifecycle\LifecycleTransition;
 use App\Models\Managers\Manager;
+use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
@@ -30,6 +32,7 @@ test('table deletions use the typed lifecycle action', function (LifecycleOwnerT
     $owner = match ($ownerType) {
         LifecycleOwnerType::Event => Event::factory()->create(),
         LifecycleOwnerType::Manager => Manager::factory()->create(),
+        LifecycleOwnerType::Match => EventMatch::factory()->create(),
         LifecycleOwnerType::Referee => Referee::factory()->create(),
         LifecycleOwnerType::Stable => Stable::factory()->inactive()->create(),
         LifecycleOwnerType::TagTeam => TagTeam::factory()->create(),
@@ -40,6 +43,7 @@ test('table deletions use the typed lifecycle action', function (LifecycleOwnerT
     $component = match ($ownerType) {
         LifecycleOwnerType::Event => EventsTable::class,
         LifecycleOwnerType::Manager => ManagersTable::class,
+        LifecycleOwnerType::Match => MatchesTable::class,
         LifecycleOwnerType::Referee => RefereesTable::class,
         LifecycleOwnerType::Stable => StablesTable::class,
         LifecycleOwnerType::TagTeam => TagTeamsTable::class,

--- a/tests/Integration/Livewire/Matches/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MainTest.php
@@ -92,6 +92,21 @@ describe('Matches Main Table Component Integration', function () {
         });
     });
 
+    describe('deletion', function () {
+        test('deletes matches through the table action', function () {
+            $match = EventMatch::factory()->create([
+                'event_id' => $this->event->id,
+            ]);
+
+            actingAs($this->admin);
+
+            livewire(Main::class)
+                ->call('delete', $match);
+
+            $this->assertModelMissing($match);
+        });
+    });
+
     describe('query optimization and performance', function () {
         test('component loads efficiently with many matches', function () {
             EventMatch::factory()->count(10)->create([

--- a/tests/Integration/Livewire/Matches/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MainTest.php
@@ -103,7 +103,7 @@ describe('Matches Main Table Component Integration', function () {
             livewire(Main::class)
                 ->call('delete', $match);
 
-            $this->assertModelMissing($match);
+            $this->assertSoftDeleted($match);
         });
     });
 

--- a/tests/Unit/Enums/Lifecycle/LifecycleOwnerTypeTest.php
+++ b/tests/Unit/Enums/Lifecycle/LifecycleOwnerTypeTest.php
@@ -6,6 +6,7 @@ use App\Enums\Lifecycle\LifecycleOwnerType;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Managers\Manager;
+use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
@@ -20,6 +21,7 @@ test('it resolves supported lifecycle owner models', function (LifecycleOwnerTyp
 })->with([
     'event' => [LifecycleOwnerType::Event, new Event()],
     'manager' => [LifecycleOwnerType::Manager, new Manager()],
+    'match' => [LifecycleOwnerType::Match, new EventMatch()],
     'referee' => [LifecycleOwnerType::Referee, new Referee()],
     'stable' => [LifecycleOwnerType::Stable, new Stable()],
     'tag team' => [LifecycleOwnerType::TagTeam, new TagTeam()],


### PR DESCRIPTION
## Summary
- route match deletion through a typed Action and explicit Livewire authorization
- soft delete EventMatch records while preserving all related match history
- record match deletion through the shared lifecycle audit
- remove generic model deletion behavior from the base table
- document and enforce the historical-preservation boundary

## Verification
- 39 focused tests passed with 135 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push passed tests, type coverage, and Rector, then reached the existing local Blade formatter baseline in unrelated views; this PR does not modify those views