### PR TITLE
refactor: simplify stable membership pivots

### DIFF
--- a/app/Models/Stables/StableTagTeam.php
+++ b/app/Models/Stables/StableTagTeam.php
@@ -11,12 +11,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
 
 /**
- * Pivot model for stable-tag team relationships.
- *
- * This model handles the many-to-many relationship between
- * stables and tag teams. It tracks when tag teams join and
- * leave stables through timestamp fields.
- *
  * @property int $id
  * @property int $stable_id
  * @property int $tag_team_id
@@ -37,18 +31,10 @@ use Illuminate\Support\Carbon;
 #[Fillable('stable_id', 'tag_team_id', 'joined_at', 'left_at')]
 class StableTagTeam extends Pivot
 {
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $table = 'stables_tag_teams';
 
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
+    /** @return array<string, string> */
     protected function casts(): array
     {
         return [
@@ -57,45 +43,15 @@ class StableTagTeam extends Pivot
         ];
     }
 
-    /**
-     * Get the stable that this membership belongs to.
-     *
-     * @return BelongsTo<Stable, $this>
-     */
+    /** @return BelongsTo<Stable, $this> */
     public function stable(): BelongsTo
     {
         return $this->belongsTo(Stable::class);
     }
 
-    /**
-     * Get the tag team for this membership.
-     *
-     * @return BelongsTo<TagTeam, $this>
-     */
+    /** @return BelongsTo<TagTeam, $this> */
     public function tagTeam(): BelongsTo
     {
         return $this->belongsTo(TagTeam::class);
-    }
-
-    /**
-     * Determine if this membership is currently active.
-     *
-     * A membership is active if the tag team has not left the stable
-     * (left_at is null).
-     */
-    public function isActive(): bool
-    {
-        return $this->left_at === null;
-    }
-
-    /**
-     * Determine if this membership has ended.
-     *
-     * A membership has ended if the tag team has left the stable
-     * (left_at is not null).
-     */
-    public function hasEnded(): bool
-    {
-        return $this->left_at !== null;
     }
 }

--- a/app/Models/Stables/StableWrestler.php
+++ b/app/Models/Stables/StableWrestler.php
@@ -11,12 +11,6 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
 
 /**
- * Pivot model for stable-wrestler relationships.
- *
- * This model handles the many-to-many relationship between
- * stables and wrestlers. It tracks when wrestlers join and
- * leave stables through timestamp fields.
- *
  * @property int $id
  * @property int $stable_id
  * @property int $wrestler_id
@@ -37,18 +31,10 @@ use Illuminate\Support\Carbon;
 #[Fillable('stable_id', 'wrestler_id', 'joined_at', 'left_at')]
 class StableWrestler extends Pivot
 {
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $table = 'stables_wrestlers';
 
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
+    /** @return array<string, string> */
     protected function casts(): array
     {
         return [
@@ -57,45 +43,15 @@ class StableWrestler extends Pivot
         ];
     }
 
-    /**
-     * Get the stable that this membership belongs to.
-     *
-     * @return BelongsTo<Stable, $this>
-     */
+    /** @return BelongsTo<Stable, $this> */
     public function stable(): BelongsTo
     {
         return $this->belongsTo(Stable::class);
     }
 
-    /**
-     * Get the wrestler for this membership.
-     *
-     * @return BelongsTo<Wrestler, $this>
-     */
+    /** @return BelongsTo<Wrestler, $this> */
     public function wrestler(): BelongsTo
     {
         return $this->belongsTo(Wrestler::class);
-    }
-
-    /**
-     * Determine if this membership is currently active.
-     *
-     * A membership is active if the wrestler has not left the stable
-     * (left_at is null).
-     */
-    public function isActive(): bool
-    {
-        return $this->left_at === null;
-    }
-
-    /**
-     * Determine if this membership has ended.
-     *
-     * A membership has ended if the wrestler has left the stable
-     * (left_at is not null).
-     */
-    public function hasEnded(): bool
-    {
-        return $this->left_at !== null;
     }
 }

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -14,6 +14,7 @@
 - Stables ↔ Wrestlers: `stables_wrestlers` table with `joined_at`/`left_at`
 - Stables ↔ Tag Teams: `stables_tag_teams` table with `joined_at`/`left_at`
 - These represent stable membership relationships
+- The nullable `left_at` column is the authoritative current/previous membership state; pivot models do not expose duplicate state aliases.
 - **DECISION: Use separate tables (not polymorphic)** for type safety and clear relationships
 
 ## Key Architecture Decisions


### PR DESCRIPTION
## Summary
- remove unused active and ended state aliases from stable membership pivots
- keep the nullable left_at column as the authoritative membership state
- reduce both pivot models to persistence metadata, casts, and relationships
- document the pivot-state boundary

## Verification
- composer test:push
- focused pivot suites: 20 tests, 94 assertions
- composer test:types
- Pint with Blade formatting
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed redundant membership status helper methods from stable membership records.
  - Stable membership status continues to be determined by the existing departure date.

- **Documentation**
  - Clarified the authoritative indicator for current or previous stable membership.
  - Documented that duplicate status aliases should not be exposed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->