### PR TITLE
refactor: centralize tag team membership ordering

### DIFF
--- a/app/Builders/Roster/TagTeamMembershipBuilder.php
+++ b/app/Builders/Roster/TagTeamMembershipBuilder.php
@@ -46,4 +46,11 @@ class TagTeamMembershipBuilder extends MembershipPeriodBuilder
 
         return $this;
     }
+
+    public function mostRecentlyJoinedFirst(): static
+    {
+        $this->orderByDesc('joined_at');
+
+        return $this;
+    }
 }

--- a/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
@@ -36,7 +36,7 @@ class PreviousWrestlers extends DataTableComponent
             ->with('wrestler')
             ->forTagTeamId($this->tagTeamId)
             ->ended()
-            ->orderByDesc('tag_teams_wrestlers.joined_at');
+            ->mostRecentlyJoinedFirst();
     }
 
     /**

--- a/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
@@ -82,7 +82,7 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
         return TagTeamWrestler::query()
             ->forWrestlerId($this->wrestlerId)
             ->ended()
-            ->orderByDesc('joined_at');
+            ->mostRecentlyJoinedFirst();
     }
 
     /**

--- a/app/Models/TagTeams/TagTeamWrestler.php
+++ b/app/Models/TagTeams/TagTeamWrestler.php
@@ -32,6 +32,7 @@ use Illuminate\Support\Carbon;
  * @method static TagTeamMembershipBuilder<static> excludingWrestlerId(int $wrestlerId)
  * @method static TagTeamMembershipBuilder<static> forTagTeamId(int $tagTeamId)
  * @method static TagTeamMembershipBuilder<static> forWrestlerId(int $wrestlerId)
+ * @method static TagTeamMembershipBuilder<static> mostRecentlyJoinedFirst()
  * @method static TagTeamMembershipBuilder<static> newModelQuery()
  * @method static TagTeamMembershipBuilder<static> newQuery()
  * @method static TagTeamMembershipBuilder<static> overlappingPeriod(Carbon $periodStart, Carbon $periodEnd)

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -20,7 +20,7 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `MembershipPeriodBuilder` owns the shared `current()` and `ended()` persistence queries for tag-team and stable membership records.
 
-`TagTeamMembershipBuilder` extends the shared membership-period queries with tag-team and wrestler filters and historical period-overlap constraints specific to `TagTeamWrestler` records.
+`TagTeamMembershipBuilder` extends the shared membership-period queries with tag-team and wrestler filters, historical period-overlap constraints, and most-recent-join ordering specific to `TagTeamWrestler` records.
 
 `StableBuilder` owns stable lifecycle-state filters and historical stable-membership projections for wrestlers and tag teams. The history methods select the persisted membership dates required by the table layer.
 

--- a/tests/Unit/Builders/Roster/TagTeamMembershipBuilderTest.php
+++ b/tests/Unit/Builders/Roster/TagTeamMembershipBuilderTest.php
@@ -87,3 +87,27 @@ test('tag team memberships can be filtered by overlapping periods', function () 
     expect($memberships)->toHaveCount(1)
         ->and($memberships->firstOrFail()->wrestler_id)->toBe($overlappingWrestler->id);
 });
+
+test('tag team memberships can be ordered by most recent join', function () {
+    $tagTeam = TagTeam::factory()->create();
+    $oldestJoinedAt = now()->subMonths(3);
+    $newestJoinedAt = now()->subMonth();
+    $middleJoinedAt = now()->subMonths(2);
+
+    foreach ([$oldestJoinedAt, $newestJoinedAt, $middleJoinedAt] as $joinedAt) {
+        TagTeamWrestler::factory()->create([
+            'tag_team_id' => $tagTeam->id,
+            'joined_at' => $joinedAt,
+        ]);
+    }
+
+    $memberships = TagTeamWrestler::query()
+        ->mostRecentlyJoinedFirst()
+        ->get();
+
+    expect($memberships->pluck('joined_at')->map->toDateTimeString()->all())->toBe([
+        $newestJoinedAt->toDateTimeString(),
+        $middleJoinedAt->toDateTimeString(),
+        $oldestJoinedAt->toDateTimeString(),
+    ]);
+});


### PR DESCRIPTION
## Summary
- add canonical most-recent-join ordering to TagTeamMembershipBuilder
- reuse the ordering in both tag-team membership history tables
- document the expanded tag-team membership query boundary
- add focused ordering coverage

## Verification
- 29 focused tests passed with 52 assertions
- application and Pest PHPStan passed
- Rector and Pest type coverage passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed

## Existing repository baseline
- composer test:push reaches inherited Blade formatting failures in untouched view files; this branch does not modify Blade files