### PR TITLE
refactor: simplify match outcome models

### DIFF
--- a/app/Collections/MatchCompetitorsCollection.php
+++ b/app/Collections/MatchCompetitorsCollection.php
@@ -137,7 +137,7 @@ class MatchCompetitorsCollection extends Collection
      */
     public function allBookable(): bool
     {
-        return $this->every(fn (MatchCompetitor $competitor) => RosterBookingEligibility::allows($competitor->getCompetitor()));
+        return $this->every(fn (MatchCompetitor $competitor) => RosterBookingEligibility::allows($competitor->competitor));
     }
 
     /**
@@ -168,7 +168,7 @@ class MatchCompetitorsCollection extends Collection
      */
     public function mapToCompetitorInstances(): BaseCollection
     {
-        return $this->map(fn (MatchCompetitor $competitor) => $competitor->getCompetitor());
+        return $this->map(fn (MatchCompetitor $competitor) => $competitor->competitor);
     }
 
     /**
@@ -183,7 +183,7 @@ class MatchCompetitorsCollection extends Collection
      */
     public function onlyWrestlers(): static
     {
-        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->getCompetitor() instanceof Wrestler
+        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->competitor instanceof Wrestler
         );
     }
 
@@ -199,7 +199,7 @@ class MatchCompetitorsCollection extends Collection
      */
     public function onlyTagTeams(): static
     {
-        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->getCompetitor() instanceof TagTeam
+        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->competitor instanceof TagTeam
         );
     }
 
@@ -231,7 +231,7 @@ class MatchCompetitorsCollection extends Collection
      */
     public function pluckCompetitors(): BaseCollection
     {
-        return $this->map(fn (MatchCompetitor $competitor) => $competitor->getCompetitor());
+        return $this->map(fn (MatchCompetitor $competitor) => $competitor->competitor);
     }
 
     /**
@@ -246,8 +246,8 @@ class MatchCompetitorsCollection extends Collection
      */
     public function pluckWrestlers(): BaseCollection
     {
-        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->getCompetitor() instanceof Wrestler
-        )->map(fn (MatchCompetitor $competitor) => $competitor->getCompetitor());
+        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->competitor instanceof Wrestler
+        )->map(fn (MatchCompetitor $competitor) => $competitor->competitor);
     }
 
     /**
@@ -262,8 +262,8 @@ class MatchCompetitorsCollection extends Collection
      */
     public function pluckTagTeams(): BaseCollection
     {
-        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->getCompetitor() instanceof TagTeam
-        )->map(fn (MatchCompetitor $competitor) => $competitor->getCompetitor());
+        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->competitor instanceof TagTeam
+        )->map(fn (MatchCompetitor $competitor) => $competitor->competitor);
     }
 
     /**
@@ -282,7 +282,7 @@ class MatchCompetitorsCollection extends Collection
         return $this->groupBy('side_number')
             ->map(function (MatchCompetitorsCollection $competitorsOnSide) {
                 return collect($competitorsOnSide)
-                    ->map(fn (MatchCompetitor $competitor) => $competitor->getCompetitor())
+                    ->map(fn (MatchCompetitor $competitor) => $competitor->competitor)
                     ->values(); // Reset keys to sequential integers
             });
     }
@@ -301,7 +301,7 @@ class MatchCompetitorsCollection extends Collection
     public function getCompetitorsForSide(int $side): BaseCollection
     {
         return $this->where('side_number', $side)
-            ->map(fn (MatchCompetitor $competitor) => $competitor->getCompetitor())
+            ->map(fn (MatchCompetitor $competitor) => $competitor->competitor)
             ->values();
     }
 }

--- a/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
@@ -55,7 +55,7 @@ abstract class BasePreviousMatchesTable extends DataTableComponent
             ArrayColumn::make(__('event-matches.competitors'))
                 ->data(fn (mixed $value, EventMatch $row) => ($row->competitors))
                 ->outputFormat(function (int $index, MatchCompetitor $value): string {
-                    $competitor = $value->getCompetitor();
+                    $competitor = $value->competitor;
                     $type = str($competitor->getMorphClass())->kebab()->plural();
 
                     return '<a href="'.route($type.'.show', $competitor->id).'">'.$competitor->name.'</a>';

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -58,7 +58,7 @@ class Main extends BaseTable
                 ->label(fn (EventMatch $row) => $row->match_type->label())
                 ->searchable(),
             Column::make(__('event-matches.competitors'))
-                ->label(fn (EventMatch $row) => $row->competitors->map(fn (MatchCompetitor $competitor) => $competitor->getCompetitor()->name)->join(' vs ')),
+                ->label(fn (EventMatch $row) => $row->competitors->map(fn (MatchCompetitor $competitor) => $competitor->competitor->name)->join(' vs ')),
             Column::make(__('event-matches.result'))
                 ->label(function (EventMatch $row): string {
                     $winner = $row->result?->winner;

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -66,7 +66,7 @@ class MatchesTable extends DataTableComponent
             ArrayColumn::make(__('matches.competitors'))
                 ->data(fn (mixed $value, EventMatch $row) => ($row->competitors))
                 ->outputFormat(function (int $index, MatchCompetitor $value): string {
-                    $competitor = $value->getCompetitor();
+                    $competitor = $value->competitor;
                     $type = str($competitor->getMorphClass())->kebab()->plural();
 
                     return '<a href="'.route($type.'.show', $competitor->id).'">'.$competitor->name.'</a>';

--- a/app/Models/Matches/MatchCompetitor.php
+++ b/app/Models/Matches/MatchCompetitor.php
@@ -70,15 +70,4 @@ class MatchCompetitor extends MorphPivot
     {
         return $this->morphTo();
     }
-
-    /**
-     * Get the resolved competitor instance (must be Wrestler or TagTeam).
-     */
-    public function getCompetitor(): Wrestler|TagTeam
-    {
-        /** @var Wrestler|TagTeam $competitor */
-        $competitor = $this->competitor;
-
-        return $competitor;
-    }
 }

