### PR TITLE
refactor: centralize stable history queries

### DIFF
--- a/app/Builders/Roster/StableBuilder.php
+++ b/app/Builders/Roster/StableBuilder.php
@@ -14,6 +14,36 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class StableBuilder extends Builder
 {
+    public function previousForTagTeamId(int $tagTeamId): static
+    {
+        $this->join('stables_tag_teams', 'stables.id', '=', 'stables_tag_teams.stable_id')
+            ->where('stables_tag_teams.tag_team_id', $tagTeamId)
+            ->whereNotNull('stables_tag_teams.left_at')
+            ->select(
+                'stables.*',
+                'stables_tag_teams.joined_at as joined_at',
+                'stables_tag_teams.left_at as left_at',
+            )
+            ->orderByDesc('stables_tag_teams.joined_at');
+
+        return $this;
+    }
+
+    public function previousForWrestlerId(int $wrestlerId): static
+    {
+        $this->join('stables_wrestlers', 'stables.id', '=', 'stables_wrestlers.stable_id')
+            ->where('stables_wrestlers.wrestler_id', $wrestlerId)
+            ->whereNotNull('stables_wrestlers.left_at')
+            ->select(
+                'stables.*',
+                'stables_wrestlers.joined_at as joined_at',
+                'stables_wrestlers.left_at as left_at',
+            )
+            ->orderByDesc('stables_wrestlers.joined_at');
+
+        return $this;
+    }
+
     public function unestablished(): static
     {
         return $this->whereDoesntHave('activityPeriods');

--- a/app/Livewire/TagTeams/Tables/PreviousStables.php
+++ b/app/Livewire/TagTeams/Tables/PreviousStables.php
@@ -7,7 +7,6 @@ namespace App\Livewire\TagTeams\Tables;
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
 use App\Models\Stables\Stable;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\DB;
 use LogicException;
 
 class PreviousStables extends BasePreviousStablesTable
@@ -26,15 +25,7 @@ class PreviousStables extends BasePreviousStablesTable
         }
 
         return Stable::query()
-            ->join('stables_tag_teams', 'stables.id', '=', 'stables_tag_teams.stable_id')
-            ->where('stables_tag_teams.tag_team_id', $this->tagTeamId)
-            ->whereNotNull('stables_tag_teams.left_at')
-            ->select('stables.*')
-            ->addSelect([
-                'joined_at' => DB::raw('stables_tag_teams.joined_at'),
-                'left_at' => DB::raw('stables_tag_teams.left_at'),
-            ])
-            ->orderByDesc('stables_tag_teams.joined_at');
+            ->previousForTagTeamId($this->tagTeamId);
     }
 
     public function configure(): void

--- a/app/Livewire/Wrestlers/Tables/PreviousStables.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousStables.php
@@ -7,7 +7,6 @@ namespace App\Livewire\Wrestlers\Tables;
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
 use App\Models\Stables\Stable;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Support\Facades\DB;
 use LogicException;
 
 class PreviousStables extends BasePreviousStablesTable
@@ -29,15 +28,7 @@ class PreviousStables extends BasePreviousStablesTable
         }
 
         return Stable::query()
-            ->join('stables_wrestlers', 'stables.id', '=', 'stables_wrestlers.stable_id')
-            ->where('stables_wrestlers.wrestler_id', $this->wrestlerId)
-            ->whereNotNull('stables_wrestlers.left_at')
-            ->select('stables.*')
-            ->addSelect([
-                'joined_at' => DB::raw('stables_wrestlers.joined_at'),
-                'left_at' => DB::raw('stables_wrestlers.left_at'),
-            ])
-            ->orderByDesc('stables_wrestlers.joined_at');
+            ->previousForWrestlerId($this->wrestlerId);
     }
 
     public function configure(): void

--- a/app/Models/Stables/Stable.php
+++ b/app/Models/Stables/Stable.php
@@ -66,6 +66,8 @@ use Tests\Unit\Models\Stables\StableTest;
  * @method static \Database\Factories\Stables\StableFactory factory($count = null, $state = [])
  * @method static StableBuilder<static>|Stable newModelQuery()
  * @method static StableBuilder<static>|Stable newQuery()
+ * @method static StableBuilder<static>|Stable previousForTagTeamId(int $tagTeamId)
+ * @method static StableBuilder<static>|Stable previousForWrestlerId(int $wrestlerId)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Stable onlyTrashed()
  * @method static StableBuilder<static>|Stable query()
  * @method static StableBuilder<static>|Stable retired()

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -22,6 +22,8 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `TagTeamMembershipBuilder` extends the shared membership-period queries with tag-team and wrestler filters and historical period-overlap constraints specific to `TagTeamWrestler` records.
 
