### PR TITLE
refactor: centralize membership period queries

### DIFF
--- a/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
+++ b/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
@@ -15,7 +15,7 @@ class EndCurrentRelationshipsAction
     {
         TagTeamWrestler::query()
             ->where('tag_team_id', $tagTeam->id)
-            ->whereNull('left_at')
+            ->current()
             ->update(['left_at' => $effectiveDate]);
 
         TagTeamManager::query()

--- a/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
+++ b/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
@@ -16,12 +16,12 @@ class EndCurrentRelationshipsAction
     {
         TagTeamWrestler::query()
             ->where('wrestler_id', $wrestler->id)
-            ->whereNull('left_at')
+            ->current()
             ->update(['left_at' => $effectiveDate]);
 
         StableWrestler::query()
             ->where('wrestler_id', $wrestler->id)
-            ->whereNull('left_at')
+            ->current()
             ->update(['left_at' => $effectiveDate]);
 
         WrestlerManager::query()

--- a/app/Builders/Roster/MembershipPeriodBuilder.php
+++ b/app/Builders/Roster/MembershipPeriodBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Roster;
+
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
+use App\Models\TagTeams\TagTeamWrestler;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @template TModel of StableTagTeam|StableWrestler|TagTeamWrestler
+ *
+ * @extends Builder<TModel>
+ */
+class MembershipPeriodBuilder extends Builder
+{
+    public function current(): static
+    {
+        $this->whereNull('left_at');
+
+        return $this;
+    }
+
+    public function ended(): static
+    {
+        $this->whereNotNull('left_at');
+
+        return $this;
+    }
+}

--- a/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
@@ -35,7 +35,7 @@ class PreviousWrestlers extends DataTableComponent
         return TagTeamWrestler::query()
             ->with('wrestler')
             ->where('tag_teams_wrestlers.tag_team_id', $this->tagTeamId)
-            ->whereNotNull('tag_teams_wrestlers.left_at')
+            ->ended()
             ->orderByDesc('tag_teams_wrestlers.joined_at');
     }
 

--- a/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
@@ -81,7 +81,7 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
 
         return TagTeamWrestler::query()
             ->where('wrestler_id', $this->wrestlerId)
-            ->whereNotNull('left_at')
+            ->ended()
             ->orderByDesc('joined_at');
     }
 

--- a/app/Models/Stables/StableTagTeam.php
+++ b/app/Models/Stables/StableTagTeam.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models\Stables;
 
+use App\Builders\Roster\MembershipPeriodBuilder;
 use App\Models\TagTeams\TagTeam;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
@@ -22,13 +24,16 @@ use Illuminate\Support\Carbon;
  * @property-read Stable $stable
  * @property-read TagTeam $tagTeam
  *
- * @method static \Illuminate\Database\Eloquent\Builder<static>|StableTagTeam newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|StableTagTeam newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|StableTagTeam query()
+ * @method static MembershipPeriodBuilder<static> current()
+ * @method static MembershipPeriodBuilder<static> ended()
+ * @method static MembershipPeriodBuilder<static> newModelQuery()
+ * @method static MembershipPeriodBuilder<static> newQuery()
+ * @method static MembershipPeriodBuilder<static> query()
  *
  * @mixin \Eloquent
  */
 #[Fillable('stable_id', 'tag_team_id', 'joined_at', 'left_at')]
