### PR TITLE
refactor: introduce venue address value

### DIFF
--- a/app/Actions/Venues/CreateAction.php
+++ b/app/Actions/Venues/CreateAction.php
@@ -24,10 +24,7 @@ class CreateAction
     {
         return Venue::query()->create([
             'name' => $venueData->name,
-            'street_address' => $venueData->street_address,
-            'city' => $venueData->city,
-            'state' => $venueData->state,
-            'zipcode' => $venueData->zipcode,
+            'address' => $venueData->address,
         ]);
     }
 }

--- a/app/Actions/Venues/UpdateAction.php
+++ b/app/Actions/Venues/UpdateAction.php
@@ -25,10 +25,7 @@ class UpdateAction
     {
         $venue->update([
             'name' => $venueData->name,
-            'street_address' => $venueData->street_address,
-            'city' => $venueData->city,
-            'state' => $venueData->state,
-            'zipcode' => $venueData->zipcode,
+            'address' => $venueData->address,
         ]);
 
         return $venue;

--- a/app/Casts/AddressCast.php
+++ b/app/Casts/AddressCast.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Casts;
+
+use App\ValueObjects\Address;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/** @implements CastsAttributes<Address, Address> */
+class AddressCast implements CastsAttributes
+{
+    /** @param array<string, mixed> $attributes */
+    public function get(Model $model, string $key, mixed $value, array $attributes): Address
+    {
+        return new Address(
+            streetAddress: (string) $attributes['street_address'],
+            city: (string) $attributes['city'],
+            state: (string) $attributes['state'],
+            zipcode: (string) $attributes['zipcode'],
+        );
+    }
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     * @return array{street_address: string, city: string, state: string, zipcode: string}
+     */
+    public function set(Model $model, string $key, mixed $value, array $attributes): array
+    {
+        return $value->toAttributes();
+    }
+}

--- a/app/Data/Events/VenueData.php
+++ b/app/Data/Events/VenueData.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace App\Data\Events;
 
+use App\ValueObjects\Address;
+
 readonly class VenueData
 {
+    public Address $address;
+
     /**
      * Create a new venue data instance.
      */
@@ -15,5 +19,7 @@ readonly class VenueData
         public string $city,
         public string $state,
         public string $zipcode,
-    ) {}
+    ) {
+        $this->address = new Address($street_address, $city, $state, $zipcode);
+    }
 }

--- a/app/Livewire/Venues/Forms/CreateEditForm.php
+++ b/app/Livewire/Venues/Forms/CreateEditForm.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Venues\Forms;
 
 use App\Livewire\Base\BaseForm;
 use App\Models\Events\Venue;
+use App\ValueObjects\Address;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rule;
 
@@ -125,10 +126,12 @@ class CreateEditForm extends BaseForm
     {
         return [
             'name' => $this->name,
-            'street_address' => $this->street_address,
-            'city' => $this->city,
-            'state' => $this->state,
-            'zipcode' => $this->zipcode,
+            'address' => new Address(
+                streetAddress: $this->street_address,
+                city: $this->city,
+                state: $this->state,
+                zipcode: (string) $this->zipcode,
+            ),
         ];
     }
 

--- a/app/Models/Events/Venue.php
+++ b/app/Models/Events/Venue.php
@@ -5,9 +5,11 @@ declare(strict_types=1);
 namespace App\Models\Events;
 
 use App\Builders\Events\VenueBuilder;
+use App\Casts\AddressCast;
 use App\Models\Concerns\HasLifecycleTransitions;
 use App\Models\Concerns\HoldsEvents;
 use App\Models\Contracts\SoftDeletable;
+use App\ValueObjects\Address;
 use Database\Factories\Events\VenueFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
@@ -25,6 +27,7 @@ use Illuminate\Support\Carbon;
  * @property string $city
  * @property string $state
  * @property string $zipcode
+ * @property Address $address
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
@@ -47,7 +50,7 @@ use Illuminate\Support\Carbon;
  *
  * @mixin \Eloquent
  */
-#[Fillable('name', 'street_address', 'city', 'state', 'zipcode')]
+#[Fillable('name', 'street_address', 'city', 'state', 'zipcode', 'address')]
 #[UseFactory(VenueFactory::class)]
 #[UseEloquentBuilder(VenueBuilder::class)]
 class Venue extends Model implements SoftDeletable
@@ -58,4 +61,12 @@ class Venue extends Model implements SoftDeletable
     use HasLifecycleTransitions;
     use HoldsEvents;
     use SoftDeletes;
+
+    /** @return array<string, string> */
+    protected function casts(): array
+    {
+        return [
+            'address' => AddressCast::class,
+        ];
+    }
 }

--- a/app/ValueObjects/Address.php
+++ b/app/ValueObjects/Address.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\ValueObjects;
+
+use InvalidArgumentException;
+
+readonly class Address
+{
+    public function __construct(
+        public string $streetAddress,
+        public string $city,
+        public string $state,
+        public string $zipcode,
+    ) {
+        if (mb_trim($this->streetAddress) === '' || mb_trim($this->city) === '' || mb_trim($this->state) === '') {
+            throw new InvalidArgumentException('Address fields cannot be empty.');
+        }
+
+        if (preg_match('/^\d{5}$/', $this->zipcode) !== 1) {
+            throw new InvalidArgumentException('ZIP code must contain exactly five digits.');
+        }
+    }
+
+    public function formatted(): string
+    {
+        return "{$this->streetAddress}, {$this->city}, {$this->state} {$this->zipcode}";
+    }
+
+    /** @return array{street_address: string, city: string, state: string, zipcode: string} */
+    public function toAttributes(): array
+    {
+        return [
+            'street_address' => $this->streetAddress,
+            'city' => $this->city,
+            'state' => $this->state,
+            'zipcode' => $this->zipcode,
+        ];
+    }
+}

