### PR TITLE
refactor: centralize match competitor queries

### DIFF
--- a/app/Builders/Matches/MatchCompetitorBuilder.php
+++ b/app/Builders/Matches/MatchCompetitorBuilder.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Matches;
+
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+
+/**
+ * @template TModel of MatchCompetitor
+ *
+ * @extends Builder<TModel>
+ */
+class MatchCompetitorBuilder extends Builder
+{
+    /**
+     * @param  class-string<TagTeam|Wrestler>  $competitorType
+     * @param  Collection<int, int>  $competitorIds
+     */
+    public function forCompetitorIds(string $competitorType, Collection $competitorIds): static
+    {
+        $this->where('competitor_type', $competitorType)
+            ->whereIn('competitor_id', $competitorIds);
+
+        return $this;
+    }
+
+    /**
+     * @param  Collection<int, int>  $eventIds
+     */
+    public function forEventIds(Collection $eventIds): static
+    {
+        $this->whereIn(
+            'match_id',
+            EventMatch::query()
+                ->whereIn('event_id', $eventIds)
+                ->select('id'),
+        );
+
+        return $this;
+    }
+}

--- a/app/Models/Matches/MatchCompetitor.php
+++ b/app/Models/Matches/MatchCompetitor.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace App\Models\Matches;
 
+use App\Builders\Matches\MatchCompetitorBuilder;
 use App\Collections\MatchCompetitorsCollection;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Database\Factories\Matches\MatchCompetitorFactory;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -32,14 +34,17 @@ use Illuminate\Support\Carbon;
  * @method static MatchCompetitorsCollection<int, static> all($columns = ['*'])
  * @method static MatchCompetitorsCollection<int, static> get($columns = ['*'])
  * @method static \Database\Factories\Matches\MatchCompetitorFactory factory($count = null, $state = [])
- * @method static \Illuminate\Database\Eloquent\Builder<static>|MatchCompetitor newModelQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|MatchCompetitor newQuery()
- * @method static \Illuminate\Database\Eloquent\Builder<static>|MatchCompetitor query()
+ * @method static MatchCompetitorBuilder<static>|MatchCompetitor forCompetitorIds(string $competitorType, \Illuminate\Support\Collection<int, int> $competitorIds)
+ * @method static MatchCompetitorBuilder<static>|MatchCompetitor forEventIds(\Illuminate\Support\Collection<int, int> $eventIds)
+ * @method static MatchCompetitorBuilder<static>|MatchCompetitor newModelQuery()
+ * @method static MatchCompetitorBuilder<static>|MatchCompetitor newQuery()
+ * @method static MatchCompetitorBuilder<static>|MatchCompetitor query()
  *
  * @mixin \Eloquent
  */
 #[CollectedBy(MatchCompetitorsCollection::class)]
 #[Fillable('match_id', 'competitor_id', 'competitor_type', 'side_number')]