--- a/app/Models/Matches/MatchLoser.php
+++ b/app/Models/Matches/MatchLoser.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Models\Matches;
 
-use App\Models\TagTeams\TagTeam;
-use App\Models\Wrestlers\Wrestler;
 use Database\Factories\Matches\MatchLoserFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Table;
@@ -14,7 +12,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use LogicException;
 
 /**
  * Event match loser model for tracking match losers.
@@ -32,7 +29,6 @@ use LogicException;
  *
  * @property-read MatchResult $matchResult
  * @property-read MatchCompetitor $competitor
- * @property-read Wrestler|TagTeam $loser
  *
  * @method static \Database\Factories\Matches\MatchLoserFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder<static>|MatchLoser newModelQuery()
@@ -67,45 +63,5 @@ class MatchLoser extends Model
     public function competitor(): BelongsTo
     {
         return $this->belongsTo(MatchCompetitor::class, 'match_competitor_id');
-    }
-
-    /**
-     * Get the loser entity through the competitor relationship.
-     */
-    public function loser(): Wrestler|TagTeam
-    {
-        return $this->competitor->competitor;
-    }
-
-    /**
-     * Get the loser entity with type safety.
-     *
-     * @throws LogicException
-     */
-    public function getLoser(): Wrestler|TagTeam
-    {
-        $loser = $this->loser();
-
-        return match ($loser::class) {
-            Wrestler::class,
-            TagTeam::class => $loser,
-            default => throw new LogicException('Unexpected loser type: '.$loser::class),
-        };
-    }
-
-    /**
-     * Get loser type for backward compatibility.
-     */
-    public function getLoserTypeAttribute(): string
-    {
-        return $this->competitor->competitor_type;
-    }
-
-    /**
-     * Get loser ID for backward compatibility.
-     */
-    public function getLoserIdAttribute(): int
-    {
-        return $this->competitor->competitor_id;
     }
 }

--- a/app/Models/Matches/MatchWinner.php
+++ b/app/Models/Matches/MatchWinner.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Models\Matches;
 
-use App\Models\TagTeams\TagTeam;
-use App\Models\Wrestlers\Wrestler;
 use Database\Factories\Matches\MatchWinnerFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Table;
