### PR TITLE
refactor: introduce phone number value

### DIFF
--- a/app/Casts/PhoneNumberCast.php
+++ b/app/Casts/PhoneNumberCast.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Casts;
+
+use App\ValueObjects\PhoneNumber;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @implements CastsAttributes<PhoneNumber, PhoneNumber|string>
+ */
+class PhoneNumberCast implements CastsAttributes, SerializesCastableAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): ?PhoneNumber
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return new PhoneNumber((string) $value);
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return $value instanceof PhoneNumber
+            ? $value->toDigits()
+            : (new PhoneNumber((string) $value))->toDigits();
+    }
+
+    public function serialize(Model $model, string $key, mixed $value, array $attributes): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        return $value instanceof PhoneNumber ? $value->toDigits() : (string) $value;
+    }
+}

--- a/app/Livewire/Users/Tables/Main.php
+++ b/app/Livewire/Users/Tables/Main.php
@@ -45,7 +45,7 @@ class Main extends BaseTable
             Column::make(__('users.email'), 'email')
                 ->searchable(),
             Column::make(__('users.phone'), 'phone_number')
-                ->label(fn (User $row, Column $column): string => $row->formatted_phone_number),
+                ->label(fn (User $row, Column $column): string => $row->phone_number?->formatted() ?? ''),
         ];
     }
 }

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Models\Users;
 
 use App\Builders\Users\UserBuilder;
+use App\Casts\PhoneNumberCast;
 use App\Enums\Users\Role;
 use App\Enums\Users\UserStatus;
 use App\Models\Wrestlers\Wrestler;
+use App\ValueObjects\PhoneNumber;
 use Database\Factories\Users\UserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
@@ -35,14 +37,13 @@ use Illuminate\Support\Carbon;
  * @property string $password
  * @property UserStatus $status
  * @property string|null $avatar_path
- * @property string|null $phone_number
+ * @property PhoneNumber|null $phone_number
  * @property string|null $remember_token
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
  *
  * @property-read Role $role
- * @property-read string $formatted_phone_number
  * @property-read DatabaseNotificationCollection<int, DatabaseNotification> $notifications
  * @property-read Wrestler|null $wrestler
  * @property-read Collection<int, Wrestler> $wrestlers
@@ -82,6 +83,7 @@ class User extends Authenticatable
         return [
             'role' => Role::class,
             'status' => UserStatus::class,
+            'phone_number' => PhoneNumberCast::class,
         ];
     }
 
