### PR TITLE
refactor: focus title builder queries

### DIFF
--- a/app/Builders/Titles/TitleBuilder.php
+++ b/app/Builders/Titles/TitleBuilder.php
@@ -9,56 +9,7 @@ use App\Models\Titles\Title;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
- * Custom query builder for the Title model.
- *
- * Provides specialized query methods for filtering titles by their activity periods
- * and business logic state. Uses activity period tracking rather than enum status
- * to determine title state, providing more accurate business logic representation.
- *
- * ## Business Logic States
- *
- * - **Undebuted**: Created but never debuted/activated
- * - **Active**: Currently active with an activity period
- * - **Inactive**: Previously active but no current activity period
- * - **Future Debut**: Scheduled to be activated in the future
- *
- * ## Championship Availability
- *
- * Titles have simplified status compared to roster members:
- * - Only activation/deactivation and retirement states matter
- * - No employment, injury, or suspension concepts
- * - Available = Active (can be defended or won)
- *
- * ## Key Architecture Decisions
- *
- * This builder uses activity periods rather than the TitleStatus enum because:
- * - Activity periods provide accurate time-based tracking
- * - Business operations (debut/pull/reinstate) work with activity periods
- * - Eliminates dual status system confusion
- * - Aligns with other entity builders (Stable, etc.)
- *
  * @template TModel of Title
- *
- * @extends Builder<TModel>
- *
- * @example
- * ```php
- * // Basic activity states
- * $activeTitles = Title::query()->active()->get();
- * $undebutedTitles = Title::query()->undebuted()->get();
- * $inactiveTitles = Title::query()->inactive()->get();
- *
- * // Future debuts
- * $futureTitles = Title::query()->withPendingDebut()->get();
- *
- * // Complex queries
- * $vacantActiveTitles = Title::query()
- *     ->active()
- *     ->whereDoesntHave('currentChampionship')
- *     ->get();
- * ```
- *
- * @template TModel of \App\Models\Titles\Title
  *
  * @extends Builder<TModel>
  */
@@ -66,40 +17,16 @@ class TitleBuilder extends Builder
 {
     use HasRetirementScopes;
 
-    /**
-     * Scope a query to include undebuted titles.
-     *
-     * Filters titles that have been created but never debuted.
-     * These titles exist in the system but haven't been introduced yet.
-     *
-     * @return static The builder instance for method chaining
-     */
     public function undebuted(): static
     {
         return $this->whereDoesntHave('activityPeriods');
     }
 
-    /**
-     * Scope a query to include active titles.
-     *
-     * Filters titles that are currently active and can be featured
-     * in events and championship matches. Active titles have a current activity period.
-     *
-     * @return static The builder instance for method chaining
-     */
     public function active(): static
     {
         return $this->whereHas('currentActivityPeriod');
     }
 
-    /**
-     * Scope a query to include inactive titles.
-     *
-     * Filters titles that were previously active but are currently inactive.
-     * These titles can be reinstated when needed for future use.
-     *
-     * @return static The builder instance for method chaining
-     */
     public function inactive(): static
     {
         return $this->whereHas('previousActivityPeriods')
@@ -107,94 +34,8 @@ class TitleBuilder extends Builder
             ->whereDoesntHave('futureActivityPeriod');
     }
 
-    /**
-     * Scope a query to include titles with future debut.
-     *
-     * Filters titles that are scheduled to be activated on a future date.
-     * These titles have been planned but their debut date hasn't arrived yet.
-     *
-     * @return static The builder instance for method chaining
-     */
     public function withPendingDebut(): static
     {
         return $this->whereHas('futureActivityPeriod');
-    }
-
-    /**
-     * Scope a query to include available titles.
-     *
-     * Filters titles that are currently available for use in championship matches.
-     * Available titles are active and can be defended or awarded to new champions.
-     * This provides a consistent availability interface across all entity types.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get all available titles for match booking
-     * $availableTitles = Title::query()->available()->get();
-     *
-     * // Find available titles without current champions
-     * $vacantTitles = Title::query()
-     *     ->available()
-     *     ->whereDoesntHave('currentChampionship')
-     *     ->get();
-     * ```
-     */
-    public function available(): static
-    {
-        return $this->active();
-    }
-
-    /**
-     * Scope a query to include unavailable titles.
-     *
-     * Filters titles that cannot currently be used in championship matches.
-     * This includes titles that are inactive, retired, or have never been debuted.
-     * Provides a consistent unavailability interface across all entity types.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get all unavailable titles
-     * $unavailableTitles = Title::query()->unavailable()->get();
-     *
-     * // Find titles that need attention (inactive or retired)
-     * $needsAttention = Title::query()
-     *     ->unavailable()
-     *     ->with(['currentRetirement'])
-     *     ->get();
-     * ```
-     */
-    public function unavailable(): static
-    {
-        return $this->whereDoesntHave('currentActivityPeriod');
-    }
-
-    /**
-     * Scope a query to include vacant titles.
-     *
-     * Filters titles that are currently active but do not have a current champion.
-     * Vacant titles are available to be awarded to new champions in matches.
-     *
-     * @return static The builder instance for method chaining
-     *
-     * @example
-     * ```php
-     * // Get all vacant titles that need new champions
-     * $vacantTitles = Title::query()->vacant()->get();
-     *
-     * // Find vacant titles for upcoming tournament
-     * $tournamentTitles = Title::query()
-     *     ->vacant()
-     *     ->whereIn('id', $tournamentTitleIds)
-     *     ->get();
-     * ```
-     */
-    public function vacant(): static
-    {
-        return $this->active()
-            ->whereDoesntHave('currentChampionship');
     }
 }

