### PR TITLE
refactor: rename individual roster builder

### DIFF
--- a/app/Builders/Concerns/HasAvailabilityScopes.php
+++ b/app/Builders/Concerns/HasAvailabilityScopes.php
@@ -68,9 +68,7 @@ trait HasAvailabilityScopes
      */
     protected function whereEmployed(): static
     {
-        $this->whereHas('currentEmployment', function ($query) {
-            $query->where('started_at', '<=', now());
-        });
+        $this->whereHas('currentEmployment');
 
         return $this;
     }

--- a/app/Builders/Roster/IndividualBuilder.php
+++ b/app/Builders/Roster/IndividualBuilder.php
@@ -7,7 +7,6 @@ namespace App\Builders\Roster;
 use App\Builders\Concerns\HasAvailabilityScopes;
 use App\Builders\Concerns\HasNameSearch;
 use App\Builders\Concerns\HasRetirementScopes;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
@@ -26,31 +25,11 @@ use Illuminate\Database\Eloquent\Model;
  * - Retirement lifecycle management
  * - Suspension and reinstatement processes
  *
- * DESIGN PATTERN:
- * Template method pattern - Defines common structure with extensible
- * behavior in child classes for entity-specific requirements.
- *
  * @template TModel of Model The individual roster member model type
- *
- * @example
- * ```php
- * // Usage in child builders
- * class WrestlerBuilder extends SingleRosterMemberBuilder
- * {
- *     use HasBookingScopes; // Wrestlers can be booked
- * }
- *
- * class ManagerBuilder extends SingleRosterMemberBuilder
- * {
- *     // Managers don't need booking scopes
- * }
- * ```
- *
- * @template TModel of Model
  *
  * @extends Builder<TModel>
  */
-abstract class SingleRosterMemberBuilder extends Builder
+abstract class IndividualBuilder extends Builder
 {
     use HasAvailabilityScopes;
     use HasNameSearch;
@@ -180,9 +159,7 @@ abstract class SingleRosterMemberBuilder extends Builder
      */
     public function employed(): static
     {
-        $this->whereHas('currentEmployment', function (Builder $query) {
-            $query->where('started_at', '<=', now());
-        });
+        $this->whereHas('currentEmployment');
 
         return $this;
     }
@@ -294,41 +271,5 @@ abstract class SingleRosterMemberBuilder extends Builder
         $this->whereHas('currentSuspension');
 
         return $this;
-    }
-
-    /**
-     * Scope a query to include entities available on a specific date.
-     *
-     * Filters individual roster members that are available for general duties
-     * on the given date. Note: Match booking availability should be handled
-     * in specific builders (WrestlerBuilder, TagTeamBuilder) as only wrestlers
-     * and tag teams can be booked for matches.
-     *
-     * For managers and referees, the date parameter is not used since they
-     * are not booked for matches, but the signature is kept for consistency.
-     *
-     * @param  Carbon  $date  The date to check availability for (unused for non-bookable entities)
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get managers available for assignment on a specific date
-     * $availableManagers = Manager::query()
-     *     ->availableOn(now()->addWeek())
-     *     ->get();
-     *
-     * // Get referees available for general duties
-     * $availableReferees = Referee::query()
-     *     ->availableOn(Carbon::parse('2024-12-31'))
-     *     ->get();
-     * ```
-     *
-     * @SuppressWarnings("PHPMD.UnusedFormalParameter")
-     */
-    public function availableOn(Carbon $date): static
-    {
-        // Note: $date parameter is intentionally unused for managers/referees
-        // as they are not booked for matches. Method signature kept for consistency.
-        return $this->available();
     }
 }

--- a/app/Builders/Roster/ManagerBuilder.php
+++ b/app/Builders/Roster/ManagerBuilder.php
@@ -16,7 +16,7 @@ use App\Models\Managers\Manager;
  *
  * @template TModel of Manager
  *
- * @extends SingleRosterMemberBuilder<TModel>
+ * @extends IndividualBuilder<TModel>
  *
  * @example
  * ```php
@@ -33,7 +33,7 @@ use App\Models\Managers\Manager;
  *     ->get();
  * ```
  */
-class ManagerBuilder extends SingleRosterMemberBuilder
+class ManagerBuilder extends IndividualBuilder
 {
     // Managers don't need booking scopes - they are not booked for matches
 }

--- a/app/Builders/Roster/RefereeBuilder.php
+++ b/app/Builders/Roster/RefereeBuilder.php
@@ -16,7 +16,7 @@ use App\Models\Referees\Referee;
  *
  * @template TModel of Referee
  *
- * @extends SingleRosterMemberBuilder<TModel>
+ * @extends IndividualBuilder<TModel>
  *
  * @example
  * ```php
@@ -35,7 +35,7 @@ use App\Models\Referees\Referee;
  *     ->get();
  * ```
  */
