### PR TITLE
refactor: focus stable builder queries

### DIFF
--- a/app/Builders/Roster/StableBuilder.php
+++ b/app/Builders/Roster/StableBuilder.php
@@ -5,70 +5,10 @@ declare(strict_types=1);
 namespace App\Builders\Roster;
 
 use App\Builders\Concerns\HasRetirementScopes;
-use App\Data\Stables\StableMembershipData;
 use App\Models\Stables\Stable;
-use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\DB;
 
 /**
- * Custom query builder for the Stable model.
- *
- * Provides specialized query methods for filtering stables by their activity periods
- * and business logic state. Uses activity period tracking rather than enum status
- * to determine stable state, providing more accurate business logic representation.
- *
- * ## Business Logic States
- *
- * - **Unestablished**: Created but never debuted/established
- * - **Established**: Currently active with an activity period
- * - **Disbanded**: Previously established but no current activity period
- * - **Future Establishment**: Scheduled to be established in the future
- *
- * ## Member Counting Logic
- *
- * Stables require a minimum of 3 members, where:
- * - Tag teams count as 2 members each (minimum wrestlers in a tag team)
- * - Individual wrestlers count as 1 member each
- * - Managers count as 1 member each
- *
- * ## Key Architecture Decisions
- *
- * This builder uses activity periods rather than the StableStatus enum because:
- * - Activity periods provide accurate time-based tracking
- * - Business operations (debut/disband) work with activity periods
- * - Eliminates dual status system confusion
- * - Aligns with other entity builders (Title, etc.)
- *
- * @template TModel of Stable
- *
- * @extends Builder<TModel>
- *
- * @example
- * ```php
- * // Basic activity states
- * $establishedStables = Stable::query()->established()->get();
- * $unestablishedStables = Stable::query()->unestablished()->get();
- * $disbandedStables = Stable::query()->disbanded()->get();
- *
- * // Member-based filtering
- * $readyStables = Stable::query()
- *     ->established()
- *     ->withMinimumMembers()
- *     ->get();
- *
- * $needingMembers = Stable::query()
- *     ->established()
- *     ->belowMinimumMembers()
- *     ->get();
- *
- * // Complex queries
- * $futureStables = Stable::query()
- *     ->withFutureEstablishment()
- *     ->with('currentWrestlers', 'currentTagTeams', 'managers')
- *     ->get();
- * ```
- *
  * @template TModel of Stable
  *
  * @extends Builder<TModel>
@@ -77,40 +17,16 @@ class StableBuilder extends Builder
 {
     use HasRetirementScopes;
 
-    /**
-     * Scope a query to include unestablished stables.
-     *
-     * Filters stables that have been created but never established.
-     * These stables exist in the system but haven't debuted yet.
-     *
-     * @return static The builder instance for method chaining
-     */
     public function unestablished(): static
     {
         return $this->whereDoesntHave('activityPeriods');
     }
 
-    /**
-     * Scope a query to include established stables.
-     *
-     * Filters stables that are currently established and can be featured
-     * in events and storylines. Established stables have an active activity period.
-     *
-     * @return static The builder instance for method chaining
-     */
     public function established(): static
     {
         return $this->whereHas('currentActivityPeriod');
     }
 
-    /**
-     * Scope a query to include disbanded stables.
-     *
-     * Filters stables that were previously established but are currently disbanded.
-     * These stables can be reunited when needed for future storylines.
-     *
-     * @return static The builder instance for method chaining
-     */
     public function disbanded(): static
     {
         return $this->whereHas('previousActivityPeriods')
@@ -118,155 +34,8 @@ class StableBuilder extends Builder
             ->whereDoesntHave('currentRetirement');
     }
 
