### PR TITLE
refactor: centralize tag team membership queries

### DIFF
--- a/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
+++ b/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
@@ -14,7 +14,7 @@ class EndCurrentRelationshipsAction
     public function handle(TagTeam $tagTeam, Carbon $effectiveDate): void
     {
         TagTeamWrestler::query()
-            ->where('tag_team_id', $tagTeam->id)
+            ->forTagTeamId($tagTeam->id)
             ->current()
             ->update(['left_at' => $effectiveDate]);
 

--- a/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
+++ b/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
@@ -15,7 +15,7 @@ class EndCurrentRelationshipsAction
     public function handle(Wrestler $wrestler, Carbon $effectiveDate): void
     {
         TagTeamWrestler::query()
-            ->where('wrestler_id', $wrestler->id)
+            ->forWrestlerId($wrestler->id)
             ->current()
             ->update(['left_at' => $effectiveDate]);
 

--- a/app/Builders/Roster/TagTeamMembershipBuilder.php
+++ b/app/Builders/Roster/TagTeamMembershipBuilder.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Roster;
+
+use App\Models\TagTeams\TagTeamWrestler;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
+
+/**
+ * @template TModel of TagTeamWrestler
+ *
+ * @extends MembershipPeriodBuilder<TModel>
+ */
+class TagTeamMembershipBuilder extends MembershipPeriodBuilder
+{
+    public function forTagTeamId(int $tagTeamId): static
+    {
+        $this->where('tag_team_id', $tagTeamId);
+
+        return $this;
+    }
+
+    public function forWrestlerId(int $wrestlerId): static
+    {
+        $this->where('wrestler_id', $wrestlerId);
+
+        return $this;
+    }
+
+    public function excludingWrestlerId(int $wrestlerId): static
+    {
+        $this->where('wrestler_id', '!=', $wrestlerId);
+
+        return $this;
+    }
+
+    public function overlappingPeriod(Carbon $periodStart, Carbon $periodEnd): static
+    {
+        $this->where('joined_at', '<=', $periodEnd)
+            ->where(function (Builder $query) use ($periodStart): void {
+                $query->whereNull('left_at')
+                    ->orWhere('left_at', '>=', $periodStart);
+            });
+
+        return $this;
+    }
+}

--- a/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
@@ -34,7 +34,7 @@ class PreviousWrestlers extends DataTableComponent
 
         return TagTeamWrestler::query()
             ->with('wrestler')
-            ->where('tag_teams_wrestlers.tag_team_id', $this->tagTeamId)
+            ->forTagTeamId($this->tagTeamId)
             ->ended()
             ->orderByDesc('tag_teams_wrestlers.joined_at');
     }

--- a/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
@@ -80,7 +80,7 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
         }
 
         return TagTeamWrestler::query()
-            ->where('wrestler_id', $this->wrestlerId)
+            ->forWrestlerId($this->wrestlerId)
             ->ended()
             ->orderByDesc('joined_at');
     }
