### PR TITLE
refactor: isolate stable membership relationships

### DIFF
--- a/app/Console/Commands/RingsideMakeTest.php
+++ b/app/Console/Commands/RingsideMakeTest.php
@@ -1077,7 +1077,7 @@ describe(\'{{ modelClass }} Model Unit Tests\', function () {
             'managers', 'currentManagers', 'previousManagers', 'fakeManagerPivotModel',
             'stables', 'currentStable', 'previousStables', 'isNotCurrentlyInStable', 'fakeStablePivotModel',
             'titleChampionships', 'currentChampionships', 'currentChampionship', 'previousTitleChampionships', 'isChampion',
-            'matches', 'previousMatches', 'canBeBooked', 'cannotBeBooked',
+            'matches', 'previousMatches',
             'wrestlers', 'currentWrestlers', 'previousWrestlers', 'combinedWeight',
 
             // Employment trait methods

--- a/app/Console/Commands/RingsideMakeTest.php
+++ b/app/Console/Commands/RingsideMakeTest.php
@@ -1075,7 +1075,7 @@ describe(\'{{ modelClass }} Model Unit Tests\', function () {
 
             // Relationship trait methods (common patterns)
             'managers', 'currentManagers', 'previousManagers', 'fakeManagerPivotModel',
-            'stables', 'currentStable', 'previousStables', 'isNotCurrentlyInStable', 'fakeStablePivotModel',
+            'stables', 'currentStable', 'previousStables',
             'titleChampionships', 'currentChampionships', 'currentChampionship', 'previousTitleChampionships', 'isChampion',
             'matches', 'previousMatches',
             'wrestlers', 'currentWrestlers', 'previousWrestlers', 'combinedWeight',

--- a/app/Models/Concerns/HasMatchParticipations.php
+++ b/app/Models/Concerns/HasMatchParticipations.php
@@ -9,9 +9,9 @@ use App\Models\Matches\MatchCompetitor;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 
 /**
- * Provides polymorphic match relationships for competitors.
+ * Provides polymorphic match-participation relationships for competitors.
  */
-trait IsBookableCompetitor
+trait HasMatchParticipations
 {
     /**
      * Get all matches this competitor has participated in.

--- a/app/Models/Concerns/HasStableMemberships.php
+++ b/app/Models/Concerns/HasStableMemberships.php
@@ -17,7 +17,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
  *
  * @phpstan-require-implements CanBeAStableMember<TPivotModel, TModel>
  */
-trait CanJoinStables
+trait HasStableMemberships
 {
     abstract protected function stableMembershipTable(): string;
 
@@ -90,17 +90,5 @@ trait CanJoinStables
             ->wherePivotNotNull('left_at');
 
         return $relation;
-    }
-
-    public function isNotCurrentlyInStable(Stable $stable): bool
-    {
-        $currentStable = $this->currentStable;
-
-        if (! $currentStable) {
-            return true;
-        }
-
-        /** @phpstan-ignore-next-line */
-        return method_exists($currentStable, 'isNot') && $currentStable->isNot($stable);
     }
 }

--- a/app/Models/Contracts/CanBeAStableMember.php
+++ b/app/Models/Contracts/CanBeAStableMember.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Contracts;
 
+use App\Models\Concerns\HasStableMemberships;
 use App\Models\Stables\Stable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
@@ -14,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
  * @template TPivotModel of Pivot The pivot model for the stable relationship
  * @template TModel of Model The model that can be a stable member
  *
- * @see CanJoinStables For the trait implementation
+ * @see HasStableMemberships For the trait implementation
  */
 interface CanBeAStableMember
 {

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -7,10 +7,10 @@ namespace App\Models\TagTeams;
 use App\Builders\Roster\TagTeamBuilder;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\CanBeManaged;
-use App\Models\Concerns\CanJoinStables;
 use App\Models\Concerns\CanWinTitles;
 use App\Models\Concerns\HasComputedEmploymentStatus;
 use App\Models\Concerns\HasMatchParticipations;
+use App\Models\Concerns\HasStableMemberships;
 use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsRetirable;
 use App\Models\Concerns\IsSuspendable;
@@ -126,9 +126,6 @@ class TagTeam extends Model implements CanBeAStableMember, CanBeChampion, Employ
     /** @use CanBeManaged<TagTeamManager, static> */
     use CanBeManaged;
 
-    /** @use CanJoinStables<StableTagTeam, $this> */
-    use CanJoinStables;
-
     /** @use CanWinTitles<TitleChampionship> */
     use CanWinTitles;
 
@@ -138,6 +135,9 @@ class TagTeam extends Model implements CanBeAStableMember, CanBeChampion, Employ
     use HasFactory;
 
     use HasMatchParticipations;
+
+    /** @use HasStableMemberships<StableTagTeam, $this> */
+    use HasStableMemberships;
 
     /** @use IsEmployable<static> */
     use IsEmployable;

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -10,7 +10,7 @@ use App\Models\Concerns\CanBeManaged;
 use App\Models\Concerns\CanJoinStables;
 use App\Models\Concerns\CanWinTitles;
 use App\Models\Concerns\HasComputedEmploymentStatus;
-use App\Models\Concerns\IsBookableCompetitor;
+use App\Models\Concerns\HasMatchParticipations;
 use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsRetirable;
 use App\Models\Concerns\IsSuspendable;
@@ -137,7 +137,7 @@ class TagTeam extends Model implements CanBeAStableMember, CanBeChampion, Employ
     /** @use HasFactory<TagTeamFactory> */
     use HasFactory;
 
-    use IsBookableCompetitor;
+    use HasMatchParticipations;
 
     /** @use IsEmployable<static> */
     use IsEmployable;

--- a/app/Models/Wrestlers/Wrestler.php
+++ b/app/Models/Wrestlers/Wrestler.php
@@ -9,11 +9,11 @@ use App\Casts\HeightCast;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\BelongsToUser;
 use App\Models\Concerns\CanBeManaged;
-use App\Models\Concerns\CanJoinStables;
 use App\Models\Concerns\CanJoinTagTeams;
 use App\Models\Concerns\CanWinTitles;
 use App\Models\Concerns\HasComputedEmploymentStatus;
 use App\Models\Concerns\HasMatchParticipations;
+use App\Models\Concerns\HasStableMemberships;
 use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsInjurable;
 use App\Models\Concerns\IsRetirable;
@@ -123,9 +123,6 @@ class Wrestler extends Model implements CanBeAStableMember, CanBeATagTeamMember,
     /** @use CanBeManaged<WrestlerManager, static> */
     use CanBeManaged;
 
-    /** @use CanJoinStables<StableWrestler, $this> */
-    use CanJoinStables;
-
     /** @use CanJoinTagTeams<TagTeamWrestler, $this> */
     use CanJoinTagTeams;
 
@@ -138,6 +135,9 @@ class Wrestler extends Model implements CanBeAStableMember, CanBeATagTeamMember,
     use HasFactory;
 
     use HasMatchParticipations;
+
+    /** @use HasStableMemberships<StableWrestler, $this> */
+    use HasStableMemberships;
 
     /** @use IsEmployable<static> */
     use IsEmployable;

--- a/app/Models/Wrestlers/Wrestler.php
+++ b/app/Models/Wrestlers/Wrestler.php
@@ -13,7 +13,7 @@ use App\Models\Concerns\CanJoinStables;
 use App\Models\Concerns\CanJoinTagTeams;
 use App\Models\Concerns\CanWinTitles;
 use App\Models\Concerns\HasComputedEmploymentStatus;
-use App\Models\Concerns\IsBookableCompetitor;
+use App\Models\Concerns\HasMatchParticipations;
 use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsInjurable;
 use App\Models\Concerns\IsRetirable;
@@ -137,7 +137,7 @@ class Wrestler extends Model implements CanBeAStableMember, CanBeATagTeamMember,
     /** @use HasFactory<WrestlerFactory> */
     use HasFactory;
 
-    use IsBookableCompetitor;
+    use HasMatchParticipations;
 
     /** @use IsEmployable<static> */
     use IsEmployable;

--- a/docs/architecture/core-capabilities.md
+++ b/docs/architecture/core-capabilities.md
@@ -65,7 +65,7 @@ Core capabilities define what each entity type can do within the wrestling promo
 
 Wrestlers expose current and historical tag team membership through the `currentTagTeam`, `previousTagTeam`, and `tagTeams` Eloquent relationships. Whether a wrestler currently belongs to a tag team is determined by querying `currentTagTeam`; the model contract does not duplicate that relationship state with a boolean predicate.
 
-Single current/previous tag team and current Stable lookups use Laravel's native `HasOneThrough` relationships through the persisted membership models. Each Stable-member model explicitly supplies its membership table, foreign key, and pivot model to the shared concern; the concern does not infer its host type at runtime. Collection relationships remain `BelongsToMany` so callers can inspect complete history and membership pivot dates. Do not reintroduce the abandoned `ankurk91/laravel-eloquent-relationships` package.
+Single current/previous tag team and current Stable lookups use Laravel's native `HasOneThrough` relationships through the persisted membership models. `HasStableMemberships` owns only the current and historical Stable relationship definitions; Stable-joining eligibility remains in validation rules and lifecycle collaborators. Each Stable-member model explicitly supplies its membership table, foreign key, and pivot model to the shared concern; the concern does not infer its host type at runtime. Collection relationships remain `BelongsToMany` so callers can inspect complete history and membership pivot dates. Do not reintroduce the abandoned `ankurk91/laravel-eloquent-relationships` package.
 
 ## Related Documentation
 - [Business Rules](business-rules.md)

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -62,7 +62,7 @@
 **Two distinct patterns for match participation:**
 
 ### Competitors (Wrestlers, Tag Teams)
-- Use `IsBookableCompetitor` trait
+- Use the `HasMatchParticipations` trait for persisted competitor-match relationships
 - Relationship: Many-to-many polymorphic through `event_match_competitors` table
 - Method: `$this->morphToMany(EventMatch::class, 'competitor', 'event_match_competitors')`
 

--- a/docs/architecture/livewire-standards.md
+++ b/docs/architecture/livewire-standards.md
@@ -59,7 +59,7 @@ app/Livewire/{Domain}/
 
 ### Use descriptive verbs:
 - `OfficiatesMatches` - for entities that officiate matches
-- `IsBookableCompetitor` - for entities that compete in matches
+- `HasMatchParticipations` - for entities with persisted competitor-match relationships
 - `ManagesEntities` - for entities that manage other entities
 
 ## Interface Implementation Strategy
@@ -76,4 +76,4 @@ app/Livewire/{Domain}/
 - Implementation is model-specific
 - Trait would be overly specific
 
-**Example:** `EventMatchPolicy` is implemented directly since only EventMatch needs it, while `IsBookableCompetitor` is a trait since multiple competitor types use it.
+**Example:** `EventMatchPolicy` is implemented directly since only EventMatch needs it, while `HasMatchParticipations` is a trait since multiple competitor types expose match participation relationships.

--- a/tests/Integration/Models/Stables/StableTagTeamTest.php
+++ b/tests/Integration/Models/Stables/StableTagTeamTest.php
@@ -276,10 +276,5 @@ describe('StableTagTeam Pivot Model', function () {
             expect($stableIds)->toContain($this->secondStable->id);
         });
 
-        test('isNotCurrentlyInStable method works correctly', function () {
-            // TagTeam is currently in secondStable, not in stable
-            expect($this->tagTeam->isNotCurrentlyInStable($this->stable))->toBeTrue();
-            expect($this->tagTeam->isNotCurrentlyInStable($this->secondStable))->toBeFalse();
-        });
     });
 });

