### PR TITLE
refactor: separate individual booking eligibility

### DIFF
--- a/app/Builders/Roster/RefereeBuilder.php
+++ b/app/Builders/Roster/RefereeBuilder.php
@@ -35,35 +35,4 @@ use App\Models\Referees\Referee;
  *     ->get();
  * ```
  */
-class RefereeBuilder extends IndividualBuilder
-{
-    // Referees inherit all availability, employment, injury, retirement, and suspension scopes from base class
-
-    /**
-     * Scope a query to include bookable referees.
-     *
-     * Filters referees that are currently available for assignment to officiate matches.
-     * Bookable referees must be available (employed, not injured, not suspended,
-     * not retired) and ready for match assignment.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get all bookable referees
-     * $bookableReferees = Referee::query()->bookable()->get();
-     *
-     * // Find referees ready for championship matches
-     * $championshipReferees = Referee::query()
-     *     ->bookable()
-     *     ->whereHas('matches', function ($query) {
-     *         $query->where('type', 'championship');
-     *     })
-     *     ->get();
-     * ```
-     */
-    public function bookable(): static
-    {
-        return $this->available();
-    }
-}
+class RefereeBuilder extends IndividualBuilder {}

--- a/app/Builders/Roster/WrestlerBuilder.php
+++ b/app/Builders/Roster/WrestlerBuilder.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Builders\Roster;
 
 use App\Models\Wrestlers\Wrestler;
-use Carbon\Carbon;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
  * Custom query builder for the Wrestler model.
@@ -34,96 +32,4 @@ use Illuminate\Database\Eloquent\Builder;
  *     ->get();
  * ```
  */
-class WrestlerBuilder extends IndividualBuilder
-{
-    // Wrestlers inherit all availability, employment, injury, retirement, and suspension scopes from base class
-
-    /**
-     * Scope a query to include wrestlers available on a specific date.
-     *
-     * Filters wrestlers that are available for booking on the given date,
-     * considering both their general availability status and any existing
-     * match bookings on that date.
-     *
-     * @param  Carbon  $date  The date to check availability for
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get wrestlers available for a specific event date
-     * $availableWrestlers = Wrestler::query()
-     *     ->availableOn(Carbon::parse('2024-12-31'))
-     *     ->get();
-     *
-     * // Find wrestlers available for next week's shows
-     * $availableWrestlers = Wrestler::query()
-     *     ->availableOn(now()->addWeek())
-     *     ->get();
-     * ```
-     */
-    public function availableOn(Carbon $date): static
-    {
-        return $this->available()
-            ->notBookedOn($date);
-    }
-
-    /**
-     * Scope a query to include bookable wrestlers.
-     *
-     * Filters wrestlers that are currently available for booking in matches.
-     * Bookable wrestlers must be available (employed, not injured, not suspended,
-     * not retired) and ready for competition assignment.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get all bookable wrestlers
-     * $bookableWrestlers = Wrestler::query()->bookable()->get();
-     *
-     * // Find wrestlers ready for title matches
-     * $titleReadyWrestlers = Wrestler::query()
-     *     ->bookable()
-     *     ->whereDoesntHave('currentChampionships')
-     *     ->get();
-     * ```
-     */
-    public function bookable(): static
-    {
-        return $this->available();
-    }
-
-    /**
-     * Scope a query to exclude wrestlers already booked on a specific date.
-     *
-     * Filters out wrestlers that have existing match bookings on the given
-     * date to prevent double-booking conflicts.
-     *
-     * @param  Carbon  $date  The date to check for existing bookings
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get wrestlers not already booked for New Year's Eve
-     * $unbookedWrestlers = Wrestler::query()
-     *     ->notBookedOn(Carbon::parse('2024-12-31'))
-     *     ->get();
-     *
-     * // Find wrestlers available for emergency booking
-     * $emergencyWrestlers = Wrestler::query()
-     *     ->available()
-     *     ->notBookedOn(now())
-     *     ->get();
-     * ```
-     */
-    public function notBookedOn(Carbon $date): static
-    {
-        $this->whereDoesntHave('matches', function (Builder $query) use ($date) {
-            $query->whereHas('event', function (Builder $eventQuery) use ($date) {
-                $eventQuery->whereDate('date', $date->toDateString());
-            });
-        });
-
-        return $this;
-    }
-}
+class WrestlerBuilder extends IndividualBuilder {}

