### PR TITLE
refactor: align tag team wrestler pivot

### DIFF
--- a/app/Models/TagTeams/TagTeamWrestler.php
+++ b/app/Models/TagTeams/TagTeamWrestler.php
@@ -6,6 +6,7 @@ namespace App\Models\TagTeams;
 
 use App\Models\Wrestlers\Wrestler;
 use Database\Factories\TagTeams\TagTeamWrestlerFactory;
+use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -30,24 +31,17 @@ use Illuminate\Support\Carbon;
  *
  * @mixin \Eloquent
  */
+#[Fillable('tag_team_id', 'wrestler_id', 'joined_at', 'left_at')]
 #[UseFactory(TagTeamWrestlerFactory::class)]
 class TagTeamWrestler extends Pivot
 {
     /** @use HasFactory<TagTeamWrestlerFactory> */
     use HasFactory;
 
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
+    /** @var string */
     protected $table = 'tag_teams_wrestlers';
 
-    /**
-     * Get the attributes that should be cast.
-     *
-     * @return array<string, string>
-     */
+    /** @return array<string, string> */
     protected function casts(): array
     {
         return [
@@ -56,21 +50,13 @@ class TagTeamWrestler extends Pivot
         ];
     }
 
-    /**
-     * Get the tag team associated with this tag team partner.
-     *
-     * @return BelongsTo<TagTeam, $this>
-     */
+    /** @return BelongsTo<TagTeam, $this> */
     public function tagTeam(): BelongsTo
     {
         return $this->belongsTo(TagTeam::class);
     }
 
-    /**
-     * Get the wrestler associated with this tag team relationship.
-     *
-     * @return BelongsTo<Wrestler, $this>
-     */
+    /** @return BelongsTo<Wrestler, $this> */
     public function wrestler(): BelongsTo
     {
         return $this->belongsTo(Wrestler::class, 'wrestler_id');

--- a/tests/Unit/Models/TagTeams/TagTeamWrestlerTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamWrestlerTest.php
@@ -5,93 +5,20 @@ declare(strict_types=1);
 use App\Models\TagTeams\TagTeamWrestler;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 
-/**
- * Unit tests for TagTeamWrestler model structure and configuration.
- *
- * UNIT TEST SCOPE:
- * - Model attribute configuration (fillable, casts, defaults)
- * - Custom builder class verification
- * - Trait integration verification
- * - Interface implementation verification
- *
- * These tests verify that the TagTeamWrestler model is properly configured
- * and structured according to the data layer requirements.
- */
-describe('TagTeamWrestler Model Unit Tests', function () {
-    describe('model attributes and configuration', function () {
-        test('has correct fillable properties', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
+test('defines its pivot persistence metadata', function () {
+    $membership = new TagTeamWrestler();
 
-            // Model has no explicitly defined fillable properties (uses Pivot defaults)
-            expect($tagTeamWrestler->getFillable())->toBeArray();
-        });
-
-        test('has correct casts configuration', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
-            $casts = $tagTeamWrestler->getCasts();
-
-            expect($casts)->toBeArray();
-            expect($casts['joined_at'])->toBe('datetime');
-            expect($casts['left_at'])->toBe('datetime');
-        });
-
-        test('uses correct table name', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
-
-            expect($tagTeamWrestler->getTable())->toBe('tag_teams_wrestlers');
-        });
-
-        test('has correct default values', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
-
-            // Model has no custom default values
-            expect($tagTeamWrestler)->toBeInstanceOf(TagTeamWrestler::class);
-        });
-
-        test('has custom eloquent builder', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
-
-            // Model has no custom builder
-            expect($tagTeamWrestler->query())->toBeObject();
-        });
-
-        test('extends Pivot base class', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
-
-            expect($tagTeamWrestler)->toBeInstanceOf(Pivot::class);
-        });
-    });
-
-    describe('trait integration', function () {
-        test('extends Pivot class', function () {
-            $tagTeamWrestler = new TagTeamWrestler();
-            expect($tagTeamWrestler)->toBeInstanceOf(Pivot::class);
-        });
-    });
-
-    describe('interface implementation', function () {
-        test('implements all required interfaces', function () {
-            $interfaces = class_implements(TagTeamWrestler::class);
-
-            // Model implements no specific interfaces beyond base Pivot
-            expect($interfaces)->toBeArray();
-        });
-    });
-
-    describe('model constants', function () {
-        test('has no model-specific constants defined', function () {
-            $reflection = new ReflectionClass(TagTeamWrestler::class);
-            $constants = $reflection->getConstants();
-
-            // Filter out inherited constants from parent classes
-            $modelConstants = array_filter($constants, function ($value, $key) use ($reflection) {
-                $constant = $reflection->getReflectionConstant($key);
-
-                return $constant && $constant->getDeclaringClass()->getName() === TagTeamWrestler::class;
-            }, ARRAY_FILTER_USE_BOTH);
-
-            expect($modelConstants)->toBeEmpty();
-        });
-    });
-
+    expect($membership)->toBeInstanceOf(Pivot::class)
+        ->and($membership->getTable())->toBe('tag_teams_wrestlers')
+        ->and($membership->getFillable())->toBe([
+            'tag_team_id',
+            'wrestler_id',
+            'joined_at',
+            'left_at',
+        ])
+        ->and($membership->getCasts())
+        ->toMatchArray([
+            'joined_at' => 'datetime',
+            'left_at' => 'datetime',
+        ]);
 });


### PR DESCRIPTION
## Summary
- declare the tag team wrestler pivot's mass-assignable persistence fields explicitly
- keep its casts and table metadata focused on persistence
- replace redundant structural checks with a focused metadata regression test

## Verification
- 25 focused tests passed with 96 assertions
- application and Pest PHPStan passed
- Pint with Blade passed
- Rector and type coverage passed
- composer test:push passed