### PR TITLE
refactor: simplify employment state predicates

### DIFF
--- a/app/Console/Commands/RingsideMakeTest.php
+++ b/app/Console/Commands/RingsideMakeTest.php
@@ -1083,8 +1083,8 @@ describe(\'{{ modelClass }} Model Unit Tests\', function () {
 
             // Employment trait methods
             'employments', 'currentEmployment', 'futureEmployment', 'previousEmployments', 'previousEmployment',
-            'firstEmployment', 'hasEmployments', 'isEmployed', 'isCurrentlyEmployed', 'hasFutureEmployment',
-            'isNotInEmployment', 'isReleased', 'employmentStartedOn', 'employmentStartedBefore',
+            'firstEmployment', 'isEmployed', 'hasFutureEmployment',
+            'isNotInEmployment', 'isReleased',
             'hasEmploymentHistory', 'hasStatus',
             'hasAnyStatus', 'doesNotHaveStatus', 'hasNoneOfStatuses',
 

--- a/app/Livewire/TagTeams/Forms/CreateEditForm.php
+++ b/app/Livewire/TagTeams/Forms/CreateEditForm.php
@@ -136,7 +136,7 @@ class CreateEditForm extends BaseForm
         }
 
         // Load employment start date from relationship (with type safety)
-        if ($this->formModel->hasEmployments()) {
+        if ($this->formModel->hasEmploymentHistory()) {
             $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
         }
 

--- a/app/Models/Concerns/IsEmployable.php
+++ b/app/Models/Concerns/IsEmployable.php
@@ -9,7 +9,6 @@ use App\Models\Lifecycle\Employment;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
-use Illuminate\Support\Carbon;
 
 /**
  * Adds employment-related behavior to a model.
@@ -201,29 +200,6 @@ trait IsEmployable
     }
 
     /**
-     * Determine if the model has any employments at all.
-     *
-     * Checks if there are any employment records associated with this model,
-     * regardless of their status (active or completed). This is useful for
-     * determining if a model has an employment history.
-     *
-     * @return bool True if the model has any employments, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     *
-     * if ($wrestler->hasEmployments()) {
-     *     echo "This wrestler has an employment history";
-     * }
-     * ```
-     */
-    public function hasEmployments(): bool
-    {
-        return $this->employments()->exists();
-    }
-
-    /**
      * Determine if the model is currently employed.
      *
      * Checks if there is an active employment (one with a null 'ended_at' field).
@@ -244,31 +220,6 @@ trait IsEmployable
     public function isEmployed(): bool
     {
         return $this->currentEmployment()->exists();
-    }
-
-    /**
-     * Check if the model is currently employed (alias for consistency).
-     *
-     * This method provides a consistent naming convention with other status methods
-     * like isInjured(), isSuspended(), isRetired().
-     *
-     * @return bool True if currently employed, false otherwise
-     */
-    public function isCurrentlyEmployed(): bool
-    {
-        return $this->isEmployed();
-    }
-
-    /**
-     * Check if the model is currently unemployed.
-     *
-     * This method provides the opposite of isEmployed() for clearer test logic.
-     *
-     * @return bool True if currently unemployed, false otherwise
-     */
-    public function isUnemployed(): bool
-    {
-        return ! $this->isEmployed();
     }
 
     /**
@@ -334,52 +285,6 @@ trait IsEmployable
     public function isReleased(): bool
     {
         return ! $this->isEmployed() && ! $this->isRetired() && $this->previousEmployments()->exists();
-    }
-
-    /**
-     * Check if the current employment started on a specific date.
-     *
-     * @param  Carbon  $employmentDate  The date to check against
-     * @return bool True if employed on the specified date, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $targetDate = Carbon::parse('2024-01-15');
-     *
-     * if ($wrestler->employmentStartedOn($targetDate)) {
-     *     echo "Wrestler was employed exactly on January 15, 2024";
-     * }
-     * ```
-     */
-    public function employmentStartedOn(Carbon $employmentDate): bool
-    {
-        $currentEmployment = $this->currentEmployment;
-
-        return $currentEmployment ? $currentEmployment->started_at->eq($employmentDate) : false;
-    }
-
-    /**
-     * Check if the current employment started on or before a specific date.
-     *
-     * @param  Carbon  $employmentDate  The date to check against
-     * @return bool True if employed before or on the specified date, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $targetDate = Carbon::parse('2024-01-15');
-     *
-     * if ($wrestler->employmentStartedBefore($targetDate)) {
-     *     echo "Wrestler was employed before January 15, 2024";
-     * }
-     * ```
-     */
-    public function employmentStartedBefore(Carbon $employmentDate): bool
-    {
-        $currentEmployment = $this->currentEmployment;
-
-        return $currentEmployment ? $currentEmployment->started_at->lte($employmentDate) : false;
     }
 
     /**

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -27,6 +27,7 @@
 
 - Employment history uses the shared `App\Models\Lifecycle\Employment` model and an `employable` polymorphic owner.
 - Wrestlers, managers, referees, and tag teams expose the same typed employment relationships through `IsEmployable`.
+- Employment state uses one predicate per distinct meaning: `isEmployed()`, `hasFutureEmployment()`, `isReleased()`, and `hasEmploymentHistory()`. Do not add aliases for those states.
 - Employment models are not resolved from entity naming conventions and entity-specific employment record classes must not be introduced.
 - Injury history uses the shared `App\Models\Lifecycle\Injury` model and an `injurable` polymorphic owner.
 - Suspension history uses the shared `App\Models\Lifecycle\Suspension` model and a `suspendable` polymorphic owner.

--- a/tests/Unit/Models/Concerns/IsEmployableTest.php
+++ b/tests/Unit/Models/Concerns/IsEmployableTest.php
@@ -170,15 +170,6 @@ describe('IsEmployable Trait Unit Tests', function () {
             expect($model->isEmployed())->toBeFalse();
         });
 
-        test('can check if model has employments', function () {
-            $modelWith = new EmploymentStateModel();
-            $modelWith->employmentExists = true;
-            $modelWithout = new EmploymentStateModel();
-
-            expect($modelWith->hasEmployments())->toBeTrue();
-            expect($modelWithout->hasEmployments())->toBeFalse();
-        });
-
         test('can check if model has future employment', function () {
             $modelWith = new EmploymentStateModel();
             $modelWith->futureEmploymentExists = true;


### PR DESCRIPTION
## Summary
- remove duplicate and unused employment-state aliases from `IsEmployable`
- retain one canonical predicate for each distinct employment state
- update the Tag Team form to use `hasEmploymentHistory()`
- remove stale generator exclusions and document the predicate vocabulary

## Verification
- 54 focused tests passed with 141 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- Pint with Blade passed
- `git diff --check` passed