@@ -14,7 +12,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Carbon;
-use LogicException;
 
 /**
  * Match winner model for tracking match winners.
@@ -32,7 +29,6 @@ use LogicException;
  *
  * @property-read MatchResult $matchResult
  * @property-read MatchCompetitor $competitor
- * @property-read Wrestler|TagTeam $winner
  *
  * @method static \Database\Factories\Matches\MatchWinnerFactory factory($count = null, $state = [])
  * @method static \Illuminate\Database\Eloquent\Builder<static>|MatchWinner newModelQuery()
@@ -67,45 +63,5 @@ class MatchWinner extends Model
     public function competitor(): BelongsTo
     {
         return $this->belongsTo(MatchCompetitor::class, 'match_competitor_id');
-    }
-
-    /**
-     * Get the winner entity through the competitor relationship.
-     */
-    public function winner(): Wrestler|TagTeam
-    {
-        return $this->competitor->competitor;
-    }
-
-    /**
-     * Get the winner entity with type safety.
-     *
-     * @throws LogicException
-     */
-    public function getWinner(): Wrestler|TagTeam
-    {
-        $winner = $this->winner();
-
-        return match ($winner::class) {
-            Wrestler::class,
-            TagTeam::class => $winner,
-            default => throw new LogicException('Unexpected winner type: '.$winner::class),
-        };
-    }
-
-    /**
-     * Get winner type for backward compatibility.
-     */
-    public function getWinnerTypeAttribute(): string
-    {
-        return $this->competitor->competitor_type;
-    }
-
-    /**
-     * Get winner ID for backward compatibility.
-     */
-    public function getWinnerIdAttribute(): int
-    {
-        return $this->competitor->competitor_id;
     }
 }

--- a/docs/architecture/winner-loser-architecture.md
+++ b/docs/architecture/winner-loser-architecture.md
@@ -1,404 +1,148 @@
-# Winner/Loser Architecture
+# Winner and Loser Architecture
 
 ## Overview
 
-The winner/loser architecture in Ringside has been modernized to use foreign key relationships instead of polymorphic columns, providing better data integrity, performance, and referential consistency. This architecture supports complex match scenarios with multiple winners and losers.
+Match outcomes distinguish the primary winner recorded on `MatchResult` from the complete winner and loser sets recorded through `MatchWinner` and `MatchLoser`.
 
-## Architectural Evolution
+- `MatchResult::winner()` is a polymorphic relationship to the primary winning wrestler or tag team. It may be absent for decisions without a winner.
+- `MatchResult::winners()` and `MatchResult::losers()` contain every winning and losing match entry, including outcomes with multiple winners or losers.
+- Each `MatchWinner` and `MatchLoser` belongs to the exact `MatchCompetitor` entry that participated in the match.
+- `MatchCompetitor::competitor()` resolves the participating wrestler or tag team.
 
-### Previous Architecture (Polymorphic)
-
-The original design used polymorphic relationships:
-
-```php
-// Old schema (deprecated)  
-events_matches_winners:
-- id
-- match_result_id
-- winner_type (morph column)
-- winner_id (morph column)
-
-events_matches_losers:
-- id  
-- match_result_id
-- loser_type (morph column)
-- loser_id (morph column)
-```
-
-### Current Architecture (Foreign Key)
-
-The modernized design uses proper foreign key relationships:
-
-```php
-// New schema (current)
-events_matches_winners:
-- id
-- match_result_id → events_matches_results.id
-- match_competitor_id → events_matches_competitors.id
-
-events_matches_losers:
-- id
-- match_result_id → events_matches_results.id  
-- match_competitor_id → events_matches_competitors.id
-```
-
-## Benefits of Foreign Key Architecture
-
-### Data Integrity
-
-1. **Referential Integrity**: Database-level constraints prevent orphaned records
-2. **Cascading Deletes**: Automatic cleanup when parent records are deleted
-3. **Type Safety**: Eliminates polymorphic type mismatches
-
-### Performance Improvements
-
-1. **Optimized Queries**: Foreign key joins are more efficient than polymorphic queries
-2. **Better Indexing**: Standard foreign key indexes improve query performance
-3. **Query Planning**: Database optimizers work better with foreign key relationships
-
-### Maintenance Benefits
-
-1. **Simplified Relationships**: Cleaner Eloquent relationship definitions
-2. **Consistent Data Model**: All match-related entities use consistent foreign key patterns
-3. **Easier Debugging**: Clearer data relationships and query paths
+The competitor record is the authoritative path from a winner or loser record to its roster entity. Winner and loser models do not duplicate the competitor type or identifier through convenience methods or virtual attributes.
 
 ## Database Schema
 