-    /**
-     * Scope a query to include stables with future establishment.
-     *
-     * Filters stables that are scheduled to be established on a future date.
-     * These stables have been planned but their establishment date hasn't
-     * arrived yet.
-     *
-     * @return static The builder instance for method chaining
-     */
     public function withFutureEstablishment(): static
     {
         return $this->whereHas('futureActivityPeriod');
-    }
-
-    /**
-     * Scope a query to include stables with minimum required members.
-     *
-     * Filters stables that have at least the minimum number of members (3)
-     * required for a stable to be considered properly formed.
-     * Tag teams count as 2 members each and wrestlers count as 1 each.
-     *
-     * @return static The builder instance for method chaining
-     */
-    public function withMinimumMembers(): static
-    {
-        return $this->where(
-            $this->currentMemberCountExpression(),
-            '>=',
-            StableMembershipData::MINIMUM_MEMBER_COUNT,
-        );
-    }
-
-    /**
-     * Scope a query to include stables below minimum member threshold.
-     *
-     * Filters stables that have fewer than the minimum number of members
-     * and may need additional recruitment or should be disbanded.
-     * Tag teams count as 2 members each and wrestlers count as 1 each.
-     *
-     * @return static The builder instance for method chaining
-     */
-    public function belowMinimumMembers(): static
-    {
-        return $this->where(
-            $this->currentMemberCountExpression(),
-            '<',
-            StableMembershipData::MINIMUM_MEMBER_COUNT,
-        );
-    }
-
-    /**
-     * Scope a query to include available stables.
-     *
-     * Filters stables that are currently available for use in wrestling programming.
-     * Available stables are established, have minimum members, and are not retired.
-     * This provides a consistent availability interface across all entity types.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get all available stables for booking
-     * $availableStables = Stable::query()->available()->get();
-     *
-     * ```
-     */
-    public function available(): static
-    {
-        return $this->established()
-            ->withMinimumMembers()
-            ->whereDoesntHave('currentRetirement');
-    }
-
-    /**
-     * Scope a query to include unavailable stables.
-     *
-     * Filters stables that cannot currently be used in wrestling programming.
-     * This includes stables that are unestablished, disbanded, retired, or below
-     * minimum member requirements. Provides a consistent unavailability interface.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get all unavailable stables
-     * $unavailableStables = Stable::query()->unavailable()->get();
-     *
-     * // Find stables that need attention
-     * $needsAttention = Stable::query()
-     *     ->unavailable()
-     *     ->with(['currentRetirement', 'currentWrestlers'])
-     *     ->get();
-     * ```
-     */
-    public function unavailable(): static
-    {
-        $this->where(function (Builder $query) {
-            $query->whereDoesntHave('activityPeriods')
-                ->orWhere(function (Builder $subQuery) {
-                    $subQuery->whereHas('activityPeriods')
-                        ->whereDoesntHave('currentActivityPeriod');
-                })
-                ->orWhereHas('currentRetirement')
-                ->orWhere(
-                    $this->currentMemberCountExpression(),
-                    '<',
-                    StableMembershipData::MINIMUM_MEMBER_COUNT,
-                );
-        });
-
-        return $this;
-    }
-
-    /**
-     * Scope a query to include stables with flexible member count.
-     *
-     * Filters stables that have between the specified minimum and maximum
-     * number of members. Provides more flexible member counting than the
-     * binary withMinimumMembers() method.
-     *
-     * @param  int  $min  Minimum number of members required
-     * @param  int|null  $max  Maximum number of members (null for no limit)
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get small stables (3-5 members)
-     * $smallStables = Stable::query()->withMemberCount(3, 5)->get();
-     *
-     * // Get large stables (6+ members)
-     * $largeStables = Stable::query()->withMemberCount(6)->get();
-     * ```
-     */
-    public function withMemberCount(int $min, ?int $max = null): static
-    {
-        $this->where($this->currentMemberCountExpression(), '>=', $min);
-
-        if ($max !== null) {
-            $this->where($this->currentMemberCountExpression(), '<=', $max);
-        }
-
-        return $this;
-    }
-
-    private function currentMemberCountExpression(): Expression
-    {
-        return DB::raw('(
-            (SELECT COUNT(*) FROM stables_wrestlers WHERE stable_id = stables.id AND left_at IS NULL) +
-            (SELECT COUNT(*) * 2 FROM stables_tag_teams WHERE stable_id = stables.id AND left_at IS NULL)
-        )');
     }
 }

--- a/app/Models/Stables/Stable.php
+++ b/app/Models/Stables/Stable.php
@@ -61,8 +61,6 @@ use Tests\Unit\Models\Stables\StableTest;
  * @property-read ActivityPeriod|null $previousActivityPeriod
  * @property-read Collection<int, ActivityPeriod> $previousActivityPeriods
  *
- * @method static StableBuilder<static>|Stable available()
- * @method static StableBuilder<static>|Stable belowMinimumMembers()
  * @method static StableBuilder<static>|Stable disbanded()
  * @method static StableBuilder<static>|Stable established()
  * @method static \Database\Factories\Stables\StableFactory factory($count = null, $state = [])