--- a/app/Models/Referees/Referee.php
+++ b/app/Models/Referees/Referee.php
@@ -73,7 +73,6 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, EventMatch> $previousMatches
  *
  * @method static RefereeBuilder<static>|Referee available()
- * @method static RefereeBuilder<static>|Referee bookable()
  * @method static RefereeBuilder<static>|Referee employed()
  * @method static \Database\Factories\Referees\RefereeFactory factory($count = null, $state = [])
  * @method static RefereeBuilder<static>|Referee futureEmployed()

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -1,195 +1,66 @@
 # Builder Architecture
 
-## Overview
+## Responsibility
 
-Ringside uses a comprehensive builder pattern for constructing complex Eloquent queries with wrestling-specific business logic. All builders are organized by domain in `app/Builders/{Domain}/` and extend Laravel's base query builder functionality.
+Ringside uses typed Eloquent builders for reusable queries over persisted state. Builders answer questions such as whether a roster member is currently employed, injured, suspended, retired, or generally available. They do not decide whether a model may perform a lifecycle transition or be assigned to a match.
 
-Shared activity-period queries remain in `App\Builders\Concerns\HasActivityPeriodScopes` and are composed by the typed `StableBuilder` and `TitleBuilder`. Eloquent models do not define local query scopes.
+Models bind their builders with Laravel's `#[UseEloquentBuilder]` attribute. Reusable builder behavior is shared through typed parent builders and concerns rather than local model scopes.
 
-## Builder Organization
+## Organization
 
-### Domain Structure
-```
+```text
 app/Builders/
-├── Concerns/           # Shared builder traits and contracts
-├── Events/            # Event and venue builders
-├── Roster/            # Wrestling roster member builders  
-├── Titles/            # Title and championship builders
-└── Users/             # User builders
+├── Concerns/           # Shared query behavior
+├── Events/             # Event and venue builders
+├── Roster/             # Roster and stable builders
+├── Titles/             # Title and championship builders
+└── Users/              # User builders
 ```
 
-### Builder Hierarchy
+`IndividualBuilder` contains persisted-state queries shared by wrestlers, managers, and referees. `WrestlerBuilder`, `ManagerBuilder`, and `RefereeBuilder` provide the model-specific builder types. Tag teams, stables, events, venues, titles, title championships, and users each have their own typed builder.
 
-**Base Builders:**
-- `IndividualBuilder` - Base for individual roster members (wrestlers, managers, referees)
-- `BaseRepository` - Foundation for repository pattern implementation
+## Persisted-State Queries
 
-**Domain-Specific Builders:**
-- `WrestlerBuilder` - Wrestler-specific query logic
-- `ManagerBuilder` - Manager-specific query logic  
-- `RefereeBuilder` - Referee-specific query logic
-- `TagTeamBuilder` - Tag team query logic
-- `StableBuilder` - Stable query logic
-- `TitleBuilder` - Title query logic
-- `EventBuilder` - Event query logic
-- `VenueBuilder` - Venue query logic
-- `UserBuilder` - User query logic
+Builders may compose database relationships to select records in a known state:
 
-## Builder Capabilities
-
-### Employment Status Scopes
 ```php
-// Available in roster member builders
-$wrestlers = Wrestler::query()
-    ->employed()           // Currently employed
-    ->available()          // Available for booking
-    ->unemployed()         // Not currently employed
-    ->get();
-```
-
-### Availability Scopes
-```php
-// Booking availability logic
 $availableWrestlers = Wrestler::query()
-    ->bookable()           // Can be booked for matches
-    ->notInjured()         // Not currently injured
-    ->notSuspended()       // Not currently suspended
+    ->available()
+    ->orderBy('last_name')
     ->get();
