### PR TITLE
refactor: type stable membership history

### DIFF
--- a/app/Builders/Roster/MembershipPeriodBuilder.php
+++ b/app/Builders/Roster/MembershipPeriodBuilder.php
@@ -29,4 +29,11 @@ class MembershipPeriodBuilder extends Builder
 
         return $this;
     }
+
+    public function mostRecentlyJoinedFirst(): static
+    {
+        $this->orderByDesc('joined_at');
+
+        return $this;
+    }
 }

--- a/app/Builders/Roster/StableMembershipBuilder.php
+++ b/app/Builders/Roster/StableMembershipBuilder.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Roster;
+
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
+
+/**
+ * @template TModel of StableTagTeam|StableWrestler
+ *
+ * @extends MembershipPeriodBuilder<TModel>
+ */
+class StableMembershipBuilder extends MembershipPeriodBuilder
+{
+    public function forStableId(int $stableId): static
+    {
+        $this->where('stable_id', $stableId);
+
+        return $this;
+    }
+}

--- a/app/Builders/Roster/TagTeamMembershipBuilder.php
+++ b/app/Builders/Roster/TagTeamMembershipBuilder.php
@@ -46,11 +46,4 @@ class TagTeamMembershipBuilder extends MembershipPeriodBuilder
 
         return $this;
     }
-
-    public function mostRecentlyJoinedFirst(): static
-    {
-        $this->orderByDesc('joined_at');
-
-        return $this;
-    }
 }

--- a/app/Livewire/Stables/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Stables/Tables/PreviousTagTeams.php
@@ -4,26 +4,27 @@ declare(strict_types=1);
 
 namespace App\Livewire\Stables\Tables;
 
+use App\Livewire\Concerns\ShowTableTrait;
 use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\Stables\StableTagTeam;
-use App\Models\TagTeams\TagTeam;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use LogicException;
 
 class PreviousTagTeams extends DataTableComponent
 {
+    use ShowTableTrait;
+
     protected string $resourceName = 'tag teams';
 
-    protected string $databaseTableName = 'tag_teams';
+    protected string $databaseTableName = 'stables_tag_teams';
 
     public ?int $stableId;
 
     /**
-     * @return Builder<TagTeam>
+     * @return Builder<StableTagTeam>
      */
     public function builder(): Builder
     {
@@ -31,16 +32,11 @@ class PreviousTagTeams extends DataTableComponent
             throw new LogicException('A stable was not provided.');
         }
 
-        return TagTeam::query()
-            ->whereHas('stables', function (Builder $query) {
-                $query->where('stable_id', $this->stableId)
-                    ->whereNotNull('left_at');
-            })
-            ->with(['stables' => function (BelongsToMany $query) {
-                $query->where('stable_id', $this->stableId)
-                    ->whereNotNull('left_at')
-                    ->withPivot(['joined_at', 'left_at']);
-            }]);
+        return StableTagTeam::query()
+            ->with('tagTeam')
+            ->forStableId($this->stableId)
+            ->ended()
+            ->mostRecentlyJoinedFirst();
     }
 
     /**
@@ -50,55 +46,22 @@ class PreviousTagTeams extends DataTableComponent
     {
         return [
             LinkColumn::make(__('tag-teams.name'))
-                ->title(fn (TagTeam $row) => $row->name ?? 'Unknown')
-                ->location(fn (TagTeam $row) => route('tag-teams.show', $row)),
-            Column::make(__('stables.date_joined'))
-                ->label(function (TagTeam $row): string {
-                    $stable = $row->stables->first();
-                    if (! $stable || ! isset($stable->pivot)) {
-                        return '';
-                    }
-
-                    /** @var StableTagTeam $pivot */
-                    $pivot = $stable->pivot;
-                    $joinedAt = $pivot->getAttribute('joined_at');
-                    if (! $joinedAt) {
-                        return '';
-                    }
-
-                    return is_string($joinedAt) ?
-                        Carbon::parse($joinedAt)->format('Y-m-d') :
-                        $joinedAt->format('Y-m-d');
-                }),
-            Column::make(__('stables.date_left'))
-                ->label(function (TagTeam $row): string {
-                    $stable = $row->stables->first();
-                    if (! $stable || ! isset($stable->pivot)) {
-                        return '';
-                    }
-
-                    /** @var StableTagTeam $pivot */
-                    $pivot = $stable->pivot;
-                    $leftAt = $pivot->getAttribute('left_at');
-                    if (! $leftAt) {
-                        return '';
-                    }
-
-                    return is_string($leftAt) ?
-                        Carbon::parse($leftAt)->format('Y-m-d') :
-                        $leftAt->format('Y-m-d');
-                }),
+                ->title(fn (StableTagTeam $row) => $row->tagTeam->name ?? 'Unknown')
+                ->location(fn (StableTagTeam $row) => $row->tagTeam ? route('tag-teams.show', $row->tagTeam) : '#'),
+            DateColumn::make(__('stables.date_joined'), 'joined_at')
+                ->outputFormat('Y-m-d'),
+            DateColumn::make(__('stables.date_left'), 'left_at')
+                ->outputFormat('Y-m-d'),
         ];
     }
 
     public function configure(): void
     {
-        $this->setPrimaryKey('id')
-            ->setColumnSelectDisabled()
-            ->setSearchPlaceholder('Search '.$this->resourceName)
-            ->setPaginationEnabled()
-            ->setPerPageAccepted([5, 10, 25, 50, 100])
-            ->setLoadingPlaceholderContent('Loading')
-            ->setLoadingPlaceholderEnabled();
+        $this->addAdditionalSelects([
+            'stables_tag_teams.tag_team_id',
+            'stables_tag_teams.stable_id',
+            'stables_tag_teams.joined_at',
+            'stables_tag_teams.left_at',
+        ]);
     }
 }

