### PR TITLE
refactor: clarify employment absence predicate

### DIFF
--- a/app/Console/Commands/RingsideMakeTest.php
+++ b/app/Console/Commands/RingsideMakeTest.php
@@ -1084,7 +1084,7 @@ describe(\'{{ modelClass }} Model Unit Tests\', function () {
             // Employment trait methods
             'employments', 'currentEmployment', 'futureEmployment', 'previousEmployments', 'previousEmployment',
             'firstEmployment', 'isEmployed', 'hasFutureEmployment',
-            'isNotInEmployment', 'isReleased',
+            'hasNoCurrentOrFutureEmployment', 'isReleased',
             'hasEmploymentHistory', 'hasStatus',
             'hasAnyStatus', 'doesNotHaveStatus', 'hasNoneOfStatuses',
 

--- a/app/Lifecycle/IndividualEmploymentEligibility.php
+++ b/app/Lifecycle/IndividualEmploymentEligibility.php
@@ -51,7 +51,7 @@ final class IndividualEmploymentEligibility
 
     public function ensureCanRelease(Wrestler|Manager|Referee $individual): void
     {
-        if ($individual->isNotInEmployment()) {
+        if ($individual->hasNoCurrentOrFutureEmployment()) {
             throw CannotBeReleasedException::unemployed($individual);
         }
 

--- a/app/Lifecycle/IndividualInjuryEligibility.php
+++ b/app/Lifecycle/IndividualInjuryEligibility.php
@@ -25,7 +25,7 @@ final class IndividualInjuryEligibility
 
     public function ensureCanInjure(Wrestler|Manager|Referee $individual): void
     {
-        if ($individual->isNotInEmployment()) {
+        if ($individual->hasNoCurrentOrFutureEmployment()) {
             throw CannotBeInjuredException::unemployed($individual);
         }
 

--- a/app/Lifecycle/IndividualSuspensionEligibility.php
+++ b/app/Lifecycle/IndividualSuspensionEligibility.php
@@ -72,7 +72,7 @@ final class IndividualSuspensionEligibility
             throw CannotBeReinstatedException::available($individual);
         }
 
-        if ($individual->isNotInEmployment()) {
+        if ($individual->hasNoCurrentOrFutureEmployment()) {
             throw CannotBeReinstatedException::unemployed($individual);
         }
 

--- a/app/Lifecycle/RosterBookingEligibility.php
+++ b/app/Lifecycle/RosterBookingEligibility.php
@@ -19,7 +19,7 @@ final class RosterBookingEligibility
         }
 
         return ! (
-            $rosterMember->isNotInEmployment()
+            $rosterMember->hasNoCurrentOrFutureEmployment()
             || $rosterMember->isSuspended()
             || $rosterMember->isInjured()
             || $rosterMember->hasFutureEmployment()

--- a/app/Models/Concerns/IsEmployable.php
+++ b/app/Models/Concerns/IsEmployable.php
@@ -243,24 +243,7 @@ trait IsEmployable
         return $this->futureEmployment()->exists();
     }
 
-    /**
-     * Determine if the model is not currently employed.
-     *
-     * Considers a model as not employed if they are explicitly marked
-     * as unemployed, released, or retired.
-     *
-     * @return bool True if the model is not in employment, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     *
-     * if ($wrestler->isNotInEmployment()) {
-     *     echo "Wrestler is not currently available";
-     * }
-     * ```
-     */
-    public function isNotInEmployment(): bool
+    public function hasNoCurrentOrFutureEmployment(): bool
     {
         return ! $this->isEmployed() && ! $this->hasFutureEmployment();
     }

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -27,7 +27,7 @@
 
 - Employment history uses the shared `App\Models\Lifecycle\Employment` model and an `employable` polymorphic owner.
 - Wrestlers, managers, referees, and tag teams expose the same typed employment relationships through `IsEmployable`.
-- Employment state uses one predicate per distinct meaning: `isEmployed()`, `hasFutureEmployment()`, `isReleased()`, and `hasEmploymentHistory()`. Do not add aliases for those states.
+- Employment state uses one predicate per distinct meaning: `isEmployed()`, `hasFutureEmployment()`, `hasNoCurrentOrFutureEmployment()`, `isReleased()`, and `hasEmploymentHistory()`. Do not add aliases for those states.
 - Employment models are not resolved from entity naming conventions and entity-specific employment record classes must not be introduced.
 - Injury history uses the shared `App\Models\Lifecycle\Injury` model and an `injurable` polymorphic owner.
 - Suspension history uses the shared `App\Models\Lifecycle\Suspension` model and a `suspendable` polymorphic owner.

--- a/tests/Helpers/StatusTestExpectations.php
+++ b/tests/Helpers/StatusTestExpectations.php
@@ -54,7 +54,7 @@ function expectToBeBookable(Wrestler|Referee|TagTeam $entity): void
     $entity = freshModel($entity);
     expect($entity->isEmployed())->toBeTrue();
     expect(RosterBookingEligibility::allows($entity))->toBeTrue();
-    expect($entity->isNotInEmployment())->toBeFalse();
+    expect($entity->hasNoCurrentOrFutureEmployment())->toBeFalse();
 }
 
 /**

--- a/tests/Unit/Models/Concerns/IsEmployableTest.php
+++ b/tests/Unit/Models/Concerns/IsEmployableTest.php
@@ -179,6 +179,18 @@ describe('IsEmployable Trait Unit Tests', function () {
             expect($modelWithout->hasFutureEmployment())->toBeFalse();
         });
 
+        test('detects the absence of current and future employment', function () {
+            $withoutEmployment = new EmploymentStateModel();
+            $currentlyEmployed = new EmploymentStateModel();
+            $currentlyEmployed->currentEmploymentExists = true;
+            $futureEmployment = new EmploymentStateModel();
+            $futureEmployment->futureEmploymentExists = true;
+
+            expect($withoutEmployment->hasNoCurrentOrFutureEmployment())->toBeTrue()
+                ->and($currentlyEmployed->hasNoCurrentOrFutureEmployment())->toBeFalse()
+                ->and($futureEmployment->hasNoCurrentOrFutureEmployment())->toBeFalse();
+        });
+
         test('can check if model has employment history', function () {
             $modelWith = new EmploymentStateModel();
             $modelWith->employmentExists = true;


### PR DESCRIPTION
## Summary
- rename the ambiguous `isNotInEmployment()` predicate to `hasNoCurrentOrFutureEmployment()`
- update lifecycle eligibility and booking callers to use the precise vocabulary
- add direct coverage for absent, current, and future employment states
- update architecture documentation and generator metadata

## Verification
- 57 focused tests passed with 103 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- Pint with Blade passed
- `git diff --check` passed