--- a/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
+++ b/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Venues\Forms\CreateEditForm;
 use App\Models\Events\Venue;
+use App\ValueObjects\Address;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Exists;
@@ -147,14 +148,11 @@ describe('VenueForm Integration Tests', function () {
             $data = $this->form->modelDataForTesting();
 
             expect($data)->toBeArray();
-            expect($data)->toHaveKeys([
-                'name', 'street_address', 'city', 'state', 'zipcode',
-            ]);
-            expect($data['name'])->toBe('Madison Square Garden');
-            expect($data['street_address'])->toBe('4 Pennsylvania Plaza');
-            expect($data['city'])->toBe('New York');
-            expect($data['state'])->toBe('New York');
-            expect($data['zipcode'])->toBe('10001');
+            expect($data)->toHaveKeys(['name', 'address']);
+            expect($data['name'])->toBe('Madison Square Garden')
+                ->and($data['address'])->toEqual(
+                    new Address('4 Pennsylvania Plaza', 'New York', 'New York', '10001'),
+                );
         });
     });
 

--- a/tests/Unit/Casts/AddressCastTest.php
+++ b/tests/Unit/Casts/AddressCastTest.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Events\Venue;
+use App\ValueObjects\Address;
+
+test('it casts venue address columns to an address', function () {
+    $venue = Venue::factory()->create([
+        'street_address' => '4 Pennsylvania Plaza',
+        'city' => 'New York',
+        'state' => 'New York',
+        'zipcode' => '10001',
+    ]);
+
+    expect($venue->address)->toEqual(
+        new Address('4 Pennsylvania Plaza', 'New York', 'New York', '10001'),
+    );
+});
+
+test('it stores an address across the existing venue columns', function () {
+    $venue = Venue::factory()->create([
+        'address' => new Address('4 Pennsylvania Plaza', 'New York', 'New York', '10001'),
+    ]);
+
+    expect($venue->getRawOriginal('street_address'))->toBe('4 Pennsylvania Plaza')
+        ->and($venue->getRawOriginal('city'))->toBe('New York')
+        ->and($venue->getRawOriginal('state'))->toBe('New York')
+        ->and($venue->getRawOriginal('zipcode'))->toBe('10001');
+});

--- a/tests/Unit/Models/Events/VenueTest.php
+++ b/tests/Unit/Models/Events/VenueTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Builders\Events\VenueBuilder;
+use App\Casts\AddressCast;
 use App\Models\Concerns\HoldsEvents;
 use App\Models\Events\Venue;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -36,6 +37,7 @@ describe('Venue Model Unit Tests', function () {
                 'city',
                 'state',
                 'zipcode',
+                'address',
             ]);
         });
 
@@ -43,8 +45,9 @@ describe('Venue Model Unit Tests', function () {
             $venue = new Venue();
             $casts = $venue->getCasts();
 
-            // Venue model has no custom casts
-            expect($casts)->toBeArray();
+            expect($casts)->toMatchArray([
+                'address' => AddressCast::class,
+            ]);
         });
 
         test('has custom eloquent builder', function () {

--- a/tests/Unit/ValueObjects/AddressTest.php
+++ b/tests/Unit/ValueObjects/AddressTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use App\ValueObjects\Address;
+
+test('it represents and formats a venue address', function () {
+    $address = new Address('4 Pennsylvania Plaza', 'New York', 'New York', '10001');
+
+    expect($address->formatted())->toBe('4 Pennsylvania Plaza, New York, New York 10001')
+        ->and($address->toAttributes())->toBe([
+            'street_address' => '4 Pennsylvania Plaza',
+            'city' => 'New York',
+            'state' => 'New York',
+            'zipcode' => '10001',
+        ]);
+});
+
+test('it rejects incomplete address fields', function (string $street, string $city, string $state) {
+    expect(fn () => new Address($street, $city, $state, '10001'))
+        ->toThrow(InvalidArgumentException::class);
+})->with([
+    'missing street' => ['', 'New York', 'New York'],
+    'missing city' => ['4 Pennsylvania Plaza', '', 'New York'],
+    'missing state' => ['4 Pennsylvania Plaza', 'New York', ''],
+]);
+
+test('it rejects invalid ZIP codes', function (string $zipcode) {
+    expect(fn () => new Address('4 Pennsylvania Plaza', 'New York', 'New York', $zipcode))
+        ->toThrow(InvalidArgumentException::class);
+})->with(['1234', '123456', 'abcde']);


### PR DESCRIPTION
## Summary
- introduce an immutable Address value object for venue location data
- map the value across existing venue columns with a multi-column Eloquent cast
- route venue Actions and Livewire persistence through the address boundary
- preserve direct column access and the existing database schema

## Verification
- 78 focused tests passed with 224 assertions after rebasing onto development
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- touched files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- the repository-wide local Blade check still reports formatter drift in untouched development views; this branch does not modify those files.