### PR TITLE
refactor: align event status queries

### DIFF
--- a/app/Builders/Events/EventBuilder.php
+++ b/app/Builders/Events/EventBuilder.php
@@ -8,83 +8,26 @@ use App\Models\Events\Event;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Custom query builder for the Event model.
- *
- * Provides query methods for filtering events by their scheduling state.
- *
  * @template TModel of Event
  *
  * @extends Builder<TModel>
- *
- * @example
- * ```php
- * // Get all scheduled events
- * $scheduledEvents = Event::query()->scheduled()->get();
- *
- * // Get recent past events
- * $recentPastEvents = Event::query()
- *     ->past()
- *     ->where('date', '>=', now()->subMonths(3))
- *     ->orderBy('date', 'desc')
- *     ->get();
- * ```
  */
 class EventBuilder extends Builder
 {
-    /**
-     * Scope a query to include scheduled events.
-     *
-     * Filters events that have been officially scheduled with a confirmed date.
-     * Scheduled events have a non-null date value and are ready for promotion and ticket sales.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * $scheduledEvents = Event::query()->scheduled()->get();
-     * ```
-     */
     public function scheduled(): static
     {
-        $this->whereNotNull('date');
+        $this->where('date', '>=', now());
 
         return $this;
     }
 
-    /**
-     * Scope a query to include past events.
-     *
-     * Filters events that have already occurred based on their date.
-     * Past events have a date before today and are used for record keeping and statistics.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * $pastEvents = Event::query()->past()->get();
-     * ```
-     */
     public function past(): static
     {
-        $this->where('date', '<', now()->toDateString());
+        $this->where('date', '<', now());
 
         return $this;
     }
 
-    /**
-     * Scope a query to include unscheduled events.
-     *
-     * Filters events that have been created but don't have a confirmed date yet.
-     * Unscheduled events are in planning stages and need date assignment
-     * before they can be promoted or tickets sold.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * $unscheduledEvents = Event::query()->unscheduled()->get();
-     * ```
-     */
     public function unscheduled(): static
     {
         $this->whereNull('date');

--- a/app/Builders/Events/EventBuilder.php
+++ b/app/Builders/Events/EventBuilder.php
@@ -10,10 +10,7 @@ use Illuminate\Database\Eloquent\Builder;
 /**
  * Custom query builder for the Event model.
  *
- * Provides specialized query methods for filtering events by their status and date conditions,
- * including scheduled, past, unscheduled, future dated, and past dated events. This builder
- * enables easy filtering of events based on their scheduling status and temporal relationships
- * for event management and booking systems.
+ * Provides query methods for filtering events by their scheduling state.
  *
  * @template TModel of Event
  *
@@ -24,12 +21,9 @@ use Illuminate\Database\Eloquent\Builder;
  * // Get all scheduled events
  * $scheduledEvents = Event::query()->scheduled()->get();
  *
- * // Get events with future dates for upcoming shows
- * $upcomingEvents = Event::query()->withFutureDate()->get();
- *
- * // Chain conditions for complex queries
+ * // Get recent past events
  * $recentPastEvents = Event::query()
- *     ->withPastDate()
+ *     ->past()
  *     ->where('date', '>=', now()->subMonths(3))
  *     ->orderBy('date', 'desc')
  *     ->get();
@@ -94,49 +88,6 @@ class EventBuilder extends Builder
     public function unscheduled(): static
     {
         $this->whereNull('date');
-
-        return $this;
-    }
-
-    /**
-     * Scope a query to include events with future dates.
-     *
-     * Filters events that have a confirmed date in the future.
-     * This is useful for finding upcoming events that need preparation,
-     * promotion, or booking activities.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * $upcomingEvents = Event::query()->withFutureDate()->get();
-     * ```
-     */
-    public function withFutureDate(): static
-    {
-        $this->whereNotNull('date')
-            ->where('date', '>=', now()->toDateString());
-
-        return $this;
-    }
-
-    /**
-     * Scope a query to include events with past dates.
-     *
-     * Filters events that have a confirmed date in the past.
-     * This is useful for historical analysis and reporting.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * $historicalEvents = Event::query()->withPastDate()->get();
-     * ```
-     */
-    public function withPastDate(): static
-    {
-        $this->whereNotNull('date')
-            ->where('date', '<', now()->toDateString());
 
         return $this;
     }

--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Events\Tables;
 use App\Actions\Events\DeleteAction;
 use App\Actions\Events\RestoreAction;
 use App\Builders\Events\EventBuilder;
+use App\Enums\EventStatus;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\DateColumn;
@@ -76,34 +77,27 @@ class Main extends BaseTable
      */
     public function filters(): array
     {
-        /** @var array<string, string> $statuses */
-        $statuses = [
-            'scheduled' => 'Scheduled',
-            'unscheduled' => 'Unscheduled',
-            'past' => 'Past',
-            'future' => 'Future',
-        ];
-
         $venues = Venue::query()
             ->alphabetical()
             ->pluck('name', 'id')
             ->toArray();
 
+        $statusOptions = ['' => __('core.all')];
+
+        foreach (EventStatus::cases() as $status) {
+            $statusOptions[$status->value] = $status->label();
+        }
+
         return [
             SelectFilter::make(__('core.status'))
                 ->setFilterPillTitle(__('core.status'))
-                ->options([
-                    '' => __('core.all'),
-                    'schedule' => 'Scheduled',
-                    'past' => 'Past',
-                    'unscheduled' => 'Unscheduled',
-                ])
-                ->filter(function (EventBuilder $builder, string $value) {
+                ->options($statusOptions)
+                ->filter(function (EventBuilder $builder, string $value): void {
                     /** @var EventBuilder<Event> $builder */
-                    match ($value) {
-                        'scheduled' => $builder->scheduled(),
-                        'past' => $builder->past(),
-                        'unscheduled' => $builder->unscheduled(),
+                    match (EventStatus::tryFrom($value)) {
+                        EventStatus::Scheduled => $builder->scheduled(),
+                        EventStatus::Past => $builder->past(),
+                        EventStatus::Unscheduled => $builder->unscheduled(),
                         default => null,
                     };
                 }),

--- a/app/Models/Events/Event.php
+++ b/app/Models/Events/Event.php
@@ -45,8 +45,6 @@ use Illuminate\Support\Carbon;
  * @method static EventBuilder<static>|Event query()
  * @method static EventBuilder<static>|Event scheduled()
  * @method static EventBuilder<static>|Event unscheduled()
- * @method static EventBuilder<static>|Event withFutureDate()
- * @method static EventBuilder<static>|Event withPastDate()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Event withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Event withoutTrashed()
  *

--- a/tests/Integration/Builders/EventQueryBuilderTest.php
+++ b/tests/Integration/Builders/EventQueryBuilderTest.php
@@ -32,7 +32,10 @@ describe('EventQueryBuilder Unit Tests', function () {
             $scheduledEvents = Event::scheduled()->get();
 
             // Assert
-            expect($scheduledEvents->pluck('id'))->toContain($this->scheduledEvent->id);
+            expect($scheduledEvents->pluck('id'))
+                ->toContain($this->scheduledEvent->id)
+                ->not->toContain($this->unscheduledEvent->id)
+                ->not->toContain($this->pastEvent->id);
         });
 
         test('unscheduled events can be retrieved', function () {
@@ -40,7 +43,10 @@ describe('EventQueryBuilder Unit Tests', function () {
             $unscheduledEvents = Event::unscheduled()->get();
 
             // Assert
-            expect($unscheduledEvents->pluck('id'))->toContain($this->unscheduledEvent->id);
+            expect($unscheduledEvents->pluck('id'))
+                ->toContain($this->unscheduledEvent->id)
+                ->not->toContain($this->scheduledEvent->id)
+                ->not->toContain($this->pastEvent->id);
         });
 
         test('past events can be retrieved', function () {
@@ -48,7 +54,10 @@ describe('EventQueryBuilder Unit Tests', function () {
             $pastEvents = Event::past()->get();
 
             // Assert
-            expect($pastEvents->pluck('id'))->toContain($this->pastEvent->id);
+            expect($pastEvents->pluck('id'))
+                ->toContain($this->pastEvent->id)
+                ->not->toContain($this->scheduledEvent->id)
+                ->not->toContain($this->unscheduledEvent->id);
         });
     });
 });

--- a/tests/Integration/Livewire/Events/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Events/Tables/MainTest.php
@@ -151,8 +151,20 @@ describe('EventsTable Component Integration', function () {
                 ->assertSee('Unscheduled Event')
                 ->assertSee('Past Event');
 
-            // Test filtering (exact filter implementation depends on component)
-            $component->assertOk();
+            $component->set('filterValues.status', EventStatus::Scheduled->value)
+                ->assertSee('Scheduled Event')
+                ->assertDontSee('Unscheduled Event')
+                ->assertDontSee('Past Event');
+
+            $component->set('filterValues.status', EventStatus::Past->value)
+                ->assertDontSee('Scheduled Event')
+                ->assertDontSee('Unscheduled Event')
+                ->assertSee('Past Event');
+
+            $component->set('filterValues.status', EventStatus::Unscheduled->value)
+                ->assertDontSee('Scheduled Event')
+                ->assertSee('Unscheduled Event')
+                ->assertDontSee('Past Event');
         });
 
         test('venue filter functionality', function () {

--- a/tests/Unit/Builders/Events/EventBuilderTest.php
+++ b/tests/Unit/Builders/Events/EventBuilderTest.php
@@ -15,9 +15,10 @@ test('scheduled events can be retrieved', function () {
     $scheduledEvents = Event::scheduled()->get();
 
     expect($scheduledEvents)
-        ->toHaveCount(2)
+        ->toHaveCount(1)
         ->and($scheduledEvents->contains($scheduledEvent))->toBeTrue()
-        ->and($scheduledEvents->contains($pastEvent))->toBeTrue();
+        ->and($scheduledEvents->contains($unscheduledEvent))->toBeFalse()
+        ->and($scheduledEvents->contains($pastEvent))->toBeFalse();
 });
 
 test('unscheduled events can be retrieved', function () {


### PR DESCRIPTION
## Summary
- remove redundant Event builder methods that duplicated the canonical scheduling scopes
- make scheduled, past, and unscheduled queries mutually exclusive and consistent with EventStatus
- build status filter options from EventStatus and fix the nonfunctional scheduled filter key
- add focused query and Livewire regression coverage for each scheduling state

## Verification
- 36 focused tests passed with 125 assertions
- application and Pest PHPStan passed
- application and Pest Rector passed
- Pest type coverage passed
- touched PHP files passed Blade-aware Pint
- git diff check passed

## Existing baseline
- composer test:push reaches the repository-wide Blade formatting check, which reports pre-existing formatting differences in untouched Blade views