--- a/app/Livewire/Stables/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Stables/Tables/PreviousWrestlers.php
@@ -4,26 +4,27 @@ declare(strict_types=1);
 
 namespace App\Livewire\Stables\Tables;
 
+use App\Livewire\Concerns\ShowTableTrait;
 use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\Stables\StableWrestler;
-use App\Models\Wrestlers\Wrestler;
-use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Relations\Relation;
 use LogicException;
 
 class PreviousWrestlers extends DataTableComponent
 {
+    use ShowTableTrait;
+
     protected string $resourceName = 'wrestlers';
 
-    protected string $databaseTableName = 'wrestlers';
+    protected string $databaseTableName = 'stables_wrestlers';
 
     public ?int $stableId;
 
     /**
-     * @return Builder<Wrestler>
+     * @return Builder<StableWrestler>
      */
     public function builder(): Builder
     {
@@ -31,15 +32,11 @@ class PreviousWrestlers extends DataTableComponent
             throw new LogicException('A stable was not provided.');
         }
 
-        return Wrestler::query()
-            ->whereHas('stables', function (Builder $query) {
-                $query->where('stable_id', $this->stableId)
-                    ->whereNotNull('left_at');
-            })
-            ->with(['stables' => function (Relation $query) {
-                $query->where('stable_id', $this->stableId)
-                    ->whereNotNull('left_at');
-            }]);
+        return StableWrestler::query()
+            ->with('wrestler')
+            ->forStableId($this->stableId)
+            ->ended()
+            ->mostRecentlyJoinedFirst();
     }
 
     /**
@@ -49,55 +46,22 @@ class PreviousWrestlers extends DataTableComponent
     {
         return [
             LinkColumn::make(__('wrestlers.name'))
-                ->title(fn (Wrestler $row) => $row->name ?? 'Unknown')
-                ->location(fn (Wrestler $row) => route('wrestlers.show', $row)),
-            Column::make(__('stables.date_joined'))
-                ->label(function (Wrestler $row): string {
-                    $stable = $row->stables->first();
-                    if (! $stable || ! isset($stable->pivot)) {
-                        return '';
-                    }
-
-                    /** @var StableWrestler $pivot */
-                    $pivot = $stable->pivot;
-                    $joinedAt = $pivot->getAttribute('joined_at');
-                    if (! $joinedAt) {
-                        return '';
-                    }
-
-                    return is_string($joinedAt) ?
-                        Carbon::parse($joinedAt)->format('Y-m-d') :
-                        $joinedAt->format('Y-m-d');
-                }),
-            Column::make(__('stables.date_left'))
-                ->label(function (Wrestler $row): string {
-                    $stable = $row->stables->first();
-                    if (! $stable || ! isset($stable->pivot)) {
-                        return '';
-                    }
-
-                    /** @var StableWrestler $pivot */
-                    $pivot = $stable->pivot;
-                    $leftAt = $pivot->getAttribute('left_at');
-                    if (! $leftAt) {
-                        return '';
-                    }
-
-                    return is_string($leftAt) ?
-                        Carbon::parse($leftAt)->format('Y-m-d') :
-                        $leftAt->format('Y-m-d');
-                }),
+                ->title(fn (StableWrestler $row) => $row->wrestler->name ?? 'Unknown')
+                ->location(fn (StableWrestler $row) => $row->wrestler ? route('wrestlers.show', $row->wrestler) : '#'),
+            DateColumn::make(__('stables.date_joined'), 'joined_at')
+                ->outputFormat('Y-m-d'),
+            DateColumn::make(__('stables.date_left'), 'left_at')
+                ->outputFormat('Y-m-d'),
         ];
     }
 
     public function configure(): void
     {
-        $this->setPrimaryKey('id')
-            ->setColumnSelectDisabled()
-            ->setSearchPlaceholder('Search '.$this->resourceName)
-            ->setPaginationEnabled()
-            ->setPerPageAccepted([5, 10, 25, 50, 100])
-            ->setLoadingPlaceholderContent('Loading')
-            ->setLoadingPlaceholderEnabled();
+        $this->addAdditionalSelects([
+            'stables_wrestlers.wrestler_id',
+            'stables_wrestlers.stable_id',
+            'stables_wrestlers.joined_at',
+            'stables_wrestlers.left_at',
+        ]);
     }
 }

