### PR TITLE
refactor: introduce wrestler measurement values

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -19,6 +19,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/Exceptions/{Matches,Scheduling}/** | .ai/rules/matches-scheduling.md |
 | app/{Actions/Matches,Services}/** | .ai/rules/matches-services.md |
 | database/migrations/** | .ai/rules/migrations.md |
+| app/{Models,ValueObjects,Casts}/** | .ai/rules/models-value-objects-casts.md |
 | app/Models/** | .ai/rules/models.md |
 | app/{Livewire,Http/Requests,Actions,Services}/** | .ai/rules/requests-actions-services.md |
 | app/Http/Requests/** | .ai/rules/requests.md |

--- a/.ai/rules/models-value-objects-casts.md
+++ b/.ai/rules/models-value-objects-casts.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Models,ValueObjects,Casts}/**'
+---
+
+# Models Value Objects Casts
+
+## Keep models persistence-only
+Keep Eloquent models and model concerns limited to persistence metadata, casts, relationships, and query definitions. Move lifecycle eligibility, can/ensure decisions, transitions, orchestration, and cross-model business rules into focused Actions, policies, rules, or state evaluators. Use immutable value objects only for domain values with real invariants or behavior; value objects must not query or orchestrate persistence.

--- a/app/Actions/Wrestlers/CreateAction.php
+++ b/app/Actions/Wrestlers/CreateAction.php
@@ -22,8 +22,8 @@ class CreateAction
         return DB::transaction(function () use ($wrestlerData): Wrestler {
             $wrestler = Wrestler::query()->create([
                 'name' => $wrestlerData->name,
-                'height' => $wrestlerData->height,
-                'weight' => $wrestlerData->weight,
+                'height' => $wrestlerData->height->toInches(),
+                'weight' => $wrestlerData->weight->toPounds(),
                 'hometown' => $wrestlerData->hometown,
                 'signature_move' => $wrestlerData->signature_move,
             ]);

--- a/app/Actions/Wrestlers/UpdateAction.php
+++ b/app/Actions/Wrestlers/UpdateAction.php
@@ -47,8 +47,8 @@ class UpdateAction
             // Update the wrestler's basic information
             $wrestler->update([
                 'name' => $wrestlerData->name,
-                'height' => $wrestlerData->height,
-                'weight' => $wrestlerData->weight,
+                'height' => $wrestlerData->height->toInches(),
+                'weight' => $wrestlerData->weight->toPounds(),
                 'hometown' => $wrestlerData->hometown,
                 'signature_move' => $wrestlerData->signature_move,
             ]);

--- a/app/Casts/HeightCast.php
+++ b/app/Casts/HeightCast.php
@@ -9,21 +9,21 @@ use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * @implements CastsAttributes<Height, int>
+ * @implements CastsAttributes<Height, Height|int>
  */
 class HeightCast implements CastsAttributes
 {
     public function get(Model $model, string $key, mixed $value, array $attributes): Height
     {
-        /** @var int $value */
-        $feet = (int) floor($value / 12);
-        $inches = $value % 12;
-
-        return new Height($feet, $inches);
+        return Height::fromInches((int) $value);
     }
 
-    public function set(Model $model, string $key, mixed $value, array $attributes): mixed
+    public function set(Model $model, string $key, mixed $value, array $attributes): int
     {
-        return $value;
+        if ($value instanceof Height) {
+            return $value->toInches();
+        }
+
+        return Height::fromInches((int) $value)->toInches();
     }
 }

--- a/app/Data/Wrestlers/WrestlerData.php
+++ b/app/Data/Wrestlers/WrestlerData.php
@@ -5,17 +5,23 @@ declare(strict_types=1);
 namespace App\Data\Wrestlers;
 
 use App\Models\Managers\Manager;
