### PR TITLE
refactor: consolidate tag team booking eligibility

### DIFF
--- a/app/Builders/Roster/TagTeamBuilder.php
+++ b/app/Builders/Roster/TagTeamBuilder.php
@@ -283,48 +283,18 @@ class TagTeamBuilder extends Builder
     }
 
     /**
-     * Scope a query to include bookable tag teams.
+     * Scope a query to include tag teams below a minimum wrestler count.
      *
-     * Filters tag teams that satisfy the persisted team-level prerequisites for
-     * booking: current employment, no suspension or retirement, and at least two
-     * current wrestlers. Per-wrestler eligibility remains a lifecycle concern.
+     * Filters tag teams that have fewer than the specified number of current
+     * wrestler partners. Defaults to fewer than two wrestlers.
      *
+     * @param  int  $count  Minimum number of wrestlers required
      * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get all bookable tag teams
-     * $bookableTeams = TagTeam::query()->bookable()->get();
-     *
-     * // Find bookable teams for title matches
-     * $titleBookableTeams = TagTeam::query()
-     *     ->bookable()
-     *     ->whereDoesntHave('currentChampionships')
-     *     ->get();
-     * ```
      */
-    public function bookable(): static
+    public function belowMinimumWrestlers(int $count = 2): static
     {
-        return $this->available()
-            ->withMinimumWrestlers();
-    }
+        $this->has('currentWrestlers', '<', $count);
 
-    /**
-     * Scope a query to include unbookable tag teams.
-     *
-     * Filters tag teams that fail a persisted team-level booking prerequisite.
-     * This is the inverse of bookable() and includes teams with fewer than two
-     * current wrestlers.
-     *
-     * @return static The builder instance for method chaining
-     */
-    public function unbookable(): static
-    {
-        return $this->where(function (Builder $query): void {
-            $query->whereDoesntHave('currentEmployment')
-                ->orWhereHas('currentSuspension')
-                ->orWhereHas('currentRetirement')
-                ->orHas('currentWrestlers', '<', 2);
-        });
+        return $this;
     }
 }