--- a/app/Models/Stables/StableTagTeam.php
+++ b/app/Models/Stables/StableTagTeam.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Stables;
 
-use App\Builders\Roster\MembershipPeriodBuilder;
+use App\Builders\Roster\StableMembershipBuilder;
 use App\Models\TagTeams\TagTeam;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
@@ -22,18 +22,20 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  *
  * @property-read Stable $stable
- * @property-read TagTeam $tagTeam
+ * @property-read TagTeam|null $tagTeam
  *
- * @method static MembershipPeriodBuilder<static> current()
- * @method static MembershipPeriodBuilder<static> ended()
- * @method static MembershipPeriodBuilder<static> newModelQuery()
- * @method static MembershipPeriodBuilder<static> newQuery()
- * @method static MembershipPeriodBuilder<static> query()
+ * @method static StableMembershipBuilder<static> current()
+ * @method static StableMembershipBuilder<static> ended()
+ * @method static StableMembershipBuilder<static> forStableId(int $stableId)
+ * @method static StableMembershipBuilder<static> mostRecentlyJoinedFirst()
+ * @method static StableMembershipBuilder<static> newModelQuery()
+ * @method static StableMembershipBuilder<static> newQuery()
+ * @method static StableMembershipBuilder<static> query()
  *
  * @mixin \Eloquent
  */
 #[Fillable('stable_id', 'tag_team_id', 'joined_at', 'left_at')]