-### Migration Structure
+```text
+events_matches_results
+├── id
+├── match_id → events_matches.id
+├── match_decision
+├── winner_type (nullable primary winner morph type)
+└── winner_id (nullable primary winner morph identifier)
 
-```php
-// Winner table migration
-Schema::create('events_matches_winners', function (Blueprint $table) {
-    $table->id();
-    $table->foreignId('match_result_id')
-        ->constrained('events_matches_results')
-        ->cascadeOnDelete();
-    $table->foreignId('match_competitor_id')
-        ->constrained('events_matches_competitors')
-        ->cascadeOnDelete();
-    $table->timestamps();
-    
-    // Indexes for performance
-    $table->index(['match_result_id', 'match_competitor_id']);
-});
+events_matches_competitors
+├── id
+├── match_id → events_matches.id
+├── competitor_type
+├── competitor_id
+└── side_number
 
-// Loser table migration  
-Schema::create('events_matches_losers', function (Blueprint $table) {
-    $table->id();
-    $table->foreignId('match_result_id')
-        ->constrained('events_matches_results')
-        ->cascadeOnDelete();
-    $table->foreignId('match_competitor_id')
-        ->constrained('events_matches_competitors')
-        ->cascadeOnDelete();
-    $table->timestamps();
-    
-    // Indexes for performance
-    $table->index(['match_result_id', 'match_competitor_id']);
-});
+events_matches_winners
+├── id
+├── match_result_id → events_matches_results.id
+└── match_competitor_id → events_matches_competitors.id
+
+events_matches_losers
+├── id
+├── match_result_id → events_matches_results.id
+└── match_competitor_id → events_matches_competitors.id
 ```
 
-### Relationship Chain
+Foreign keys ensure that winner and loser rows cannot reference competitors or results that do not exist. The historical match-deletion workflow soft deletes only the match and preserves these related records.
 
-The complete relationship chain provides full context:
+## Relationship Graph
 
-```
+```text
 EventMatch
-    ↓
-MatchCompetitor (competitor_type, competitor_id → Wrestler/TagTeam)
-    ↓
-MatchWinner/MatchLoser (match_competitor_id → MatchCompetitor)
-    ↓
-MatchResult (match_result_id → MatchResult)
+├── competitors ──> MatchCompetitor ──morphTo──> Wrestler|TagTeam
+└── result ───────> MatchResult
+                    ├── winner ──────morphTo──> Wrestler|TagTeam|null
+                    ├── winners ─────hasMany──> MatchWinner ──belongsTo──> MatchCompetitor
+                    └── losers ──────hasMany──> MatchLoser ───belongsTo──> MatchCompetitor
 ```
 
-## Model Implementation
+The result-level `winner` relationship answers which roster entity is considered the primary winner. The winner and loser collections answer which match competitor records belong to each outcome set.
 
-### MatchWinner Model
+## Canonical Access
+
+Use relationships directly:
 
 ```php
-class MatchWinner extends Model
-{
-    protected $table = 'events_matches_winners';
-    
-    protected $fillable = [
-        'match_result_id',
-        'match_competitor_id',
-    ];
-    
-    // Core relationships
-    public function matchResult(): BelongsTo
-    {
-        return $this->belongsTo(MatchResult::class);
-    }
-    
-    public function competitor(): BelongsTo
-    {
-        return $this->belongsTo(MatchCompetitor::class, 'match_competitor_id');
-    }
-    
-    // Convenience methods
-    public function winner(): Wrestler|TagTeam
-    {
-        return $this->competitor->competitor;
-    }
-    
-    // Backward compatibility accessors
-    public function getWinnerTypeAttribute(): string
-    {
-        return $this->competitor->competitor_type;
-    }
-    
-    public function getWinnerIdAttribute(): int
-    {
-        return $this->competitor->competitor_id;
-    }
-}
+$result = $eventMatch->result;
+$primaryWinner = $result?->winner;
+
+$winnerRecord = $result?->winners->first();
+$winningEntry = $winnerRecord?->competitor;
+$winningRosterEntity = $winningEntry?->competitor;
+
+$loserRecord = $result?->losers->first();
+$losingEntry = $loserRecord?->competitor;
+$losingRosterEntity = $losingEntry?->competitor;
 ```
 