--- a/app/Lifecycle/RosterBookingEligibility.php
+++ b/app/Lifecycle/RosterBookingEligibility.php
@@ -13,7 +13,18 @@ final class RosterBookingEligibility
     public static function allows(Wrestler|Referee|TagTeam $rosterMember): bool
     {
         if ($rosterMember instanceof TagTeam) {
-            return $rosterMember->currentWrestlers->every(
+            if (
+                $rosterMember->hasNoCurrentOrFutureEmployment()
+                || $rosterMember->isSuspended()
+                || $rosterMember->isRetired()
+                || $rosterMember->hasFutureEmployment()
+            ) {
+                return false;
+            }
+
+            $currentWrestlers = $rosterMember->currentWrestlers;
+
+            return $currentWrestlers->count() >= 2 && $currentWrestlers->every(
                 fn (Wrestler $wrestler): bool => self::allows($wrestler),
             );
         }

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -89,7 +89,7 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, TitleChampionship> $previousTitleChampionships
  *
  * @method static TagTeamBuilder<static>|TagTeam available()
- * @method static TagTeamBuilder<static>|TagTeam bookable()
+ * @method static TagTeamBuilder<static>|TagTeam belowMinimumWrestlers(int $count = 2)
  * @method static TagTeamBuilder<static>|TagTeam employed()
  * @method static \Database\Factories\TagTeams\TagTeamFactory factory($count = null, $state = [])
  * @method static TagTeamBuilder<static>|TagTeam futureEmployed()
@@ -101,7 +101,6 @@ use Illuminate\Support\Carbon;
  * @method static TagTeamBuilder<static>|TagTeam retired()
  * @method static TagTeamBuilder<static>|TagTeam suspended()
  * @method static TagTeamBuilder<static>|TagTeam unavailable()
- * @method static TagTeamBuilder<static>|TagTeam unbookable()
  * @method static TagTeamBuilder<static>|TagTeam unemployed()
  * @method static TagTeamBuilder<static>|TagTeam withMinimumWrestlers(int $count = 2)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeam withTrashed()

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -37,13 +37,18 @@ $activeStables = Stable::query()
     ->currentlyActive()
     ->withMinimumMembers()
     ->get();
+
+$structurallyCompleteTagTeams = TagTeam::query()
+    ->available()
+    ->withMinimumWrestlers()
+    ->get();
 ```
 
 Shared activity-period queries live in `App\Builders\Concerns\HasActivityPeriodScopes` and are composed by `StableBuilder` and `TitleBuilder`.
 
 ## Booking Boundary
 
-`available()` narrows a query to roster members whose persisted lifecycle state makes them candidates for booking. It is not the final assignment decision.
+`available()` narrows a query to roster members whose persisted lifecycle state makes them candidates for booking. Tag-team builders additionally expose `withMinimumWrestlers()` and `belowMinimumWrestlers()` for structural queries. None of these methods makes the final assignment decision.
 
 Use `App\Lifecycle\RosterBookingEligibility` to decide whether a loaded wrestler, referee, or tag team satisfies booking rules. Use `App\Services\MatchAssignmentConflictService` when assigning models to a match so conflicts with existing event and match assignments are checked transactionally.
 
@@ -61,6 +66,7 @@ Do not add date-specific booking or scheduling methods to a model builder. Those
 - Keep reusable filtering and relationship-existence queries on typed builders.
 - Keep lifecycle transition rules in the established lifecycle or validation collaborators.
 - Keep match booking eligibility in `RosterBookingEligibility`.
+- Keep tag-team state, minimum-membership, and partner eligibility checks together in `RosterBookingEligibility`.
 - Keep event and match assignment conflicts in `MatchAssignmentConflictService`.
 - Eager-load relationships on the query that consumes them rather than adding model-level eager-loading defaults.
 - Test builders against realistic factory states and assert the exact records returned.

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -55,7 +55,7 @@ single-consumer relationship traits or speculative override helpers.
 ## Factory Method Patterns
 - **Employable entities**: `employed()`, `unemployed()`, `retired()`, `released()`, `suspended()`, `injured()`
 - **Bookable fixtures**: Competitor and official factories may use `bookable()` to construct an eligible test fixture
-- **Persisted availability queries**: Individual roster builders use `available()` to select candidates; `RosterBookingEligibility` makes the final booking decision
+- **Persisted availability queries**: Roster builders use `available()` to select candidates; tag-team builders use explicit minimum-wrestler queries, and `RosterBookingEligibility` makes the final booking decision
 - **Non-bookable entities**: Managers and stables do not expose a `bookable()` factory state
 - **Activation entities**: `active()`, `inactive()`, `unactivated()`
 - **User entities**: `verified()`, `unverified()`

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -42,7 +42,7 @@ Match assignments observe these collision rules:
 
 Assignment actions lock the affected event rows and enforce these rules inside their database transactions. This serializes assignment commands that use the application boundary. The schema cannot enforce overlapping match windows because individual matches do not currently have their own start and end times.
 
-Roster booking eligibility is evaluated by `RosterBookingEligibility`, not by Eloquent models. The policy combines persisted employment, injury, suspension, future-employment, and tag-team membership state. Models expose those relationships and state predicates; validation rules, assignment Actions, and collections invoke the policy when deciding whether a participant may be booked.
+Roster booking eligibility is evaluated by `RosterBookingEligibility`, not by Eloquent models or builders. The policy combines persisted employment, injury, suspension, future-employment, and tag-team membership state. A tag team must satisfy its own lifecycle state, have at least two current wrestlers, and have every current wrestler individually eligible. Models expose those relationships and state predicates; validation rules, assignment Actions, and collections invoke the policy when deciding whether a participant may be booked.
 
 `MatchStipulation` is a persistence record containing its configured name, slug, description, active flag, and match relationship. Stipulation capabilities and match presentation must be implemented by the match domain when they are enforced; the model does not infer behavior from hard-coded slug lists.
 

--- a/tests/Integration/Builders/TagTeamQueryBuilderTest.php
+++ b/tests/Integration/Builders/TagTeamQueryBuilderTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Builders\TagTeamBuilder;
+use App\Builders\Roster\TagTeamBuilder;
 use App\Models\TagTeams\TagTeam;
 
 /**
@@ -10,9 +10,9 @@ use App\Models\TagTeams\TagTeam;
  *
  * UNIT TEST SCOPE:
  * - Builder class structure and scope functionality
- * - Employment status filtering scopes (bookable, futureEmployed, unemployed, released)
+ * - Employment status filtering scopes (available, futureEmployed, unemployed, released)
  * - Status-based filtering scopes (suspended, retired)
- * - Complex business logic scopes (unbookable with multiple entities)
+ * - Current wrestler count scopes
  * - Query scope accuracy and entity isolation
  *
  * These tests verify that the TagTeamQueryBuilder correctly implements
@@ -31,20 +31,24 @@ describe('TagTeamQueryBuilder Unit Tests', function () {
         $this->releasedTagTeam = TagTeam::factory()->released()->create();
         $this->unemployedTagTeam = TagTeam::factory()->unemployed()->create();
         $this->unbookableTagTeam = TagTeam::factory()->unbookable()->create();
+        $this->undersizedTagTeam = TagTeam::factory()->employed()->create();
+        $this->undersizedTagTeam->currentWrestlers()->updateExistingPivot(
+            $this->undersizedTagTeam->currentWrestlers()->firstOrFail(),
+            ['left_at' => now()],
+        );
     });
 
     describe('employment status scopes', function () {
-        test('bookable tag teams can be retrieved', function () {
-            // Use the existing bookable tag team from beforeEach
+        test('available tag teams with minimum wrestlers can be retrieved', function () {
             $tagTeam = $this->bookableTagTeam;
 
             // Act
-            $bookableTagTeams = TagTeam::bookable()->get();
+            $availableTagTeams = TagTeam::available()->withMinimumWrestlers()->get();
 
             // Assert
-            expect($bookableTagTeams)
+            expect($availableTagTeams)
                 ->toHaveCount(1)
-                ->and($bookableTagTeams->contains($tagTeam))->toBeTrue();
+                ->and($availableTagTeams->contains($tagTeam))->toBeTrue();
         });
 
         test('future employed tag teams can be retrieved', function () {
@@ -101,18 +105,16 @@ describe('TagTeamQueryBuilder Unit Tests', function () {
         });
     });
 
-    describe('complex business logic scopes', function () {
-        test('unbookable tag teams can be retrieved', function () {
+    describe('current wrestler count scopes', function () {
+        test('tag teams below the minimum wrestler count can be retrieved', function () {
             // Act
-            $unbookableTagTeams = TagTeam::unbookable()->get();
+            $undersizedTagTeams = TagTeam::belowMinimumWrestlers()->get();
 
-            // Assert - Unbookable includes any entity that cannot be booked
-            // (suspended, retired, released, unemployed, and unbookable)
-            expect($unbookableTagTeams->pluck('id'))->toContain($this->suspendedTagTeam->id);
-            expect($unbookableTagTeams->pluck('id'))->toContain($this->retiredTagTeam->id);
-            expect($unbookableTagTeams->pluck('id'))->toContain($this->releasedTagTeam->id);
-            expect($unbookableTagTeams->pluck('id'))->toContain($this->unemployedTagTeam->id);
-            expect($unbookableTagTeams->pluck('id'))->toContain($this->unbookableTagTeam->id);
+            // Assert
+            expect($undersizedTagTeams->pluck('id'))
+                ->toContain($this->unbookableTagTeam->id)
+                ->toContain($this->undersizedTagTeam->id)
+                ->not->toContain($this->bookableTagTeam->id);
         });
     });
 });

--- a/tests/Integration/Lifecycle/RosterBookingEligibilityTest.php
+++ b/tests/Integration/Lifecycle/RosterBookingEligibilityTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Lifecycle\RosterBookingEligibility;
+use App\Models\TagTeams\TagTeam;
+
+test('a tag team must satisfy its own roster state requirements', function (string $factoryState, bool $eligible) {
+    $tagTeam = TagTeam::factory()->{$factoryState}()->create();
+
+    expect(RosterBookingEligibility::allows($tagTeam))->toBe($eligible);
+})->with([
+    'available' => ['bookable', true],
+    'future employed' => ['withFutureEmployment', false],
+    'suspended' => ['suspended', false],
+    'retired' => ['retired', false],
+    'released' => ['released', false],
+    'unemployed' => ['unemployed', false],
+]);
+
+test('a tag team requires at least two current wrestlers', function () {
+    $tagTeam = TagTeam::factory()->bookable()->create();
+    $wrestler = $tagTeam->currentWrestlers()->firstOrFail();
+
+    $tagTeam->currentWrestlers()->updateExistingPivot($wrestler, ['left_at' => now()]);
+    $tagTeam->refresh();
+
+    expect(RosterBookingEligibility::allows($tagTeam))->toBeFalse();
+});
+
+test('every current tag team wrestler must be eligible', function () {
+    $tagTeam = TagTeam::factory()->bookable()->create();
+    $wrestler = $tagTeam->currentWrestlers()->firstOrFail();
+
+    $wrestler->currentEmployment()->firstOrFail()->update(['ended_at' => now()]);
+    $tagTeam->refresh();
+
+    expect(RosterBookingEligibility::allows($tagTeam))->toBeFalse();
+});

--- a/tests/Unit/Builders/Contracts/BuilderContractsTest.php
+++ b/tests/Unit/Builders/Contracts/BuilderContractsTest.php
@@ -30,6 +30,6 @@ test('shared roster query methods retain each concrete builder type', function (
 
 test('domain-specific query methods retain their concrete builder types', function () {
     expect(Wrestler::query()->available())->toBeInstanceOf(WrestlerBuilder::class)
-        ->and(TagTeam::query()->bookable())->toBeInstanceOf(TagTeamBuilder::class)
+        ->and(TagTeam::query()->withMinimumWrestlers())->toBeInstanceOf(TagTeamBuilder::class)
         ->and(Title::query()->vacant())->toBeInstanceOf(TitleBuilder::class);
 });

--- a/tests/Unit/Builders/Roster/TagTeamBuilderTest.php
+++ b/tests/Unit/Builders/Roster/TagTeamBuilderTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use App\Models\TagTeams\TagTeam;
 
-test('bookable tag teams can be retrieved', function () {
+test('available tag teams with minimum wrestlers can be retrieved', function () {
     $futureEmployedTagTeam = TagTeam::factory()->withFutureEmployment()->create();
     $bookableTagTeam = TagTeam::factory()->bookable()->create();
     $suspendedTagTeam = TagTeam::factory()->suspended()->create();
@@ -18,11 +18,11 @@ test('bookable tag teams can be retrieved', function () {
         ['left_at' => now()],
     );
 
-    $bookableTagTeams = TagTeam::bookable()->get();
+    $availableTagTeams = TagTeam::available()->withMinimumWrestlers()->get();
 
-    expect($bookableTagTeams)
+    expect($availableTagTeams)
         ->toHaveCount(1)
-        ->and($bookableTagTeams->contains($bookableTagTeam))->toBeTrue();
+        ->and($availableTagTeams->contains($bookableTagTeam))->toBeTrue();
 });
 
 test('future employed tag teams can be retrieved', function () {
@@ -41,7 +41,7 @@ test('future employed tag teams can be retrieved', function () {
         ->and($futureEmployedTagTeams->contains($futureEmployedTagTeam))->toBeTrue();
 });
 
-test('unbookable tag teams can be retrieved', function () {
+test('tag teams below the minimum wrestler count can be retrieved', function () {
     $futureEmployedTagTeam = TagTeam::factory()->withFutureEmployment()->create();
     $bookableTagTeam = TagTeam::factory()->bookable()->create();
     $suspendedTagTeam = TagTeam::factory()->suspended()->create();
@@ -55,17 +55,12 @@ test('unbookable tag teams can be retrieved', function () {
         ['left_at' => now()],
     );
 
-    $unbookableTagTeams = TagTeam::unbookable()->get();
+    $undersizedTagTeams = TagTeam::belowMinimumWrestlers()->get();
 
-    expect($unbookableTagTeams)
-        ->toHaveCount(7)
-        ->and($unbookableTagTeams->contains($futureEmployedTagTeam))->toBeTrue()
-        ->and($unbookableTagTeams->contains($suspendedTagTeam))->toBeTrue()
-        ->and($unbookableTagTeams->contains($retiredTagTeam))->toBeTrue()
-        ->and($unbookableTagTeams->contains($releasedTagTeam))->toBeTrue()
-        ->and($unbookableTagTeams->contains($unemployedTagTeam))->toBeTrue()
-        ->and($unbookableTagTeams->contains($unbookableTagTeam))->toBeTrue()
-        ->and($unbookableTagTeams->contains($undersizedTagTeam))->toBeTrue();
+    expect($undersizedTagTeams)
+        ->toHaveCount(2)
+        ->and($undersizedTagTeams->contains($unbookableTagTeam))->toBeTrue()
+        ->and($undersizedTagTeams->contains($undersizedTagTeam))->toBeTrue();
 });
 
 test('released tag teams can be retrieved', function () {


### PR DESCRIPTION
## Summary
- make RosterBookingEligibility validate tag-team lifecycle state, minimum membership, and every current partner
- replace tag-team bookable/unbookable Builder methods with explicit minimum-wrestler structural queries
- add regression coverage for empty, undersized, unavailable, suspended, retired, released, and future-employed teams
- document the Builder and match-assignment boundary

## Verification
- 29 focused tests passed with 59 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- targeted Pint with Blade formatting passed
- git diff --check passed

## Local suite note
- composer test:push reached the existing local Blade/Node formatter baseline after type coverage and Rector passed; the equivalent GitHub formatting check passed on the prerequisite PR