-#[UseEloquentBuilder(MembershipPeriodBuilder::class)]
+#[UseEloquentBuilder(StableMembershipBuilder::class)]
 class StableTagTeam extends Pivot
 {
     /** @var string */

--- a/app/Models/Stables/StableWrestler.php
+++ b/app/Models/Stables/StableWrestler.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Stables;
 
-use App\Builders\Roster\MembershipPeriodBuilder;
+use App\Builders\Roster\StableMembershipBuilder;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
@@ -22,18 +22,20 @@ use Illuminate\Support\Carbon;
  * @property Carbon|null $updated_at
  *
  * @property-read Stable $stable
- * @property-read Wrestler $wrestler
+ * @property-read Wrestler|null $wrestler
  *
- * @method static MembershipPeriodBuilder<static> current()
- * @method static MembershipPeriodBuilder<static> ended()
- * @method static MembershipPeriodBuilder<static> newModelQuery()
- * @method static MembershipPeriodBuilder<static> newQuery()
- * @method static MembershipPeriodBuilder<static> query()
+ * @method static StableMembershipBuilder<static> current()
+ * @method static StableMembershipBuilder<static> ended()
+ * @method static StableMembershipBuilder<static> forStableId(int $stableId)
+ * @method static StableMembershipBuilder<static> mostRecentlyJoinedFirst()
+ * @method static StableMembershipBuilder<static> newModelQuery()
+ * @method static StableMembershipBuilder<static> newQuery()
+ * @method static StableMembershipBuilder<static> query()
  *
  * @mixin \Eloquent
  */
 #[Fillable('stable_id', 'wrestler_id', 'joined_at', 'left_at')]
-#[UseEloquentBuilder(MembershipPeriodBuilder::class)]
+#[UseEloquentBuilder(StableMembershipBuilder::class)]
 class StableWrestler extends Pivot
 {
     /** @var string */

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -18,9 +18,11 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `ManagerAssignmentBuilder` owns the shared manager filter, lifecycle-state constraints, and most-recent-hire ordering for wrestler and tag-team manager assignment records.
 
-`MembershipPeriodBuilder` owns the shared `current()` and `ended()` persistence queries for tag-team and stable membership records.
+`MembershipPeriodBuilder` owns the shared `current()`, `ended()`, and most-recent-join ordering queries for tag-team and stable membership records.
 
-`TagTeamMembershipBuilder` extends the shared membership-period queries with tag-team and wrestler filters, historical period-overlap constraints, and most-recent-join ordering specific to `TagTeamWrestler` records.
+`TagTeamMembershipBuilder` extends the shared membership-period queries with tag-team and wrestler filters and historical period-overlap constraints specific to `TagTeamWrestler` records.
+
+`StableMembershipBuilder` extends the shared membership-period queries with stable filtering for both `StableWrestler` and `StableTagTeam` records. Stable membership-history tables query these typed records directly so membership dates remain first-class persisted data rather than manually extracted pivot attributes.
 
 `StableBuilder` owns stable lifecycle-state filters and historical stable-membership projections for wrestlers and tag teams. The history methods select the persisted membership dates required by the table layer.
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -229,19 +229,13 @@ parameters:
 			path: app/Livewire/Stables/Tables/PreviousManagers.php
 
 		-
-			message: '#^Parameter \#1 \$relations of method Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\TagTeams\\TagTeam\>\:\:with\(\) expects array\<array\|\(Closure\(Illuminate\\Database\\Eloquent\\Relations\\Relation\<\*, \*, \*\>\)\: mixed\)\|string\>\|string, array\{stables\: Closure\(Illuminate\\Database\\Eloquent\\Relations\\BelongsToMany\)\: void\} given\.$#'
-			identifier: argument.type
-			count: 1
-			path: app/Livewire/Stables/Tables/PreviousTagTeams.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\TagTeams\\TagTeam\>\) of method App\\Livewire\\Stables\\Tables\\PreviousTagTeams\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
+			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Stables\\StableTagTeam\>\) of method App\\Livewire\\Stables\\Tables\\PreviousTagTeams\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
 			identifier: method.childReturnType
 			count: 1
 			path: app/Livewire/Stables/Tables/PreviousTagTeams.php
 
 		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Wrestlers\\Wrestler\>\) of method App\\Livewire\\Stables\\Tables\\PreviousWrestlers\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
+			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Stables\\StableWrestler\>\) of method App\\Livewire\\Stables\\Tables\\PreviousWrestlers\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
 			identifier: method.childReturnType
 			count: 1
 			path: app/Livewire/Stables/Tables/PreviousWrestlers.php