+use App\ValueObjects\Height;
+use App\ValueObjects\Weight;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Support\Carbon;
 
 class WrestlerData
 {
+    public Height $height;
+
+    public Weight $weight;
+
     /**
      * Create a new wrestler data instance.
      *
      * @param  string  $name  Wrestler's ring name
-     * @param  int  $height  Wrestler's height in inches
-     * @param  int  $weight  Wrestler's weight in pounds
+     * @param  Height|int  $height  Wrestler's height or height in inches
+     * @param  Weight|int  $weight  Wrestler's weight or weight in pounds
      * @param  string  $hometown  Wrestler's hometown/origin
      * @param  string|null  $signature_move  Wrestler's signature finishing move
      * @param  Carbon|null  $employment_date  Employment start date (if provided, wrestler will be employed)
@@ -23,13 +29,16 @@ class WrestlerData
      */
     public function __construct(
         public string $name,
-        public int $height,
-        public int $weight,
+        Height|int $height,
+        Weight|int $weight,
         public string $hometown,
         public ?string $signature_move,
         public ?Carbon $employment_date,
         public ?Collection $managers = null,
-    ) {}
+    ) {
+        $this->height = $height instanceof Height ? $height : Height::fromInches($height);
+        $this->weight = $weight instanceof Weight ? $weight : new Weight($weight);
+    }
 
     /**
      * Check if wrestler has any managers assigned.

--- a/app/ValueObjects/Height.php
+++ b/app/ValueObjects/Height.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\ValueObjects;
 
+use InvalidArgumentException;
+
 /**
  * Value object representing a wrestler's height in feet and inches.
  *
@@ -31,7 +33,28 @@ readonly class Height
     public function __construct(
         public int $feet,
         public int $inches
-    ) {}
+    ) {
+        if ($feet < 0) {
+            throw new InvalidArgumentException('Height feet cannot be negative.');
+        }
+
+        if ($inches < 0 || $inches > 11) {
+            throw new InvalidArgumentException('Height inches must be between 0 and 11.');
+        }
+
+        if ($feet === 0 && $inches === 0) {
+            throw new InvalidArgumentException('Height must be greater than zero.');
+        }
+    }
+
+    public static function fromInches(int $inches): self
+    {
+        if ($inches <= 0) {
+            throw new InvalidArgumentException('Height must be greater than zero.');
+        }
+
+        return new self(intdiv($inches, 12), $inches % 12);
+    }
 
     /**
      * Get the height formatted as a string in wrestling notation.

--- a/app/ValueObjects/Weight.php
+++ b/app/ValueObjects/Weight.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ValueObjects;
+
+use InvalidArgumentException;
+
+readonly class Weight
+{
+    public function __construct(public int $pounds)
+    {
+        if ($pounds <= 0) {
+            throw new InvalidArgumentException('Weight must be greater than zero.');
+        }
+    }
+
+    public function __toString(): string
+    {
+        return "{$this->pounds} lbs";
+    }
+
+    public function toPounds(): int
+    {
+        return $this->pounds;
+    }
+}

--- a/tests/Unit/Casts/HeightCastTest.php
+++ b/tests/Unit/Casts/HeightCastTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Wrestlers\Wrestler;
+use App\ValueObjects\Height;
+
+test('it casts stored inches to height', function () {
+    $wrestler = Wrestler::factory()->create(['height' => 74]);
+
+    expect($wrestler->height)->toEqual(new Height(6, 2));
+});
+
+test('it stores height values as total inches', function () {
+    $wrestler = Wrestler::factory()->create(['height' => new Height(6, 2)]);
+
+    expect($wrestler->getRawOriginal('height'))->toBe(74)
+        ->and($wrestler->height)->toEqual(new Height(6, 2));
+});
+
+test('it rejects invalid stored height values', function () {
+    expect(fn () => Wrestler::factory()->create(['height' => 0]))
+        ->toThrow(InvalidArgumentException::class);
+});

--- a/tests/Unit/ValueObjects/HeightTest.php
+++ b/tests/Unit/ValueObjects/HeightTest.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use App\ValueObjects\Height;
+
+test('it creates height from feet and inches', function () {
+    $height = new Height(6, 2);
+
+    expect($height->toInches())->toBe(74)
+        ->and((string) $height)->toBe('6\'2"');
+});
+
+test('it creates height from total inches', function () {
+    $height = Height::fromInches(74);
+
+    expect($height->feet)->toBe(6)
+        ->and($height->inches)->toBe(2);
+});
+
+test('it rejects invalid height components', function (int $feet, int $inches) {
+    expect(fn () => new Height($feet, $inches))->toThrow(InvalidArgumentException::class);
+})->with([
+    'negative feet' => [-1, 0],
+    'negative inches' => [6, -1],
+    'too many inches' => [6, 12],
+    'zero height' => [0, 0],
+]);
+
+test('it rejects invalid total inches', function (int $inches) {
+    expect(fn () => Height::fromInches($inches))->toThrow(InvalidArgumentException::class);
+})->with([0, -1]);

--- a/tests/Unit/ValueObjects/WeightTest.php
+++ b/tests/Unit/ValueObjects/WeightTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\ValueObjects\Weight;
+
+test('it represents weight in pounds', function () {
+    $weight = new Weight(225);
+
+    expect($weight->toPounds())->toBe(225)
+        ->and((string) $weight)->toBe('225 lbs');
+});
+
+test('it rejects non-positive weight', function (int $pounds) {
+    expect(fn () => new Weight($pounds))->toThrow(InvalidArgumentException::class);
+})->with([0, -1]);


### PR DESCRIPTION
## Summary
- harden Height as an immutable validated value and correct its Eloquent cast storage behavior
- introduce Weight as a validated operation-boundary value while retaining integer database storage for aggregation
- normalize WrestlerData measurements before typed Actions persist them
- record the persistence-only model and value-object boundary through Boost

## Verification
- 31 focused tests passed with 95 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed with no changes
- Blade-aware formatting passed for touched files
- git diff check passed