### PR TITLE
refactor: simplify activity state predicates

### DIFF
--- a/app/Lifecycle/StableActivityEligibility.php
+++ b/app/Lifecycle/StableActivityEligibility.php
@@ -60,7 +60,7 @@ final class StableActivityEligibility
             throw CannotBeDisbandedException::unactivated($stable);
         }
 
-        if ($stable->hasFutureActivation()) {
+        if ($stable->hasFutureActivity()) {
             throw CannotBeDisbandedException::hasFutureActivation($stable);
         }
 
@@ -94,7 +94,7 @@ final class StableActivityEligibility
             throw CannotBeReunitedException::neverActive($stable);
         }
 
-        if ($stable->isCurrentlyActive() || $stable->hasFutureActivation()) {
+        if ($stable->isCurrentlyActive() || $stable->hasFutureActivity()) {
             throw CannotBeReunitedException::currentlyActive($stable);
         }
 

--- a/app/Lifecycle/StableRetirementEligibility.php
+++ b/app/Lifecycle/StableRetirementEligibility.php
@@ -34,7 +34,7 @@ final class StableRetirementEligibility
             throw CannotBeRetiredException::alreadyRetired($stable);
         }
 
-        if (! $stable->hasActivityPeriods() || (! $stable->isCurrentlyActive() && $stable->hasFutureActivation())) {
+        if (! $stable->hasActivityPeriods() || (! $stable->isCurrentlyActive() && $stable->hasFutureActivity())) {
             throw CannotBeRetiredException::notActive($stable);
         }
     }

--- a/app/Models/Concerns/HasActivityPeriods.php
+++ b/app/Models/Concerns/HasActivityPeriods.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Models\Concerns;
 
 use App\Models\Contracts\HasActivityPeriods as HasActivityPeriodsContract;
-use App\Models\Contracts\Retirable;
 use App\Models\Lifecycle\ActivityPeriod;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
@@ -118,19 +117,6 @@ trait HasActivityPeriods
         return $this->futureActivityPeriod()->exists();
     }
 
-    public function isNotCurrentlyActive(): bool
-    {
-        if ($this->isInactive()) {
-            return true;
-        }
-
-        if ($this->hasFutureActivity()) {
-            return true;
-        }
-
-        return $this instanceof Retirable && $this->isRetired();
-    }
-
     public function isUnactivated(): bool
     {
         return ! $this->hasActivityPeriods();
@@ -151,23 +137,6 @@ trait HasActivityPeriods
         $currentPeriod = $this->currentActivityPeriod;
 
         return $currentPeriod ? $currentPeriod->started_at->isSameDay($activityDate) : false;
-    }
-
-    /**
-     * Check if the current activity period started on or before a specific date.
-     *
-     * @param  Carbon  $activityDate  The date to check against
-     */
-    public function wasActiveBefore(Carbon $activityDate): bool
-    {
-        $currentPeriod = $this->currentActivityPeriod;
-
-        return $currentPeriod ? $currentPeriod->started_at->lte($activityDate) : false;
-    }
-
-    public function hasFutureActivation(): bool
-    {
-        return $this->futureActivityPeriod()->exists();
     }
 
     protected function getActivityPeriodTableName(): string

--- a/app/Models/Contracts/HasActivityPeriods.php
+++ b/app/Models/Contracts/HasActivityPeriods.php
@@ -28,13 +28,6 @@ interface HasActivityPeriods
     public function isCurrentlyActive(): bool;
 
     /**
-     * Check if the model is not currently active.
-     *
-     * @return bool True if the model does not have an active period
-     */
-    public function isNotCurrentlyActive(): bool;
-
-    /**
      * Check if the model has never been activated.
      *
      * @return bool True if the model has no activity periods
@@ -55,14 +48,6 @@ interface HasActivityPeriods
      * @return bool True if the model was active on the given date
      */
     public function wasActiveOn(Carbon $date): bool;
-
-    /**
-     * Check if the model was active before a given date.
-     *
-     * @param  Carbon  $date  The date to check against
-     * @return bool True if the model was active before the given date
-     */
-    public function wasActiveBefore(Carbon $date): bool;
 
     /**
      * Get all activity periods for this model.

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -40,6 +40,7 @@
 - **Status fields are computed, not stored** - eliminates data inconsistency
 - Models use computed attributes: `protected function status(): Attribute`
 - Factory methods NEVER set status fields manually
+- Activity-period state uses the canonical predicates `isCurrentlyActive()`, `isInactive()`, `isUnactivated()`, `hasFutureActivity()`, and `wasActiveOn()` without duplicate aliases.
 - Status computed from relationships (employment, retirement, injury, suspension)
 - Priority order: Retired > Employed > FutureEmployment > Released > Unemployed
 

--- a/tests/Unit/Models/Concerns/HasActivityPeriodsTraitTest.php
+++ b/tests/Unit/Models/Concerns/HasActivityPeriodsTraitTest.php
@@ -182,20 +182,6 @@ describe('HasActivityPeriods Trait Unit Tests', function () {
             expect($model->hasFutureActivity())->toBeFalse();
         });
 
-        test('isNotCurrentlyActive returns true when model is not active', function () {
-            $model = Title::factory()->unactivated()->create();
-            expect($model->isNotCurrentlyActive())->toBeTrue();
-        });
-
-        test('isNotCurrentlyActive returns false when model is active', function () {
-            $model = $this->model;
-            ActivityPeriod::factory()->for($model, 'activeable')->create([
-                'started_at' => now()->subWeek(),
-                'ended_at' => null,
-            ]);
-            expect($model->isNotCurrentlyActive())->toBeFalse();
-        });
-
         test('isUnactivated returns true when model has no periods', function () {
             $model = Title::factory()->unactivated()->create();
             expect($model->isUnactivated())->toBeTrue();
@@ -246,23 +232,6 @@ describe('HasActivityPeriods Trait Unit Tests', function () {
             expect($model->wasActiveOn(now()->subMonth()))->toBeFalse();
         });
 
-        test('wasActiveBefore returns true when current period started before date', function () {
-            $model = $this->model;
-            ActivityPeriod::factory()->for($model, 'activeable')->create([
-                'started_at' => now()->subMonth(),
-                'ended_at' => null,
-            ]);
-            expect($model->wasActiveBefore(now()->subWeek()))->toBeTrue();
-        });
-
-        test('wasActiveBefore returns false when current period started after date', function () {
-            $model = $this->model;
-            ActivityPeriod::factory()->for($model, 'activeable')->create([
-                'started_at' => now()->subWeek(),
-                'ended_at' => null,
-            ]);
-            expect($model->wasActiveBefore(now()->subMonth()))->toBeFalse();
-        });
     });
 
     describe('utility methods', function () {


### PR DESCRIPTION
## Summary
- remove duplicate and unused activity-period state predicates
- standardize stable lifecycle eligibility on `hasFutureActivity()`
- narrow the activity-period contract to canonical relationship-derived state
- document the supported activity predicate vocabulary

## Verification
- 52 focused tests passed with 108 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- Pint with Blade passed
- `git diff --check` passed