### PR TITLE
refactor: move administrator predicate to role

### DIFF
--- a/app/Enums/Users/Role.php
+++ b/app/Enums/Users/Role.php
@@ -9,6 +9,11 @@ enum Role: string
     case Administrator = 'administrator';
     case Basic = 'basic';
 
+    public function isAdministrator(): bool
+    {
+        return $this === self::Administrator;
+    }
+
     public function color(): string
     {
         return match ($this) {

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -93,5 +93,4 @@ class User extends Authenticatable
             set: fn (string $value) => bcrypt($value),
         );
     }
-
 }

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -94,11 +94,4 @@ class User extends Authenticatable
         );
     }
 
-    /**
-     * Check to see if the user is an administrator.
-     */
-    public function isAdministrator(): bool
-    {
-        return $this->role === Role::Administrator;
-    }
 }

--- a/app/Policies/EventMatchPolicy.php
+++ b/app/Policies/EventMatchPolicy.php
@@ -22,7 +22,7 @@ class EventMatchPolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -25,7 +25,7 @@ class EventPolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/ManagerPolicy.php
+++ b/app/Policies/ManagerPolicy.php
@@ -25,7 +25,7 @@ class ManagerPolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/MatchPolicy.php
+++ b/app/Policies/MatchPolicy.php
@@ -25,7 +25,7 @@ class MatchPolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/RefereePolicy.php
+++ b/app/Policies/RefereePolicy.php
@@ -25,7 +25,7 @@ class RefereePolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/StablePolicy.php
+++ b/app/Policies/StablePolicy.php
@@ -26,7 +26,7 @@ class StablePolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/TagTeamPolicy.php
+++ b/app/Policies/TagTeamPolicy.php
@@ -26,7 +26,7 @@ class TagTeamPolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/TitlePolicy.php
+++ b/app/Policies/TitlePolicy.php
@@ -25,7 +25,7 @@ class TitlePolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -25,7 +25,7 @@ class UserPolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/VenuePolicy.php
+++ b/app/Policies/VenuePolicy.php
@@ -25,7 +25,7 @@ class VenuePolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/app/Policies/WrestlerPolicy.php
+++ b/app/Policies/WrestlerPolicy.php
@@ -26,7 +26,7 @@ class WrestlerPolicy
      */
     public function before(User $user, string $ability): ?bool
     {
-        if ($user->isAdministrator()) {
+        if ($user->role->isAdministrator()) {
             return true;
         }
 

--- a/docs/architecture/enums.md
+++ b/docs/architecture/enums.md
@@ -117,8 +117,15 @@ enum Role: string
 {
     case Administrator = 'administrator';    // Full system access
     case Basic = 'basic';                   // Limited access
+
+    public function isAdministrator(): bool
+    {
+        return $this === self::Administrator;
+    }
 }
 ```
+
+Authorization policies inspect role behavior through the cast `Role` value. The `User` model stores and casts the role but does not define role-specific predicates.
 
 #### User Status (Users/UserStatus.php)
 User account states.

--- a/tests/Integration/Actions/Users/RoleAuthorizationTest.php
+++ b/tests/Integration/Actions/Users/RoleAuthorizationTest.php
@@ -70,14 +70,14 @@ describe('User Role Integration Tests', function () {
             $user4 = User::factory()->create(['role' => Role::Basic]);
 
             // All administrators should have same permissions
-            expect($user1->isAdministrator())->toBeTrue();
-            expect($user2->isAdministrator())->toBeTrue();
+            expect($user1->role->isAdministrator())->toBeTrue();
+            expect($user2->role->isAdministrator())->toBeTrue();
             expect(Gate::forUser($user1)->allows('create', User::class))->toBeTrue();
             expect(Gate::forUser($user2)->allows('create', User::class))->toBeTrue();
 
             // All basic users should have same restrictions
-            expect($user3->isAdministrator())->toBeFalse();
-            expect($user4->isAdministrator())->toBeFalse();
+            expect($user3->role->isAdministrator())->toBeFalse();
+            expect($user4->role->isAdministrator())->toBeFalse();
             expect(Gate::forUser($user3)->denies('create', User::class))->toBeTrue();
             expect(Gate::forUser($user4)->denies('create', User::class))->toBeTrue();
         });
@@ -108,7 +108,7 @@ describe('User Role Integration Tests', function () {
             $user = User::factory()->create(['role' => Role::Basic]);
 
             // Initially basic user should be denied
-            expect($user->isAdministrator())->toBeFalse();
+            expect($user->role->isAdministrator())->toBeFalse();
             expect(Gate::forUser($user)->denies('create', User::class))->toBeTrue();
 
             // Change role to administrator
@@ -116,7 +116,7 @@ describe('User Role Integration Tests', function () {
             $user->refresh();
 
             // Should now have administrator permissions
-            expect($user->isAdministrator())->toBeTrue();
+            expect($user->role->isAdministrator())->toBeTrue();
             expect(Gate::forUser($user)->allows('create', User::class))->toBeTrue();
         });
 
@@ -131,7 +131,7 @@ describe('User Role Integration Tests', function () {
             $admin->refresh();
 
             // Should still have administrator permissions
-            expect($admin->isAdministrator())->toBeTrue();
+            expect($admin->role->isAdministrator())->toBeTrue();
             expect(Gate::forUser($admin)->allows('create', User::class))->toBeTrue();
         });
     });
@@ -157,11 +157,11 @@ describe('User Role Integration Tests', function () {
             // Test authentication state integration with roles
             actingAs($this->administrator);
             expect(auth()->check())->toBeTrue();
-            expect(requiredModel(auth()->user())->isAdministrator())->toBeTrue();
+            expect(requiredModel(auth()->user())->role->isAdministrator())->toBeTrue();
 
             actingAs($this->basicUser);
             expect(auth()->check())->toBeTrue();
-            expect(requiredModel(auth()->user())->isAdministrator())->toBeFalse();
+            expect(requiredModel(auth()->user())->role->isAdministrator())->toBeFalse();
         });
     });
 
@@ -171,7 +171,7 @@ describe('User Role Integration Tests', function () {
 
             // Verify initial state
             expect($user->role)->toBe(Role::Basic);
-            expect($user->isAdministrator())->toBeFalse();
+            expect($user->role->isAdministrator())->toBeFalse();
             expect(Gate::forUser($user)->denies('create', User::class))->toBeTrue();
 
             // Promote to administrator
@@ -180,13 +180,13 @@ describe('User Role Integration Tests', function () {
 
             // Verify promotion worked across all systems
             expect($user->role)->toBe(Role::Administrator);
-            expect($user->isAdministrator())->toBeTrue();
+            expect($user->role->isAdministrator())->toBeTrue();
             expect(Gate::forUser($user)->allows('create', User::class))->toBeTrue();
 
             // Verify in database
             $userFromDb = User::findOrFail($user->id);
             expect($userFromDb->role)->toBe(Role::Administrator);
-            expect($userFromDb->isAdministrator())->toBeTrue();
+            expect($userFromDb->role->isAdministrator())->toBeTrue();
         });
 
         test('role demotion workflow maintains consistency', function () {
@@ -194,7 +194,7 @@ describe('User Role Integration Tests', function () {
 
             // Verify initial administrator state
             expect($user->role)->toBe(Role::Administrator);
-            expect($user->isAdministrator())->toBeTrue();
+            expect($user->role->isAdministrator())->toBeTrue();
             expect(Gate::forUser($user)->allows('create', User::class))->toBeTrue();
 
             // Demote to basic user
@@ -203,13 +203,13 @@ describe('User Role Integration Tests', function () {
 
             // Verify demotion worked across all systems
             expect($user->role)->toBe(Role::Basic);
-            expect($user->isAdministrator())->toBeFalse();
+            expect($user->role->isAdministrator())->toBeFalse();
             expect(Gate::forUser($user)->denies('create', User::class))->toBeTrue();
 
             // Verify in database
             $userFromDb = User::findOrFail($user->id);
             expect($userFromDb->role)->toBe(Role::Basic);
-            expect($userFromDb->isAdministrator())->toBeFalse();
+            expect($userFromDb->role->isAdministrator())->toBeFalse();
         });
 
         test('bulk role operations maintain system integrity', function () {
@@ -217,7 +217,7 @@ describe('User Role Integration Tests', function () {
 
             // Verify all are basic users initially
             foreach ($users as $user) {
-                expect($user->isAdministrator())->toBeFalse();
+                expect($user->role->isAdministrator())->toBeFalse();
             }
 
             // Bulk promote to administrators
@@ -226,7 +226,7 @@ describe('User Role Integration Tests', function () {
             // Verify all are now administrators
             $updatedUsers = User::whereIn('id', $users->pluck('id'))->get();
             foreach ($updatedUsers as $user) {
-                expect($user->isAdministrator())->toBeTrue();
+                expect($user->role->isAdministrator())->toBeTrue();
                 expect(Gate::forUser($user)->allows('create', User::class))->toBeTrue();
             }
         });
@@ -285,20 +285,20 @@ describe('User Role Integration Tests', function () {
             $admin = User::factory()->administrator()->create();
 
             // Verify initial state
-            expect($admin->isAdministrator())->toBeTrue();
+            expect($admin->role->isAdministrator())->toBeTrue();
 
             // Soft delete user
             $admin->delete();
 
             // Role should still be maintained on deleted user
             $deletedAdmin = User::withTrashed()->findOrFail($admin->id);
-            expect($deletedAdmin->isAdministrator())->toBeTrue();
+            expect($deletedAdmin->role->isAdministrator())->toBeTrue();
 
             // Restore user
             $admin->restore();
 
             // Role should still work after restoration
-            expect(freshModel($admin)->isAdministrator())->toBeTrue();
+            expect(freshModel($admin)->role->isAdministrator())->toBeTrue();
             expect(Gate::forUser(freshModel($admin))->allows('create', User::class))->toBeTrue();
         });
     });

--- a/tests/Integration/Builders/UserQueryBuilderTest.php
+++ b/tests/Integration/Builders/UserQueryBuilderTest.php
@@ -153,7 +153,7 @@ describe('UserBuilder Unit Tests', function () {
             expect($adminUsers)->toBeInstanceOf(Collection::class);
 
             foreach ($adminUsers as $user) {
-                expect($user->isAdministrator())->toBeTrue();
+                expect($user->role->isAdministrator())->toBeTrue();
             }
         });
 

--- a/tests/Unit/Enums/Users/RoleTest.php
+++ b/tests/Unit/Enums/Users/RoleTest.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Users\Role;
+
+test('identifies whether a role is an administrator', function (Role $role, bool $expected) {
+    expect($role->isAdministrator())->toBe($expected);
+})->with([
+    'administrator' => [Role::Administrator, true],
+    'basic' => [Role::Basic, false],
+]);

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -244,8 +244,8 @@ describe('UserPolicy business context', function () {
         $basic = basicUser();
 
         // Verify the policy respects the user's isAdministrator method
-        expect($admin->isAdministrator())->toBeTrue();
-        expect($basic->isAdministrator())->toBeFalse();
+        expect($admin->role->isAdministrator())->toBeTrue();
+        expect($basic->role->isAdministrator())->toBeFalse();
 
         expect($this->policy->before($admin, 'any-operation'))->toBeTrue();
         expect($this->policy->before($basic, 'any-operation'))->toBeNull();

--- a/tests/Unit/database/Factories/Users/UserFactoryTest.php
+++ b/tests/Unit/database/Factories/Users/UserFactoryTest.php
@@ -72,7 +72,7 @@ describe('UserFactory Unit Tests', function () {
 
             // Assert
             expect($admin->role)->toBe(Role::Administrator);
-            expect($admin->isAdministrator())->toBeTrue();
+            expect($admin->role->isAdministrator())->toBeTrue();
         });
 
         test('unverified state works correctly', function () {
@@ -89,7 +89,7 @@ describe('UserFactory Unit Tests', function () {
 
             // Assert
             expect($user->role)->toBe(Role::Basic);
-            expect($user->isAdministrator())->toBeFalse();
+            expect($user->role->isAdministrator())->toBeFalse();
         });
     });
 


### PR DESCRIPTION
## Summary
- move administrator identification from the User model to the Role enum
- update policy bypasses and role assertions to use the cast enum value
- add focused Role enum coverage
- document role behavior as enum-owned rather than model-owned

## Verification
- focused Pest suites: 272 passed, 1,466 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- Pint with Blade passed for changed files
- git diff checks passed

## Full-suite note
- composer test:push passed tests, static analysis, Rector, and type coverage, then reached the existing repository-wide Blade formatting drift in untouched views; this PR changes no Blade files.