--- a/tests/Feature/Livewire/Stables/Tables/PreviousMembershipsTest.php
+++ b/tests/Feature/Livewire/Stables/Tables/PreviousMembershipsTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Stables\Tables\PreviousTagTeams;
+use App\Livewire\Stables\Tables\PreviousWrestlers;
+use App\Models\Stables\Stable;
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Users\User;
+use App\Models\Wrestlers\Wrestler;
+
+use function Pest\Laravel\actingAs;
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    actingAs(User::factory()->administrator()->create());
+
+    $this->stable = Stable::factory()->create();
+});
+
+test('previous wrestlers renders typed membership history for one stable', function () {
+    $formerWrestler = Wrestler::factory()->create();
+    $currentWrestler = Wrestler::factory()->create();
+    $otherStableWrestler = Wrestler::factory()->create();
+    $otherStable = Stable::factory()->create();
+    $joinedAt = now()->subMonths(3);
+    $leftAt = now()->subMonth();
+
+    StableWrestler::query()->create([
+        'stable_id' => $this->stable->id,
+        'wrestler_id' => $formerWrestler->id,
+        'joined_at' => $joinedAt,
+        'left_at' => $leftAt,
+    ]);
+    StableWrestler::query()->create([
+        'stable_id' => $this->stable->id,
+        'wrestler_id' => $currentWrestler->id,
+        'joined_at' => now()->subWeek(),
+    ]);
+    StableWrestler::query()->create([
+        'stable_id' => $otherStable->id,
+        'wrestler_id' => $otherStableWrestler->id,
+        'joined_at' => now()->subMonths(2),
+        'left_at' => now()->subWeek(),
+    ]);
+
+    livewire(PreviousWrestlers::class, ['stableId' => $this->stable->id])
+        ->assertOk()
+        ->assertSee($formerWrestler->name)
+        ->assertSee(route('wrestlers.show', $formerWrestler))
+        ->assertSee($joinedAt->format('Y-m-d'))
+        ->assertSee($leftAt->format('Y-m-d'))
+        ->assertDontSee($currentWrestler->name)
+        ->assertDontSee($otherStableWrestler->name);
+});
+
+test('previous tag teams renders typed membership history for one stable', function () {
+    $formerTagTeam = TagTeam::factory()->create();
+    $currentTagTeam = TagTeam::factory()->create();
+    $otherStableTagTeam = TagTeam::factory()->create();
+    $otherStable = Stable::factory()->create();
+    $joinedAt = now()->subMonths(4);
+    $leftAt = now()->subMonths(2);
+
+    StableTagTeam::query()->create([
+        'stable_id' => $this->stable->id,
+        'tag_team_id' => $formerTagTeam->id,
+        'joined_at' => $joinedAt,
+        'left_at' => $leftAt,
+    ]);
+    StableTagTeam::query()->create([
+        'stable_id' => $this->stable->id,
+        'tag_team_id' => $currentTagTeam->id,
+        'joined_at' => now()->subWeek(),
+    ]);
+    StableTagTeam::query()->create([
+        'stable_id' => $otherStable->id,
+        'tag_team_id' => $otherStableTagTeam->id,
+        'joined_at' => now()->subMonths(3),
+        'left_at' => now()->subMonth(),
+    ]);
+
+    livewire(PreviousTagTeams::class, ['stableId' => $this->stable->id])
+        ->assertOk()
+        ->assertSee($formerTagTeam->name)
+        ->assertSee(route('tag-teams.show', $formerTagTeam))
+        ->assertSee($joinedAt->format('Y-m-d'))
+        ->assertSee($leftAt->format('Y-m-d'))
+        ->assertDontSee($currentTagTeam->name)
+        ->assertDontSee($otherStableTagTeam->name);
+});

--- a/tests/Integration/Models/Stables/StableTagTeamTest.php
+++ b/tests/Integration/Models/Stables/StableTagTeamTest.php
@@ -199,7 +199,7 @@ describe('StableTagTeam Pivot Model', function () {
             expect($pivotRecord->left_at)->toBeNull();
 
             // Test pivot relationships
-            expect($pivotRecord->tagTeam->id)->toBe($this->tagTeam->id);
+            expect($pivotRecord->tagTeam?->id)->toBe($this->tagTeam->id);
             expect($pivotRecord->stable->id)->toBe($this->stable->id);
         });
 