-### MatchLoser Model
+Do not read `winner_type` or `winner_id` from a `MatchWinner`, or `loser_type` or `loser_id` from a `MatchLoser`. Those values are not columns on the outcome-set tables. When the type or identifier is needed, read it from the related `MatchCompetitor`:
 
 ```php
-class MatchLoser extends Model
-{
-    protected $table = 'events_matches_losers';
-    
-    protected $fillable = [
-        'match_result_id', 
-        'match_competitor_id',
-    ];
-    
-    // Core relationships
-    public function matchResult(): BelongsTo
-    {
-        return $this->belongsTo(MatchResult::class);
-    }
-    
-    public function competitor(): BelongsTo
-    {
-        return $this->belongsTo(MatchCompetitor::class, 'match_competitor_id');
-    }
-    
-    // Convenience methods  
-    public function loser(): Wrestler|TagTeam
-    {
-        return $this->competitor->competitor;
-    }
-    
-    // Backward compatibility accessors
-    public function getLoserTypeAttribute(): string
-    {
-        return $this->competitor->competitor_type;
-    }
-    
-    public function getLoserIdAttribute(): int
-    {
-        return $this->competitor->competitor_id;
-    }
-}
+$winnerRecord->competitor->competitor_type;
+$winnerRecord->competitor->competitor_id;
 ```
 
-## Factory Integration
+The similarly named `winner_type` and `winner_id` columns on `MatchResult` belong only to its primary-winner relationship.
 
-### Winner/Loser Creation
+## Eager Loading
 
-The MatchFactory creates winner/loser records through the foreign key architecture:
+Load both relationship levels when rendering or processing roster entities for multiple results:
 
 ```php
-private function createFullMatchResult(EventMatch $eventMatch, array $config): void
-{
-    $competitors = $eventMatch->competitors;
-    [$winners, $losers] = $this->resolveWinnersAndLosers($competitors, $winnerStrategy);
-    
-    // Create match result
-    $matchResult = MatchResult::factory()->create([
-        'match_id' => $eventMatch->id,
-        'match_decision_id' => $decision->id,
-        'winner_type' => $primaryWinner->competitor_type,
-        'winner_id' => $primaryWinner->competitor_id,
+$matches = EventMatch::query()
+    ->with([
+        'result.winner',
+        'result.winners.competitor.competitor',
+        'result.losers.competitor.competitor',
+    ])
+    ->get();
+```
+
+This avoids querying each competitor record and polymorphic roster entity separately.
+
+## Querying Outcomes
+
+Filter winner or loser rows through their competitor relationship:
+
+```php
+$wrestlerWins = MatchWinner::query()
+    ->whereHas('competitor', function (Builder $query) use ($wrestler): void {
+        $query
+            ->where('competitor_type', Wrestler::class)
+            ->where('competitor_id', $wrestler->id);
+    })
+    ->get();
+```
+
+Reusable reporting queries belong in a typed query or builder boundary rather than as convenience methods on `MatchWinner`, `MatchLoser`, or `MatchCompetitor`.
+
+## Factory Expectations
+
+Match factories create the result first and then associate outcome rows with existing match competitor records:
+
+```php
+$matchResult = MatchResult::factory()->create([
+    'match_id' => $eventMatch->id,
+    'winner_type' => $primaryWinner?->competitor_type,
+    'winner_id' => $primaryWinner?->competitor_id,
+]);
+
+foreach ($winners as $winner) {
+    MatchWinner::factory()->create([
+        'match_result_id' => $matchResult->id,
+        'match_competitor_id' => $winner->id,
     ]);
-    
-    // Create winner records via foreign keys
-    foreach ($winners as $winner) {
-        MatchWinner::factory()->create([
-            'match_result_id' => $matchResult->id,
-            'match_competitor_id' => $winner->id,  // Foreign key to competitor
-        ]);
-    }
-    
-    // Create loser records via foreign keys
-    foreach ($losers as $loser) {
-        MatchLoser::factory()->create([
-            'match_result_id' => $matchResult->id,
-            'match_competitor_id' => $loser->id,  // Foreign key to competitor
-        ]);
-    }
+}
+
+foreach ($losers as $loser) {
+    MatchLoser::factory()->create([
+        'match_result_id' => $matchResult->id,
+        'match_competitor_id' => $loser->id,
+    ]);
 }
 ```
 