+#[UseEloquentBuilder(MembershipPeriodBuilder::class)]
 class StableTagTeam extends Pivot
 {
     /** @var string */

--- a/app/Models/Stables/StableWrestler.php
+++ b/app/Models/Stables/StableWrestler.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models\Stables;
 
+use App\Builders\Roster\MembershipPeriodBuilder;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
@@ -22,13 +24,16 @@ use Illuminate\Support\Carbon;
  * @property-read Stable $stable
  * @property-read Wrestler $wrestler
  *
- * @method static \Illuminate\Database\Eloquent\Builder<static>|StableWrestler newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|StableWrestler newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|StableWrestler query()
+ * @method static MembershipPeriodBuilder<static> current()
+ * @method static MembershipPeriodBuilder<static> ended()
+ * @method static MembershipPeriodBuilder<static> newModelQuery()
+ * @method static MembershipPeriodBuilder<static> newQuery()
+ * @method static MembershipPeriodBuilder<static> query()
  *
  * @mixin \Eloquent
  */
 #[Fillable('stable_id', 'wrestler_id', 'joined_at', 'left_at')]
+#[UseEloquentBuilder(MembershipPeriodBuilder::class)]
 class StableWrestler extends Pivot
 {
     /** @var string */

--- a/app/Models/TagTeams/TagTeamWrestler.php
+++ b/app/Models/TagTeams/TagTeamWrestler.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Models\TagTeams;
 
+use App\Builders\Roster\MembershipPeriodBuilder;
 use App\Models\Wrestlers\Wrestler;
 use Database\Factories\TagTeams\TagTeamWrestlerFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -25,13 +27,16 @@ use Illuminate\Support\Carbon;
  * @property-read TagTeam|null $tagTeam
  * @property-read Wrestler|null $wrestler
  *
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeamWrestler newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeamWrestler newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeamWrestler query()
+ * @method static MembershipPeriodBuilder<static> current()
+ * @method static MembershipPeriodBuilder<static> ended()
+ * @method static MembershipPeriodBuilder<static> newModelQuery()
+ * @method static MembershipPeriodBuilder<static> newQuery()
+ * @method static MembershipPeriodBuilder<static> query()
  *
  * @mixin \Eloquent
  */
 #[Fillable('tag_team_id', 'wrestler_id', 'joined_at', 'left_at')]
+#[UseEloquentBuilder(MembershipPeriodBuilder::class)]
 #[UseFactory(TagTeamWrestlerFactory::class)]
 class TagTeamWrestler extends Pivot
 {

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -18,6 +18,8 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `ManagerAssignmentBuilder` owns the shared `current()` and `ended()` persistence queries for wrestler and tag-team manager assignment records.
 
+`MembershipPeriodBuilder` owns the shared `current()` and `ended()` persistence queries for tag-team and stable membership records.
+
 ## Shared Concerns
 
 - `HasEmploymentScopes` provides relationship-backed `employed()`, `unemployed()`, `released()`, and `futureEmployed()` queries for individual roster members and tag teams.

--- a/tests/Unit/Builders/Roster/MembershipPeriodBuilderTest.php
+++ b/tests/Unit/Builders/Roster/MembershipPeriodBuilderTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Stables\Stable;
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
+use App\Models\TagTeams\TagTeam;
+use App\Models\TagTeams\TagTeamWrestler;
+use App\Models\Wrestlers\Wrestler;
+
+test('membership periods can be queried by lifecycle state', function () {
+    $stable = Stable::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+    $currentWrestler = Wrestler::factory()->create();
+    $formerWrestler = Wrestler::factory()->create();
+
+    TagTeamWrestler::query()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $currentWrestler->id,
+        'joined_at' => now()->subMonth(),
+    ]);
+    TagTeamWrestler::query()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $formerWrestler->id,
+        'joined_at' => now()->subMonths(3),
+        'left_at' => now()->subMonths(2),
+    ]);
+
+    StableWrestler::query()->create([
+        'stable_id' => $stable->id,
+        'wrestler_id' => $currentWrestler->id,
+        'joined_at' => now()->subMonth(),
+    ]);
+    StableWrestler::query()->create([
+        'stable_id' => $stable->id,
+        'wrestler_id' => $formerWrestler->id,
+        'joined_at' => now()->subMonths(3),
+        'left_at' => now()->subMonths(2),
+    ]);
+
+    $formerTagTeam = TagTeam::factory()->create();
+    StableTagTeam::query()->create([
+        'stable_id' => $stable->id,
+        'tag_team_id' => $tagTeam->id,
+        'joined_at' => now()->subMonth(),
+    ]);
+    StableTagTeam::query()->create([
+        'stable_id' => $stable->id,
+        'tag_team_id' => $formerTagTeam->id,
+        'joined_at' => now()->subMonths(3),
+        'left_at' => now()->subMonths(2),
+    ]);
+
+    expect(TagTeamWrestler::query()->current()->count())->toBe(1)
+        ->and(TagTeamWrestler::query()->ended()->count())->toBe(1)
+        ->and(StableWrestler::query()->current()->count())->toBe(1)
+        ->and(StableWrestler::query()->ended()->count())->toBe(1)
+        ->and(StableTagTeam::query()->current()->count())->toBe(1)
+        ->and(StableTagTeam::query()->ended()->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary
- add a typed membership-period builder shared by tag-team and stable membership pivots
- centralize current and ended membership predicates
- update relationship-ending actions and history tables to use the shared queries
- document and test the builder boundary

## Verification
- 28 focused tests passed with 59 assertions
- application and Pest PHPStan passed
- Rector and type coverage passed
- touched files passed Pint with Blade formatting
- git diff --check passed

## Baseline note
- composer test:push reaches the existing repository-wide Blade formatting mismatch on unchanged views from development