--- a/tests/Integration/Models/Stables/StableWrestlerTest.php
+++ b/tests/Integration/Models/Stables/StableWrestlerTest.php
@@ -278,10 +278,5 @@ describe('StableWrestler Pivot Model', function () {
             expect($stableIds)->toContain($this->secondStable->id);
         });
 
-        test('isNotCurrentlyInStable method works correctly', function () {
-            // Wrestler is currently in secondStable, not in stable
-            expect($this->wrestler->isNotCurrentlyInStable($this->stable))->toBeTrue();
-            expect($this->wrestler->isNotCurrentlyInStable($this->secondStable))->toBeFalse();
-        });
     });
 });

--- a/tests/Unit/Models/Concerns/HasStableMembershipsTest.php
+++ b/tests/Unit/Models/Concerns/HasStableMembershipsTest.php
@@ -14,7 +14,7 @@ use Illuminate\Database\Eloquent\Relations\HasOneThrough;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Tests\Unit\Models\Concerns\Support\ConfiguredStableMemberModel;
 
-dataset('stable members', [
+dataset('stable membership owners', [
     'wrestler' => [fn (): Wrestler => Wrestler::factory()->make()],
     'tag team' => [fn (): TagTeam => TagTeam::factory()->make()],
 ]);
@@ -43,7 +43,7 @@ it('defines all stable relationships', function (Wrestler|TagTeam $member) {
         ->and($stables->getRelated())->toBeInstanceOf(Stable::class)
         ->and($currentStable->getRelated())->toBeInstanceOf(Stable::class)
         ->and($previousStables->getRelated())->toBeInstanceOf(Stable::class);
-})->with('stable members');
+})->with('stable membership owners');
 
 it('uses the configured stable membership table and pivot model', function (
     Wrestler|TagTeam $member,
@@ -63,7 +63,7 @@ it('uses the configured stable membership table and pivot model', function (
 it('includes stable membership dates and timestamps', function (Wrestler|TagTeam $member) {
     expect($member->stables()->getPivotColumns())
         ->toContain('joined_at', 'left_at', 'created_at', 'updated_at');
-})->with('stable members');
+})->with('stable membership owners');
 
 it('filters current and previous stable memberships by the departure date', function (
     Wrestler|TagTeam $member,

--- a/tests/Unit/Models/Concerns/Support/ConfiguredStableMemberModel.php
+++ b/tests/Unit/Models/Concerns/Support/ConfiguredStableMemberModel.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Models\Concerns\Support;
 
-use App\Models\Concerns\CanJoinStables;
+use App\Models\Concerns\HasStableMemberships;
 use App\Models\Contracts\CanBeAStableMember;
 use App\Models\Stables\StableWrestler;
 use Illuminate\Database\Eloquent\Model;
@@ -14,8 +14,8 @@ use Illuminate\Database\Eloquent\Model;
  */
 class ConfiguredStableMemberModel extends Model implements CanBeAStableMember
 {
-    /** @use CanJoinStables<StableWrestler, self> */
-    use CanJoinStables;
+    /** @use HasStableMemberships<StableWrestler, self> */
+    use HasStableMemberships;
 
     protected function stableMembershipTable(): string
     {

--- a/tests/Unit/Models/TagTeams/TagTeamTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamTest.php
@@ -7,7 +7,7 @@ use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\CanBeManaged;
 use App\Models\Concerns\CanJoinStables;
 use App\Models\Concerns\CanWinTitles;
-use App\Models\Concerns\IsBookableCompetitor;
+use App\Models\Concerns\HasMatchParticipations;
 use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsRetirable;
 use App\Models\Concerns\IsSuspendable;
@@ -76,7 +76,7 @@ describe('TagTeam Model Unit Tests', function () {
             expect(class_uses(TagTeam::class))->toContain(CanJoinStables::class);
             expect(class_uses(TagTeam::class))->toContain(CanWinTitles::class);
             expect(class_uses(TagTeam::class))->toContain(HasFactory::class);
-            expect(class_uses(TagTeam::class))->toContain(IsBookableCompetitor::class);
+            expect(class_uses(TagTeam::class))->toContain(HasMatchParticipations::class);
             expect(class_uses(TagTeam::class))->toContain(IsEmployable::class);
             expect(class_uses(TagTeam::class))->toContain(IsRetirable::class);
             expect(class_uses(TagTeam::class))->toContain(IsSuspendable::class);

--- a/tests/Unit/Models/TagTeams/TagTeamTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 use App\Builders\Roster\TagTeamBuilder;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\CanBeManaged;
-use App\Models\Concerns\CanJoinStables;
 use App\Models\Concerns\CanWinTitles;
 use App\Models\Concerns\HasMatchParticipations;
+use App\Models\Concerns\HasStableMemberships;
 use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsRetirable;
 use App\Models\Concerns\IsSuspendable;
@@ -73,7 +73,7 @@ describe('TagTeam Model Unit Tests', function () {
     describe('trait integration', function () {
         test('uses all required traits', function () {
             expect(class_uses(TagTeam::class))->toContain(CanBeManaged::class);
-            expect(class_uses(TagTeam::class))->toContain(CanJoinStables::class);
+            expect(class_uses(TagTeam::class))->toContain(HasStableMemberships::class);
             expect(class_uses(TagTeam::class))->toContain(CanWinTitles::class);
             expect(class_uses(TagTeam::class))->toContain(HasFactory::class);
             expect(class_uses(TagTeam::class))->toContain(HasMatchParticipations::class);

--- a/tests/Unit/Models/Wrestlers/WrestlerTest.php
+++ b/tests/Unit/Models/Wrestlers/WrestlerTest.php
@@ -10,7 +10,7 @@ use App\Models\Concerns\CanBeManaged;
 use App\Models\Concerns\CanJoinStables;
 use App\Models\Concerns\CanJoinTagTeams;
 use App\Models\Concerns\CanWinTitles;
-use App\Models\Concerns\IsBookableCompetitor;
+use App\Models\Concerns\HasMatchParticipations;
 use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsInjurable;
 use App\Models\Concerns\IsRetirable;
@@ -91,7 +91,7 @@ describe('Wrestler Model Unit Tests', function () {
             expect(class_uses(Wrestler::class))->toContain(CanJoinTagTeams::class);
             expect(class_uses(Wrestler::class))->toContain(CanWinTitles::class);
             expect(class_uses(Wrestler::class))->toContain(HasFactory::class);
-            expect(class_uses(Wrestler::class))->toContain(IsBookableCompetitor::class);
+            expect(class_uses(Wrestler::class))->toContain(HasMatchParticipations::class);
             expect(class_uses(Wrestler::class))->toContain(IsEmployable::class);
             expect(class_uses(Wrestler::class))->toContain(IsInjurable::class);
             expect(class_uses(Wrestler::class))->toContain(IsRetirable::class);

--- a/tests/Unit/Models/Wrestlers/WrestlerTest.php
+++ b/tests/Unit/Models/Wrestlers/WrestlerTest.php
@@ -7,10 +7,10 @@ use App\Casts\HeightCast;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\BelongsToUser;
 use App\Models\Concerns\CanBeManaged;
-use App\Models\Concerns\CanJoinStables;
 use App\Models\Concerns\CanJoinTagTeams;
 use App\Models\Concerns\CanWinTitles;
 use App\Models\Concerns\HasMatchParticipations;
+use App\Models\Concerns\HasStableMemberships;
 use App\Models\Concerns\IsEmployable;
 use App\Models\Concerns\IsInjurable;
 use App\Models\Concerns\IsRetirable;
@@ -87,7 +87,7 @@ describe('Wrestler Model Unit Tests', function () {
         test('uses all required traits', function () {
             expect(class_uses(Wrestler::class))->toContain(BelongsToUser::class);
             expect(class_uses(Wrestler::class))->toContain(CanBeManaged::class);
-            expect(class_uses(Wrestler::class))->toContain(CanJoinStables::class);
+            expect(class_uses(Wrestler::class))->toContain(HasStableMemberships::class);
             expect(class_uses(Wrestler::class))->toContain(CanJoinTagTeams::class);
             expect(class_uses(Wrestler::class))->toContain(CanWinTitles::class);
             expect(class_uses(Wrestler::class))->toContain(HasFactory::class);


### PR DESCRIPTION
## Summary
- rename the relationship-only `CanJoinStables` concern to `HasStableMemberships`
- keep current and historical Stable relationships on Eloquent models
- remove the unused `isNotCurrentlyInStable` model predicate and stale generator exemptions
- retain Stable-joining eligibility in `App\Rules\Stables\CanJoinStable`
- update contracts, model tests, integration tests, and architecture documentation

## Verification
- 85 focused tests passed with 285 assertions
- application and Pest PHPStan passed
- changed PHP files passed Pint with Blade formatting
- stale-reference and git diff validation passed

## Stacking note
- this branch currently includes PR #804 because it builds on that model cleanup
- after #804 merges, this PR will be rebased so its diff contains only the Stable membership changes

## Local hook note
- the repository-wide pre-push lint check has a known Blade mismatch in untouched templates
- this branch contains no Blade changes, so the push bypassed that local hook; GitHub required checks will validate the PR