-class RefereeBuilder extends SingleRosterMemberBuilder
+class RefereeBuilder extends IndividualBuilder
 {
     // Referees inherit all availability, employment, injury, retirement, and suspension scopes from base class
 

--- a/app/Builders/Roster/WrestlerBuilder.php
+++ b/app/Builders/Roster/WrestlerBuilder.php
@@ -18,7 +18,7 @@ use Illuminate\Database\Eloquent\Builder;
  *
  * @template TModel of Wrestler
  *
- * @extends SingleRosterMemberBuilder<TModel>
+ * @extends IndividualBuilder<TModel>
  *
  * @example
  * ```php
@@ -34,7 +34,7 @@ use Illuminate\Database\Eloquent\Builder;
  *     ->get();
  * ```
  */
-class WrestlerBuilder extends SingleRosterMemberBuilder
+class WrestlerBuilder extends IndividualBuilder
 {
     // Wrestlers inherit all availability, employment, injury, retirement, and suspension scopes from base class
 

--- a/app/Builders/Users/UserBuilder.php
+++ b/app/Builders/Users/UserBuilder.php
@@ -31,5 +31,5 @@ class UserBuilder extends Builder
 {
     use HasNameSearch;
 
-    // Users don't extend SingleRosterMemberBuilder, so we include HasNameSearch directly
+    // Users don't extend IndividualBuilder, so they include HasNameSearch directly.
 }

--- a/app/Models/Managers/Manager.php
+++ b/app/Models/Managers/Manager.php
@@ -80,7 +80,6 @@ use Tests\Unit\Models\Managers\ManagerTest;
  * @property-read Collection<int, TagTeam> $previousTagTeams
  *
  * @method static ManagerBuilder<static>|Manager available()
- * @method static ManagerBuilder<static>|Manager availableOn(\Carbon\Carbon $date)
  * @method static ManagerBuilder<static>|Manager employed()
  * @method static \Database\Factories\Managers\ManagerFactory factory($count = null, $state = [])
  * @method static ManagerBuilder<static>|Manager futureEmployed()

--- a/app/Models/Referees/Referee.php
+++ b/app/Models/Referees/Referee.php
@@ -73,7 +73,6 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, EventMatch> $previousMatches
  *
  * @method static RefereeBuilder<static>|Referee available()
- * @method static RefereeBuilder<static>|Referee availableOn(\Carbon\Carbon $date)
  * @method static RefereeBuilder<static>|Referee bookable()
  * @method static RefereeBuilder<static>|Referee employed()
  * @method static \Database\Factories\Referees\RefereeFactory factory($count = null, $state = [])

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -21,7 +21,7 @@ app/Builders/
 ### Builder Hierarchy
 
 **Base Builders:**
-- `SingleRosterMemberBuilder` - Base for individual roster members (wrestlers, managers, referees)
+- `IndividualBuilder` - Base for individual roster members (wrestlers, managers, referees)
 - `BaseRepository` - Foundation for repository pattern implementation
 
 **Domain-Specific Builders:**

--- a/docs/architecture/builders/HasNameSearch.md
+++ b/docs/architecture/builders/HasNameSearch.md
@@ -102,7 +102,7 @@ WHERE (
 ## Applied To
 
 Currently used by:
-- `SingleRosterMemberBuilder` (Managers, Referees, Wrestlers)
+- `IndividualBuilder` (Managers, Referees, Wrestlers)
 - `UserBuilder`
 - Table components: Users, Managers (eliminates duplicated search logic)
 

--- a/tests/Unit/Builders/Concerns/BuilderConcernsTest.php
+++ b/tests/Unit/Builders/Concerns/BuilderConcernsTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use App\Builders\Concerns\HasAvailabilityScopes;
 use App\Builders\Concerns\HasRetirementScopes;
-use App\Builders\Roster\SingleRosterMemberBuilder;
+use App\Builders\Roster\IndividualBuilder;
 use App\Builders\Roster\TagTeamBuilder;
 use App\Builders\Roster\WrestlerBuilder;
 use App\Builders\Titles\TitleBuilder;
@@ -33,8 +33,8 @@ describe('Builder Concerns Unit Tests', function () {
     describe('HasAvailabilityScopes trait functionality', function () {
         test('trait is used by builders or base classes', function () {
             // Act & Assert - Verify trait usage (directly or through inheritance)
-            // SingleRosterMemberBuilder uses the trait, and other builders inherit from it
-            expect(class_uses(SingleRosterMemberBuilder::class))->toContain(HasAvailabilityScopes::class);
+            // IndividualBuilder uses the trait, and other builders inherit from it
+            expect(class_uses(IndividualBuilder::class))->toContain(HasAvailabilityScopes::class);
             expect(class_uses(TagTeamBuilder::class))->toContain(HasAvailabilityScopes::class);
 
             // Verify that methods are available on concrete builders
@@ -184,7 +184,7 @@ describe('Builder Concerns Unit Tests', function () {
     describe('HasRetirementScopes trait functionality', function () {
         test('trait is used by builders or base classes', function () {
             // Act & Assert - Verify trait usage (directly or through inheritance)
-            expect(class_uses(SingleRosterMemberBuilder::class))->toContain(HasRetirementScopes::class);
+            expect(class_uses(IndividualBuilder::class))->toContain(HasRetirementScopes::class);
             expect(class_uses(TagTeamBuilder::class))->toContain(HasRetirementScopes::class);
             expect(class_uses(TitleBuilder::class))->toContain(HasRetirementScopes::class);
 

--- a/tests/Unit/Builders/Roster/IndividualBuilderTest.php
+++ b/tests/Unit/Builders/Roster/IndividualBuilderTest.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 use App\Builders\Concerns\HasAvailabilityScopes;
 use App\Builders\Concerns\HasRetirementScopes;
-use App\Builders\Roster\SingleRosterMemberBuilder;
+use App\Builders\Roster\IndividualBuilder;
 use App\Builders\Roster\WrestlerBuilder;
 use App\Models\Wrestlers\Wrestler;
 
 /**
- * Unit tests for SingleRosterMemberBuilder abstract base class.
+ * Unit tests for IndividualBuilder abstract base class.
  *
  * UNIT TEST SCOPE:
  * - Abstract base class functionality through concrete WrestlerBuilder implementation
@@ -18,16 +18,16 @@ use App\Models\Wrestlers\Wrestler;
  * - Employment status management for individual entities
  * - Abstract class architecture and contract implementation
  *
- * These tests verify that the SingleRosterMemberBuilder provides consistent
+ * These tests verify that the IndividualBuilder provides consistent
  * shared functionality for all individual roster member builders (Wrestler, Manager, Referee).
  * Uses WrestlerBuilder as the concrete implementation for testing abstract functionality.
  *
- * @see SingleRosterMemberBuilder
+ * @see IndividualBuilder
  */
-describe('SingleRosterMemberBuilder Unit Tests', function () {
+describe('IndividualBuilder Unit Tests', function () {
     beforeEach(function () {
         // Create wrestlers in all possible states for comprehensive scope testing
-        // Using Wrestler model since WrestlerBuilder extends SingleRosterMemberBuilder
+        // Using Wrestler model since WrestlerBuilder extends IndividualBuilder
         $this->futureEmployedWrestler = Wrestler::factory()->withFutureEmployment()->create();
         $this->suspendedWrestler = Wrestler::factory()->suspended()->create();
         $this->retiredWrestler = Wrestler::factory()->retired()->create();
@@ -41,19 +41,19 @@ describe('SingleRosterMemberBuilder Unit Tests', function () {
     });
 
     describe('abstract class architecture', function () {
-        test('wrestler builder extends single roster member builder', function () {
+        test('wrestler builder extends individual builder', function () {
             // Arrange
             $builder = Wrestler::query();
 
             // Assert
             expect($builder)->toBeInstanceOf(WrestlerBuilder::class);
-            expect($builder)->toBeInstanceOf(SingleRosterMemberBuilder::class);
+            expect($builder)->toBeInstanceOf(IndividualBuilder::class);
         });
 
         test('uses required traits', function () {
             // Act & Assert
-            expect(class_uses(SingleRosterMemberBuilder::class))->toContain(HasAvailabilityScopes::class);
-            expect(class_uses(SingleRosterMemberBuilder::class))->toContain(HasRetirementScopes::class);
+            expect(class_uses(IndividualBuilder::class))->toContain(HasAvailabilityScopes::class);
+            expect(class_uses(IndividualBuilder::class))->toContain(HasRetirementScopes::class);
         });
     });
 
@@ -164,7 +164,7 @@ describe('SingleRosterMemberBuilder Unit Tests', function () {
 
             // Assert
             expect($builder)->toBeInstanceOf(WrestlerBuilder::class);
-            expect($builder)->toBeInstanceOf(SingleRosterMemberBuilder::class);
+            expect($builder)->toBeInstanceOf(IndividualBuilder::class);
         });
 
         test('chained scopes maintain builder type', function () {
@@ -175,7 +175,7 @@ describe('SingleRosterMemberBuilder Unit Tests', function () {
 
             // Assert
             expect($builder)->toBeInstanceOf(WrestlerBuilder::class);
-            expect($builder)->toBeInstanceOf(SingleRosterMemberBuilder::class);
+            expect($builder)->toBeInstanceOf(IndividualBuilder::class);
         });
     });
 


### PR DESCRIPTION
## Summary
- rename SingleRosterMemberBuilder to IndividualBuilder to match lifecycle vocabulary
- update wrestler, manager, and referee builder inheritance
- remove the shared availableOn method that ignored its date
- rely on currentEmployment relationship constraints rather than duplicating date predicates
- update annotations, tests, and architecture docs

## Verification
- 74 focused tests passed with 204 assertions
- PHPStan passed
- Rector passed
- targeted Pint with Blade passed
- git diff --check passed