@@ -108,20 +110,6 @@ class User extends Authenticatable
     public function getAvatar(): string
     {
         return $this->avatar_path ?? 'blank.png';
-    }
-
-    /**
-     * Get the formatted phone number attribute.
-     *
-     * @return Attribute<string, never>
-     */
-    public function formattedPhoneNumber(): Attribute
-    {
-        return new Attribute(
-            get: fn () => $this->phone_number
-                ? sprintf('(%s) %s-%s', mb_substr($this->phone_number, 0, 3), mb_substr($this->phone_number, 3, 3), mb_substr($this->phone_number, 6, 4))
-                : '',
-        );
     }
 
     /**

--- a/app/ValueObjects/PhoneNumber.php
+++ b/app/ValueObjects/PhoneNumber.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ValueObjects;
+
+use InvalidArgumentException;
+
+readonly class PhoneNumber
+{
+    private string $digits;
+
+    public function __construct(string $value)
+    {
+        $digits = preg_replace('/\D+/', '', $value);
+
+        if ($digits === null || mb_strlen($digits) !== 10) {
+            throw new InvalidArgumentException('Phone number must contain exactly 10 digits.');
+        }
+
+        $this->digits = $digits;
+    }
+
+    public function __toString(): string
+    {
+        return $this->digits;
+    }
+
+    public function formatted(): string
+    {
+        return sprintf(
+            '(%s) %s-%s',
+            mb_substr($this->digits, 0, 3),
+            mb_substr($this->digits, 3, 3),
+            mb_substr($this->digits, 6, 4),
+        );
+    }
+
+    public function toDigits(): string
+    {
+        return $this->digits;
+    }
+}

--- a/database/factories/Users/UserFactory.php
+++ b/database/factories/Users/UserFactory.php
@@ -29,7 +29,7 @@ class UserFactory extends Factory
             'remember_token' => Str::random(10),
             'role' => Role::Basic,
             'avatar_path' => '300-3.png',
-            'phone_number' => fake()->unique()->phoneNumber(),
+            'phone_number' => fake()->unique()->numerify('##########'),
         ];
     }
 

--- a/database/seeders/UsersTableSeeder.php
+++ b/database/seeders/UsersTableSeeder.php
@@ -26,7 +26,7 @@ class UsersTableSeeder extends Seeder
             'password' => 'password',
             'status' => UserStatus::Active,
             'avatar_path' => '300-3.png',
-            'phone_number' => fake()->unique()->numberBetween(0000000000, 9999999999),
+            'phone_number' => fake()->unique()->numerify('##########'),
         ]
         )->create();
 
@@ -37,7 +37,7 @@ class UsersTableSeeder extends Seeder
             'password' => 'password',
             'status' => UserStatus::Active,
             'avatar_path' => '300-3.png',
-            'phone_number' => fake()->unique()->numberBetween(0000000000, 9999999999),
+            'phone_number' => fake()->unique()->numerify('##########'),
         ]
         )->create();
     }

--- a/tests/Integration/Database/Seeders/UsersTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/UsersTableSeederTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Enums\Users\Role;
 use App\Enums\Users\UserStatus;
 use App\Models\Users\User;
+use App\ValueObjects\PhoneNumber;
 use Database\Seeders\UsersTableSeeder;
 use Illuminate\Support\Facades\Artisan;
 
@@ -85,7 +86,7 @@ describe('UsersTableSeeder Integration Tests', function () {
                 expect($admin->last_name)->toBe('User');
                 expect($admin->email)->toContain('@example.com');
                 expect($admin->avatar_path)->toBe('300-3.png');
-                expect($admin->phone_number)->toBeString();
+                expect($admin->phone_number)->toBeInstanceOf(PhoneNumber::class);
                 expect($admin->status)->toBe(UserStatus::Active);
             }
         });
@@ -134,7 +135,7 @@ describe('UsersTableSeeder Integration Tests', function () {
                 expect($user->last_name)->toBe('User');
                 expect($user->email)->toContain('@example.com');
                 expect($user->avatar_path)->toBe('300-3.png');
-                expect($user->phone_number)->toBeString();
+                expect($user->phone_number)->toBeInstanceOf(PhoneNumber::class);
                 expect($user->status)->toBe(UserStatus::Active);
             }
         });

--- a/tests/Unit/Casts/PhoneNumberCastTest.php
+++ b/tests/Unit/Casts/PhoneNumberCastTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Users\User;
+use App\ValueObjects\PhoneNumber;
+
+test('it casts stored digits to a phone number', function () {
+    $user = User::factory()->create(['phone_number' => '1234567890']);
+
+    expect($user->phone_number)->toEqual(new PhoneNumber('1234567890'));
+});
+
+test('it normalizes phone number values for storage', function () {
+    $user = User::factory()->create(['phone_number' => new PhoneNumber('(123) 456-7890')]);
+
+    expect($user->getRawOriginal('phone_number'))->toBe('1234567890')
+        ->and($user->toArray()['phone_number'])->toBe('1234567890');
+});
+
+test('it preserves null phone numbers', function () {
+    $user = User::factory()->create(['phone_number' => null]);
+
+    expect($user->phone_number)->toBeNull();
+});

--- a/tests/Unit/ValueObjects/PhoneNumberTest.php
+++ b/tests/Unit/ValueObjects/PhoneNumberTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use App\ValueObjects\PhoneNumber;
+
+test('it normalizes and formats a phone number', function () {
+    $phoneNumber = new PhoneNumber('(123) 456-7890');
+
+    expect($phoneNumber->toDigits())->toBe('1234567890')
+        ->and($phoneNumber->formatted())->toBe('(123) 456-7890')
+        ->and((string) $phoneNumber)->toBe('1234567890');
+});
+
+test('it rejects values without exactly ten digits', function (string $value) {
+    expect(fn () => new PhoneNumber($value))->toThrow(InvalidArgumentException::class);
+})->with([
+    'too short' => '123456789',
+    'too long' => '11234567890',
+    'empty' => '',
+]);


### PR DESCRIPTION
## Summary
- introduce a validated PhoneNumber value object and Eloquent cast
- keep phone formatting outside the User persistence model
- store canonical ten-digit values while preserving nullable phone numbers
- update user factories, seeders, table display, and focused tests

## Verification
- 74 focused tests passed with 275 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- touched files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push passed tests, type coverage, and Rector, then encountered existing Blade formatter drift in untouched view files on development; those unrelated files were not changed by this PR.