### PR TITLE
refactor: centralize manager assignment queries

### DIFF
--- a/app/Actions/Managers/EndCurrentRelationshipsAction.php
+++ b/app/Actions/Managers/EndCurrentRelationshipsAction.php
@@ -15,12 +15,12 @@ class EndCurrentRelationshipsAction
     {
         WrestlerManager::query()
             ->where('manager_id', $manager->id)
-            ->whereNull('fired_at')
+            ->current()
             ->update(['fired_at' => $effectiveDate]);
 
         TagTeamManager::query()
             ->where('manager_id', $manager->id)
-            ->whereNull('fired_at')
+            ->current()
             ->update(['fired_at' => $effectiveDate]);
     }
 }

--- a/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
+++ b/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
@@ -20,7 +20,7 @@ class EndCurrentRelationshipsAction
 
         TagTeamManager::query()
             ->where('tag_team_id', $tagTeam->id)
-            ->whereNull('fired_at')
+            ->current()
             ->update(['fired_at' => $effectiveDate]);
     }
 }

--- a/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
+++ b/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
@@ -26,7 +26,7 @@ class EndCurrentRelationshipsAction
 
         WrestlerManager::query()
             ->where('wrestler_id', $wrestler->id)
-            ->whereNull('fired_at')
+            ->current()
             ->update(['fired_at' => $effectiveDate]);
 
         $wrestler->currentChampionships()->update([

--- a/app/Builders/Roster/ManagerAssignmentBuilder.php
+++ b/app/Builders/Roster/ManagerAssignmentBuilder.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Roster;
+
+use App\Models\TagTeams\TagTeamManager;
+use App\Models\Wrestlers\WrestlerManager;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @template TModel of WrestlerManager|TagTeamManager
+ *
+ * @extends Builder<TModel>
+ */
+class ManagerAssignmentBuilder extends Builder
+{
+    public function current(): static
+    {
+        $this->whereNull('fired_at');
+
+        return $this;
+    }
+
+    public function ended(): static
+    {
+        $this->whereNotNull('fired_at');
+
+        return $this;
+    }
+}

--- a/app/Livewire/Managers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeams.php
@@ -36,7 +36,7 @@ class PreviousTagTeams extends DataTableComponent
 
         return TagTeamManager::query()
             ->where('manager_id', $this->managerId)
-            ->whereNotNull('fired_at')
+            ->ended()
             ->orderByDesc('hired_at');
     }
 

--- a/app/Livewire/Managers/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlers.php
@@ -33,7 +33,7 @@ class PreviousWrestlers extends DataTableComponent
 
         return WrestlerManager::query()
             ->where('manager_id', $this->managerId)
-            ->whereNotNull('fired_at')
+            ->ended()
             ->orderByDesc('hired_at');
     }
 

--- a/app/Livewire/TagTeams/Tables/PreviousManagers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousManagers.php
@@ -29,7 +29,7 @@ class PreviousManagers extends BasePreviousManagersTable
 
         return TagTeamManager::query()
             ->where('tag_team_id', $this->tagTeamId)
-            ->whereNotNull('fired_at')
+            ->ended()
             ->orderByDesc('hired_at');
     }
 

--- a/app/Livewire/Wrestlers/Tables/PreviousManagers.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousManagers.php
@@ -31,7 +31,7 @@ class PreviousManagers extends BasePreviousManagersTable
             ->with('manager')
             ->whereHas('manager') // Only include records where manager exists (not soft deleted)
             ->where('wrestler_id', $this->wrestlerId)
-            ->whereNotNull('fired_at')
+            ->ended()
             ->orderByDesc('hired_at');
     }
 

--- a/app/Models/TagTeams/TagTeamManager.php
+++ b/app/Models/TagTeams/TagTeamManager.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models\TagTeams;
 
+use App\Builders\Roster\ManagerAssignmentBuilder;
 use App\Models\Managers\Manager;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
@@ -22,13 +24,16 @@ use Illuminate\Support\Carbon;
  * @property-read Manager|null $manager
  * @property-read TagTeam|null $tagTeam
  *
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeamManager newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeamManager newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeamManager query()
+ * @method static ManagerAssignmentBuilder<static> current()
+ * @method static ManagerAssignmentBuilder<static> ended()
+ * @method static ManagerAssignmentBuilder<static> newModelQuery()
+ * @method static ManagerAssignmentBuilder<static> newQuery()
+ * @method static ManagerAssignmentBuilder<static> query()
  *
  * @mixin \Eloquent
  */
 #[Fillable('tag_team_id', 'manager_id', 'hired_at', 'fired_at')]