-```
 
-### Activity Period Scopes
-```php
-// Historical data queries
+$injuredWrestlers = Wrestler::query()
+    ->injured()
+    ->get();
+
 $activeStables = Stable::query()
-    ->currentlyActive()    // Active right now
-    ->activeDuring($start, $end)  // Active during period
-    ->debutedAfter($date)  // Debuted after date
-    ->get();
-```
-
-### Retirement Scopes
-```php
-// Retirement status queries
-$activeWrestlers = Wrestler::query()
-    ->notRetired()         // Currently active
-    ->retiredAfter($date)  // Retired after specific date
-    ->get();
-```
-
-## Builder Traits and Concerns
-
-### HasAvailabilityScopes
-Provides booking availability logic for entities that can be scheduled for matches.
-
-**Methods:**
-- `available()` - Available for booking
-- `unavailable()` - Not available for booking
-- `bookable()` - Can be booked (employed + available + not injured/suspended)
-
-### HasRetirementScopes  
-Provides retirement status filtering for entities that can be retired.
-
-**Methods:**
-- `retired()` - Currently retired
-- `notRetired()` - Not retired (active)
-- `retiredBetween($start, $end)` - Retired within date range
-
-## Usage Examples
-
-### Complex Wrestler Queries
-```php
-// Find wrestlers available for a championship match
-$championshipContenders = Wrestler::query()
-    ->employed()
-    ->bookable()
-    ->notCurrentChampion($titleId)
-    ->hasMinimumExperience(6) // months
-    ->orderByExperience('desc')
-    ->limit(5)
-    ->get();
-```
-
-### Stable Membership Queries
-```php
-// Find stables with available members for events
-$availableStables = Stable::query()
     ->currentlyActive()
-    ->hasAvailableMembers()
-    ->whereHas('wrestlers', function ($query) {
-        $query->bookable()->count('>=', 2);
-    })
+    ->withMinimumMembers()
     ->get();
 ```
 
-### Historical Analysis
+Shared activity-period queries live in `App\Builders\Concerns\HasActivityPeriodScopes` and are composed by `StableBuilder` and `TitleBuilder`.
+
+## Booking Boundary
+
+`available()` narrows a query to roster members whose persisted lifecycle state makes them candidates for booking. It is not the final assignment decision.
+
+Use `App\Lifecycle\RosterBookingEligibility` to decide whether a loaded wrestler, referee, or tag team satisfies booking rules. Use `App\Services\MatchAssignmentConflictService` when assigning models to a match so conflicts with existing event and match assignments are checked transactionally.
+
 ```php
