### PR TITLE
refactor: move tag team weight calculation

### DIFF
--- a/app/Console/Commands/RingsideMakeTest.php
+++ b/app/Console/Commands/RingsideMakeTest.php
@@ -1079,7 +1079,7 @@ describe(\'{{ modelClass }} Model Unit Tests\', function () {
             'tagTeams', 'currentTagTeam', 'previousTagTeam', 'previousTagTeams',
             'titleChampionships', 'currentChampionships', 'previousTitleChampionships',
             'matches', 'previousMatches',
-            'wrestlers', 'currentWrestlers', 'previousWrestlers', 'combinedWeight',
+            'wrestlers', 'currentWrestlers', 'previousWrestlers',
 
             // Employment trait methods
             'employments', 'currentEmployment', 'futureEmployment', 'previousEmployments', 'previousEmployment',

--- a/app/Data/TagTeams/TagTeamMembershipData.php
+++ b/app/Data/TagTeams/TagTeamMembershipData.php
@@ -40,6 +40,8 @@ readonly class TagTeamMembershipData
 
     /**
      * Get the wrestlers collection, defaulting to empty Eloquent collection.
+     *
+     * @return Collection<int, Wrestler>
      */
     public function getWrestlers(): Collection
     {
@@ -68,5 +70,12 @@ readonly class TagTeamMembershipData
     public function hasManagers(): bool
     {
         return $this->managers !== null && $this->managers->isNotEmpty();
+    }
+
+    public function combinedWeightInPounds(): int
+    {
+        return (int) $this->getWrestlers()->sum(
+            fn (Wrestler $wrestler): int => $wrestler->weight
+        );
     }
 }

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -35,7 +35,6 @@ use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -55,9 +54,6 @@ use Illuminate\Support\Carbon;
  * @property string $name
  * @property string|null $signature_move
  * @property EmploymentStatus $status
- *
- * @property-read int $combined_weight
- *
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  * @property Carbon|null $deleted_at
@@ -167,12 +163,6 @@ class TagTeam extends Model implements CanBeAStableMember, CanBeChampion, Employ
     public function previousWrestlers(): BelongsToMany
     {
         return $this->wrestlers()->wherePivotNotNull('left_at');
-    }
-
-    /** @return Attribute<int, never> */
-    protected function combinedWeight(): Attribute
-    {
-        return Attribute::get(fn (): int => (int) $this->currentWrestlers->sum('weight'));
     }
 
     protected function stableMembershipTable(): string

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -39,6 +39,7 @@
 ## Computed Status Pattern
 - **Status fields are computed, not stored** - eliminates data inconsistency
 - Models use computed attributes: `protected function status(): Attribute`
+- Membership-derived calculations belong to typed membership data objects. For example, `TagTeamMembershipData` calculates combined wrestler weight without adding a presentation aggregate to the Eloquent model.
 - Factory methods NEVER set status fields manually
 - Status computed from relationships (employment, retirement, injury, suspension)
 - Priority order: Retired > Employed > FutureEmployment > Released > Unemployed

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -37,12 +37,6 @@ parameters:
 			path: app/Data/TagTeams/TagTeamMembershipData.php
 
 		-
-			message: '#^Method App\\Data\\TagTeams\\TagTeamMembershipData\:\:getWrestlers\(\) return type with generic class Illuminate\\Database\\Eloquent\\Collection does not specify its types\: TKey, TModel$#'
-			identifier: missingType.generics
-			count: 1
-			path: app/Data/TagTeams/TagTeamMembershipData.php
-
-		-
 			message: '#^Access to an undefined property App\\Models\\Users\\User\:\:\$name\.$#'
 			identifier: property.notFound
 			count: 1

--- a/tests/Unit/Data/TagTeams/TagTeamMembershipDataTest.php
+++ b/tests/Unit/Data/TagTeams/TagTeamMembershipDataTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\TagTeams\TagTeamMembershipData;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
+
+test('calculates the combined wrestler weight in pounds', function () {
+    $members = new TagTeamMembershipData(new Collection([
+        Wrestler::factory()->make(['weight' => 225]),
+        Wrestler::factory()->make(['weight' => 275]),
+    ]));
+
+    expect($members->combinedWeightInPounds())->toBe(500);
+});
+
+test('returns zero without wrestlers', function () {
+    $members = new TagTeamMembershipData();
+
+    expect($members->combinedWeightInPounds())->toBe(0);
+});


### PR DESCRIPTION
## Summary
- move combined wrestler-weight calculation from the TagTeam Eloquent model to `TagTeamMembershipData`
- make the unit explicit through `combinedWeightInPounds()`
- remove the stale model-test generator exclusion
- document membership-derived calculations as data-object behavior
- remove the resolved PHPStan baseline entry for the typed wrestler collection

## Verification
- 10 focused tests passed with 24 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- Pint with Blade passed
- `git diff --check` passed