### PR TITLE
refactor: centralize past event match queries

### DIFF
--- a/app/Builders/Matches/EventMatchBuilder.php
+++ b/app/Builders/Matches/EventMatchBuilder.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Matches;
+
+use App\Models\Matches\EventMatch;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+/**
+ * @template TModel of EventMatch
+ *
+ * @extends Builder<TModel>
+ */
+class EventMatchBuilder extends Builder
+{
+    public function forPastEvents(): static
+    {
+        $this->withWhereHas('event', function (Builder|Relation $query): void {
+            $query->where('date', '<', now());
+        });
+
+        return $this;
+    }
+}

--- a/app/Livewire/Referees/Tables/PreviousMatches.php
+++ b/app/Livewire/Referees/Tables/PreviousMatches.php
@@ -30,12 +30,10 @@ class PreviousMatches extends BasePreviousMatchesTable
         }
 
         return EventMatch::query()
+            ->forPastEvents()
             ->with(['titles', 'competitors', 'result.winner', 'result.decision'])
             ->withWhereHas('referees', function (Builder $query): void {
                 $query->whereIn('referee_id', [$this->refereeId]);
-            })
-            ->withWhereHas('event', function (Builder $query): void {
-                $query->whereNotNull('date')->where('date', '<', now()->toDateString());
             })
             ->orderByDesc('date');
     }

--- a/app/Livewire/TagTeams/Tables/PreviousMatches.php
+++ b/app/Livewire/TagTeams/Tables/PreviousMatches.php
@@ -33,12 +33,10 @@ class PreviousMatches extends BasePreviousMatchesTable
         $tagTeam = TagTeam::find($this->tagTeamId);
 
         return EventMatch::query()
+            ->forPastEvents()
             ->with(['titles', 'result.winner', 'result.decision'])
             ->withWhereHas('competitors', function (Builder $query) use ($tagTeam): void {
                 $query->whereMorphedTo('competitor', $tagTeam);
-            })
-            ->withWhereHas('event', function (Builder $query): void {
-                $query->whereNotNull('date')->where('date', '<', now()->toDateString());
             })
             ->orderByDesc('date');
     }

--- a/app/Livewire/Wrestlers/Tables/PreviousMatches.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousMatches.php
@@ -31,12 +31,10 @@ class PreviousMatches extends BasePreviousMatchesTable
         $wrestler = Wrestler::find($this->wrestlerId);
 
         return EventMatch::query()
+            ->forPastEvents()
             ->with(['titles', 'result.winner', 'result.decision'])
             ->withWhereHas('competitors', function (Builder $query) use ($wrestler): void {
                 $query->whereMorphedTo('competitor', $wrestler);
-            })
-            ->withWhereHas('event', function (Builder $query): void {
-                $query->whereNotNull('date')->where('date', '<', now()->toDateString());
             })
             ->orderByDesc('date');
     }

--- a/app/Models/Matches/EventMatch.php
+++ b/app/Models/Matches/EventMatch.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Matches;
 
+use App\Builders\Matches\EventMatchBuilder;
 use App\Collections\MatchCompetitorsCollection;
 use App\Enums\MatchType;
 use App\Models\Concerns\HasLifecycleTransitions;
@@ -16,6 +17,7 @@ use App\Models\Wrestlers\Wrestler;
 use Database\Factories\Matches\MatchFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -53,10 +55,11 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, Wrestler> $wrestlers
  *
  * @method static \Database\Factories\Matches\MatchFactory factory($count = null, $state = [])
- * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch newQuery()
+ * @method static EventMatchBuilder<static>|EventMatch forPastEvents()
+ * @method static EventMatchBuilder<static>|EventMatch newModelQuery()
+ * @method static EventMatchBuilder<static>|EventMatch newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch onlyTrashed()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch query()
+ * @method static EventMatchBuilder<static>|EventMatch query()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch withoutTrashed()
  *
@@ -65,6 +68,7 @@ use Illuminate\Support\Carbon;
 #[Table('events_matches')]
 #[Fillable('event_id', 'match_number', 'match_type', 'match_stipulation_id', 'preview')]
 #[UseFactory(MatchFactory::class)]
+#[UseEloquentBuilder(EventMatchBuilder::class)]
 class EventMatch extends Model implements SoftDeletable
 {
     /** @use HasFactory<MatchFactory> */

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -8,6 +8,7 @@ Ringside uses typed custom Eloquent builders for reusable persisted-state querie
 app/Builders/
 ├── Concerns/
 ├── Events/
+├── Matches/
 ├── Roster/
 ├── Titles/
 └── Users/

--- a/tests/Unit/Builders/Matches/EventMatchBuilderTest.php
+++ b/tests/Unit/Builders/Matches/EventMatchBuilderTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Events\Event;
+use App\Models\Matches\EventMatch;
+
+it('retrieves matches for past events and eager loads their events', function () {
+    $pastEvent = Event::factory()->past()->create();
+    $scheduledEvent = Event::factory()->scheduled()->create();
+    $unscheduledEvent = Event::factory()->unscheduled()->create();
+    $pastMatch = EventMatch::factory()->forEvent($pastEvent)->create();
+    EventMatch::factory()->forEvent($scheduledEvent)->create();
+    EventMatch::factory()->forEvent($unscheduledEvent)->create();
+
+    $matches = EventMatch::query()->forPastEvents()->get();
+
+    expect($matches)->toHaveCount(1)
+        ->and($matches->firstOrFail()->is($pastMatch))->toBeTrue()
+        ->and($matches->firstOrFail()->relationLoaded('event'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add a typed EventMatch Builder for reusable match-history queries
- centralize past-event filtering and event eager loading
- reuse the query from wrestler, tag-team, and referee match-history tables
- document the EventMatch Builder boundary

## Verification
- 12 focused tests passed with 23 assertions
- application and Pest PHPStan passed
- Rector passed
- Pest type coverage remained 100%
- Pint with Blade passed
- git diff --check passed