-### Multiple Winners/Losers Support
-
-The architecture naturally supports multiple winners and losers:
+Tests should assert the foreign-key relationship instead of relying on compatibility attributes:
 
 ```php
-// Triple threat with 2 winners, 1 loser
-$match = MatchFactory::new()->generateFullMatch([
-    'match_type' => 'triple-threat',
-    'winner_strategy' => 'multiple'  // Randomly selects 1-2 winners
-])->create();
+$winner = $match->result->winners->firstOrFail();
 
-// Battle royal with single winner, many losers
-$match = MatchFactory::new()->generateFullMatch([
-    'match_type' => 'battle-royal',
-    'competitor_count' => 20,
-    'winner_strategy' => 'single'    // 1 winner, 19 losers
-])->create();
+expect($winner->competitor->competitor_id)
+    ->toBe($expectedCompetitor->competitor_id);
 ```
-
-## Backward Compatibility
-
-### Accessor Methods
-
-To maintain compatibility with existing code, accessor methods provide the old polymorphic interface:
-
-```php
-$winner = MatchWinner::first();
-
-// New foreign key approach
-$competitor = $winner->competitor->competitor;  // Wrestler or TagTeam model
-
-// Old polymorphic interface (still works)
-$winnerType = $winner->winner_type;  // 'App\Models\Wrestlers\Wrestler'
-$winnerId = $winner->winner_id;      // 123
-```
-
-### Migration Strategy
-
-The migration preserves existing functionality:
-
-1. **Create New Tables**: New foreign key tables are created
-2. **Preserve Old Columns**: Original morph columns remain (for rollback)
-3. **Accessor Compatibility**: Getters maintain old interface
-4. **Gradual Migration**: Code can be updated incrementally
-
-## Query Patterns
-
-### Eager Loading
-
-The foreign key architecture enables efficient eager loading:
-
-```php
-// Load winners with competitors and their models
-$winners = MatchWinner::with([
-    'competitor.competitor',  // Load the actual wrestler/tag team
-    'matchResult.match'       // Load match context
-])->get();
-
-// Load match with all winners and losers
-$match = EventMatch::with([
-    'result.winners.competitor.competitor',
-    'result.losers.competitor.competitor'
-])->find($matchId);
-```
-
-### Complex Queries
-
-Foreign keys enable complex queries:
-
-```php
-// Find all matches where a specific wrestler won
-$wrestlerWins = MatchWinner::whereHas('competitor', function ($query) use ($wrestler) {
-    $query->where('competitor_type', Wrestler::class)
-          ->where('competitor_id', $wrestler->id);
-})->get();
-
-// Find matches with multiple winners  
-$multiWinnerMatches = MatchResult::whereHas('winners', function ($query) {
-    $query->select('match_result_id')
-          ->groupBy('match_result_id')
-          ->havingRaw('COUNT(*) > 1');
-})->get();
-```
-
-### Performance Queries
-
-```php
-// Count wins for a wrestler efficiently
-$winCount = MatchWinner::join('events_matches_competitors', 
-    'events_matches_winners.match_competitor_id', '=', 
-    'events_matches_competitors.id')
-    ->where('competitor_type', Wrestler::class)
-    ->where('competitor_id', $wrestler->id)
-    ->count();
-```
-
-## Testing Architecture
-
-### Unit Tests
-
-```php
-test('winner has proper foreign key relationship', function () {
-    $match = MatchFactory::new()->complete()->create(); 
-    $winner = $match->result->winners->first();
-    
-    expect($winner->competitor)->toBeInstanceOf(MatchCompetitor::class);
-    expect($winner->competitor->competitor)->toBeInstanceOf(Wrestler::class);
-});
-
-test('backward compatibility accessors work', function () {
-    $winner = MatchWinner::factory()->create();
-    
-    expect($winner->winner_type)->toBe($winner->competitor->competitor_type);
-    expect($winner->winner_id)->toBe($winner->competitor->competitor_id);
-});
-```
-
-### Integration Tests
-
-```php
-test('multiple winners are properly created', function () {
-    $match = MatchFactory::new()->generateFullMatch([
-        'match_type' => 'fatal-4-way',
-        'winner_strategy' => 'multiple'
-    ])->create();
-    
-    expect($match->result->winners)->toHaveCount(
-        fake()->numberBetween(1, 3)
-    );
-    
-    $match->result->winners->each(function ($winner) {
-        expect($winner->competitor)->toBeInstanceOf(MatchCompetitor::class);
-    });
-});
-```
-
-## Migration Path
-
-### Data Migration
-
-When migrating from polymorphic to foreign key architecture:
-
-```php
-// Migration to populate new foreign key columns
-foreach (MatchWinner::all() as $winner) {
-    $competitor = MatchCompetitor::where('match_id', $winner->match_result->match_id)
-        ->where('competitor_type', $winner->winner_type)
-        ->where('competitor_id', $winner->winner_id)
-        ->first();
-        
-    if ($competitor) {
-        $winner->update(['match_competitor_id' => $competitor->id]);
-    }
-}
-```
-
-### Rollback Strategy
-
-The architecture maintains rollback capability:
-
-1. **Keep Morph Columns**: Don't drop original columns immediately
-2. **Dual Population**: Populate both old and new columns during transition
-3. **Feature Flags**: Use flags to switch between old/new queries
-4. **Gradual Rollout**: Test new architecture with subset of matches
-
-The foreign key architecture provides a robust, performant, and maintainable foundation for winner/loser tracking while preserving backward compatibility and enabling future enhancements.