+`StableBuilder` owns stable lifecycle-state filters and historical stable-membership projections for wrestlers and tag teams. The history methods select the persisted membership dates required by the table layer.
+
 ## Shared Concerns
 
 - `FiltersByEmploymentStatus` provides relationship-backed `employed()`, `unemployed()`, `released()`, and `futureEmployed()` filters for individual roster members and tag teams.

--- a/tests/Feature/Livewire/TagTeams/Tables/PreviousStablesTest.php
+++ b/tests/Feature/Livewire/TagTeams/Tables/PreviousStablesTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\TagTeams\Tables\PreviousStables;
+use App\Models\Stables\Stable;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Users\User;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->administrator()->create());
+});
+
+it('requires a tag team', function () {
+    expect(fn () => (new PreviousStables())->builder())
+        ->toThrow(LogicException::class, 'A tag team was not provided.');
+});
+
+it('shows only previous stables for the selected tag team', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $otherTagTeam = TagTeam::factory()->create();
+    $previousStable = Stable::factory()->create();
+    $currentStable = Stable::factory()->create();
+    $otherStable = Stable::factory()->create();
+    $previousStable->tagTeams()->attach($tagTeam, [
+        'joined_at' => now()->subMonths(2),
+        'left_at' => now()->subMonth(),
+    ]);
+    $currentStable->tagTeams()->attach($tagTeam, [
+        'joined_at' => now(),
+    ]);
+    $otherStable->tagTeams()->attach($otherTagTeam, [
+        'joined_at' => now()->subMonths(2),
+        'left_at' => now()->subMonth(),
+    ]);
+    $component = testLivewire(PreviousStables::class, ['tagTeamId' => $tagTeam->id]);
+
+    $stables = $component->instance()->builder()->get();
+
+    expect($stables)->toHaveCount(1)
+        ->and($stables->firstOrFail()->is($previousStable))->toBeTrue();
+});
+
+it('renders for an administrator', function () {
+    $tagTeam = TagTeam::factory()->create();
+
+    testLivewire(PreviousStables::class, ['tagTeamId' => $tagTeam->id])
+        ->assertSuccessful();
+});

--- a/tests/Unit/Builders/Roster/StableBuilderTest.php
+++ b/tests/Unit/Builders/Roster/StableBuilderTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Models\Stables\Stable;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
 
 test('established stables can be retrieved', function () {
     $activeStable = Stable::factory()->active()->create();
@@ -58,4 +60,48 @@ test('unestablished stables can be retrieved', function () {
     expect($unactivatedStables)
         ->toHaveCount(1)
         ->and($unactivatedStables->contains($unactivatedStable))->toBeTrue();
+});
+
+test('previous stables can be retrieved for a wrestler', function () {
+    $wrestler = Wrestler::factory()->create();
+    $previousStable = Stable::factory()->create();
+    $currentStable = Stable::factory()->create();
+    $previousStable->wrestlers()->attach($wrestler, [
+        'joined_at' => now()->subMonths(2),
+        'left_at' => now()->subMonth(),
+    ]);
+    $currentStable->wrestlers()->attach($wrestler, [
+        'joined_at' => now(),
+    ]);
+
+    $stables = Stable::query()
+        ->previousForWrestlerId($wrestler->id)
+        ->get();
+
+    expect($stables)->toHaveCount(1)
+        ->and($stables->firstOrFail()->is($previousStable))->toBeTrue()
+        ->and($stables->firstOrFail()->getAttribute('joined_at'))->not->toBeNull()
+        ->and($stables->firstOrFail()->getAttribute('left_at'))->not->toBeNull();
+});
+
+test('previous stables can be retrieved for a tag team', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $previousStable = Stable::factory()->create();
+    $currentStable = Stable::factory()->create();
+    $previousStable->tagTeams()->attach($tagTeam, [
+        'joined_at' => now()->subMonths(2),
+        'left_at' => now()->subMonth(),
+    ]);
+    $currentStable->tagTeams()->attach($tagTeam, [
+        'joined_at' => now(),
+    ]);
+
+    $stables = Stable::query()
+        ->previousForTagTeamId($tagTeam->id)
+        ->get();
+
+    expect($stables)->toHaveCount(1)
+        ->and($stables->firstOrFail()->is($previousStable))->toBeTrue()
+        ->and($stables->firstOrFail()->getAttribute('joined_at'))->not->toBeNull()
+        ->and($stables->firstOrFail()->getAttribute('left_at'))->not->toBeNull();
 });


### PR DESCRIPTION
## Summary
- centralize wrestler and tag-team historical stable joins in StableBuilder
- preserve persisted membership dates needed by both Livewire history tables
- add focused builder and tag-team component coverage
- document the StableBuilder history-query boundary

## Verification
- 18 focused tests passed with 34 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Existing repository baseline
- composer test:push reaches inherited Blade formatting failures in untouched view files; this branch does not modify Blade files