### PR TITLE
refactor: make manager relationships explicit

### DIFF
--- a/app/Console/Commands/RingsideMakeTest.php
+++ b/app/Console/Commands/RingsideMakeTest.php
@@ -1074,7 +1074,7 @@ describe(\'{{ modelClass }} Model Unit Tests\', function () {
             'forceDeleting', 'forceDeleted', 'isForceDeleting',
 
             // Relationship trait methods (common patterns)
-            'managers', 'currentManagers', 'previousManagers', 'fakeManagerPivotModel',
+            'managers', 'currentManagers', 'previousManagers',
             'stables', 'currentStable', 'previousStables',
             'tagTeams', 'currentTagTeam', 'previousTagTeam', 'previousTagTeams',
             'titleChampionships', 'currentChampionships', 'previousTitleChampionships',

--- a/app/Models/Concerns/CanBeManaged.php
+++ b/app/Models/Concerns/CanBeManaged.php
@@ -9,7 +9,6 @@ use App\Models\Managers\Manager;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
-use LogicException;
 
 /**
  * Provides manager relationship support for models that can be managed by `Manager` instances.
@@ -37,12 +36,10 @@ use LogicException;
  */
 trait CanBeManaged
 {
-    /**
-     * The resolved manager pivot model class name.
-     *
-     * @var class-string<TPivotModel>|null
-     */
-    protected static ?string $resolvedManagerPivotModel = null;
+    abstract protected function managerAssignmentTable(): string;
+
+    /** @return class-string<TPivotModel> */
+    abstract protected function managerAssignmentPivotModel(): string;
 
     /**
      * Define a BelongsToMany relationship to the model's managers.
@@ -63,8 +60,8 @@ trait CanBeManaged
     public function managers(): BelongsToMany
     {
         /** @var BelongsToMany<Manager, static, TPivotModel> $relation */
-        $relation = $this->belongsToMany(Manager::class, $this->getManagersPivotTable())
-            ->using($this->resolveManagersPivotModel())
+        $relation = $this->belongsToMany(Manager::class, $this->managerAssignmentTable())
+            ->using($this->managerAssignmentPivotModel())
             ->withPivot(['hired_at', 'fired_at'])
             ->withTimestamps();
 
@@ -93,8 +90,8 @@ trait CanBeManaged
     public function currentManagers(): BelongsToMany
     {
         /** @var BelongsToMany<Manager, static, TPivotModel> $relation */
-        $relation = $this->belongsToMany(Manager::class, $this->getManagersPivotTable())
-            ->using($this->resolveManagersPivotModel())
+        $relation = $this->belongsToMany(Manager::class, $this->managerAssignmentTable())
+            ->using($this->managerAssignmentPivotModel())
             ->withPivot(['hired_at', 'fired_at'])
             ->withTimestamps()
             ->wherePivotNull('fired_at');
@@ -121,98 +118,12 @@ trait CanBeManaged
     public function previousManagers(): BelongsToMany
     {
         /** @var BelongsToMany<Manager, static, TPivotModel> $relation */
-        $relation = $this->belongsToMany(Manager::class, $this->getManagersPivotTable())
-            ->using($this->resolveManagersPivotModel())
+        $relation = $this->belongsToMany(Manager::class, $this->managerAssignmentTable())
+            ->using($this->managerAssignmentPivotModel())
             ->withPivot(['hired_at', 'fired_at'])
             ->withTimestamps()
             ->wherePivotNotNull('fired_at');
 
         return $relation;
-    }
-
-    /**
-     * Get the name of the pivot table for the manager relationship.
-     *
-     * The default naming convention is `<model_plural>_managers`,
-     * e.g., `wrestlers_managers` or `tag_teams_managers`.
-     *
-     * Override this method in the model to customize the pivot table name.
-     *
-     * @return string The pivot table name
-     *
-     * @example
-     * For a Wrestler model, this returns 'wrestlers_managers'
-     */
-    protected function getManagersPivotTable(): string
-    {
-        return str(class_basename($this))
-            ->plural()
-            ->snake()
-            ->append('_managers')
-            ->toString(); // e.g., "wrestlers_managers" or "tag_teams_managers"
-    }
-
-    /**
-     * Resolve the pivot model class for manager relationships.
-     *
-     * This method automatically determines the pivot model class based on naming
-     * conventions. For example, if the parent model is 'Wrestler', it will look for
-     * a 'WrestlerManager' pivot model class.
-     *
-     *
-     * @throws LogicException If the resolved model class doesn't exist
-     * @return class-string<TPivotModel> The fully qualified class name of the pivot model
-     *
-     * @example
-     * For a 'Wrestler' model, this will resolve to 'App\\Models\\WrestlerManager'
-     */
-    protected function resolveManagersPivotModel(): string
-    {
-        if (static::$resolvedManagerPivotModel !== null) {
-            return static::$resolvedManagerPivotModel;
-        }
-
-        return $this->resolveManagersPivotModelInternal();
-    }
-
-    /**
-     * Internal method to resolve manager pivot model class.
-     *
-     * @return class-string<TPivotModel>
-     */
-    private function resolveManagersPivotModelInternal(): string
-    {
-        $declaring = static::class;
-        $baseName = class_basename($declaring);
-
-        // Build the related model class name by replacing only the class name, not the namespace
-        $relatedModelName = $baseName.'Manager';
-        $namespace = mb_substr($declaring, 0, mb_strrpos($declaring, '\\'));
-        $resolved = $namespace.'\\'.$relatedModelName;
-
-        if (! class_exists($resolved)) {
-            throw new LogicException("Related pivot model [{$resolved}] not found for [{$declaring}]. Override the resolution method or ensure the class exists.");
-        }
-
-        /** @var class-string<TPivotModel> */
-        return $resolved;
-    }
-
-    /**
-     * Override the resolved pivot model class for testing or customization.
-     *
-     * @param  class-string<TPivotModel>|null  $class  The fully qualified class name to use, or null to reset
-     *
-     * @example
-     * ```php
-     * // In a test:
-     * Wrestler::fakeManagerPivotModel(MockWrestlerManager::class);
-     * // Reset:
-     * Wrestler::fakeManagerPivotModel(null);
-     * ```
-     */
-    public static function fakeManagerPivotModel(?string $class): void
-    {
-        static::$resolvedManagerPivotModel = $class;
     }
 }

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -144,6 +144,16 @@ class TagTeam extends Model implements CanBeAStableMember, CanBeChampion, Employ
 
     use SoftDeletes;
 
+    protected function managerAssignmentTable(): string
+    {
+        return (new TagTeamManager())->getTable();
+    }
+
+    protected function managerAssignmentPivotModel(): string
+    {
+        return TagTeamManager::class;
+    }
+
     /** @return BelongsToMany<Wrestler, $this, TagTeamWrestler> */
     public function wrestlers(): BelongsToMany
     {

--- a/app/Models/Wrestlers/Wrestler.php
+++ b/app/Models/Wrestlers/Wrestler.php
@@ -141,6 +141,16 @@ class Wrestler extends Model implements CanBeAStableMember, CanBeChampion, Emplo
 
     use SoftDeletes;
 
+    protected function managerAssignmentTable(): string
+    {
+        return (new WrestlerManager())->getTable();
+    }
+
+    protected function managerAssignmentPivotModel(): string
+    {
+        return WrestlerManager::class;
+    }
+
     protected function stableMembershipTable(): string
     {
         return (new StableWrestler())->getTable();

--- a/docs/architecture/core-capabilities.md
+++ b/docs/architecture/core-capabilities.md
@@ -67,6 +67,8 @@ Wrestlers explicitly define current and historical tag team membership through t
 
 Single current/previous tag team and current Stable lookups use Laravel's native `HasOneThrough` relationships through the persisted membership models. `HasStableMemberships` owns only the current and historical Stable relationship definitions; Stable-joining eligibility remains in validation rules and lifecycle collaborators. Each Stable-member model explicitly supplies its membership table, foreign key, and pivot model to the shared concern; the concern does not infer its host type at runtime. Collection relationships remain `BelongsToMany` so callers can inspect complete history and membership pivot dates. Do not reintroduce the abandoned `ankurk91/laravel-eloquent-relationships` package.
 
+Wrestlers and Tag Teams share current and historical manager relationships through `CanBeManaged`. Each model explicitly supplies its manager-assignment table and pivot model; the concern defines only the shared Eloquent relationships and does not infer classes from namespaces or expose mutable test configuration.
+
 ## User and Roster Separation
 
 Application users authenticate and operate the promotion management system; they do not own wrestler or other roster records. User and roster models therefore have no direct Eloquent relationship or foreign key.

--- a/tests/Unit/Models/Concerns/CanBeManagedTest.php
+++ b/tests/Unit/Models/Concerns/CanBeManagedTest.php
@@ -2,194 +2,42 @@
 
 declare(strict_types=1);
 
-/**
- * Unit tests for CanBeManaged trait in complete isolation.
- *
- * UNIT TEST SCOPE:
- * - Trait relationship method definitions (managers, currentManagers, previousManagers)
- * - Related model class resolution and caching
- * - Static override methods for testing flexibility
- * - Pivot model configuration and foreign key handling
- * - Cache reset mechanisms and error handling
- *
- * This test ensures the CanBeManaged trait is agnostic, reusable, and not tied to any business/domain model.
- * It verifies that the trait can be safely reused across any model without business logic dependencies.
- * This is NOT a business logic test - it focuses on trait mechanics and structure only.
- *
- * @see CanBeManaged
- */
-
 namespace Tests\Unit\Models\Concerns;
 
-use App\Models\Concerns\CanBeManaged;
-use App\Models\Contracts\Manageable;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use LogicException;
 use Tests\Unit\Models\Concerns\Support\FakeManageableModel;
 use Tests\Unit\Models\Concerns\Support\FakeManagerPivotModel;
 
-describe('CanBeManaged Trait Unit Tests', function () {
-    describe('manager relationships', function () {
-        test('provides managers relationship', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
-
-                public function resolveManagersPivotModel(): string
-                {
-                    return FakeManagerPivotModel::class;
-                }
-            };
-            expect($model->managers())->toBeInstanceOf(BelongsToMany::class);
-        });
-
-        test('provides currentManagers relationship', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
-
-                public function resolveManagersPivotModel(): string
-                {
-                    return FakeManagerPivotModel::class;
-                }
-            };
-            expect($model->currentManagers())->toBeInstanceOf(BelongsToMany::class);
-        });
-
-        test('provides previousManagers relationship', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
-
-                public function resolveManagersPivotModel(): string
-                {
-                    return FakeManagerPivotModel::class;
-                }
-            };
-            expect($model->previousManagers())->toBeInstanceOf(BelongsToMany::class);
-        });
+describe('CanBeManaged manager relationships', function () {
+    beforeEach(function () {
+        $this->model = new FakeManageableModel();
     });
 
-    describe('manager pivot model resolution', function () {
-        test('reports missing convention-based pivot models as logic errors', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
-
-                public function resolvePivotModel(): string
-                {
-                    return $this->resolveManagersPivotModel();
-                }
-            };
-
-            expect(fn () => $model->resolvePivotModel())
-                ->toThrow(LogicException::class, 'Related pivot model');
-        });
-
-        test('can fake manager pivot model class', function () {
-            FakeManageableModel::fakeManagerPivotModel(FakeManagerPivotModel::class);
-            $model = new FakeManageableModel();
-            expect($model->resolveManagersPivotModel())->toBe(FakeManagerPivotModel::class);
-            // Reset static override
-            FakeManageableModel::fakeManagerPivotModel(null);
-        });
+    test('provides all manager relationships', function () {
+        expect($this->model->managers())->toBeInstanceOf(BelongsToMany::class)
+            ->and($this->model->currentManagers())->toBeInstanceOf(BelongsToMany::class)
+            ->and($this->model->previousManagers())->toBeInstanceOf(BelongsToMany::class);
     });
 
-    describe('manager pivot table naming', function () {
-        test('generates correct pivot table name', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
+    test('uses the explicitly configured table and pivot model', function () {
+        $relationship = $this->model->managers();
 
-                public function resolveManagersPivotModel(): string
-                {
-                    return FakeManagerPivotModel::class;
-                }
-
-                public function getManagersPivotTable(): string
-                {
-                    $self = str(class_basename(self::class))->snake()->plural();
-
-                    return $self.'_managers';
-                }
-            };
-            $pivotTable = $model->getManagersPivotTable();
-            expect($pivotTable)->toContain('managers');
-            expect(str_contains($pivotTable, '_'))->toBeTrue();
-        });
+        expect($relationship->getTable())->toBe((new FakeManagerPivotModel())->getTable())
+            ->and($relationship->getPivotClass())->toBe(FakeManagerPivotModel::class);
     });
 
-    describe('manager relationship queries', function () {
-        test('managers relationship includes pivot data', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
+    test('includes assignment history columns and timestamps', function () {
+        expect($this->model->managers()->getPivotColumns())
+            ->toContain('hired_at', 'fired_at', 'created_at', 'updated_at');
+    });
 
-                public function resolveManagersPivotModel(): string
-                {
-                    return FakeManagerPivotModel::class;
-                }
-            };
-            $relation = $model->managers();
-            $pivotColumns = $relation->getPivotColumns();
-            expect($pivotColumns)->toContain('hired_at');
-            expect($pivotColumns)->toContain('fired_at');
-        });
+    test('filters current assignments', function () {
+        expect($this->model->currentManagers()->toRawSql())
+            ->toContain('"fired_at" is null');
+    });
 
-        test('currentManagers relationship includes wherePivotNull constraint', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
-
-                public function resolveManagersPivotModel(): string
-                {
-                    return FakeManagerPivotModel::class;
-                }
-            };
-            $relation = $model->currentManagers();
-            expect($relation)->toBeInstanceOf(BelongsToMany::class);
-        });
-
-        test('previousManagers relationship includes wherePivotNotNull constraint', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
-
-                public function resolveManagersPivotModel(): string
-                {
-                    return FakeManagerPivotModel::class;
-                }
-            };
-            $relation = $model->previousManagers();
-            expect($relation)->toBeInstanceOf(BelongsToMany::class);
-        });
-
-        test('all manager relationships use timestamps', function () {
-            $model = new class extends Model implements Manageable
-            {
-                /** @use CanBeManaged<FakeManagerPivotModel, self> */
-                use CanBeManaged;
-
-                public function resolveManagersPivotModel(): string
-                {
-                    return FakeManagerPivotModel::class;
-                }
-            };
-            $managersRelation = $model->managers();
-            $currentManagersRelation = $model->currentManagers();
-            $previousManagersRelation = $model->previousManagers();
-            expect($managersRelation)->toBeInstanceOf(BelongsToMany::class);
-            expect($currentManagersRelation)->toBeInstanceOf(BelongsToMany::class);
-            expect($previousManagersRelation)->toBeInstanceOf(BelongsToMany::class);
-        });
+    test('filters previous assignments', function () {
+        expect($this->model->previousManagers()->toRawSql())
+            ->toContain('"fired_at" is not null');
     });
 });

--- a/tests/Unit/Models/Concerns/Support/FakeManageableModel.php
+++ b/tests/Unit/Models/Concerns/Support/FakeManageableModel.php
@@ -22,7 +22,12 @@ class FakeManageableModel extends Model implements Manageable
     /** @use CanBeManaged<FakeManagerPivotModel, self> */
     use CanBeManaged;
 
-    public function resolveManagersPivotModel(): string
+    protected function managerAssignmentTable(): string
+    {
+        return (new FakeManagerPivotModel())->getTable();
+    }
+
+    protected function managerAssignmentPivotModel(): string
     {
         return FakeManagerPivotModel::class;
     }


### PR DESCRIPTION
## Summary
- replace manager pivot naming conventions and runtime discovery with explicit model configuration
- remove mutable manager pivot test configuration and obsolete generator exclusions
- focus manager relationship tests on observable Eloquent behavior
- document the explicit manager-assignment relationship boundary

## Verification
- composer test:push
- focused manager relationship tests: 25 tests, 79 assertions
- composer test:types
- Pint with Blade formatting
- git diff --check