--- a/tests/Integration/Models/Stables/StableWrestlerTest.php
+++ b/tests/Integration/Models/Stables/StableWrestlerTest.php
@@ -201,7 +201,7 @@ describe('StableWrestler Pivot Model', function () {
             expect($pivotRecord->left_at)->toBeNull();
 
             // Test pivot relationships
-            expect($pivotRecord->wrestler->id)->toBe($this->wrestler->id);
+            expect($pivotRecord->wrestler?->id)->toBe($this->wrestler->id);
             expect($pivotRecord->stable->id)->toBe($this->stable->id);
         });
 

--- a/tests/Unit/Builders/Roster/StableMembershipBuilderTest.php
+++ b/tests/Unit/Builders/Roster/StableMembershipBuilderTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Builders\Roster\StableMembershipBuilder;
+use App\Models\Stables\Stable;
+use App\Models\Stables\StableTagTeam;
+use App\Models\Stables\StableWrestler;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+
+test('stable membership models use the stable membership builder', function () {
+    expect(StableWrestler::query())->toBeInstanceOf(StableMembershipBuilder::class)
+        ->and(StableTagTeam::query())->toBeInstanceOf(StableMembershipBuilder::class);
+});
+
+test('stable memberships can be filtered and ordered by their stable history', function () {
+    $stable = Stable::factory()->create();
+    $otherStable = Stable::factory()->create();
+    $recentWrestler = Wrestler::factory()->create();
+    $olderWrestler = Wrestler::factory()->create();
+    $currentTagTeam = TagTeam::factory()->create();
+    $formerTagTeam = TagTeam::factory()->create();
+
+    StableWrestler::query()->create([
+        'stable_id' => $stable->id,
+        'wrestler_id' => $olderWrestler->id,
+        'joined_at' => now()->subMonths(4),
+        'left_at' => now()->subMonths(3),
+    ]);
+    StableWrestler::query()->create([
+        'stable_id' => $stable->id,
+        'wrestler_id' => $recentWrestler->id,
+        'joined_at' => now()->subMonths(2),
+        'left_at' => now()->subMonth(),
+    ]);
+    StableWrestler::query()->create([
+        'stable_id' => $otherStable->id,
+        'wrestler_id' => Wrestler::factory()->create()->id,
+        'joined_at' => now()->subWeek(),
+        'left_at' => now()->subDay(),
+    ]);
+    StableTagTeam::query()->create([
+        'stable_id' => $stable->id,
+        'tag_team_id' => $currentTagTeam->id,
+        'joined_at' => now()->subMonth(),
+    ]);
+    StableTagTeam::query()->create([
+        'stable_id' => $stable->id,
+        'tag_team_id' => $formerTagTeam->id,
+        'joined_at' => now()->subMonths(3),
+        'left_at' => now()->subMonths(2),
+    ]);
+
+    $wrestlerIds = StableWrestler::query()
+        ->forStableId($stable->id)
+        ->ended()
+        ->mostRecentlyJoinedFirst()
+        ->pluck('wrestler_id')
+        ->all();
+    $formerTagTeamIds = StableTagTeam::query()
+        ->forStableId($stable->id)
+        ->ended()
+        ->pluck('tag_team_id')
+        ->all();
+
+    expect($wrestlerIds)->toBe([$recentWrestler->id, $olderWrestler->id])
+        ->and($formerTagTeamIds)->toBe([$formerTagTeam->id]);
+});


### PR DESCRIPTION
## Summary
- introduce a typed StableMembershipBuilder for stable membership records
- share membership-period ordering across stable and tag-team membership builders
- query stable history tables through typed membership models instead of extracting pivot attributes
- document the builder boundary and reduce the PHPStan baseline

## Verification
- 40 focused tests passed with 143 assertions
- application and Pest PHPStan passed
- Rector passed
- changed PHP files passed Pint with Blade formatting
- git diff checks passed

## Local suite note
- composer test:push passed type coverage and Rector, then reached the existing Blade formatter mismatch across untouched views; this PR does not modify those Blade files