### PR TITLE
refactor: centralize title championship queries

### DIFF
--- a/app/Builders/Titles/TitleChampionshipBuilder.php
+++ b/app/Builders/Titles/TitleChampionshipBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Titles;
+
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\TitleChampionship;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * @template TModel of TitleChampionship
+ *
+ * @extends Builder<TModel>
+ */
+class TitleChampionshipBuilder extends Builder
+{
+    public function current(): static
+    {
+        return $this->whereNull('lost_at');
+    }
+
+    public function previous(): static
+    {
+        return $this->whereNotNull('lost_at');
+    }
+
+    public function forChampion(Wrestler|TagTeam $champion): static
+    {
+        return $this->whereMorphedTo('champion', $champion);
+    }
+}

--- a/app/Builders/Titles/TitleChampionshipBuilder.php
+++ b/app/Builders/Titles/TitleChampionshipBuilder.php
@@ -18,12 +18,16 @@ class TitleChampionshipBuilder extends Builder
 {
     public function current(): static
     {
-        return $this->whereNull('lost_at');
+        $this->whereNull('lost_at');
+
+        return $this;
     }
 
     public function previous(): static
     {
-        return $this->whereNotNull('lost_at');
+        $this->whereNotNull('lost_at');
+
+        return $this;
     }
 
     public function forChampion(Wrestler|TagTeam $champion): static

--- a/app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
@@ -26,14 +26,11 @@ class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
             throw new LogicException('A tag team was not provided.');
         }
 
+        $tagTeam = TagTeam::query()->findOrFail($this->tagTeamId);
+
         return TitleChampionship::query()
-            ->whereHasMorph(
-                'champion',
-                [TagTeam::class],
-                function (Builder $query): void {
-                    $query->whereIn('id', [$this->tagTeamId]);
-                }
-            )
-            ->whereNotNull('lost_at');
+            ->forChampion($tagTeam)
+            ->previous()
+            ->with('title');
     }
 }

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -43,6 +43,7 @@ class PreviousTitleChampionships extends DataTableComponent
 
         return TitleChampionship::query()
             ->where('title_id', $this->titleId)
+            ->previous()
             ->orderByDesc('lost_at');
     }
 

--- a/app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php
@@ -30,23 +30,11 @@ class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
             throw new LogicException('A wrestler was not provided.');
         }
 
-        // dd(TitleChampionship::query()
-        //     ->whereHasMorph(
-        //         'previousChampion',
-        //         [Wrestler::class],
-        //         function (Builder $query) {
-        //             $query->whereIn('id', [$this->wrestlerId]);
-        //         }
-        //     )->get());
+        $wrestler = Wrestler::query()->findOrFail($this->wrestlerId);
 
         return TitleChampionship::query()
-            ->whereHasMorph(
-                'champion',
-                [Wrestler::class],
-                function (Builder $query): void {
-                    $query->whereIn('id', [$this->wrestlerId]);
-                }
-            )
-            ->whereNotNull('lost_at');
+            ->forChampion($wrestler)
+            ->previous()
+            ->with('title');
     }
 }

--- a/app/Models/Titles/TitleChampionship.php
+++ b/app/Models/Titles/TitleChampionship.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Models\Titles;
 
+use App\Builders\Titles\TitleChampionshipBuilder;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Database\Factories\Titles\TitleChampionshipFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -37,14 +39,18 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  *
  * @method static \Database\Factories\Titles\TitleChampionshipFactory factory($count = null, $state = [])
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TitleChampionship newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TitleChampionship newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|TitleChampionship query()
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship current()
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship forChampion(Wrestler|TagTeam $champion)
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship newModelQuery()
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship newQuery()
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship previous()
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship query()
  *
  * @mixin \Eloquent
  */
 #[Table('titles_championships')]
 #[Fillable('title_id', 'champion_type', 'champion_id', 'won_match_id', 'lost_match_id', 'won_at', 'lost_at')]
+#[UseEloquentBuilder(TitleChampionshipBuilder::class)]
 #[UseFactory(TitleChampionshipFactory::class)]
 class TitleChampionship extends Model
 {

--- a/app/Queries/Titles/TitleChampionshipQuery.php
+++ b/app/Queries/Titles/TitleChampionshipQuery.php
@@ -22,9 +22,9 @@ final class TitleChampionshipQuery
 
     public static function previousChampionship(Title $title): ?TitleChampionship
     {
-        return $title->championships()
-            ->whereNotNull('lost_at')
-            ->reorder()
+        return TitleChampionship::query()
+            ->whereBelongsTo($title)
+            ->previous()
             ->latest('lost_at')
             ->first();
     }

--- a/app/Rules/Titles/ChampionInMatch.php
+++ b/app/Rules/Titles/ChampionInMatch.php
@@ -49,8 +49,8 @@ class ChampionInMatch implements DataAwareRule, ValidationRule
             }
 
             $currentChampionship = TitleChampionship::query()
