### PR TITLE
refactor: remove unused lifecycle history predicates

### DIFF
--- a/app/Console/Commands/RingsideMakeTest.php
+++ b/app/Console/Commands/RingsideMakeTest.php
@@ -1090,11 +1090,11 @@ describe(\'{{ modelClass }} Model Unit Tests\', function () {
 
             // Retirement trait methods
             'retirements', 'currentRetirement', 'previousRetirements', 'previousRetirement',
-            'isRetired', 'hasRetirements',
+            'isRetired',
 
             // Suspension trait methods
             'suspensions', 'currentSuspension', 'previousSuspensions', 'previousSuspension',
-            'isSuspended', 'hasSuspensions',
+            'isSuspended',
 
         ];
 

--- a/app/Models/Concerns/IsInjurable.php
+++ b/app/Models/Concerns/IsInjurable.php
@@ -63,9 +63,4 @@ trait IsInjurable
     {
         return $this->currentInjury()->exists();
     }
-
-    public function hasInjuries(): bool
-    {
-        return $this->injuries()->exists();
-    }
 }

--- a/app/Models/Concerns/IsRetirable.php
+++ b/app/Models/Concerns/IsRetirable.php
@@ -63,9 +63,4 @@ trait IsRetirable
     {
         return $this->currentRetirement()->exists();
     }
-
-    public function hasRetirements(): bool
-    {
-        return $this->retirements()->exists();
-    }
 }

--- a/app/Models/Concerns/IsSuspendable.php
+++ b/app/Models/Concerns/IsSuspendable.php
@@ -63,9 +63,4 @@ trait IsSuspendable
     {
         return $this->currentSuspension()->exists();
     }
-
-    public function hasSuspensions(): bool
-    {
-        return $this->suspensions()->exists();
-    }
 }

--- a/tests/Unit/Models/Concerns/IsInjurableTest.php
+++ b/tests/Unit/Models/Concerns/IsInjurableTest.php
@@ -25,8 +25,6 @@ final class InjuryStateModel extends Model implements Injurable
 
     public bool $currentInjuryExists = false;
 
-    public bool $injuryExists = false;
-
     /** @return MorphOne<Injury, self> */
     public function currentInjury(): MorphOne
     {
@@ -36,7 +34,7 @@ final class InjuryStateModel extends Model implements Injurable
     /** @return MorphMany<Injury, self> */
     public function injuries(): MorphMany
     {
-        $builder = $this->injuryBuilder($this->injuryExists);
+        $builder = $this->injuryBuilder(false);
 
         return new MorphMany($builder, new self(), 'injurable_type', 'injurable_id', 'id');
     }
@@ -75,17 +73,14 @@ describe('IsInjurable', function () {
             ->and($model->injuries()->getRelated())->toBeInstanceOf(Injury::class);
     });
 
-    test('checks current and historical injury state', function () {
+    test('checks current injury state', function () {
         $model = new InjuryStateModel();
 
-        expect($model->isInjured())->toBeFalse()
-            ->and($model->hasInjuries())->toBeFalse();
+        expect($model->isInjured())->toBeFalse();
 
         $model->currentInjuryExists = true;
-        $model->injuryExists = true;
 
-        expect($model->isInjured())->toBeTrue()
-            ->and($model->hasInjuries())->toBeTrue();
+        expect($model->isInjured())->toBeTrue();
     });
 
     test('constrains current and previous injury relationships', function () {

--- a/tests/Unit/Models/Concerns/IsRetirableTest.php
+++ b/tests/Unit/Models/Concerns/IsRetirableTest.php
@@ -25,8 +25,6 @@ final class RetirementStateModel extends Model implements Retirable
 
     public bool $currentRetirementExists = false;
 
-    public bool $retirementExists = false;
-
     /** @return MorphOne<Retirement, self> */
     public function currentRetirement(): MorphOne
     {
@@ -36,7 +34,7 @@ final class RetirementStateModel extends Model implements Retirable
     /** @return MorphMany<Retirement, self> */
     public function retirements(): MorphMany
     {
-        $builder = $this->retirementBuilder($this->retirementExists);
+        $builder = $this->retirementBuilder(false);
 
         return new MorphMany($builder, new self(), 'retirable_type', 'retirable_id', 'id');
     }
@@ -75,17 +73,14 @@ describe('IsRetirable', function () {
             ->and($model->retirements()->getRelated())->toBeInstanceOf(Retirement::class);
     });
 
-    test('checks current and historical retirement state', function () {
+    test('checks current retirement state', function () {
         $model = new RetirementStateModel();
 
-        expect($model->isRetired())->toBeFalse()
-            ->and($model->hasRetirements())->toBeFalse();
+        expect($model->isRetired())->toBeFalse();
 
         $model->currentRetirementExists = true;
-        $model->retirementExists = true;
 
-        expect($model->isRetired())->toBeTrue()
-            ->and($model->hasRetirements())->toBeTrue();
+        expect($model->isRetired())->toBeTrue();
     });
 
     test('constrains current and previous retirement relationships', function () {

--- a/tests/Unit/Models/Concerns/IsSuspendableTest.php
+++ b/tests/Unit/Models/Concerns/IsSuspendableTest.php
@@ -25,8 +25,6 @@ final class SuspensionStateModel extends Model implements Suspendable
 
     public bool $currentSuspensionExists = false;
 
-    public bool $suspensionExists = false;
-
     /** @return MorphOne<Suspension, self> */
     public function currentSuspension(): MorphOne
     {
@@ -36,7 +34,7 @@ final class SuspensionStateModel extends Model implements Suspendable
     /** @return MorphMany<Suspension, self> */
     public function suspensions(): MorphMany
     {
-        $builder = $this->suspensionBuilder($this->suspensionExists);
+        $builder = $this->suspensionBuilder(false);
 
         return new MorphMany($builder, new self(), 'suspendable_type', 'suspendable_id', 'id');
     }
@@ -75,17 +73,14 @@ describe('IsSuspendable', function () {
             ->and($model->suspensions()->getRelated())->toBeInstanceOf(Suspension::class);
     });
 
-    test('checks current and historical suspension state', function () {
+    test('checks current suspension state', function () {
         $model = new SuspensionStateModel();
 
-        expect($model->isSuspended())->toBeFalse()
-            ->and($model->hasSuspensions())->toBeFalse();
+        expect($model->isSuspended())->toBeFalse();
 
         $model->currentSuspensionExists = true;
-        $model->suspensionExists = true;
 
-        expect($model->isSuspended())->toBeTrue()
-            ->and($model->hasSuspensions())->toBeTrue();
+        expect($model->isSuspended())->toBeTrue();
     });
 
     test('constrains current and previous suspension relationships', function () {


### PR DESCRIPTION
## Summary
- remove unused hasInjuries, hasRetirements, and hasSuspensions model aliases
- retain authoritative current-state predicates and full lifecycle history relationships
- update focused concern tests and generated-test method exclusions

## Verification
- 9 focused tests passed with 27 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- targeted Pint with Blade formatting passed
- git diff --check passed

## Local suite note
- composer test:push reached the existing repository-wide Blade formatting mismatch also present on development; this branch does not modify those Blade files