@@ -71,11 +69,8 @@ use Tests\Unit\Models\Stables\StableTest;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Stable onlyTrashed()
  * @method static StableBuilder<static>|Stable query()
  * @method static StableBuilder<static>|Stable retired()
- * @method static StableBuilder<static>|Stable unavailable()
  * @method static StableBuilder<static>|Stable unestablished()
  * @method static StableBuilder<static>|Stable withFutureEstablishment()
- * @method static StableBuilder<static>|Stable withMemberCount(int $min, ?int $max = null)
- * @method static StableBuilder<static>|Stable withMinimumMembers()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Stable withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Stable withoutTrashed()
  *

--- a/tests/Integration/Builders/StableQueryBuilderTest.php
+++ b/tests/Integration/Builders/StableQueryBuilderTest.php
@@ -3,9 +3,7 @@
 declare(strict_types=1);
 
 use App\Builders\Roster\StableBuilder;
-use App\Models\Lifecycle\ActivityPeriod;
 use App\Models\Stables\Stable;
-use App\Models\Wrestlers\Wrestler;
 
 /**
  * Unit tests for StableQueryBuilder query scopes and methods.
@@ -84,52 +82,5 @@ describe('StableQueryBuilder Unit Tests', function () {
                 ->toHaveCount(1)
                 ->and($retiredStables->contains($this->retiredStable))->toBeTrue();
         });
-    });
-
-    test('stables can be filtered by a member count range', function () {
-        $belowRange = Stable::factory()->create();
-        $withinRange = Stable::factory()->create();
-        $aboveRange = Stable::factory()->create();
-        $historicalOnly = Stable::factory()->create();
-
-        $belowRange->wrestlers()->attach(Wrestler::factory()->create(), ['joined_at' => now()]);
-        $withinRange->wrestlers()->attach(Wrestler::factory()->count(2)->create(), ['joined_at' => now()]);
-        $aboveRange->wrestlers()->attach(Wrestler::factory()->count(3)->create(), ['joined_at' => now()]);
-        $historicalOnly->wrestlers()->attach(Wrestler::factory()->count(2)->create(), [
-            'joined_at' => now()->subMonth(),
-            'left_at' => now()->subDay(),
-        ]);
-
-        $stables = Stable::query()->withMemberCount(2, 2)->get();
-
-        expect($stables)
-            ->toHaveCount(1)
-            ->and($stables->contains($withinRange))->toBeTrue()
-            ->and($stables->contains($historicalOnly))->toBeFalse();
-    });
-
-    test('availability uses the current weighted member count', function () {
-        $availableStable = Stable::factory()->has(ActivityPeriod::factory(), 'activityPeriods')->create();
-        $belowMinimumStable = Stable::factory()->has(ActivityPeriod::factory(), 'activityPeriods')->create();
-        $historicalOnlyStable = Stable::factory()->has(ActivityPeriod::factory(), 'activityPeriods')->create();
-
-        $availableStable->wrestlers()->attach(Wrestler::factory()->count(3)->create(), ['joined_at' => now()]);
-        $belowMinimumStable->wrestlers()->attach(Wrestler::factory()->count(2)->create(), ['joined_at' => now()]);
-        $historicalOnlyStable->wrestlers()->attach(Wrestler::factory()->count(3)->create(), [
-            'joined_at' => now()->subMonth(),
-            'left_at' => now()->subDay(),
-        ]);
-
-        $availableStables = Stable::query()->available()->get();
-        $unavailableStables = Stable::query()->unavailable()->get();
-
-        expect($availableStables->pluck('id'))
-            ->toContain($availableStable->id)
-            ->not->toContain($belowMinimumStable->id)
-            ->not->toContain($historicalOnlyStable->id)
-            ->and($unavailableStables->pluck('id'))
-            ->not->toContain($availableStable->id)
-            ->toContain($belowMinimumStable->id)
-            ->toContain($historicalOnlyStable->id);
     });
 });


### PR DESCRIPTION
## Summary
- retain only the Stable query methods used by the production table filters
- remove unused availability and member-count query APIs and their raw SQL expression
- remove stale model annotations and artificial builder coverage for the unused surface

## Verification
- 38 focused tests passed with 106 assertions
- application and Pest PHPStan passed
- application and Pest Rector passed
- Pest type coverage passed
- touched PHP files passed Blade-aware Pint
- git diff check passed

## Existing baseline
- composer test:push reaches the repository-wide Blade formatting check, which reports pre-existing formatting differences in untouched Blade views