### PR TITLE
refactor: scope builder name search

### DIFF
--- a/app/Builders/Concerns/HasNameSearch.php
+++ b/app/Builders/Concerns/HasNameSearch.php
@@ -5,14 +5,7 @@ declare(strict_types=1);
 namespace App\Builders\Concerns;
 
 /**
- * Provides name-based search functionality for builders of models with first_name and last_name columns.
- *
- * This trait adds query scopes for intelligent name searching that handles:
- * - Case-insensitive exact matching
- * - Word boundary prefix matching to prevent false positives
- * - Proper SQL injection protection with parameter binding
- *
- * Used by UserBuilder, ManagerBuilder, RefereeBuilder, etc.
+ * Provides name search for models with first_name and last_name columns.
  */
 trait HasNameSearch
 {
@@ -33,23 +26,6 @@ trait HasNameSearch
                 ->orWhereRaw('LOWER(last_name) = LOWER(?)', [$trimmedTerm])
                 ->orWhereRaw('LOWER(first_name) LIKE LOWER(?)', [$trimmedTerm.' %'])
                 ->orWhereRaw('LOWER(last_name) LIKE LOWER(?)', [$trimmedTerm.' %']);
-        });
-    }
-
-    /**
-     * Scope a query to search for records where names contain the search term.
-     *
-     * Uses broader LIKE matching for more flexible search results.
-     *
-     * @param  string  $searchTerm  The term to search for
-     */
-    public function whereNameContains(string $searchTerm): static
-    {
-        $trimmedTerm = mb_trim($searchTerm);
-
-        return $this->where(function ($query) use ($trimmedTerm) {
-            $query->whereRaw('LOWER(first_name) LIKE LOWER(?)', ['%'.$trimmedTerm.'%'])
-                ->orWhereRaw('LOWER(last_name) LIKE LOWER(?)', ['%'.$trimmedTerm.'%']);
         });
     }
 }

--- a/app/Builders/Concerns/HasNameSearch.php
+++ b/app/Builders/Concerns/HasNameSearch.php
@@ -22,10 +22,10 @@ trait HasNameSearch
         $trimmedTerm = mb_trim($searchTerm);
 
         return $this->where(function ($query) use ($trimmedTerm) {
-            $query->whereRaw('LOWER(first_name) = LOWER(?)', [$trimmedTerm])
-                ->orWhereRaw('LOWER(last_name) = LOWER(?)', [$trimmedTerm])
-                ->orWhereRaw('LOWER(first_name) LIKE LOWER(?)', [$trimmedTerm.' %'])
-                ->orWhereRaw('LOWER(last_name) LIKE LOWER(?)', [$trimmedTerm.' %']);
+            $query->whereLike('first_name', $trimmedTerm)
+                ->orWhereLike('last_name', $trimmedTerm)
+                ->orWhereLike('first_name', $trimmedTerm.' %')
+                ->orWhereLike('last_name', $trimmedTerm.' %');
         });
     }
 }

--- a/app/Builders/Roster/IndividualBuilder.php
+++ b/app/Builders/Roster/IndividualBuilder.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Builders\Roster;
 