-// Championship analysis
-$titleReigns = Title::query()
-    ->activeDuring($year)
-    ->with(['championships' => function ($query) use ($year) {
-        $query->activeDuring($year)
-              ->with('champion')
-              ->orderBy('started_at');
-    }])
-    ->get();
+$candidates = Wrestler::query()
+    ->available()
+    ->get()
+    ->filter(RosterBookingEligibility::allows(...));
 ```
 
-## Builder Best Practices
+Do not add date-specific booking or scheduling methods to a model builder. Those decisions depend on the assignment context and belong in the booking eligibility and scheduling collaborators.
 
-### 1. Domain Organization
-- Keep builders in appropriate domain directories
-- Use descriptive names that match the model's purpose
-- Extend appropriate base builders for shared functionality
+## Guidelines
 
-### 2. Scope Naming
-- Use clear, business-focused method names
-- Prefix with context when needed (`currently`, `not`, `has`)
-- Group related scopes in traits for reusability
-
-### 3. Query Optimization
-- Use eager loading for related models
-- Implement database indexes for commonly queried fields
-- Consider query caching for expensive operations
-
-### 4. Business Logic Integration
-- Encode wrestling business rules in builder methods
-- Use scopes to ensure data consistency
-- Validate business constraints in builder logic
-
-## Testing Builders
-
-### Unit Testing
-```php
-test('wrestler builder filters by employment status', function () {
-    $employedWrestler = Wrestler::factory()->employed()->create();
-    $unemployedWrestler = Wrestler::factory()->unemployed()->create();
-    
-    $employed = Wrestler::query()->employed()->get();
-    
-    expect($employed)->toContain($employedWrestler)
-                     ->not->toContain($unemployedWrestler);
-});
-```
-
-### Integration Testing
-```php
-test('complex availability queries work correctly', function () {
-    $availableWrestler = Wrestler::factory()
-        ->employed()
-        ->notInjured()
-        ->notSuspended()
-        ->create();
-        
-    $bookableWrestlers = Wrestler::query()->bookable()->get();
-    
-    expect($bookableWrestlers)->toContain($availableWrestler);
-});
-```
-
-## Architecture Benefits
-
-1. **Separation of Concerns**: Business logic stays in builders, not controllers
-2. **Reusability**: Common query patterns shared across the application  
-3. **Testability**: Complex queries can be unit tested in isolation
-4. **Maintainability**: Wrestling business rules centralized in builders
-5. **Performance**: Optimized queries with proper eager loading and indexes
+- Keep reusable filtering and relationship-existence queries on typed builders.
+- Keep lifecycle transition rules in the established lifecycle or validation collaborators.
+- Keep match booking eligibility in `RosterBookingEligibility`.
+- Keep event and match assignment conflicts in `MatchAssignmentConflictService`.
+- Eager-load relationships on the query that consumes them rather than adding model-level eager-loading defaults.
+- Test builders against realistic factory states and assert the exact records returned.

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -54,8 +54,9 @@ single-consumer relationship traits or speculative override helpers.
 
 ## Factory Method Patterns
 - **Employable entities**: `employed()`, `unemployed()`, `retired()`, `released()`, `suspended()`, `injured()`
-- **Bookable entities**: `bookable()` (alias for employed() for competitors and officials)
-- **Non-bookable entities**: NO `bookable()` method (Managers, Stables, etc.)
+- **Bookable fixtures**: Competitor and official factories may use `bookable()` to construct an eligible test fixture
+- **Persisted availability queries**: Individual roster builders use `available()` to select candidates; `RosterBookingEligibility` makes the final booking decision
+- **Non-bookable entities**: Managers and stables do not expose a `bookable()` factory state
 - **Activation entities**: `active()`, `inactive()`, `unactivated()`
 - **User entities**: `verified()`, `unverified()`
 - **Relationships**: Set via `has()` relationships, never direct field assignment

--- a/docs/architecture/livewire/dynamic-match-ui.md
+++ b/docs/architecture/livewire/dynamic-match-ui.md
@@ -202,14 +202,18 @@ private function getMatchTypeSpecificRules(MatchType $matchType): array
 public function getWrestlers(): Collection
 {
     return Cache::remember('bookable_wrestlers', 300, function () {
-        return Wrestler::bookable()
+        return Wrestler::query()
+            ->available()
             ->select(['id', 'first_name', 'last_name'])
             ->orderBy('last_name')
             ->get()
+            ->filter(RosterBookingEligibility::allows(...))
             ->mapWithKeys(fn($wrestler) => [$wrestler->id => $wrestler->full_name]);
     });
 }
 ```
+
+The availability query only selects candidates from persisted roster state. Assignment actions must still use `RosterBookingEligibility` and `MatchAssignmentConflictService` before attaching a wrestler to a match.
 
 ## Testing Strategy
 

--- a/tests/Integration/Builders/RefereeQueryBuilderTest.php
+++ b/tests/Integration/Builders/RefereeQueryBuilderTest.php
@@ -10,7 +10,7 @@ use App\Models\Referees\Referee;
  *
  * UNIT TEST SCOPE:
  * - Builder class structure and scope functionality
- * - Employment status filtering scopes (bookable, futureEmployed, unemployed, released)
+ * - Employment status filtering scopes (available, futureEmployed, unemployed, released)
  * - Individual roster member status scopes (suspended, retired, injured)
  * - Query scope accuracy and entity isolation
  *
