### PR TITLE
refactor: centralize manager history ordering

### DIFF
--- a/app/Builders/Roster/ManagerAssignmentBuilder.php
+++ b/app/Builders/Roster/ManagerAssignmentBuilder.php
@@ -22,6 +22,13 @@ class ManagerAssignmentBuilder extends Builder
         return $this;
     }
 
+    public function mostRecentlyHiredFirst(): static
+    {
+        $this->orderByDesc('hired_at');
+
+        return $this;
+    }
+
     public function current(): static
     {
         $this->whereNull('fired_at');

--- a/app/Livewire/Managers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeams.php
@@ -37,7 +37,7 @@ class PreviousTagTeams extends DataTableComponent
         return TagTeamManager::query()
             ->forManagerId($this->managerId)
             ->ended()
-            ->orderByDesc('hired_at');
+            ->mostRecentlyHiredFirst();
     }
 
     public function configure(): void

--- a/app/Livewire/Managers/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlers.php
@@ -34,7 +34,7 @@ class PreviousWrestlers extends DataTableComponent
         return WrestlerManager::query()
             ->forManagerId($this->managerId)
             ->ended()
-            ->orderByDesc('hired_at');
+            ->mostRecentlyHiredFirst();
     }
 
     public function configure(): void

--- a/app/Livewire/TagTeams/Tables/PreviousManagers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousManagers.php
@@ -30,7 +30,7 @@ class PreviousManagers extends BasePreviousManagersTable
         return TagTeamManager::query()
             ->where('tag_team_id', $this->tagTeamId)
             ->ended()
-            ->orderByDesc('hired_at');
+            ->mostRecentlyHiredFirst();
     }
 
     public function configure(): void

--- a/app/Livewire/Wrestlers/Tables/PreviousManagers.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousManagers.php
@@ -32,7 +32,7 @@ class PreviousManagers extends BasePreviousManagersTable
             ->whereHas('manager') // Only include records where manager exists (not soft deleted)
             ->where('wrestler_id', $this->wrestlerId)
             ->ended()
-            ->orderByDesc('hired_at');
+            ->mostRecentlyHiredFirst();
     }
 
     public function configure(): void

--- a/app/Models/TagTeams/TagTeamManager.php
+++ b/app/Models/TagTeams/TagTeamManager.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Carbon;
  * @method static ManagerAssignmentBuilder<static> current()
  * @method static ManagerAssignmentBuilder<static> ended()
  * @method static ManagerAssignmentBuilder<static> forManagerId(int $managerId)
+ * @method static ManagerAssignmentBuilder<static> mostRecentlyHiredFirst()
  * @method static ManagerAssignmentBuilder<static> newModelQuery()
  * @method static ManagerAssignmentBuilder<static> newQuery()
  * @method static ManagerAssignmentBuilder<static> query()

--- a/app/Models/Wrestlers/WrestlerManager.php
+++ b/app/Models/Wrestlers/WrestlerManager.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Carbon;
  * @method static ManagerAssignmentBuilder<static> current()
  * @method static ManagerAssignmentBuilder<static> ended()
  * @method static ManagerAssignmentBuilder<static> forManagerId(int $managerId)
+ * @method static ManagerAssignmentBuilder<static> mostRecentlyHiredFirst()
  * @method static ManagerAssignmentBuilder<static> newModelQuery()
  * @method static ManagerAssignmentBuilder<static> newQuery()
  * @method static ManagerAssignmentBuilder<static> query()

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -16,7 +16,7 @@ app/Builders/
 
 Builders are grouped by technical layer first and wrestling entity second. A concrete builder belongs to the model it queries. A concern is appropriate only when multiple builders share the same query semantics.
 
-`ManagerAssignmentBuilder` owns the shared manager filter and `current()` and `ended()` persistence queries for wrestler and tag-team manager assignment records.
+`ManagerAssignmentBuilder` owns the shared manager filter, lifecycle-state constraints, and most-recent-hire ordering for wrestler and tag-team manager assignment records.
 
 `MembershipPeriodBuilder` owns the shared `current()` and `ended()` persistence queries for tag-team and stable membership records.
 

--- a/tests/Unit/Builders/Roster/ManagerAssignmentBuilderTest.php
+++ b/tests/Unit/Builders/Roster/ManagerAssignmentBuilderTest.php
@@ -87,3 +87,36 @@ test('manager assignments can be queried by manager', function () {
         ->and($tagTeamAssignments)->toHaveCount(1)
         ->and($tagTeamAssignments->firstOrFail()->manager_id)->toBe($manager->id);
 });
+
+test('manager assignments can be ordered by most recent hire', function () {
+    $manager = Manager::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+    $oldestHiredAt = now()->subMonths(3);
+    $newestHiredAt = now()->subMonth();
+    $middleHiredAt = now()->subMonths(2);
+    WrestlerManager::query()->create([
+        'manager_id' => $manager->id,
+        'wrestler_id' => $wrestler->id,
+        'hired_at' => $oldestHiredAt,
+    ]);
+    WrestlerManager::query()->create([
+        'manager_id' => $manager->id,
+        'wrestler_id' => $wrestler->id,
+        'hired_at' => $newestHiredAt,
+    ]);
+    WrestlerManager::query()->create([
+        'manager_id' => $manager->id,
+        'wrestler_id' => $wrestler->id,
+        'hired_at' => $middleHiredAt,
+    ]);
+
+    $assignments = WrestlerManager::query()
+        ->mostRecentlyHiredFirst()
+        ->get();
+
+    expect($assignments->pluck('hired_at')->map->toDateTimeString()->all())->toBe([
+        $newestHiredAt->toDateTimeString(),
+        $middleHiredAt->toDateTimeString(),
+        $oldestHiredAt->toDateTimeString(),
+    ]);
+});


### PR DESCRIPTION
## Summary
- add canonical most-recent-hire ordering to ManagerAssignmentBuilder
- reuse the ordering across manager, wrestler, and tag-team history tables
- document the expanded manager-assignment query boundary
- add focused ordering coverage

## Verification
- 25 focused tests passed with 57 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Existing repository baseline
- composer test:push reaches inherited Blade formatting failures in untouched view files; this branch does not modify Blade files