### PR TITLE
refactor: centralize manager assignment queries

### DIFF
--- a/app/Actions/Managers/EndCurrentRelationshipsAction.php
+++ b/app/Actions/Managers/EndCurrentRelationshipsAction.php
@@ -14,12 +14,12 @@ class EndCurrentRelationshipsAction
     public function handle(Manager $manager, Carbon $effectiveDate): void
     {
         WrestlerManager::query()
-            ->where('manager_id', $manager->id)
+            ->forManagerId($manager->id)
             ->current()
             ->update(['fired_at' => $effectiveDate]);
 
         TagTeamManager::query()
-            ->where('manager_id', $manager->id)
+            ->forManagerId($manager->id)
             ->current()
             ->update(['fired_at' => $effectiveDate]);
     }

--- a/app/Builders/Roster/ManagerAssignmentBuilder.php
+++ b/app/Builders/Roster/ManagerAssignmentBuilder.php
@@ -15,6 +15,13 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class ManagerAssignmentBuilder extends Builder
 {
+    public function forManagerId(int $managerId): static
+    {
+        $this->where('manager_id', $managerId);
+
+        return $this;
+    }
+
     public function current(): static
     {
         $this->whereNull('fired_at');

--- a/app/Livewire/Managers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeams.php
@@ -35,7 +35,7 @@ class PreviousTagTeams extends DataTableComponent
         }
 
         return TagTeamManager::query()
-            ->where('manager_id', $this->managerId)
+            ->forManagerId($this->managerId)
             ->ended()
             ->orderByDesc('hired_at');
     }

--- a/app/Livewire/Managers/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlers.php
@@ -32,7 +32,7 @@ class PreviousWrestlers extends DataTableComponent
         }
 
         return WrestlerManager::query()
-            ->where('manager_id', $this->managerId)
+            ->forManagerId($this->managerId)
             ->ended()
             ->orderByDesc('hired_at');
     }

--- a/app/Models/TagTeams/TagTeamManager.php
+++ b/app/Models/TagTeams/TagTeamManager.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Carbon;
  *
  * @method static ManagerAssignmentBuilder<static> current()
  * @method static ManagerAssignmentBuilder<static> ended()
+ * @method static ManagerAssignmentBuilder<static> forManagerId(int $managerId)
  * @method static ManagerAssignmentBuilder<static> newModelQuery()
  * @method static ManagerAssignmentBuilder<static> newQuery()
  * @method static ManagerAssignmentBuilder<static> query()

--- a/app/Models/Wrestlers/WrestlerManager.php
+++ b/app/Models/Wrestlers/WrestlerManager.php
@@ -26,6 +26,7 @@ use Illuminate\Support\Carbon;
  *
  * @method static ManagerAssignmentBuilder<static> current()
  * @method static ManagerAssignmentBuilder<static> ended()
+ * @method static ManagerAssignmentBuilder<static> forManagerId(int $managerId)
  * @method static ManagerAssignmentBuilder<static> newModelQuery()
  * @method static ManagerAssignmentBuilder<static> newQuery()
  * @method static ManagerAssignmentBuilder<static> query()

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -16,7 +16,7 @@ app/Builders/
 
 Builders are grouped by technical layer first and wrestling entity second. A concrete builder belongs to the model it queries. A concern is appropriate only when multiple builders share the same query semantics.
 
-`ManagerAssignmentBuilder` owns the shared `current()` and `ended()` persistence queries for wrestler and tag-team manager assignment records.
+`ManagerAssignmentBuilder` owns the shared manager filter and `current()` and `ended()` persistence queries for wrestler and tag-team manager assignment records.
 
 `MembershipPeriodBuilder` owns the shared `current()` and `ended()` persistence queries for tag-team and stable membership records.
 

--- a/tests/Unit/Builders/Roster/ManagerAssignmentBuilderTest.php
+++ b/tests/Unit/Builders/Roster/ManagerAssignmentBuilderTest.php
@@ -47,3 +47,43 @@ test('tag team manager assignments can be queried by lifecycle state', function 
     expect(TagTeamManager::query()->current()->count())->toBe(1)
         ->and(TagTeamManager::query()->ended()->count())->toBe(1);
 });
+
+test('manager assignments can be queried by manager', function () {
+    $manager = Manager::factory()->create();
+    $otherManager = Manager::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+
+    WrestlerManager::query()->create([
+        'manager_id' => $manager->id,
+        'wrestler_id' => $wrestler->id,
+        'hired_at' => now(),
+    ]);
+    WrestlerManager::query()->create([
+        'manager_id' => $otherManager->id,
+        'wrestler_id' => $wrestler->id,
+        'hired_at' => now(),
+    ]);
+    TagTeamManager::query()->create([
+        'manager_id' => $manager->id,
+        'tag_team_id' => $tagTeam->id,
+        'hired_at' => now(),
+    ]);
+    TagTeamManager::query()->create([
+        'manager_id' => $otherManager->id,
+        'tag_team_id' => $tagTeam->id,
+        'hired_at' => now(),
+    ]);
+
+    $wrestlerAssignments = WrestlerManager::query()
+        ->forManagerId($manager->id)
+        ->get();
+    $tagTeamAssignments = TagTeamManager::query()
+        ->forManagerId($manager->id)
+        ->get();
+
+    expect($wrestlerAssignments)->toHaveCount(1)
+        ->and($wrestlerAssignments->firstOrFail()->manager_id)->toBe($manager->id)
+        ->and($tagTeamAssignments)->toHaveCount(1)
+        ->and($tagTeamAssignments->firstOrFail()->manager_id)->toBe($manager->id);
+});


### PR DESCRIPTION
## Summary\n- add a shared ManagerAssignmentBuilder filter for manager identifiers\n- reuse the filter when closing and displaying manager relationships\n- cover both wrestler and tag-team manager assignment models\n- document the expanded builder boundary\n\n## Verification\n- 29 focused tests passed with 57 assertions\n- application and Pest PHPStan passed\n- Rector and Pest type coverage passed\n- touched PHP files passed Pint with Blade formatting\n- git diff checks passed\n\n## Existing baseline\n- composer test:push reaches inherited Blade formatting failures in untouched view files; this PR does not modify Blade files