### PR TITLE
refactor: remove redundant title status cast

### DIFF
--- a/app/Models/Titles/Title.php
+++ b/app/Models/Titles/Title.php
@@ -175,7 +175,6 @@ class Title extends Model implements HasActivityPeriodsContract, HasDisplayName,
     protected function casts(): array
     {
         return [
-            'status' => TitleStatus::class,
             'type' => TitleType::class,
         ];
     }

--- a/docs/architecture/championship-system.md
+++ b/docs/architecture/championship-system.md
@@ -20,6 +20,8 @@ The championship system manages title matches and ensures proper competitor vali
 
 `TitleType` is the canonical classification value; consumers compare the model's cast `type` attribute with its enum cases instead of relying on model predicate aliases. Wrestlers and tag teams implement `CanBeChampion` and share their polymorphic championship-history relationships through `HasChampionshipReigns`. Because either champion type may hold multiple titles simultaneously, `currentChampionships` is the authoritative current-state relationship; champion models do not expose a singular `currentChampionship` relationship. A `Title` owns its `championships` and singular `currentChampionship` relationships directly because each title has at most one current reign.
 
+`Title::status` is computed from activity-period relationships and is not a stored or cast database attribute. Only the persisted title `type` value is enum-cast.
+
 ## Related Documentation
 - [Business Rules](business-rules.md)
 - [Match System](match-system.md)

--- a/tests/Unit/Models/Titles/TitleTest.php
+++ b/tests/Unit/Models/Titles/TitleTest.php
@@ -44,7 +44,7 @@ describe('Title Model Unit Tests', function () {
             $casts = $title->getCasts();
 
             expect($casts['type'])->toBe(TitleType::class);
-            expect($casts['status'])->toBe(TitleStatus::class);
+            expect($casts)->not->toHaveKey('status');
         });
 
         test('has custom eloquent builder', function () {


### PR DESCRIPTION
## Summary
- remove the redundant enum cast for the computed Title status attribute
- keep the activity-period-derived accessor as the authoritative status source
- document the persisted type cast and computed status boundary

## Verification
- 27 focused tests passed with 99 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- Pint with Blade passed
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected title status handling so it is derived from activity periods rather than treated as a stored database attribute.
  - Preserved enum-based handling for persisted title types.

- **Documentation**
  - Clarified how title status and type values are represented and determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->