### PR TITLE
refactor: extract employment status resolution

### DIFF
--- a/app/Lifecycle/EmploymentStatusResolver.php
+++ b/app/Lifecycle/EmploymentStatusResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Enums\Shared\EmploymentStatus;
+
+final class EmploymentStatusResolver
+{
+    public static function resolve(
+        bool $isRetired,
+        bool $isEmployed,
+        bool $hasFutureEmployment,
+        bool $hasEmploymentHistory,
+    ): EmploymentStatus {
+        return match (true) {
+            $isRetired => EmploymentStatus::Retired,
+            $isEmployed => EmploymentStatus::Employed,
+            $hasFutureEmployment => EmploymentStatus::FutureEmployment,
+            $hasEmploymentHistory => EmploymentStatus::Released,
+            default => EmploymentStatus::Unemployed,
+        };
+    }
+}

--- a/app/Models/Concerns/HasComputedEmploymentStatus.php
+++ b/app/Models/Concerns/HasComputedEmploymentStatus.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Concerns;
 
 use App\Enums\Shared\EmploymentStatus;
-use App\Models\Lifecycle\Employment;
+use App\Lifecycle\EmploymentStatusResolver;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 
 trait HasComputedEmploymentStatus
@@ -13,27 +13,11 @@ trait HasComputedEmploymentStatus
     /** @return Attribute<EmploymentStatus, never> */
     protected function status(): Attribute
     {
-        return Attribute::get(fn (): EmploymentStatus => $this->computedEmploymentStatus());
-    }
-
-    protected function computedEmploymentStatus(): EmploymentStatus
-    {
-        if ($this->isRetired()) {
-            return EmploymentStatus::Retired;
-        }
-
-        if ($this->currentEmployment instanceof Employment) {
-            return EmploymentStatus::Employed;
-        }
-
-        if ($this->futureEmployment instanceof Employment) {
-            return EmploymentStatus::FutureEmployment;
-        }
-
-        if ($this->previousEmployments()->exists()) {
-            return EmploymentStatus::Released;
-        }
-
-        return EmploymentStatus::Unemployed;
+        return Attribute::get(fn (): EmploymentStatus => EmploymentStatusResolver::resolve(
+            isRetired: $this->isRetired(),
+            isEmployed: $this->isEmployed(),
+            hasFutureEmployment: $this->hasFutureEmployment(),
+            hasEmploymentHistory: $this->hasEmploymentHistory(),
+        ));
     }
 }