-                ->where('title_id', $title->id)
-                ->whereNull('lost_at')
+                ->whereBelongsTo($title)
+                ->current()
                 ->with('champion')
                 ->first();
 

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -26,6 +26,8 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `EventMatchBuilder` owns reusable match-history queries for matches on past events and matches involving a specific wrestler or tag team.
 
+`TitleChampionshipBuilder` owns current and previous reign constraints and the polymorphic champion constraint. Championship reporting and derived reign calculations remain in `TitleChampionshipQuery`.
+
 ## Boundaries
 
 Builders express database queries over relationships and stored lifecycle periods. They may:

--- a/tests/Integration/Livewire/Titles/Tables/PreviousTitleChampionshipsTest.php
+++ b/tests/Integration/Livewire/Titles/Tables/PreviousTitleChampionshipsTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Livewire\Titles\Tables\PreviousTitleChampionships;
+use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
 
 test('displays championship reign length from its dates', function () {
@@ -14,4 +15,18 @@ test('displays championship reign length from its dates', function () {
     $reignLengthColumn = (new PreviousTitleChampionships())->columns()[3];
 
     expect($reignLengthColumn->resolveValue($championship))->toBe('10');
+});
+
+test('only retrieves previous championships for the selected title', function () {
+    $title = Title::factory()->create();
+    $previousChampionship = TitleChampionship::factory()->for($title)->ended()->create();
+    TitleChampionship::factory()->for($title)->current()->create();
+    TitleChampionship::factory()->ended()->create();
+    $table = new PreviousTitleChampionships();
+    $table->titleId = $title->id;
+
+    $championships = $table->builder()->get();
+
+    expect($championships)->toHaveCount(1)
+        ->and($championships->firstOrFail()->is($previousChampionship))->toBeTrue();
 });

--- a/tests/Unit/Builders/Titles/TitleChampionshipBuilderTest.php
+++ b/tests/Unit/Builders/Titles/TitleChampionshipBuilderTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\TitleChampionship;
+use App\Models\Wrestlers\Wrestler;
+
+it('filters current and previous championships', function () {
+    $currentChampionship = TitleChampionship::factory()->current()->create();
+    $previousChampionship = TitleChampionship::factory()->ended()->create();
+
+    $currentChampionships = TitleChampionship::query()->current()->get();
+    $previousChampionships = TitleChampionship::query()->previous()->get();
+
+    expect($currentChampionships)->toHaveCount(1)
+        ->and($currentChampionships->firstOrFail()->is($currentChampionship))->toBeTrue()
+        ->and($previousChampionships)->toHaveCount(1)
+        ->and($previousChampionships->firstOrFail()->is($previousChampionship))->toBeTrue();
+});
+
+it('filters championships by supported champion type', function () {
+    $wrestler = Wrestler::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+    $wrestlerChampionship = TitleChampionship::factory()->forWrestler($wrestler)->create();
+    $tagTeamChampionship = TitleChampionship::factory()->forTagTeam($tagTeam)->create();
+
+    $wrestlerChampionships = TitleChampionship::query()->forChampion($wrestler)->get();
+    $tagTeamChampionships = TitleChampionship::query()->forChampion($tagTeam)->get();
+
+    expect($wrestlerChampionships)->toHaveCount(1)
+        ->and($wrestlerChampionships->firstOrFail()->is($wrestlerChampionship))->toBeTrue()
+        ->and($tagTeamChampionships)->toHaveCount(1)
+        ->and($tagTeamChampionships->firstOrFail()->is($tagTeamChampionship))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add a typed TitleChampionshipBuilder for current, previous, and champion constraints
- reuse the builder across title reporting, validation, and Livewire tables
- prevent previous championship tables from including current reigns
- document and test the championship query boundary

## Verification
- 33 focused tests passed with 70 assertions
- application and Pest PHPStan passed
- Rector and type coverage passed
- changed files passed Pint with Blade formatting
- git diff --check passed

## Full suite note
- composer test:push reaches the existing repository-wide Blade formatting baseline; this branch does not modify those unrelated Blade files