--- a/tests/Unit/database/Factories/Matches/MatchGenerationTest.php
+++ b/tests/Unit/database/Factories/Matches/MatchGenerationTest.php
@@ -229,8 +229,8 @@ describe('Match Comprehensive Generation Unit Tests', function () {
             $firstCompetitor = $match->competitors->firstOrFail();
             $winner = $match->result->winners->firstOrFail();
 
-            expect($winner->winner_type)->toBe($firstCompetitor->competitor_type);
-            expect($winner->winner_id)->toBe($firstCompetitor->competitor_id);
+            expect($winner->competitor->competitor_type)->toBe($firstCompetitor->competitor_type);
+            expect($winner->competitor->competitor_id)->toBe($firstCompetitor->competitor_id);
         });
 
         test('generates match with last competitor as winner', function () {
@@ -247,8 +247,8 @@ describe('Match Comprehensive Generation Unit Tests', function () {
             $lastCompetitor = $match->competitors->reverse()->firstOrFail();
             $winner = $match->result->winners->firstOrFail();
 
-            expect($winner->winner_type)->toBe($lastCompetitor->competitor_type);
-            expect($winner->winner_id)->toBe($lastCompetitor->competitor_id);
+            expect($winner->competitor->competitor_type)->toBe($lastCompetitor->competitor_type);
+            expect($winner->competitor->competitor_id)->toBe($lastCompetitor->competitor_id);
         });
 
         test('generates match with multiple winners', function () {
@@ -383,7 +383,7 @@ describe('Match Comprehensive Generation Unit Tests', function () {
 
             // Challenger should win (last competitor strategy)
             $winner = $match->result->winners->firstOrFail();
-            expect($winner->winner_id)->toBe($challenger->id);
+            expect($winner->competitor->competitor_id)->toBe($challenger->id);
         });
 
         test('generates multi-title unification match', function () {


### PR DESCRIPTION
## Summary
- remove redundant winner, loser, and competitor convenience methods
- remove virtual compatibility attributes from winner and loser records
- use the MatchWinner/MatchLoser to MatchCompetitor to competitor relationship as the authoritative path
- preserve MatchResult winner as the primary-winner relationship
- align match collections, tables, tests, and architecture documentation

## Verification
- 56 focused tests passed with 149 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- Pint with Blade passed
- git diff checks passed