### PR TITLE
fix: calculate championship reign lengths

### DIFF
--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -9,6 +9,7 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
+use App\Queries\Titles\TitleChampionshipQuery;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 use LogicException;
@@ -56,7 +57,8 @@ class PreviousTitleChampionships extends DataTableComponent
             Column::make(__('championships.new_champion'), 'current_champion'),
             Column::make(__('championships.previous_champion'), 'former_champion'),
             Column::make(__('championships.dates_held'), 'dates_held'),
-            Column::make(__('championships.days_held'), 'reign_length'),
+            Column::make(__('championships.days_held'))
+                ->label(fn (TitleChampionship $row): int => TitleChampionshipQuery::reignLengthInDays($row)),
         ];
     }
 }

--- a/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
+++ b/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
@@ -8,6 +8,7 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
+use App\Queries\Titles\TitleChampionshipQuery;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
@@ -61,7 +62,8 @@ class TitleChampionshipsTable extends DataTableComponent
             Column::make(__('title_championships.current_champion'), 'current_champion'),
             Column::make(__('title_championships.former_champion'), 'former_champion'),
             Column::make(__('title_championships.dates_held'), 'dates_held'),
-            Column::make(__('title_championships.reign_length'), 'reign_length'),
+            Column::make(__('title_championships.reign_length'))
+                ->label(fn (TitleChampionship $row): int => TitleChampionshipQuery::reignLengthInDays($row)),
         ];
     }
 }

--- a/tests/Integration/Livewire/Titles/Tables/PreviousTitleChampionshipsTest.php
+++ b/tests/Integration/Livewire/Titles/Tables/PreviousTitleChampionshipsTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Titles\Tables\PreviousTitleChampionships;
+use App\Models\Titles\TitleChampionship;
+
+test('displays championship reign length from its dates', function () {
+    $championship = new TitleChampionship([
+        'won_at' => '2025-01-01',
+        'lost_at' => '2025-01-11',
+    ]);
+
+    $reignLengthColumn = (new PreviousTitleChampionships())->columns()[3];
+
+    expect($reignLengthColumn->resolveValue($championship))->toBe('10');
+});

--- a/tests/Integration/Livewire/Titles/Tables/TitleChampionshipsTableTest.php
+++ b/tests/Integration/Livewire/Titles/Tables/TitleChampionshipsTableTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Titles\Tables\TitleChampionshipsTable;
+use App\Models\Titles\TitleChampionship;
+
+test('displays championship reign length from its dates', function () {
+    $championship = new TitleChampionship([
+        'won_at' => '2025-01-01',
+        'lost_at' => '2025-01-11',
+    ]);
+
+    $reignLengthColumn = (new TitleChampionshipsTable())->columns()[3];
+
+    expect($reignLengthColumn->resolveValue($championship))->toBe('10');
+});


### PR DESCRIPTION
## Summary
- calculate reign length in both title championship tables through TitleChampionshipQuery
- stop relying on a reign_length attribute that neither table selects
- add mirrored integration coverage for both Livewire table classes

## Verification
- 8 focused tests passed with 25 assertions
- PHPStan passed
- Rector passed
- Pest type coverage passed at 100%
- targeted Pint with Blade formatting passed
- git diff --check passed

## Repository baseline
- composer test:push reaches the existing unrelated repository-wide Blade formatting baseline; this branch does not modify Blade files