### PR TITLE
refactor: remove obsolete activity helpers

### DIFF
--- a/app/Models/Concerns/HasActivityPeriods.php
+++ b/app/Models/Concerns/HasActivityPeriods.php
@@ -116,18 +116,8 @@ trait HasActivityPeriods
         return $this->futureActivityPeriod()->exists();
     }
 
-    public function isUnactivated(): bool
-    {
-        return ! $this->hasActivityPeriods();
-    }
-
     public function isInactive(): bool
     {
         return ! $this->isCurrentlyActive();
-    }
-
-    protected function getActivityPeriodTableName(): string
-    {
-        return (new ActivityPeriod())->getTable();
     }
 }

--- a/app/Models/Contracts/HasActivityPeriods.php
+++ b/app/Models/Contracts/HasActivityPeriods.php
@@ -27,13 +27,6 @@ interface HasActivityPeriods
     public function isCurrentlyActive(): bool;
 
     /**
-     * Check if the model has never been activated.
-     *
-     * @return bool True if the model has no activity periods
-     */
-    public function isUnactivated(): bool;
-
-    /**
      * Check if the model is inactive (not currently active).
      *
      * @return bool True if the model is not currently active

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -48,7 +48,7 @@ single-consumer relationship traits or speculative override helpers.
 - Models use computed attributes: `protected function status(): Attribute`
 - Membership-derived calculations belong to typed membership data objects. For example, `TagTeamMembershipData` calculates combined wrestler weight without adding a presentation aggregate to the Eloquent model.
 - Factory methods NEVER set status fields manually
-- Activity-period state uses the canonical predicates `isCurrentlyActive()`, `isInactive()`, `isUnactivated()`, and `hasFutureActivity()` without duplicate aliases. Date-change validation compares the requested date with the current activity-period record inside its typed validation rule rather than exposing validation-specific helpers on models.
+- Activity-period state uses the canonical predicates `hasActivityPeriods()`, `isCurrentlyActive()`, `isInactive()`, and `hasFutureActivity()` without duplicate aliases. Date-change validation compares the requested date with the current activity-period record inside its typed validation rule rather than exposing validation-specific helpers on models.
 - Status computed from relationships (employment, retirement, injury, suspension)
 - Priority order: Retired > Employed > FutureEmployment > Released > Unemployed
 

--- a/tests/Unit/Models/Concerns/HasActivityPeriodsTraitTest.php
+++ b/tests/Unit/Models/Concerns/HasActivityPeriodsTraitTest.php
@@ -182,20 +182,6 @@ describe('HasActivityPeriods Trait Unit Tests', function () {
             expect($model->hasFutureActivity())->toBeFalse();
         });
 
-        test('isUnactivated returns true when model has no periods', function () {
-            $model = Title::factory()->unactivated()->create();
-            expect($model->isUnactivated())->toBeTrue();
-        });
-
-        test('isUnactivated returns false when model has periods', function () {
-            $model = $this->model;
-            ActivityPeriod::factory()->for($model, 'activeable')->create([
-                'started_at' => now()->subWeek(),
-                'ended_at' => null,
-            ]);
-            expect($model->isUnactivated())->toBeFalse();
-        });
-
         test('isInactive returns true when model is not currently active', function () {
             $model = Title::factory()->unactivated()->create();
             expect($model->isInactive())->toBeTrue();


### PR DESCRIPTION
## Summary
- remove the unused activity-period table-name helper
- remove the redundant isUnactivated predicate from the model concern and contract
- delete obsolete predicate tests and document the canonical activity-state methods

## Verification
- 28 focused tests passed with 42 assertions
- application and Pest PHPStan passed
- Pint with Blade passed
- Rector and type coverage passed
- composer test:push passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Clarified activity-period status handling by removing the obsolete “unactivated” status check.
  * Continued supporting active and inactive status detection.

* **Documentation**
  * Updated architecture guidance to recommend checking whether activity periods exist.

* **Tests**
  * Removed tests for the retired status check while preserving coverage for active and inactive states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->