--- a/app/Models/Titles/Title.php
+++ b/app/Models/Titles/Title.php
@@ -64,7 +64,6 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, ActivityPeriod> $previousActivityPeriods
  *
  * @method static TitleBuilder<static>|Title active()
- * @method static TitleBuilder<static>|Title available()
  * @method static \Database\Factories\Titles\TitleFactory factory($count = null, $state = [])
  * @method static TitleBuilder<static>|Title inactive()
  * @method static TitleBuilder<static>|Title newModelQuery()
@@ -72,9 +71,7 @@ use Illuminate\Support\Carbon;
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Title onlyTrashed()
  * @method static TitleBuilder<static>|Title query()
  * @method static TitleBuilder<static>|Title retired()
- * @method static TitleBuilder<static>|Title unavailable()
  * @method static TitleBuilder<static>|Title undebuted()
- * @method static TitleBuilder<static>|Title vacant()
  * @method static TitleBuilder<static>|Title withPendingDebut()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Title withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Title withoutTrashed()

--- a/tests/Integration/Builders/TitleQueryBuilderTest.php
+++ b/tests/Integration/Builders/TitleQueryBuilderTest.php
@@ -3,37 +3,15 @@
 declare(strict_types=1);
 
 use App\Models\Titles\Title;
-use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Builder;
 
