### PR TITLE
fix: execute custom table searches

### DIFF
--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -33,7 +33,6 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Managers\Manager;
-use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Support\Facades\Gate;
 
 class Main extends BaseTable
@@ -70,7 +69,7 @@ class Main extends BaseTable
     {
         return [
             Column::make(__('managers.name'), 'full_name')
-                ->searchable(function (Builder $builder, string $searchTerm) {
+                ->searchable(function (ManagerBuilder $builder, string $searchTerm) {
                     $builder->whereNameMatches($searchTerm);
                 }),
             Column::make(__('core.status'), 'status')

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -33,7 +33,6 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Referees\Referee;
-use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
@@ -71,9 +70,8 @@ class Main extends BaseTable
     {
         return [
             Column::make(__('referees.name'), 'full_name')
-                ->searchable(function (Builder $builder, string $searchTerm) {
-                    $builder->orWhere('first_name', 'like', '%'.$searchTerm.'%')
-                        ->orWhere('last_name', 'like', '%'.$searchTerm.'%');
+                ->searchable(function (RefereeBuilder $builder, string $searchTerm) {
+                    $builder->whereNameMatches($searchTerm);
                 }),
             Column::make(__('core.status'), 'status')
                 ->label(fn (Referee $row) => $row->status->label())

--- a/app/Livewire/Table/Column.php
+++ b/app/Livewire/Table/Column.php
@@ -6,12 +6,15 @@ namespace App\Livewire\Table;
 
 use Closure;
 use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Builder;
 
 class Column
 {
     protected string $field;
 
     protected bool $searchable = false;
+
+    protected ?Closure $searchCallback = null;
 
     protected bool $sortable = false;
 
@@ -35,11 +38,26 @@ class Column
         return new static($title, $from);
     }
 
-    public function searchable(): static
+    public function searchable(?Closure $callback = null): static
     {
         $this->searchable = true;
+        $this->searchCallback = $callback;
 
         return $this;
+    }
+
+    /**
+     * @param  Builder<*>  $query
+     */
+    public function applySearch(Builder $query, string $searchTerm): void
+    {
+        if ($this->searchCallback !== null) {
+            ($this->searchCallback)($query, $searchTerm);
+
+            return;
+        }
+
+        $query->where($this->field, 'like', "%{$searchTerm}%");
     }
 
     public function sortable(): static

--- a/app/Livewire/Table/DataTableComponent.php
+++ b/app/Livewire/Table/DataTableComponent.php
@@ -164,7 +164,9 @@ abstract class DataTableComponent extends Component
 
         $query->where(function (Builder $q) use ($searchableColumns, $searchTerm): void {
             foreach ($searchableColumns as $column) {
-                $q->orWhere($column->getField(), 'like', "%{$searchTerm}%");
+                $q->orWhere(function (Builder $columnQuery) use ($column, $searchTerm): void {
+                    $column->applySearch($columnQuery, $searchTerm);
+                });
             }
         });
     }

--- a/app/Livewire/Users/Tables/Main.php
+++ b/app/Livewire/Users/Tables/Main.php
@@ -34,7 +34,7 @@ class Main extends BaseTable
     {
         return [
             Column::make(__('users.name'), 'full_name')
-                ->searchable(function (Builder $builder, string $searchTerm) {
+                ->searchable(function (UserBuilder $builder, string $searchTerm) {
                     $builder->whereNameMatches($searchTerm);
                 }),
             Column::make(__('users.role'), 'role')

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -139,18 +139,6 @@ parameters:
 			path: app/Livewire/Managers/Components/Actions.php
 
 		-
-			message: '#^Call to an undefined method Illuminate\\Contracts\\Database\\Query\\Builder\:\:whereNameMatches\(\)\.$#'
-			identifier: method.notFound
-			count: 1
-			path: app/Livewire/Managers/Tables/Main.php
-
-		-
-			message: '#^Method App\\Livewire\\Table\\Column\:\:searchable\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: app/Livewire/Managers/Tables/Main.php
-
-		-
 			message: '#^Return type \(App\\Builders\\Roster\\ManagerBuilder\<App\\Models\\Managers\\Manager\>\) of method App\\Livewire\\Managers\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
 			identifier: method.childReturnType
 			count: 1
@@ -215,12 +203,6 @@ parameters:
 			identifier: nullsafe.neverNull
 			count: 1
 			path: app/Livewire/Matches/Tables/MatchesTable.php
-
-		-
-			message: '#^Method App\\Livewire\\Table\\Column\:\:searchable\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: app/Livewire/Referees/Tables/Main.php
 
 		-
 			message: '#^Return type \(App\\Builders\\Roster\\RefereeBuilder\<App\\Models\\Referees\\Referee\>\) of method App\\Livewire\\Referees\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
@@ -395,24 +377,6 @@ parameters:
 			identifier: method.childReturnType
 			count: 1
 			path: app/Livewire/Titles/Tables/PreviousTitleChampionships.php
-
-		-
-			message: '#^Call to method whereNameMatches\(\) on an unknown class App\\Livewire\\Users\\Tables\\Builder\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Livewire/Users/Tables/Main.php
-
-		-
-			message: '#^Method App\\Livewire\\Table\\Column\:\:searchable\(\) invoked with 1 parameter, 0 required\.$#'
-			identifier: arguments.count
-			count: 1
-			path: app/Livewire/Users/Tables/Main.php
-
-		-
-			message: '#^Parameter \$builder of anonymous function has invalid type App\\Livewire\\Users\\Tables\\Builder\.$#'
-			identifier: class.notFound
-			count: 1
-			path: app/Livewire/Users/Tables/Main.php
 
 		-
 			message: '#^Return type \(App\\Builders\\Users\\UserBuilder\<App\\Models\\Users\\User\>\) of method App\\Livewire\\Users\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'

--- a/tests/Integration/Livewire/Referees/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Referees/Tables/MainTest.php
@@ -85,6 +85,7 @@ describe('RefereesTable Component', function () {
             Referee::factory()->create(['first_name' => 'Earl', 'last_name' => 'Hebner']);
             Referee::factory()->create(['first_name' => 'Dave', 'last_name' => 'Hebner']);
             Referee::factory()->create(['first_name' => 'Mike', 'last_name' => 'Chioda']);
+            Referee::factory()->create(['first_name' => 'Nick', 'last_name' => 'Hebnerson']);
 
             $component = livewire(Main::class);
 
@@ -93,14 +94,16 @@ describe('RefereesTable Component', function () {
                 ->set('search', 'Hebner')
                 ->assertSee('Earl Hebner')
                 ->assertSee('Dave Hebner')
-                ->assertDontSee('Mike Chioda');
+                ->assertDontSee('Mike Chioda')
+                ->assertDontSee('Nick Hebnerson');
 
             // Test clearing search
             $component
                 ->set('search', '')
                 ->assertSee('Earl Hebner')
                 ->assertSee('Dave Hebner')
-                ->assertSee('Mike Chioda');
+                ->assertSee('Mike Chioda')
+                ->assertSee('Nick Hebnerson');
         });
 
         test('status filter functionality works with real data', function () {


### PR DESCRIPTION
## Summary
- execute custom searchable-column callbacks instead of silently ignoring them
- route referee, manager, and user name searches through their typed Builder methods
- group each searchable column correctly when composing OR conditions
- remove obsolete PHPStan baseline suppressions

## Verification
- 76 focused tests passed with 183 assertions
- application and Pest PHPStan passed
- Rector passed
- Pest type coverage remained 100%
- targeted Pint with Blade passed
- composer test:push passed all gates except the existing unrelated Blade formatting baseline