-use App\Builders\Concerns\HasNameSearch;
 use App\Builders\Concerns\HasRetirementScopes;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -30,7 +29,6 @@ use Illuminate\Database\Eloquent\Model;
  */
 abstract class IndividualBuilder extends Builder
 {
-    use HasNameSearch;
     use HasRetirementScopes;
 
     /**

--- a/app/Builders/Roster/ManagerBuilder.php
+++ b/app/Builders/Roster/ManagerBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Builders\Roster;
 
+use App\Builders\Concerns\HasNameSearch;
 use App\Models\Managers\Manager;
 
 /**
@@ -35,5 +36,7 @@ use App\Models\Managers\Manager;
  */
 class ManagerBuilder extends IndividualBuilder
 {
+    use HasNameSearch;
+
     // Managers don't need booking scopes - they are not booked for matches
 }

--- a/app/Builders/Roster/RefereeBuilder.php
+++ b/app/Builders/Roster/RefereeBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Builders\Roster;
 
+use App\Builders\Concerns\HasNameSearch;
 use App\Models\Referees\Referee;
 
 /**
@@ -35,4 +36,7 @@ use App\Models\Referees\Referee;
  *     ->get();
  * ```
  */
-class RefereeBuilder extends IndividualBuilder {}
+class RefereeBuilder extends IndividualBuilder
+{
+    use HasNameSearch;
+}

--- a/app/Builders/Users/UserBuilder.php
+++ b/app/Builders/Users/UserBuilder.php
@@ -30,6 +30,4 @@ use Illuminate\Database\Eloquent\Builder;
 class UserBuilder extends Builder
 {
     use HasNameSearch;
-
-    // Users don't extend IndividualBuilder, so they include HasNameSearch directly.
 }

--- a/docs/architecture/builders/HasNameSearch.md
+++ b/docs/architecture/builders/HasNameSearch.md
@@ -1,158 +1,23 @@
-# HasNameSearch Builder Trait
+# Name Search Builder Concern
 
-The `HasNameSearch` trait provides reusable name-based search functionality for Laravel Eloquent builders working with models that have `first_name` and `last_name` columns.
+`HasNameSearch` provides case-insensitive, word-boundary search for models backed by separate `first_name` and `last_name` columns.
 
-## Overview
+The concern is composed directly by:
 
-This trait eliminates code duplication across table components by centralizing intelligent name search logic that handles:
-- Case-insensitive exact matching
-- Word boundary prefix matching to prevent false positives
-- Proper SQL injection protection with parameter binding
-- Consistent search behavior across the application
-
-## Usage
-
-### Applying the Trait
-
-```php
-use App\Builders\Concerns\HasNameSearch;
-use Illuminate\Database\Eloquent\Builder;
-
-class UserBuilder extends Builder
-{
-    use HasNameSearch;
-    
-    // Other builder methods...
-}
-```
-
-### Available Methods
-
-#### `whereNameMatches(string $searchTerm): static`
-
-Searches for exact matches or word-boundary prefix matches on `first_name` and `last_name`.
-
-**Search Logic:**
-- Exact match: "John" matches "John Smith"
-- Word boundary prefix: "John" matches "John Jr" but NOT "Johnson"
-- Case insensitive: "JOHN" matches "john smith"
-
-```php
-// Find users with exact or prefix name matches
-$users = User::query()
-    ->whereNameMatches('John')
-    ->get();
-
-// Results: "John Smith", "John Jr", "Jane John-Doe"
-// Excludes: "Johnson", "Johnny"
-```
-
-#### `whereNameContains(string $searchTerm): static`
-
-Broader LIKE matching for more flexible search results.
-
-```php
-// Find users with names containing the term anywhere
-$users = User::query()
-    ->whereNameContains('ohn')
-    ->get();
-
-// Results: "John Smith", "Johnny Cash", "Bob Johnson"
-```
-
-### Method Chaining
-
-Both methods return the builder instance for fluent chaining:
-
-```php
-$users = User::query()
-    ->whereNameMatches('John')
-    ->where('status', 'active')
-    ->orderBy('last_name')
-    ->get();
-```
-
-## Implementation Details
-
-### SQL Generation
-
-**SQLite/MySQL Compatible:**
-```sql
--- whereNameMatches('John')
-WHERE (
-    LOWER(first_name) = LOWER('John') OR 
-    LOWER(last_name) = LOWER('John') OR 
-    LOWER(first_name) LIKE LOWER('John %') OR 
-    LOWER(last_name) LIKE LOWER('John %')
-)
-
--- whereNameContains('ohn')  
-WHERE (
-    LOWER(first_name) LIKE LOWER('%ohn%') OR 
-    LOWER(last_name) LIKE LOWER('%ohn%')
-)
-```
-
-### Security Features
-
-- **Parameter Binding**: All search terms use proper parameter binding to prevent SQL injection
-- **Input Sanitization**: Automatically trims whitespace from search terms
-- **Case Normalization**: Uses database-level LOWER() for consistent case handling
-
-## Applied To
-
-Currently used by:
-- `IndividualBuilder` (Managers, Referees, Wrestlers)
+- `ManagerBuilder`
+- `RefereeBuilder`
 - `UserBuilder`
-- Table components: Users, Managers (eliminates duplicated search logic)
 
-## Testing
+It intentionally is not part of `IndividualBuilder`. Wrestlers are individual roster members, but their schema stores one `name` column, so exposing this query through `WrestlerBuilder` would create an invalid API.
 
-Comprehensive integration tests verify:
-- Exact name matching behavior
-- Word boundary logic (prevents false positives)
-- Case insensitivity
-- Special character handling
-- Method chaining compatibility
-- SQL injection protection
+## Query
 
-**Test Location:** `tests/Integration/Builders/Concerns/HasNameSearchIntegrationTest.php`
+`whereNameMatches(string $searchTerm)` trims the search term and matches either name column case-insensitively. It accepts exact values and space-delimited name prefixes while avoiding arbitrary substring matches. For example, `John` matches `John` and `John Paul`, but not `Johnny` or `Johnson`.
 
-## Benefits
-
-1. **Code Reuse**: Single implementation used across multiple builders
-2. **Consistency**: Standardized search behavior application-wide  
-3. **Maintainability**: Changes to search logic update all components
-4. **Performance**: Database-level filtering with proper indexing support
-5. **Security**: Built-in SQL injection protection
-
-## Migration from Manual Search
-
-**Before (duplicated in each component):**
 ```php
-Column::make('Name', 'full_name')
-    ->searchable(function ($builder, $searchTerm) {
-        $builder->whereRaw('LOWER(first_name) LIKE LOWER(?)', ["%{$searchTerm}%"])
-               ->orWhereRaw('LOWER(last_name) LIKE LOWER(?)', ["%{$searchTerm}%"]);
-    });
+$managers = Manager::query()
+    ->whereNameMatches($searchTerm)
+    ->get();
 ```
 
-**After (using trait):**
-```php  
-Column::make('Name', 'full_name')
-    ->searchable(function ($builder, $searchTerm) {
-        $builder->whereNameMatches($searchTerm);
-    });
-```
-
-## Future Enhancements
-
-Potential additions:
-- Fuzzy matching support (Levenshtein distance)
-- Full-text search integration
-- Nickname/alias matching
-- International character normalization
-
----
-
-*Added in PR #525 - Integration Test Improvements*
+The query uses bound parameters for every user-provided value.

--- a/tests/Integration/Builders/Concerns/HasNameSearchIntegrationTest.php
+++ b/tests/Integration/Builders/Concerns/HasNameSearchIntegrationTest.php
@@ -2,202 +2,68 @@
 
 declare(strict_types=1);
 
+use App\Models\Managers\Manager;
+use App\Models\Referees\Referee;
 use App\Models\Users\User;
+use App\Models\Wrestlers\Wrestler;
 
-/**
- * Integration tests for HasNameSearch builder concern using real database queries.
- *
- * @group builders
- * @group integration
- * @group search
- */
-describe('HasNameSearch Integration Tests', function () {
+describe('name search', function () {
+    it('searches users by a case-insensitive first or last name match', function () {
+        $johnSmith = User::factory()->create([
+            'first_name' => 'John',
+            'last_name' => 'Smith',
+        ]);
+        $janeDoe = User::factory()->create([
+            'first_name' => 'Jane',
+            'last_name' => 'Doe',
+        ]);
+        User::factory()->create([
+            'first_name' => 'Johnny',
+            'last_name' => 'Johnson',
+        ]);
 
-    beforeEach(function () {
-        // Create test users with various name patterns
-        $this->users = [
-            User::factory()->create([
-                'first_name' => 'John',
-                'last_name' => 'Smith',
-                'email' => 'john.smith@example.com',
-            ]),
-            User::factory()->create([
-                'first_name' => 'Jane',
-                'last_name' => 'Doe',
-                'email' => 'jane.doe@example.com',
-            ]),
-            User::factory()->create([
-                'first_name' => 'Bob',
-                'last_name' => 'Johnson',
-                'email' => 'bob.johnson@example.com',
-            ]),
-            User::factory()->create([
-                'first_name' => 'Johnny',
-                'last_name' => 'Cash',
-                'email' => 'johnny.cash@example.com',
-            ]),
-            User::factory()->create([
-                'first_name' => 'Michael',
-                'last_name' => 'Kennedy',
-                'email' => 'michael.kennedy@example.com',
-            ]),
-        ];
+        $firstNameMatches = User::query()->whereNameMatches(' JOHN ')->get();
+        $lastNameMatches = User::query()->whereNameMatches('doe')->get();
+
+        expect($firstNameMatches)->toHaveCount(1)
+            ->and($firstNameMatches->firstOrFail()->is($johnSmith))->toBeTrue()
+            ->and($lastNameMatches)->toHaveCount(1)
+            ->and($lastNameMatches->firstOrFail()->is($janeDoe))->toBeTrue();
     });
 
-    describe('whereNameMatches method', function () {
-        it('finds exact first name matches', function () {
-            $results = User::query()->whereNameMatches('John')->get();
+    it('searches managers by name', function () {
+        $manager = Manager::factory()->create([
+            'first_name' => 'Bobby',
+            'last_name' => 'Heenan',
+        ]);
+        Manager::factory()->create([
+            'first_name' => 'Jimmy',
+            'last_name' => 'Hart',
+        ]);
 
-            expect($results)->toHaveCount(1)
-                ->and($results->firstOrFail()->first_name)->toBe('John')
-                ->and($results->firstOrFail()->last_name)->toBe('Smith');
-        });
+        $matches = Manager::query()->whereNameMatches('Heenan')->get();
 
-        it('finds exact last name matches', function () {
-            $results = User::query()->whereNameMatches('Doe')->get();
-
-            expect($results)->toHaveCount(1)
-                ->and($results->firstOrFail()->first_name)->toBe('Jane')
-                ->and($results->firstOrFail()->last_name)->toBe('Doe');
-        });
-
-        it('finds first name with space prefix matches', function () {
-            // Create a user with a space in the name for this specific test
-            $testUser = User::factory()->create([
-                'first_name' => 'Mary Jane',
-                'last_name' => 'Watson',
-                'email' => 'mary.jane.watson@example.com',
-            ]);
-
-            $results = User::query()->whereNameMatches('Mary Jane')->get();
-
-            expect($results)->toHaveCount(1)
-                ->and($results->firstOrFail()->first_name)->toBe('Mary Jane')
-                ->and($results->firstOrFail()->last_name)->toBe('Watson');
-        });
-
-        it('does NOT match substrings that are not word boundaries', function () {
-            // Searching for "John" should NOT match "Johnny" or "Johnson"
-            $results = User::query()->whereNameMatches('John')->get();
-
-            expect($results)->toHaveCount(1)
-                ->and($results->firstOrFail()->first_name)->toBe('John')
-                ->and($results->firstOrFail()->last_name)->toBe('Smith');
-
-            // Verify Johnny and Johnson are NOT included
-            $names = $results->pluck('first_name', 'last_name')->toArray();
-            expect($names)->not->toContain('Johnny')
-                ->and($names)->not->toContain('Johnson');
-        });
-
-        it('is case insensitive', function () {
-            $results = User::query()->whereNameMatches('JOHN')->get();
-
-            expect($results)->toHaveCount(1)
-                ->and($results->firstOrFail()->first_name)->toBe('John');
-
-            $results2 = User::query()->whereNameMatches('doe')->get();
-
-            expect($results2)->toHaveCount(1)
-                ->and($results2->firstOrFail()->last_name)->toBe('Doe');
-        });
-
-        it('returns empty results for non-matching terms', function () {
-            $results = User::query()->whereNameMatches('Nonexistent')->get();
-
-            expect($results)->toHaveCount(0);
-        });
+        expect($matches)->toHaveCount(1)
+            ->and($matches->firstOrFail()->is($manager))->toBeTrue();
     });
 
-    describe('whereNameContains method', function () {
-        it('finds names containing the search term anywhere', function () {
-            $results = User::query()->whereNameContains('ohn')->get();
+    it('searches referees by name', function () {
+        $referee = Referee::factory()->create([
+            'first_name' => 'Earl',
+            'last_name' => 'Hebner',
+        ]);
+        Referee::factory()->create([
+            'first_name' => 'Nick',
+            'last_name' => 'Patrick',
+        ]);
 
-            // Should match both "John" and "Johnny" and "Johnson"
-            expect($results)->toHaveCount(3);
+        $matches = Referee::query()->whereNameMatches('Earl')->get();
 
-            $firstNames = $results->pluck('first_name')->toArray();
-            expect($firstNames)->toContain('John')
-                ->and($firstNames)->toContain('Johnny');
-
-            $lastNames = $results->pluck('last_name')->toArray();
-            expect($lastNames)->toContain('Johnson');
-        });
-
-        it('is case insensitive', function () {
-            $results = User::query()->whereNameContains('OHN')->get();
-
-            expect($results)->toHaveCount(3); // John, Johnny, Johnson
-        });
-
-        it('returns empty results for non-matching terms', function () {
-            $results = User::query()->whereNameContains('xyz')->get();
-
-            expect($results)->toHaveCount(0);
-        });
+        expect($matches)->toHaveCount(1)
+            ->and($matches->firstOrFail()->is($referee))->toBeTrue();
     });
 
-    describe('method chaining', function () {
-        it('can be chained with other query methods', function () {
-            // Create an additional user to test with
-            User::factory()->create([
-                'first_name' => 'John',
-                'last_name' => 'Doe',
-                'email' => 'john.doe2@example.com',
-            ]);
-
-            $results = User::query()
-                ->whereNameMatches('John')
-                ->where('last_name', 'Smith')
-                ->get();
-
-            expect($results)->toHaveCount(1)
-                ->and($results->firstOrFail()->last_name)->toBe('Smith');
-        });
-
-        it('works with order by clauses', function () {
-            $results = User::query()
-                ->whereNameContains('John')  // Should get John, Johnny, Johnson
-                ->orderBy('first_name')
-                ->get();
-
-            expect($results)->toHaveCount(3);
-
-            // Check ordering: Bob (Johnson), John, Johnny
-            expect($results->slice(0)->firstOrFail()->first_name)->toBe('Bob')
-                ->and($results->slice(1)->firstOrFail()->first_name)->toBe('John')
-                ->and($results->slice(2)->firstOrFail()->first_name)->toBe('Johnny');
-        });
-    });
-
-    describe('edge cases', function () {
-        it('handles empty search terms gracefully', function () {
-            $results = User::query()->whereNameMatches('')->get();
-
-            // Should return no results for empty search
-            expect($results)->toHaveCount(0);
-        });
-
-        it('handles special characters in names', function () {
-            // Create user with special characters
-            $specialUser = User::factory()->create([
-                'first_name' => "O'Connor",
-                'last_name' => 'Smith-Jones',
-                'email' => 'special@example.com',
-            ]);
-
-            $results = User::query()->whereNameMatches("O'Connor")->get();
-
-            expect($results)->toHaveCount(1)
-                ->and($results->firstOrFail()->first_name)->toBe("O'Connor");
-        });
-
-        it('handles whitespace in search terms', function () {
-            $results = User::query()->whereNameMatches(' John ')->get();
-
-            // The method should handle whitespace appropriately
-            expect($results)->toHaveCount(1)
-                ->and($results->firstOrFail()->first_name)->toBe('John');
-        });
+    it('does not expose first and last name search on wrestler builders', function () {
+        expect(method_exists(Wrestler::query(), 'whereNameMatches'))->toBeFalse();
     });
 });


### PR DESCRIPTION
## Summary
- expose first/last-name search only from schema-compatible builders
- remove the invalid inherited search API from WrestlerBuilder
- remove the unused broad contains-name query
- document and test the supported builder boundary

## Verification
- 84 affected builder tests passed with 198 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Local suite note
- composer test:push reached the existing unrelated Blade formatting baseline; this branch does not modify those Blade files