@@ -132,14 +132,10 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
      */
     private function getPartner(TagTeamWrestler $row): ?Wrestler
     {
-        // Find the other wrestler in this tag team during the same time period
-        $partnerRecord = TagTeamWrestler::where('tag_team_id', $row->tag_team_id)
-            ->where('wrestler_id', '!=', $row->wrestler_id)
-            ->where('joined_at', '<=', $row->left_at ?? now())
-            ->where(function (Builder $query) use ($row) {
-                $query->whereNull('left_at')
-                    ->orWhere('left_at', '>=', $row->joined_at);
-            })
+        $partnerRecord = TagTeamWrestler::query()
+            ->forTagTeamId($row->tag_team_id)
+            ->excludingWrestlerId($row->wrestler_id)
+            ->overlappingPeriod($row->joined_at, $row->left_at ?? now())
             ->with('wrestler')
             ->first();
 

--- a/app/Models/TagTeams/TagTeamWrestler.php
+++ b/app/Models/TagTeams/TagTeamWrestler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\TagTeams;
 
-use App\Builders\Roster\MembershipPeriodBuilder;
+use App\Builders\Roster\TagTeamMembershipBuilder;
 use App\Models\Wrestlers\Wrestler;
 use Database\Factories\TagTeams\TagTeamWrestlerFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -27,16 +27,20 @@ use Illuminate\Support\Carbon;
  * @property-read TagTeam|null $tagTeam
  * @property-read Wrestler|null $wrestler
  *
- * @method static MembershipPeriodBuilder<static> current()
- * @method static MembershipPeriodBuilder<static> ended()
- * @method static MembershipPeriodBuilder<static> newModelQuery()
- * @method static MembershipPeriodBuilder<static> newQuery()
- * @method static MembershipPeriodBuilder<static> query()
+ * @method static TagTeamMembershipBuilder<static> current()
+ * @method static TagTeamMembershipBuilder<static> ended()
+ * @method static TagTeamMembershipBuilder<static> excludingWrestlerId(int $wrestlerId)
+ * @method static TagTeamMembershipBuilder<static> forTagTeamId(int $tagTeamId)
+ * @method static TagTeamMembershipBuilder<static> forWrestlerId(int $wrestlerId)
+ * @method static TagTeamMembershipBuilder<static> newModelQuery()
+ * @method static TagTeamMembershipBuilder<static> newQuery()
+ * @method static TagTeamMembershipBuilder<static> overlappingPeriod(Carbon $periodStart, Carbon $periodEnd)
+ * @method static TagTeamMembershipBuilder<static> query()
  *
  * @mixin \Eloquent
  */
 #[Fillable('tag_team_id', 'wrestler_id', 'joined_at', 'left_at')]
-#[UseEloquentBuilder(MembershipPeriodBuilder::class)]
+#[UseEloquentBuilder(TagTeamMembershipBuilder::class)]
 #[UseFactory(TagTeamWrestlerFactory::class)]
 class TagTeamWrestler extends Pivot
 {

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -20,6 +20,8 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `MembershipPeriodBuilder` owns the shared `current()` and `ended()` persistence queries for tag-team and stable membership records.
 
+`TagTeamMembershipBuilder` extends the shared membership-period queries with tag-team and wrestler filters and historical period-overlap constraints specific to `TagTeamWrestler` records.
+
 ## Shared Concerns
 
 - `FiltersByEmploymentStatus` provides relationship-backed `employed()`, `unemployed()`, `released()`, and `futureEmployed()` filters for individual roster members and tag teams.

--- a/tests/Unit/Builders/Roster/TagTeamMembershipBuilderTest.php
+++ b/tests/Unit/Builders/Roster/TagTeamMembershipBuilderTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\TagTeams\TagTeam;
+use App\Models\TagTeams\TagTeamWrestler;
+use App\Models\Wrestlers\Wrestler;
+
+test('tag team memberships can be filtered by tag team and wrestler', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $otherTagTeam = TagTeam::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+    $otherWrestler = Wrestler::factory()->create();
+    TagTeamWrestler::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $wrestler->id,
+    ]);
+    TagTeamWrestler::factory()->create([
+        'tag_team_id' => $otherTagTeam->id,
+        'wrestler_id' => $wrestler->id,
+    ]);
+    TagTeamWrestler::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $otherWrestler->id,
+    ]);
+
+    $memberships = TagTeamWrestler::query()
+        ->forTagTeamId($tagTeam->id)
+        ->forWrestlerId($wrestler->id)
+        ->get();
+
+    expect($memberships)->toHaveCount(1)
+        ->and($memberships->firstOrFail()->tag_team_id)->toBe($tagTeam->id)
+        ->and($memberships->firstOrFail()->wrestler_id)->toBe($wrestler->id);
+});
+
+test('tag team memberships can exclude a wrestler', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+    $otherWrestler = Wrestler::factory()->create();
+    TagTeamWrestler::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $wrestler->id,
+    ]);
+    TagTeamWrestler::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $otherWrestler->id,
+    ]);
+
+    $memberships = TagTeamWrestler::query()
+        ->forTagTeamId($tagTeam->id)
+        ->excludingWrestlerId($wrestler->id)
+        ->get();
+
+    expect($memberships)->toHaveCount(1)
+        ->and($memberships->firstOrFail()->wrestler_id)->toBe($otherWrestler->id);
+});
+
+test('tag team memberships can be filtered by overlapping periods', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $overlappingWrestler = Wrestler::factory()->create();
+    $earlierWrestler = Wrestler::factory()->create();
+    $laterWrestler = Wrestler::factory()->create();
+    TagTeamWrestler::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $overlappingWrestler->id,
+        'joined_at' => now()->subMonths(3),
+        'left_at' => now()->subMonth(),
+    ]);
+    TagTeamWrestler::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $earlierWrestler->id,
+        'joined_at' => now()->subMonths(6),
+        'left_at' => now()->subMonths(5),
+    ]);
+    TagTeamWrestler::factory()->create([
+        'tag_team_id' => $tagTeam->id,
+        'wrestler_id' => $laterWrestler->id,
+        'joined_at' => now(),
+    ]);
+
+    $memberships = TagTeamWrestler::query()
+        ->forTagTeamId($tagTeam->id)
+        ->overlappingPeriod(now()->subMonths(4), now()->subMonths(2))
+        ->get();
+
+    expect($memberships)->toHaveCount(1)
+        ->and($memberships->firstOrFail()->wrestler_id)->toBe($overlappingWrestler->id);
+});


### PR DESCRIPTION
## Summary\n- add a typed TagTeamMembershipBuilder extending shared membership-period queries\n- centralize tag-team, wrestler, exclusion, and historical overlap constraints\n- reuse the builder in relationship-closing actions and history tables\n- document and test the specialized builder boundary\n\n## Verification\n- 30 focused tests passed with 60 assertions\n- application and Pest PHPStan passed\n- Rector and Pest type coverage passed\n- touched PHP files passed Pint with Blade formatting\n- git diff checks passed\n\n## Existing baseline\n- composer test:push reaches inherited Blade formatting failures in untouched view files; this PR does not modify Blade files