+#[UseEloquentBuilder(MatchCompetitorBuilder::class)]
 #[UseFactory(MatchCompetitorFactory::class)]
 class MatchCompetitor extends MorphPivot
 {

--- a/app/Services/MatchAssignmentConflictService.php
+++ b/app/Services/MatchAssignmentConflictService.php
@@ -24,9 +24,8 @@ final class MatchAssignmentConflictService
     {
         $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
         $conflictingWrestlerId = MatchCompetitor::query()
-            ->where('competitor_type', Wrestler::class)
-            ->whereIn('competitor_id', $wrestlers->pluck('id'))
-            ->whereHas('eventMatch', fn (Builder $query) => $query->whereIn('event_id', $conflictingEventIds))
+            ->forCompetitorIds(Wrestler::class, $wrestlers->pluck('id'))
+            ->forEventIds($conflictingEventIds)
             ->value('competitor_id');
 
         if ($conflictingWrestlerId === null) {
@@ -45,9 +44,8 @@ final class MatchAssignmentConflictService
     {
         $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
         $conflictingTagTeamId = MatchCompetitor::query()
-            ->where('competitor_type', TagTeam::class)
-            ->whereIn('competitor_id', $tagTeams->pluck('id'))
-            ->whereHas('eventMatch', fn (Builder $query) => $query->whereIn('event_id', $conflictingEventIds))
+            ->forCompetitorIds(TagTeam::class, $tagTeams->pluck('id'))
+            ->forEventIds($conflictingEventIds)
             ->value('competitor_id');
 
         if ($conflictingTagTeamId === null) {

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -30,6 +30,8 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `TitleChampionshipBuilder` owns current and previous reign constraints and the polymorphic champion constraint. Championship reporting and derived reign calculations remain in `TitleChampionshipQuery`.
 
+`MatchCompetitorBuilder` owns persisted competitor-record filters by competitor model type, competitor identifiers, and event identifiers. Scheduling policy and conflict exceptions remain in `MatchAssignmentConflictService`.
+
 ## Boundaries
 
 Builders express database queries over relationships and stored lifecycle periods. They may:

--- a/tests/Unit/Builders/Matches/MatchCompetitorBuilderTest.php
+++ b/tests/Unit/Builders/Matches/MatchCompetitorBuilderTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Events\Event;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+
+it('filters competitor records by model type and identifiers', function () {
+    $wrestler = Wrestler::factory()->create();
+    $otherWrestler = Wrestler::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+    $wrestlerRecord = MatchCompetitor::factory()->create([
+        'competitor_type' => Wrestler::class,
+        'competitor_id' => $wrestler->id,
+    ]);
+    MatchCompetitor::factory()->create([
+        'competitor_type' => Wrestler::class,
+        'competitor_id' => $otherWrestler->id,
+    ]);
+    MatchCompetitor::factory()->create([
+        'competitor_type' => TagTeam::class,
+        'competitor_id' => $tagTeam->id,
+    ]);
+
+    $records = MatchCompetitor::query()
+        ->forCompetitorIds(Wrestler::class, collect([$wrestler->id]))
+        ->get();
+
+    expect($records)->toHaveCount(1)
+        ->and($records->firstOrFail()->match_id)->toBe($wrestlerRecord->match_id)
+        ->and($records->firstOrFail()->competitor_type)->toBe(Wrestler::class)
+        ->and($records->firstOrFail()->competitor_id)->toBe($wrestler->id);
+});
+
+it('filters competitor records by their events', function () {
+    $selectedEvent = Event::factory()->create();
+    $otherEvent = Event::factory()->create();
+    $selectedMatch = EventMatch::factory()->forEvent($selectedEvent)->create();
+    $otherMatch = EventMatch::factory()->forEvent($otherEvent)->create();
+    $selectedRecord = MatchCompetitor::factory()->for($selectedMatch, 'eventMatch')->create();
+    MatchCompetitor::factory()->for($otherMatch, 'eventMatch')->create();
+
+    $records = MatchCompetitor::query()
+        ->forEventIds(collect([$selectedEvent->id]))
+        ->get();
+
+    expect($records)->toHaveCount(1)
+        ->and($records->firstOrFail()->match_id)->toBe($selectedRecord->match_id)
+        ->and($records->firstOrFail()->competitor_id)->toBe($selectedRecord->competitor_id);
+});


### PR DESCRIPTION
## Summary\n- add a typed MatchCompetitorBuilder for competitor and event constraints\n- reuse the builder in match assignment conflict detection\n- document the builder boundary and cover its persisted filters\n\n## Verification\n- 29 focused tests passed with 69 assertions\n- application and Pest PHPStan passed\n- Rector and type coverage passed\n- touched PHP files passed Pint with Blade formatting\n- git diff checks passed\n\n## Existing baseline\n- composer test:push reaches the inherited Blade formatting failures in untouched view files; this PR does not modify Blade files