### PR TITLE
refactor: expand event match queries

### DIFF
--- a/app/Builders/Matches/EventMatchBuilder.php
+++ b/app/Builders/Matches/EventMatchBuilder.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Builders\Matches;
 
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
+use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Builder;
@@ -31,6 +33,31 @@ class EventMatchBuilder extends Builder
         $this->whereHas('competitors', function (Builder $query) use ($competitor): void {
             $query->whereMorphedTo('competitor', $competitor);
         })->with('competitors');
+
+        return $this;
+    }
+
+    public function forReferee(Referee $referee): static
+    {
+        $this->whereHas('referees', function (Builder $query) use ($referee): void {
+            $query->whereKey($referee->getKey());
+        })->with('referees');
+
+        return $this;
+    }
+
+    public function latestEventFirst(): static
+    {
+        $event = new Event();
+
+        $this->orderByDesc(
+            $event->newQuery()
+                ->select('date')
+                ->whereColumn(
+                    $event->qualifyColumn('id'),
+                    $this->getModel()->qualifyColumn('event_id'),
+                )
+        );
 
         return $this;
     }

--- a/app/Livewire/Referees/Tables/PreviousMatches.php
+++ b/app/Livewire/Referees/Tables/PreviousMatches.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Referees\Tables;
 
 use App\Livewire\Base\Tables\BasePreviousMatchesTable;
 use App\Models\Matches\EventMatch;
+use App\Models\Referees\Referee;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
@@ -29,12 +30,12 @@ class PreviousMatches extends BasePreviousMatchesTable
             throw new LogicException('A referee was not provided.');
         }
 
+        $referee = Referee::query()->findOrFail($this->refereeId);
+
         return EventMatch::query()
             ->forPastEvents()
             ->with(['titles', 'competitors', 'result.winner', 'result.decision'])
-            ->withWhereHas('referees', function (Builder $query): void {
-                $query->whereIn('referee_id', [$this->refereeId]);
-            })
-            ->orderByDesc('date');
+            ->forReferee($referee)
+            ->latestEventFirst();
     }
 }

--- a/app/Livewire/TagTeams/Tables/PreviousMatches.php
+++ b/app/Livewire/TagTeams/Tables/PreviousMatches.php
@@ -36,6 +36,6 @@ class PreviousMatches extends BasePreviousMatchesTable
             ->forPastEvents()
             ->with(['titles', 'result.winner', 'result.decision'])
             ->forCompetitor($tagTeam)
-            ->orderByDesc('date');
+            ->latestEventFirst();
     }
 }

--- a/app/Livewire/Wrestlers/Tables/PreviousMatches.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousMatches.php
@@ -34,6 +34,6 @@ class PreviousMatches extends BasePreviousMatchesTable
             ->forPastEvents()
             ->with(['titles', 'result.winner', 'result.decision'])
             ->forCompetitor($wrestler)
-            ->orderByDesc('date');
+            ->latestEventFirst();
     }
 }

--- a/app/Models/Matches/EventMatch.php
+++ b/app/Models/Matches/EventMatch.php
@@ -57,6 +57,8 @@ use Illuminate\Support\Carbon;
  * @method static \Database\Factories\Matches\MatchFactory factory($count = null, $state = [])
  * @method static EventMatchBuilder<static>|EventMatch forPastEvents()
  * @method static EventMatchBuilder<static>|EventMatch forCompetitor(Wrestler|TagTeam $competitor)
+ * @method static EventMatchBuilder<static>|EventMatch forReferee(Referee $referee)
+ * @method static EventMatchBuilder<static>|EventMatch latestEventFirst()
  * @method static EventMatchBuilder<static>|EventMatch newModelQuery()
  * @method static EventMatchBuilder<static>|EventMatch newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|EventMatch onlyTrashed()

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -24,7 +24,7 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 - `HasRetirementScopes` provides the shared `retired()` query for individual roster members and tag teams whose tables filter retirement directly.
 - `HasNameSearch` provides first-name and last-name matching for models that store those columns.
 
-`EventMatchBuilder` owns reusable match-history queries for matches on past events and matches involving a specific wrestler or tag team.
+`EventMatchBuilder` owns reusable match-history queries for matches on past events, matches involving a specific wrestler or tag team, matches officiated by a specific referee, and ordering by the related event date.
 
 ## Boundaries
 

--- a/tests/Unit/Builders/Matches/EventMatchBuilderTest.php
+++ b/tests/Unit/Builders/Matches/EventMatchBuilderTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
+use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 
@@ -48,4 +49,37 @@ it('retrieves matches for a competitor and eager loads competitors', function ()
         ->and($tagTeamMatches)
         ->toHaveCount(1)
         ->and($tagTeamMatches->contains($tagTeamMatch))->toBeTrue();
+});
+
+it('retrieves matches officiated by a referee and eager loads every assigned referee', function () {
+    $referee = Referee::factory()->create();
+    $otherReferee = Referee::factory()->create();
+    $officiatedMatch = EventMatch::factory()->create();
+    $otherMatch = EventMatch::factory()->create();
+    $officiatedMatch->referees()->attach([$referee->id, $otherReferee->id]);
+    $otherMatch->referees()->attach($otherReferee);
+
+    $matches = EventMatch::query()->forReferee($referee)->get();
+
+    expect($matches)->toHaveCount(1)
+        ->and($matches->firstOrFail()->is($officiatedMatch))->toBeTrue()
+        ->and($matches->firstOrFail()->relationLoaded('referees'))->toBeTrue()
+        ->and($matches->firstOrFail()->referees)->toHaveCount(2);
+});
+
+it('orders matches by their event date with the latest event first', function () {
+    $oldestEvent = Event::factory()->past()->create(['date' => now()->subDays(3)]);
+    $latestEvent = Event::factory()->past()->create(['date' => now()->subDay()]);
+    $middleEvent = Event::factory()->past()->create(['date' => now()->subDays(2)]);
+    $oldestMatch = EventMatch::factory()->forEvent($oldestEvent)->create();
+    $latestMatch = EventMatch::factory()->forEvent($latestEvent)->create();
+    $middleMatch = EventMatch::factory()->forEvent($middleEvent)->create();
+
+    $matches = EventMatch::query()->latestEventFirst()->get();
+
+    expect($matches->modelKeys())->toBe([
+        $latestMatch->id,
+        $middleMatch->id,
+        $oldestMatch->id,
+    ]);
 });


### PR DESCRIPTION
## Summary
- add reusable EventMatchBuilder filtering for a specific referee
- add related-event date ordering through a correlated subquery
- replace invalid direct ordering by the nonexistent events_matches.date column
- reuse the builder methods across wrestler, tag-team, and referee match history tables
- document and test the expanded builder boundary

## Verification
- 12 focused builder and Livewire tests passed with 26 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- changed files passed Pint with Blade formatting
- git diff --check passed

## Full suite note
- composer test:push reaches the existing repository-wide Blade formatting baseline; this branch does not modify those unrelated Blade files