--- a/app/Models/Concerns/IsEmployable.php
+++ b/app/Models/Concerns/IsEmployable.php
@@ -11,52 +11,15 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\Relations\MorphOne;
 
 /**
- * Adds employment-related behavior to a model.
- *
- * This trait provides a complete employment system for Eloquent models, including
- * methods to manage current employments, historical employments, and employment status.
- * Every employable model persists its history through the shared Employment model.
- *
- * @template TModel of Model The parent model class that can be employed (e.g., Wrestler)
+ * @template TModel of Model
  *
  * @phpstan-require-implements Employable<TModel>
- *
- * @see Employable
- *
- * @example
- * ```php
- * // In your model:
- * class Wrestler extends Model implements Employable
- * {
- *     use IsEmployable;
- * }
- *
- * // Usage:
- * $wrestler = Wrestler::find(1);
- * $wrestler->isEmployed();     // Check if currently employed
- * $wrestler->currentEmployment();       // Get active employment
- * $wrestler->previousEmployments();     // Get completed employments
- * ```
  */
 trait IsEmployable
 {
     use HasLifecycleTransitions;
 
-    /**
-     * Get all employments for the model.
-     *
-     * This method returns a polymorphic relationship that includes all employment records
-     * for the model, regardless of their status (active, completed, etc.).
-     *
-     * @return MorphMany<Employment, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $allEmployments = $wrestler->employments;
-     * $employmentCount = $wrestler->employments()->count();
-     * ```
-     */
+    /** @return MorphMany<Employment, TModel> */
     public function employments(): MorphMany
     {
         /** @var MorphMany<Employment, TModel> $relation */
@@ -65,24 +28,7 @@ trait IsEmployable
         return $relation;
     }
 
-    /**
-     * Get the current (active) employment.
-     *
-     * Returns a HasOne relationship for the currently active employment.
-     * An active employment is one where the 'ended_at' field is null.
-     *
-     * @return MorphOne<Employment, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $currentEmployment = $wrestler->currentEmployment;
-     *
-     * if ($wrestler->currentEmployment()->exists()) {
-     *     echo "Wrestler is currently employed";
-     * }
-     * ```
-     */
+    /** @return MorphOne<Employment, TModel> */
     public function currentEmployment(): MorphOne
     {
         /** @var MorphOne<Employment, TModel> $relation */
@@ -93,24 +39,7 @@ trait IsEmployable
         return $relation;
     }
 
-    /**
-     * Get a future employment that hasn't started yet.
-     *
-     * Returns a HasOne relationship for an employment that is scheduled for the future.
-     * A future employment has a 'started_at' date greater than now and 'ended_at' is null.
-     *
-     * @return MorphOne<Employment, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $futureEmployment = $wrestler->futureEmployment;
-     *
-     * if ($wrestler->futureEmployment()->exists()) {
-     *     echo "Wrestler has a scheduled employment";
-     * }
-     * ```
-     */
+    /** @return MorphOne<Employment, TModel> */
     public function futureEmployment(): MorphOne
     {
         /** @var MorphOne<Employment, TModel> $relation */
@@ -121,21 +50,7 @@ trait IsEmployable
         return $relation;
     }
 
-    /**
-     * Get all completed employments.
-     *
-     * Returns a HasMany relationship for employments that have ended.
-     * A completed employment is one where the 'ended_at' field is not null.
-     *
-     * @return MorphMany<Employment, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $completedEmployments = $wrestler->previousEmployments;
-     * $employmentHistory = $wrestler->previousEmployments()->orderBy('ended_at', 'desc')->get();
-     * ```
-     */
+    /** @return MorphMany<Employment, TModel> */
     public function previousEmployments(): MorphMany
     {
         /** @var MorphMany<Employment, TModel> $relation */
@@ -145,24 +60,7 @@ trait IsEmployable
         return $relation;
     }
 
-    /**
-     * Get the most recent completed employment.
-     *
-     * Returns a HasOne relationship for the most recently completed employment,
-     * determined by the highest 'ended_at' value.
-     *
-     * @return MorphOne<Employment, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $lastEmployment = $wrestler->previousEmployment;
-     *
-     * if ($wrestler->previousEmployment()->exists()) {
-     *     $endDate = $wrestler->previousEmployment->ended_at;
-     * }
-     * ```
-     */
+    /** @return MorphOne<Employment, TModel> */
     public function previousEmployment(): MorphOne
     {
         /** @var MorphOne<Employment, TModel> $relation */
@@ -173,23 +71,7 @@ trait IsEmployable
         return $relation;
     }
 
-    /**
-     * Get the earliest employment record.
-     *
-     * Returns a HasOne relationship for the earliest employment based on 'started_at'.
-     *
-     * @return MorphOne<Employment, TModel> The relationship instance
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     * $firstEmployment = $wrestler->firstEmployment;
-     *
-     * if ($wrestler->firstEmployment()->exists()) {
-     *     $startDate = $wrestler->firstEmployment->started_at;
-     * }
-     * ```
-     */
+    /** @return MorphOne<Employment, TModel> */
     public function firstEmployment(): MorphOne
     {
         /** @var MorphOne<Employment, TModel> $relation */
@@ -199,45 +81,11 @@ trait IsEmployable
         return $relation;
     }
 
-    /**
-     * Determine if the model is currently employed.
-     *
-     * Checks if there is an active employment (one with a null 'ended_at' field).
-     * This is a convenience method that's more efficient than loading the full
-     * relationship just to check existence.
-     *
-     * @return bool True if the model is currently employed, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     *
-     * if ($wrestler->isEmployed()) {
-     *     echo "This wrestler is available for booking";
-     * }
-     * ```
-     */
     public function isEmployed(): bool
     {
         return $this->currentEmployment()->exists();
     }
 
-    /**
-     * Determine if the model has a future employment scheduled.
-     *
-     * Checks if there is a scheduled employment that hasn't started yet.
-     *
-     * @return bool True if the model has a future employment, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     *
-     * if ($wrestler->hasFutureEmployment()) {
-     *     echo "This wrestler has a scheduled employment";
-     * }
-     * ```
-     */
     public function hasFutureEmployment(): bool
     {
         return $this->futureEmployment()->exists();
@@ -248,54 +96,11 @@ trait IsEmployable
         return ! $this->isEmployed() && ! $this->hasFutureEmployment();
     }
 
-    /**
-     * Determine if the model is currently released.
-     *
-     * Checks if the model has been released from employment.
-     * A released entity cannot be booked and requires re-employment to be active again.
-     *
-     * @return bool True if the model is released, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     *
-     * if ($wrestler->isReleased()) {
-     *     echo "This wrestler has been released";
-     * }
-     * ```
-     */
     public function isReleased(): bool
     {
         return ! $this->isEmployed() && ! $this->isRetired() && $this->previousEmployments()->exists();
     }
 
-    /**
-     * Check if the entity has any employment history records.
-     *
-     * This method determines whether the entity has ever been employed
-     * by checking for the existence of any employment records, regardless
-     * of their current status (active, ended, etc.).
-     *
-     * @return bool True if any employment history exists, false otherwise
-     *
-     * @example
-     * ```php
-     * $wrestler = Wrestler::find(1);
-     *
-     * if ($wrestler->hasEmploymentHistory()) {
-     *     echo "This wrestler has been employed before";
-     * } else {
-     *     echo "This wrestler has never been employed";
-     * }
-     *
-     * // Used in business logic validation
-     * public function canBeRetired(): bool
-     * {
-     *     return $this->isEmployed() || $this->hasEmploymentHistory();
-     * }
-     * ```
-     */
     public function hasEmploymentHistory(): bool
     {
         return $this->employments()->exists();

--- a/docs/architecture/core-capabilities.md
+++ b/docs/architecture/core-capabilities.md
@@ -37,6 +37,10 @@ Core capabilities define what each entity type can do within the wrestling promo
 - **Not Eligible**: Titles, Stables
 - **Rationale**: Employment represents a working relationship
 
+Employment periods remain the authoritative persisted state. Employable models expose
+relationship-backed state facts, while `EmploymentStatusResolver` maps those facts to
+the computed `EmploymentStatus` presented through each model's `status` attribute.
+
 ## Pull Capability
 
 ### Pull Rules

--- a/tests/Unit/Lifecycle/EmploymentStatusResolverTest.php
+++ b/tests/Unit/Lifecycle/EmploymentStatusResolverTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Shared\EmploymentStatus;
+use App\Lifecycle\EmploymentStatusResolver;
+
+test('resolves employment status from lifecycle state', function (
+    bool $isRetired,
+    bool $isEmployed,
+    bool $hasFutureEmployment,
+    bool $hasEmploymentHistory,
+    EmploymentStatus $expectedStatus,
+) {
+    $status = EmploymentStatusResolver::resolve(
+        isRetired: $isRetired,
+        isEmployed: $isEmployed,
+        hasFutureEmployment: $hasFutureEmployment,
+        hasEmploymentHistory: $hasEmploymentHistory,
+    );
+
+    expect($status)->toBe($expectedStatus);
+})->with([
+    'retired takes precedence' => [true, true, true, true, EmploymentStatus::Retired],
+    'employed takes precedence over scheduled employment' => [false, true, true, true, EmploymentStatus::Employed],
+    'future employment takes precedence over history' => [false, false, true, true, EmploymentStatus::FutureEmployment],
+    'released when only employment history exists' => [false, false, false, true, EmploymentStatus::Released],
+    'unemployed without employment state' => [false, false, false, false, EmploymentStatus::Unemployed],
+]);


### PR DESCRIPTION
## Summary
- extract employment status precedence into a focused lifecycle resolver
- preserve the computed model status API while limiting the model concern to persistence-backed state facts
- remove redundant instructional documentation from the employment relationship concern
- document and test the employment status boundary

## Verification
- composer test:push
- focused employable status suites: 47 tests, 152 assertions
- composer test:types
- Pint with Blade formatting
- git diff --check