-/**
- * Unit tests for TitleBuilder query scopes.
- *
- * UNIT TEST SCOPE:
- * - Query scope methods in isolation
- * - Filter logic validation
- * - Builder method chaining
- * - Activity period and championship query optimization
- * - Title availability and competition status filtering
- *
- * These tests verify that the TitleBuilder correctly filters
- * titles based on their activity periods, championship status,
- * and retirement state without executing complex database operations.
- */
 describe('TitleBuilder Query Scopes', function () {
     beforeEach(function () {
-        // Create titles with different states
         $this->undebutedTitle = Title::factory()->undebuted()->create(['name' => 'Undebuted Title']);
         $this->activeTitle = Title::factory()->active()->create(['name' => 'Active Title']);
         $this->inactiveTitle = Title::factory()->inactive()->create(['name' => 'Inactive Title']);
         $this->retiredTitle = Title::factory()->retired()->create(['name' => 'Retired Title']);
         $this->futureDebutTitle = Title::factory()->withFutureDebut()->create(['name' => 'Future Debut Title']);
-
-        // Create titles with championships
-        $champion = Wrestler::factory()->employed()->create();
-        $this->titleWithChampion = Title::factory()->active()->withCurrentChampion($champion)->create(['name' => 'Defended Title']);
-        $this->vacantTitle = Title::factory()->active()->create(['name' => 'Vacant Title']);
-        $this->newTitle = Title::factory()->active()->create(['name' => 'New Title']);
     });
 
     describe('activity state scopes', function () {
@@ -68,9 +46,6 @@ describe('TitleBuilder Query Scopes', function () {
             $activeTitles = Title::query()->active()->get();
 
             expect($activeTitles->pluck('id'))->toContain($this->activeTitle->id);
-            expect($activeTitles->pluck('id'))->toContain($this->titleWithChampion->id);
-            expect($activeTitles->pluck('id'))->toContain($this->vacantTitle->id);
-            expect($activeTitles->pluck('id'))->toContain($this->newTitle->id);
             expect($activeTitles->pluck('id'))->not->toContain($this->undebutedTitle->id);
             expect($activeTitles->pluck('id'))->not->toContain($this->inactiveTitle->id);
         });
@@ -92,43 +67,6 @@ describe('TitleBuilder Query Scopes', function () {
         });
     });
 
-    describe('availability scopes', function () {
-        test('available scope returns active titles', function () {
-            $availableTitles = Title::query()->available()->get();
-
-            expect($availableTitles->pluck('id'))->toContain($this->activeTitle->id);
-            expect($availableTitles->pluck('id'))->toContain($this->titleWithChampion->id);
-            expect($availableTitles->pluck('id'))->toContain($this->vacantTitle->id);
-            expect($availableTitles->pluck('id'))->not->toContain($this->undebutedTitle->id);
-            expect($availableTitles->pluck('id'))->not->toContain($this->inactiveTitle->id);
-            expect($availableTitles->pluck('id'))->not->toContain($this->retiredTitle->id);
-        });
-
-        test('unavailable scope returns non-active titles', function () {
-            $unavailableTitles = Title::query()->unavailable()->get();
-
-            expect($unavailableTitles->pluck('id'))->toContain($this->undebutedTitle->id);
-            expect($unavailableTitles->pluck('id'))->toContain($this->inactiveTitle->id);
-            expect($unavailableTitles->pluck('id'))->toContain($this->retiredTitle->id);
-            expect($unavailableTitles->pluck('id'))->not->toContain($this->activeTitle->id);
-            expect($unavailableTitles->pluck('id'))->not->toContain($this->titleWithChampion->id);
-        });
-
-    });
-
-    describe('championship scopes', function () {
-        test('vacant scope returns active titles without current champions', function () {
-            $vacantTitles = Title::query()->vacant()->get();
-
-            expect($vacantTitles->pluck('id'))->toContain($this->vacantTitle->id);
-            expect($vacantTitles->pluck('id'))->toContain($this->newTitle->id);
-            expect($vacantTitles->pluck('id'))->toContain($this->activeTitle->id);
-            expect($vacantTitles->pluck('id'))->not->toContain($this->titleWithChampion->id);
-            expect($vacantTitles->pluck('id'))->not->toContain($this->undebutedTitle->id);
-        });
-
-    });
-
     describe('retirement scopes', function () {
         test('retired scope returns titles with current retirement', function () {
             $retiredTitles = Title::query()->retired()->get();
@@ -141,18 +79,6 @@ describe('TitleBuilder Query Scopes', function () {
     });
 
     describe('scope method chaining', function () {
-        test('can chain active and vacant scopes', function () {
-            $activeVacantTitles = Title::query()
-                ->active()
-                ->vacant()
-                ->get();
-
-            expect($activeVacantTitles->pluck('id'))->toContain($this->vacantTitle->id);
-            expect($activeVacantTitles->pluck('id'))->toContain($this->newTitle->id);
-            expect($activeVacantTitles->pluck('id'))->not->toContain($this->titleWithChampion->id);
-            expect($activeVacantTitles->pluck('id'))->not->toContain($this->undebutedTitle->id);
-        });
-
         test('can chain scopes with additional filters', function () {
             $filteredTitles = Title::query()
                 ->active()
@@ -160,7 +86,6 @@ describe('TitleBuilder Query Scopes', function () {
                 ->get();
 
             expect($filteredTitles->pluck('id'))->toContain($this->activeTitle->id);
-            expect($filteredTitles->pluck('id'))->not->toContain($this->titleWithChampion->id);
         });
     });
 
@@ -181,14 +106,6 @@ describe('TitleBuilder Query Scopes', function () {
             expect($sql)->toContain('activity_periods');
         });
 
-        test('vacant scope combines active and championship filters', function () {
-            $query = Title::query()->vacant();
-            $sql = $query->toSql();
-
-            expect($sql)->toContain('exists');
-            expect($sql)->toContain('not exists');
-            expect($sql)->toContain('championships');
-        });
     });
 
     describe('scope edge cases', function () {
@@ -196,23 +113,18 @@ describe('TitleBuilder Query Scopes', function () {
             $deletedTitle = Title::factory()->active()->create();
             $deletedTitle->delete();
 
-            // Should not include soft deleted titles by default
             $activeTitles = Title::query()->active()->get();
             expect($activeTitles->pluck('id'))->not->toContain($deletedTitle->id);
 
-            // Should include when specifically querying trashed
             $trashedActiveTitles = Title::onlyTrashed()->active()->get();
             expect($trashedActiveTitles->pluck('id'))->toContain($deletedTitle->id);
         });
 
         test('scopes handle empty database gracefully', function () {
-            // Clear all titles
             Title::query()->delete();
 
             expect(Title::query()->active()->count())->toBe(0);
             expect(Title::query()->undebuted()->count())->toBe(0);
-            expect(Title::query()->vacant()->count())->toBe(0);
-            expect(Title::query()->available()->count())->toBe(0);
         });
     });
 
@@ -223,9 +135,7 @@ describe('TitleBuilder Query Scopes', function () {
             expect($builder->undebuted())->toBeInstanceOf(get_class($builder));
             expect($builder->active())->toBeInstanceOf(get_class($builder));
             expect($builder->inactive())->toBeInstanceOf(get_class($builder));
-            expect($builder->available())->toBeInstanceOf(get_class($builder));
-            expect($builder->unavailable())->toBeInstanceOf(get_class($builder));
-            expect($builder->vacant())->toBeInstanceOf(get_class($builder));
+            expect($builder->withPendingDebut())->toBeInstanceOf(get_class($builder));
         });
 
         test('scopes maintain query builder functionality', function () {

--- a/tests/Unit/Builders/Contracts/BuilderContractsTest.php
+++ b/tests/Unit/Builders/Contracts/BuilderContractsTest.php
@@ -31,5 +31,5 @@ test('shared roster query methods retain each concrete builder type', function (
 test('domain-specific query methods retain their concrete builder types', function () {
     expect(Wrestler::query()->available())->toBeInstanceOf(WrestlerBuilder::class)
         ->and(TagTeam::query()->withMinimumWrestlers())->toBeInstanceOf(TagTeamBuilder::class)
-        ->and(Title::query()->vacant())->toBeInstanceOf(TitleBuilder::class);
+        ->and(Title::query()->active())->toBeInstanceOf(TitleBuilder::class);
 });


### PR DESCRIPTION
## Summary
- retain only Title Builder scopes used by production title tables
- remove generic availability aliases that duplicated title activity state
- keep championship vacancy reporting in TitleChampionshipQuery
- remove obsolete model annotations and builder tests

## Verification
- 35 focused tests passed with 100 assertions
- PHPStan passed
- Rector passed
- Pest type coverage passed at 100%
- targeted Pint with Blade formatting passed
- git diff --check passed

## Repository baseline
- composer test:push reaches the existing unrelated repository-wide Blade formatting baseline; this branch does not modify Blade files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Breaking Changes**
  - Removed title filtering scopes for available, unavailable, and vacant titles.
  - Updated title query behavior and public model documentation to reflect the supported scopes.

- **Tests**
  - Expanded coverage for active, retirement, pending-debut, soft-deleted, empty-database, chaining, and return-type scenarios.
  - Removed tests for availability, vacancy, and championship-specific filtering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->