@@ -24,7 +24,7 @@ describe('RefereeQueryBuilder Unit Tests', function () {
     beforeEach(function () {
         // Create referees in all possible states for comprehensive scope testing
         $this->futureEmployedReferee = Referee::factory()->withFutureEmployment()->create();
-        $this->bookableReferee = Referee::factory()->bookable()->create();
+        $this->availableReferee = Referee::factory()->bookable()->create();
         $this->suspendedReferee = Referee::factory()->suspended()->create();
         $this->retiredReferee = Referee::factory()->retired()->create();
         $this->releasedReferee = Referee::factory()->released()->create();
@@ -33,14 +33,14 @@ describe('RefereeQueryBuilder Unit Tests', function () {
     });
 
     describe('availability status scopes', function () {
-        test('bookable referees can be retrieved', function () {
+        test('available referees can be retrieved', function () {
             // Act
-            $bookableReferees = Referee::bookable()->get();
+            $availableReferees = Referee::available()->get();
 
             // Assert
-            expect($bookableReferees)
+            expect($availableReferees)
                 ->toHaveCount(1)
-                ->and($bookableReferees->contains($this->bookableReferee))->toBeTrue();
+                ->and($availableReferees->contains($this->availableReferee))->toBeTrue();
         });
     });
 

--- a/tests/Integration/Builders/WrestlerQueryBuilderTest.php
+++ b/tests/Integration/Builders/WrestlerQueryBuilderTest.php
@@ -11,7 +11,7 @@ use App\Models\Wrestlers\Wrestler;
  * INTEGRATION TEST SCOPE:
  * - Builder integration with Model, Database, and Factory layers
  * - Business logic validation through complete data pipeline
- * - Employment status filtering with real data (bookable, futureEmployed, unemployed, released)
+ * - Employment status filtering with real data (available, futureEmployed, unemployed, released)
  * - Status-based filtering with database persistence (suspended, retired, injured)
  * - Query scope accuracy with actual database results
  *
@@ -24,7 +24,7 @@ describe('WrestlerQueryBuilder Integration Tests', function () {
     beforeEach(function () {
         // Create wrestlers in all possible states for comprehensive scope testing
         $this->futureEmployedWrestler = Wrestler::factory()->withFutureEmployment()->create();
-        $this->bookableWrestler = Wrestler::factory()->bookable()->create();
+        $this->availableWrestler = Wrestler::factory()->bookable()->create();
         $this->suspendedWrestler = Wrestler::factory()->suspended()->create();
         $this->retiredWrestler = Wrestler::factory()->retired()->create();
         $this->releasedWrestler = Wrestler::factory()->released()->create();
@@ -33,14 +33,14 @@ describe('WrestlerQueryBuilder Integration Tests', function () {
     });
 
     describe('employment status scopes', function () {
-        test('bookable wrestlers can be retrieved', function () {
+        test('available wrestlers can be retrieved', function () {
             // Act
-            $bookableWrestlers = Wrestler::bookable()->get();
+            $availableWrestlers = Wrestler::available()->get();
 
             // Assert
-            expect($bookableWrestlers)
+            expect($availableWrestlers)
                 ->toHaveCount(1)
-                ->and($bookableWrestlers->contains($this->bookableWrestler))->toBeTrue();
+                ->and($availableWrestlers->contains($this->availableWrestler))->toBeTrue();
         });
 
         test('future employed wrestlers can be retrieved', function () {

--- a/tests/Unit/Builders/Contracts/BuilderContractsTest.php
+++ b/tests/Unit/Builders/Contracts/BuilderContractsTest.php
@@ -29,7 +29,7 @@ test('shared roster query methods retain each concrete builder type', function (
 });
 
 test('domain-specific query methods retain their concrete builder types', function () {
-    expect(Wrestler::query()->bookable())->toBeInstanceOf(WrestlerBuilder::class)
+    expect(Wrestler::query()->available())->toBeInstanceOf(WrestlerBuilder::class)
         ->and(TagTeam::query()->bookable())->toBeInstanceOf(TagTeamBuilder::class)
         ->and(Title::query()->vacant())->toBeInstanceOf(TitleBuilder::class);
 });

--- a/tests/Unit/Builders/Roster/RefereeBuilderTest.php
+++ b/tests/Unit/Builders/Roster/RefereeBuilderTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 use App\Models\Referees\Referee;
 
-test('bookable referees can be retrieved', function () {
+test('available referees can be retrieved', function () {
     $futureEmployedReferee = Referee::factory()->withFutureEmployment()->create();
-    $bookableReferee = Referee::factory()->bookable()->create();
+    $availableReferee = Referee::factory()->bookable()->create();
     $suspendedReferee = Referee::factory()->suspended()->create();
     $retiredReferee = Referee::factory()->retired()->create();
     $releasedReferee = Referee::factory()->released()->create();
     $unemployedReferee = Referee::factory()->unemployed()->create();
     $injuredReferee = Referee::factory()->injured()->create();
 
-    $bookableReferees = Referee::bookable()->get();
+    $availableReferees = Referee::available()->get();
 
-    expect($bookableReferees)
+    expect($availableReferees)
         ->toHaveCount(1)
-        ->and($bookableReferees->contains($bookableReferee))->toBeTrue();
+        ->and($availableReferees->contains($availableReferee))->toBeTrue();
 });
 
 test('future employed referees can be retrieved', function () {

--- a/tests/Unit/Builders/Roster/WrestlerBuilderTest.php
+++ b/tests/Unit/Builders/Roster/WrestlerBuilderTest.php
@@ -4,20 +4,20 @@ declare(strict_types=1);
 
 use App\Models\Wrestlers\Wrestler;
 
-test('bookable wrestlers can be retrieved', function () {
+test('available wrestlers can be retrieved', function () {
     $futureEmployedWrestler = Wrestler::factory()->withFutureEmployment()->create();
-    $bookableWrestler = Wrestler::factory()->bookable()->create();
+    $availableWrestler = Wrestler::factory()->bookable()->create();
     $suspendedWrestler = Wrestler::factory()->suspended()->create();
     $retiredWrestler = Wrestler::factory()->retired()->create();
     $releasedWrestler = Wrestler::factory()->released()->create();
     $unemployedWrestler = Wrestler::factory()->unemployed()->create();
     $injuredWrestler = Wrestler::factory()->injured()->create();
 
-    $bookableWrestlers = Wrestler::bookable()->get();
+    $availableWrestlers = Wrestler::available()->get();
 
-    expect($bookableWrestlers)
+    expect($availableWrestlers)
         ->toHaveCount(1)
-        ->and($bookableWrestlers->contains($bookableWrestler))->toBeTrue();
+        ->and($availableWrestlers->contains($availableWrestler))->toBeTrue();
 });
 
 test('future employed wrestlers can be retrieved', function () {


### PR DESCRIPTION
## Summary
- remove individual Builder aliases that implied final booking decisions
- keep persisted-state candidate filtering on available()
- document RosterBookingEligibility and MatchAssignmentConflictService as the decision boundaries
- align Builder contracts and focused tests with the clarified API

## Verification
- 31 focused tests passed with 68 assertions
- application and Pest PHPStan passed
- type coverage and Rector passed
- targeted Pint with Blade formatting passed
- git diff --check passed

## Repository baseline note
- composer test:push reached unrelated Blade formatting failures already present on clean development
- the standalone full parallel Pest run emitted no failures but was stopped after several silent minutes under the bounded-command safety rule

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified the distinction between availability queries and booking eligibility.
  * Updated architecture and interface guidance for roster searches and assignments.

* **Bug Fixes**
  * Standardized referee and wrestler availability checks around the `available()` query.
  * Ensured wrestler lookup guidance includes eligibility and conflict validation.

* **Tests**
  * Updated roster and builder coverage to verify available referees and wrestlers consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->