+#[UseEloquentBuilder(ManagerAssignmentBuilder::class)]
 class TagTeamManager extends Pivot
 {
     protected $table = 'tag_teams_managers';

--- a/app/Models/Wrestlers/WrestlerManager.php
+++ b/app/Models/Wrestlers/WrestlerManager.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models\Wrestlers;
 
+use App\Builders\Roster\ManagerAssignmentBuilder;
 use App\Models\Managers\Manager;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
@@ -22,13 +24,16 @@ use Illuminate\Support\Carbon;
  * @property-read Manager $manager
  * @property-read Wrestler $wrestler
  *
- * @method static \Illuminate\Database\Eloquent\Builder<static>|WrestlerManager newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|WrestlerManager newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|WrestlerManager query()
+ * @method static ManagerAssignmentBuilder<static> current()
+ * @method static ManagerAssignmentBuilder<static> ended()
+ * @method static ManagerAssignmentBuilder<static> newModelQuery()
+ * @method static ManagerAssignmentBuilder<static> newQuery()
+ * @method static ManagerAssignmentBuilder<static> query()
  *
  * @mixin \Eloquent
  */
 #[Fillable('wrestler_id', 'manager_id', 'hired_at', 'fired_at')]
+#[UseEloquentBuilder(ManagerAssignmentBuilder::class)]
 class WrestlerManager extends Pivot
 {
     protected $table = 'wrestlers_managers';

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -15,6 +15,8 @@ app/Builders/
 
 Builders are grouped by technical layer first and wrestling entity second. A concrete builder belongs to the model it queries. A concern is appropriate only when multiple builders share the same query semantics.
 
+`ManagerAssignmentBuilder` owns the shared `current()` and `ended()` persistence queries for wrestler and tag-team manager assignment records.
+
 ## Shared Concerns
 
 - `HasEmploymentScopes` provides relationship-backed `employed()`, `unemployed()`, `released()`, and `futureEmployed()` queries for individual roster members and tag teams.

--- a/tests/Integration/Actions/TagTeams/EndCurrentRelationshipsActionTest.php
+++ b/tests/Integration/Actions/TagTeams/EndCurrentRelationshipsActionTest.php
@@ -12,13 +12,15 @@ test('it ends only the tag teams current relationships', function () {
     $wrestler = Wrestler::factory()->employed()->create();
     $manager = Manager::factory()->employed()->create();
     $effectiveDate = now();
+    $formerMembershipEndedAt = now()->subWeek();
+    $currentMembershipStartedAt = now()->subDay();
 
     $tagTeam->wrestlers()->attach($wrestler, [
         'joined_at' => now()->subMonth(),
-        'left_at' => now()->subWeek(),
+        'left_at' => $formerMembershipEndedAt,
     ]);
-    $tagTeam->wrestlers()->attach($wrestler, ['joined_at' => now()->subDay()]);
-    $tagTeam->managers()->attach($manager, ['hired_at' => now()->subDay()]);
+    $tagTeam->wrestlers()->attach($wrestler, ['joined_at' => $currentMembershipStartedAt]);
+    $tagTeam->managers()->attach($manager, ['hired_at' => $currentMembershipStartedAt]);
 
     resolve(EndCurrentRelationshipsAction::class)
         ->handle($tagTeam, $effectiveDate);
@@ -31,12 +33,12 @@ test('it ends only the tag teams current relationships', function () {
     $this->assertDatabaseHas('tag_teams_wrestlers', [
         'tag_team_id' => $tagTeam->id,
         'wrestler_id' => $wrestler->id,
-        'left_at' => now()->subWeek()->toDateTimeString(),
+        'left_at' => $formerMembershipEndedAt->toDateTimeString(),
     ]);
     $this->assertDatabaseHas('tag_teams_wrestlers', [
         'tag_team_id' => $tagTeam->id,
         'wrestler_id' => $wrestler->id,
-        'joined_at' => now()->subDay()->toDateTimeString(),
+        'joined_at' => $currentMembershipStartedAt->toDateTimeString(),
         'left_at' => $effectiveDate->toDateTimeString(),
     ]);
     $this->assertDatabaseHas('tag_teams_managers', [

--- a/tests/Unit/Builders/Roster/ManagerAssignmentBuilderTest.php
+++ b/tests/Unit/Builders/Roster/ManagerAssignmentBuilderTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Managers\Manager;
+use App\Models\TagTeams\TagTeam;
+use App\Models\TagTeams\TagTeamManager;
+use App\Models\Wrestlers\Wrestler;
+use App\Models\Wrestlers\WrestlerManager;
+
+test('wrestler manager assignments can be queried by lifecycle state', function () {
+    $manager = Manager::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+
+    WrestlerManager::query()->create([
+        'manager_id' => $manager->id,
+        'wrestler_id' => $wrestler->id,
+        'hired_at' => now()->subMonth(),
+    ]);
+    WrestlerManager::query()->create([
+        'manager_id' => $manager->id,
+        'wrestler_id' => $wrestler->id,
+        'hired_at' => now()->subMonths(3),
+        'fired_at' => now()->subMonths(2),
+    ]);
+
+    expect(WrestlerManager::query()->current()->count())->toBe(1)
+        ->and(WrestlerManager::query()->ended()->count())->toBe(1);
+});
+
+test('tag team manager assignments can be queried by lifecycle state', function () {
+    $manager = Manager::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+
+    TagTeamManager::query()->create([
+        'manager_id' => $manager->id,
+        'tag_team_id' => $tagTeam->id,
+        'hired_at' => now()->subMonth(),
+    ]);
+    TagTeamManager::query()->create([
+        'manager_id' => $manager->id,
+        'tag_team_id' => $tagTeam->id,
+        'hired_at' => now()->subMonths(3),
+        'fired_at' => now()->subMonths(2),
+    ]);
+
+    expect(TagTeamManager::query()->current()->count())->toBe(1)
+        ->and(TagTeamManager::query()->ended()->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary
- add a typed manager assignment builder shared by wrestler and tag-team assignment pivots
- centralize current and ended assignment predicates
- update relationship-ending actions and history tables to use the shared queries
- document and test the builder boundary

## Verification
- 16 focused tests passed with 40 assertions
- application and Pest PHPStan passed
- Rector and type coverage passed
- Pint with Blade formatting passed
- git diff --check passed