### PR TITLE
refactor: type data table builders

### DIFF
--- a/app/Livewire/Base/Tables/BasePreviousManagersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousManagersTable.php
@@ -8,7 +8,13 @@ use App\Livewire\Concerns\ShowTableTrait;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\DataTableComponent;
+use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TModel of Model
+ *
+ * @extends DataTableComponent<TModel>
+ */
 abstract class BasePreviousManagersTable extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
@@ -15,6 +15,9 @@ use App\Models\Matches\MatchCompetitor;
 use App\Models\Referees\Referee;
 use App\Models\Titles\Title;
 
+/**
+ * @extends DataTableComponent<EventMatch>
+ */
 abstract class BasePreviousMatchesTable extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Base/Tables/BasePreviousStablesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousStablesTable.php
@@ -8,7 +8,13 @@ use App\Livewire\Concerns\ShowTableTrait;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\DataTableComponent;
+use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TModel of Model
+ *
+ * @extends DataTableComponent<TModel>
+ */
 abstract class BasePreviousStablesTable extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
@@ -11,6 +11,9 @@ use App\Livewire\Table\Columns\LinkColumn;
 use App\Livewire\Table\DataTableComponent;
 use App\Models\TagTeams\TagTeamWrestler;
 
+/**
+ * @extends DataTableComponent<TagTeamWrestler>
+ */
 abstract class BasePreviousTagTeamsTable extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
@@ -13,6 +13,9 @@ use App\Models\Titles\TitleChampionship;
 use App\Queries\Titles\TitleChampionshipQuery;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @extends DataTableComponent<TitleChampionship>
+ */
 abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
@@ -8,7 +8,13 @@ use App\Livewire\Concerns\ShowTableTrait;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\DataTableComponent;
+use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TModel of Model
+ *
+ * @extends DataTableComponent<TModel>
+ */
 abstract class BasePreviousWrestlersTable extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Base/Tables/BaseTable.php
+++ b/app/Livewire/Base/Tables/BaseTable.php
@@ -7,7 +7,13 @@ namespace App\Livewire\Base\Tables;
 use App\Livewire\Concerns\BaseTableTrait;
 use App\Livewire\Concerns\Columns\HasActionColumn;
 use App\Livewire\Table\DataTableComponent;
+use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @template TModel of Model
+ *
+ * @extends DataTableComponent<TModel>
+ */
 abstract class BaseTable extends DataTableComponent
 {
     use BaseTableTrait;

--- a/app/Livewire/Concerns/BaseTableTrait.php
+++ b/app/Livewire/Concerns/BaseTableTrait.php
@@ -116,7 +116,7 @@ trait BaseTableTrait
                 ];
             })
             ->setTdAttributes(function (Column $column, $row, $columnIndex, $rowIndex): array {
-                if ($this->columns->count() - 1 === $columnIndex) {
+                if (count($this->getColumns()) - 1 === $columnIndex) {
                     return [
                         'default' => false,
                         'default-styling' => false,

--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -20,6 +20,7 @@ use App\Models\Events\Venue;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 
+/** @extends BaseTable<Event> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = true;

--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -34,6 +34,7 @@ use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Managers\Manager;
 use Illuminate\Support\Facades\Gate;
 
+/** @extends BaseTable<Manager> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = true;

--- a/app/Livewire/Managers/Tables/PreviousStables.php
+++ b/app/Livewire/Managers/Tables/PreviousStables.php
@@ -10,6 +10,7 @@ use App\Models\Stables\Stable;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends BasePreviousStablesTable<Stable> */
 class PreviousStables extends BasePreviousStablesTable
 {
     /**

--- a/app/Livewire/Managers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeams.php
@@ -12,6 +12,7 @@ use App\Models\TagTeams\TagTeamManager;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends DataTableComponent<TagTeamManager> */
 class PreviousTagTeams extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Managers/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlers.php
@@ -12,6 +12,7 @@ use App\Models\Wrestlers\WrestlerManager;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends DataTableComponent<WrestlerManager> */
 class PreviousWrestlers extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -13,6 +13,7 @@ use App\Models\Matches\MatchCompetitor;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 
+/** @extends BaseTable<EventMatch> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = false;

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -16,6 +16,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 use LogicException;
 
+/** @extends DataTableComponent<EventMatch> */
 class MatchesTable extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -35,6 +35,7 @@ use App\Models\Referees\Referee;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
+/** @extends BaseTable<Referee> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = true;

--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -27,6 +27,7 @@ use App\Models\Stables\Stable;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 
+/** @extends BaseTable<Stable> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = true;

--- a/app/Livewire/Stables/Tables/PreviousManagers.php
+++ b/app/Livewire/Stables/Tables/PreviousManagers.php
@@ -11,6 +11,7 @@ use App\Models\Stables\Stable;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends BasePreviousManagersTable<Manager> */
 class PreviousManagers extends BasePreviousManagersTable
 {
     public string $databaseTableName = 'managers';

--- a/app/Livewire/Stables/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Stables/Tables/PreviousTagTeams.php
@@ -13,6 +13,7 @@ use App\Models\Stables\StableTagTeam;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends DataTableComponent<StableTagTeam> */
 class PreviousTagTeams extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Stables/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Stables/Tables/PreviousWrestlers.php
@@ -13,6 +13,7 @@ use App\Models\Stables\StableWrestler;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends DataTableComponent<StableWrestler> */
 class PreviousWrestlers extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Table/DataTableComponent.php
+++ b/app/Livewire/Table/DataTableComponent.php
@@ -11,6 +11,9 @@ use Illuminate\Database\Eloquent\Model;
 use Livewire\Component;
 use Livewire\WithPagination;
 
+/**
+ * @template TModel of Model
+ */
 abstract class DataTableComponent extends Component
 {
     use WithPagination;
@@ -45,7 +48,7 @@ abstract class DataTableComponent extends Component
     /**
      * Return the query builder for the table data.
      *
-     * @return Builder<Model>
+     * @return Builder<TModel>
      */
     abstract public function builder(): Builder;
 
@@ -129,7 +132,7 @@ abstract class DataTableComponent extends Component
     }
 
     /**
-     * @return LengthAwarePaginator<int, Model>
+     * @return LengthAwarePaginator<int, TModel>
      */
     protected function getRows(): LengthAwarePaginator
     {
@@ -147,7 +150,7 @@ abstract class DataTableComponent extends Component
     }
 
     /**
-     * @param  Builder<Model>  $query
+     * @param  Builder<TModel>  $query
      */
     protected function applySearch(Builder $query): void
     {
@@ -172,7 +175,7 @@ abstract class DataTableComponent extends Component
     }
 
     /**
-     * @param  Builder<Model>  $query
+     * @param  Builder<TModel>  $query
      */
     protected function applyFilters(Builder $query): void
     {
@@ -183,7 +186,7 @@ abstract class DataTableComponent extends Component
     }
 
     /**
-     * @param  Builder<Model>  $query
+     * @param  Builder<TModel>  $query
      */
     protected function applySorting(Builder $query): void
     {

--- a/app/Livewire/Table/Filter.php
+++ b/app/Livewire/Table/Filter.php
@@ -6,7 +6,6 @@ namespace App\Livewire\Table;
 
 use Closure;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 
 abstract class Filter
 {
@@ -53,7 +52,7 @@ abstract class Filter
     /**
      * Apply this filter to the query builder.
      *
-     * @param  Builder<Model>  $builder
+     * @param  Builder<*>  $builder
      */
     public function apply(Builder $builder, mixed $value): void
     {

--- a/app/Livewire/Table/Filters/DateRangeFilter.php
+++ b/app/Livewire/Table/Filters/DateRangeFilter.php
@@ -6,7 +6,6 @@ namespace App\Livewire\Table\Filters;
 
 use App\Livewire\Table\Filter;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Eloquent\Model;
 
 class DateRangeFilter extends Filter
 {
@@ -65,7 +64,7 @@ class DateRangeFilter extends Filter
      * guard, the default empty-array value bypasses the parent class's
      * `!== ''/!== null` check and reaches callbacks that read those keys.
      *
-     * @param  Builder<Model>  $builder
+     * @param  Builder<*>  $builder
      */
     public function apply(Builder $builder, mixed $value): void
     {

--- a/app/Livewire/TagTeams/Tables/Main.php
+++ b/app/Livewire/TagTeams/Tables/Main.php
@@ -31,6 +31,7 @@ use App\Models\TagTeams\TagTeam;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
+/** @extends BaseTable<TagTeam> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = true;

--- a/app/Livewire/TagTeams/Tables/PreviousManagers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousManagers.php
@@ -9,6 +9,7 @@ use App\Models\TagTeams\TagTeamManager;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends BasePreviousManagersTable<TagTeamManager> */
 class PreviousManagers extends BasePreviousManagersTable
 {
     protected string $databaseTableName = 'tag_teams_managers';

--- a/app/Livewire/TagTeams/Tables/PreviousStables.php
+++ b/app/Livewire/TagTeams/Tables/PreviousStables.php
@@ -9,6 +9,7 @@ use App\Models\Stables\Stable;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends BasePreviousStablesTable<Stable> */
 class PreviousStables extends BasePreviousStablesTable
 {
     protected string $databaseTableName = 'stables';

--- a/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
@@ -13,6 +13,7 @@ use App\Models\TagTeams\TagTeamWrestler;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends DataTableComponent<TagTeamWrestler> */
 class PreviousWrestlers extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -51,6 +51,7 @@ use Illuminate\Support\Facades\Gate;
  * // - Tag Team Titles (Inactive, First Activated: 2021-03-10)
  * ```
  */
+/** @extends BaseTable<Title> */
 class Main extends BaseTable
 {
     /**

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 use LogicException;
 
+/** @extends DataTableComponent<TitleChampionship> */
 class PreviousTitleChampionships extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
+++ b/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
@@ -12,6 +12,7 @@ use App\Queries\Titles\TitleChampionshipQuery;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 
+/** @extends DataTableComponent<Model> */
 class TitleChampionshipsTable extends DataTableComponent
 {
     /**

--- a/app/Livewire/Users/Tables/Main.php
+++ b/app/Livewire/Users/Tables/Main.php
@@ -9,6 +9,7 @@ use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Table\Column;
 use App\Models\Users\User;
 
+/** @extends BaseTable<User> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = true;

--- a/app/Livewire/Venues/Tables/Main.php
+++ b/app/Livewire/Venues/Tables/Main.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
+/** @extends BaseTable<Venue> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = true;

--- a/app/Livewire/Venues/Tables/PreviousEvents.php
+++ b/app/Livewire/Venues/Tables/PreviousEvents.php
@@ -13,6 +13,7 @@ use App\Livewire\Table\DataTableComponent;
 use App\Models\Events\Event;
 use LogicException;
 
+/** @extends DataTableComponent<Event> */
 class PreviousEvents extends DataTableComponent
 {
     use ShowTableTrait;

--- a/app/Livewire/Wrestlers/Tables/Main.php
+++ b/app/Livewire/Wrestlers/Tables/Main.php
@@ -18,6 +18,7 @@ use App\Models\Wrestlers\Wrestler;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
+/** @extends BaseTable<Wrestler> */
 class Main extends BaseTable
 {
     protected bool $showActionColumn = true;

--- a/app/Livewire/Wrestlers/Tables/PreviousManagers.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousManagers.php
@@ -9,6 +9,7 @@ use App\Models\Wrestlers\WrestlerManager;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends BasePreviousManagersTable<WrestlerManager> */
 class PreviousManagers extends BasePreviousManagersTable
 {
     /**

--- a/app/Livewire/Wrestlers/Tables/PreviousStables.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousStables.php
@@ -9,6 +9,7 @@ use App\Models\Stables\Stable;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
+/** @extends BasePreviousStablesTable<Stable> */
 class PreviousStables extends BasePreviousStablesTable
 {
     /**

--- a/docs/architecture/livewire/component-architecture.md
+++ b/docs/architecture/livewire/component-architecture.md
@@ -209,6 +209,12 @@ class CreateEditForm extends BaseForm
 - **Runtime Safety**: Type hints prevent incorrect usage
 - **Documentation**: Clear contracts for component usage
 
+### Typed Table Rows
+
+`DataTableComponent` is generic over the Eloquent model returned by its `builder()` method. Every concrete table declares that row model through an `@extends` annotation, and generic intermediate table bases forward their model template to `DataTableComponent`.
+
+This keeps search, filters, sorting, and pagination attached to the concrete Builder type instead of widening every table to `Builder<Model>`. Fixed-purpose table bases, such as previous-match and championship-history tables, bind their known row model directly.
+
 ## Integration Patterns
 
 ### Form-Modal Integration

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -67,18 +67,6 @@ parameters:
 			path: app/Livewire/Base/Tables/BasePreviousMatchesTable.php
 
 		-
-			message: '#^Access to an undefined property App\\Livewire\\Base\\Tables\\BaseTable\:\:\$columns\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Livewire/Base/Tables/BaseTable.php
-
-		-
-			message: '#^Return type \(App\\Builders\\Events\\EventBuilder\<App\\Models\\Events\\Event\>\) of method App\\Livewire\\Events\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Events/Tables/Main.php
-
-		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$first_name\.$#'
 			identifier: property.notFound
 			count: 2
@@ -139,30 +127,6 @@ parameters:
 			path: app/Livewire/Managers/Components/Actions.php
 
 		-
-			message: '#^Return type \(App\\Builders\\Roster\\ManagerBuilder\<App\\Models\\Managers\\Manager\>\) of method App\\Livewire\\Managers\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Managers/Tables/Main.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Stables\\Stable\>\) of method App\\Livewire\\Managers\\Tables\\PreviousStables\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Managers/Tables/PreviousStables.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\TagTeams\\TagTeamManager\>\) of method App\\Livewire\\Managers\\Tables\\PreviousTagTeams\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Managers/Tables/PreviousTagTeams.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Wrestlers\\WrestlerManager\>\) of method App\\Livewire\\Managers\\Tables\\PreviousWrestlers\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Managers/Tables/PreviousWrestlers.php
-
-		-
 			message: '#^Negated boolean expression is always false\.$#'
 			identifier: booleanNot.alwaysFalse
 			count: 1
@@ -181,8 +145,8 @@ parameters:
 			path: app/Livewire/Matches/Modals/FormModal.php
 
 		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Matches\\EventMatch\>\) of method App\\Livewire\\Matches\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
+			message: '#^Using nullsafe property access on non\-nullable type App\\Models\\Matches\\MatchResult\. Use \-\> instead\.$#'
+			identifier: nullsafe.neverNull
 			count: 1
 			path: app/Livewire/Matches/Tables/Main.php
 
@@ -190,55 +154,7 @@ parameters:
 			message: '#^Using nullsafe property access on non\-nullable type App\\Models\\Matches\\MatchResult\. Use \-\> instead\.$#'
 			identifier: nullsafe.neverNull
 			count: 1
-			path: app/Livewire/Matches/Tables/Main.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Matches\\EventMatch\>\) of method App\\Livewire\\Matches\\Tables\\MatchesTable\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
 			path: app/Livewire/Matches/Tables/MatchesTable.php
-
-		-
-			message: '#^Using nullsafe property access on non\-nullable type App\\Models\\Matches\\MatchResult\. Use \-\> instead\.$#'
-			identifier: nullsafe.neverNull
-			count: 1
-			path: app/Livewire/Matches/Tables/MatchesTable.php
-
-		-
-			message: '#^Return type \(App\\Builders\\Roster\\RefereeBuilder\<App\\Models\\Referees\\Referee\>\) of method App\\Livewire\\Referees\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Referees/Tables/Main.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Matches\\EventMatch\>\) of method App\\Livewire\\Referees\\Tables\\PreviousMatches\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Referees/Tables/PreviousMatches.php
-
-		-
-			message: '#^Return type \(App\\Builders\\Roster\\StableBuilder\<App\\Models\\Stables\\Stable\>\) of method App\\Livewire\\Stables\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Stables/Tables/Main.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Managers\\Manager\>\) of method App\\Livewire\\Stables\\Tables\\PreviousManagers\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Stables/Tables/PreviousManagers.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Stables\\StableTagTeam\>\) of method App\\Livewire\\Stables\\Tables\\PreviousTagTeams\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Stables/Tables/PreviousTagTeams.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Stables\\StableWrestler\>\) of method App\\Livewire\\Stables\\Tables\\PreviousWrestlers\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Stables/Tables/PreviousWrestlers.php
 
 		-
 			message: '#^Instanceof between Illuminate\\View\\View and Illuminate\\Contracts\\View\\View will always evaluate to true\.$#'
@@ -317,111 +233,8 @@ parameters:
 			identifier: missingType.iterableValue
 			count: 1
 			path: app/Livewire/TagTeams/Components/Actions.php
-
 		-
 			message: '#^Method App\\Livewire\\TagTeams\\Components\\Actions\:\:executeActionWithContext\(\) has parameter \$actionParams with no value type specified in iterable type array\.$#'
 			identifier: missingType.iterableValue
 			count: 1
 			path: app/Livewire/TagTeams/Components/Actions.php
-
-		-
-			message: '#^Return type \(App\\Builders\\Roster\\TagTeamBuilder\<App\\Models\\TagTeams\\TagTeam\>\) of method App\\Livewire\\TagTeams\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/TagTeams/Tables/Main.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\TagTeams\\TagTeamManager\>\) of method App\\Livewire\\TagTeams\\Tables\\PreviousManagers\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/TagTeams/Tables/PreviousManagers.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Matches\\EventMatch\>\) of method App\\Livewire\\TagTeams\\Tables\\PreviousMatches\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/TagTeams/Tables/PreviousMatches.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Stables\\Stable\>\) of method App\\Livewire\\TagTeams\\Tables\\PreviousStables\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/TagTeams/Tables/PreviousStables.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Titles\\TitleChampionship\>\) of method App\\Livewire\\TagTeams\\Tables\\PreviousTitleChampionships\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\TagTeams\\TagTeamWrestler\>\) of method App\\Livewire\\TagTeams\\Tables\\PreviousWrestlers\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/TagTeams/Tables/PreviousWrestlers.php
-
-		-
-			message: '#^Return type \(App\\Builders\\Titles\\TitleBuilder\<App\\Models\\Titles\\Title\>\) of method App\\Livewire\\Titles\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Titles/Tables/Main.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Titles\\TitleChampionship\>\) of method App\\Livewire\\Titles\\Tables\\PreviousTitleChampionships\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Titles/Tables/PreviousTitleChampionships.php
-
-		-
-			message: '#^Return type \(App\\Builders\\Users\\UserBuilder\<App\\Models\\Users\\User\>\) of method App\\Livewire\\Users\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Users/Tables/Main.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Events\\Venue\>\) of method App\\Livewire\\Venues\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Venues/Tables/Main.php
-
-		-
-			message: '#^Return type \(App\\Builders\\Events\\EventBuilder\<App\\Models\\Events\\Event\>\) of method App\\Livewire\\Venues\\Tables\\PreviousEvents\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Venues/Tables/PreviousEvents.php
-
-		-
-			message: '#^Return type \(App\\Builders\\Roster\\WrestlerBuilder\<App\\Models\\Wrestlers\\Wrestler\>\) of method App\\Livewire\\Wrestlers\\Tables\\Main\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Wrestlers/Tables/Main.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Wrestlers\\WrestlerManager\>\) of method App\\Livewire\\Wrestlers\\Tables\\PreviousManagers\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Wrestlers/Tables/PreviousManagers.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Matches\\EventMatch\>\) of method App\\Livewire\\Wrestlers\\Tables\\PreviousMatches\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Wrestlers/Tables/PreviousMatches.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Stables\\Stable\>\) of method App\\Livewire\\Wrestlers\\Tables\\PreviousStables\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Wrestlers/Tables/PreviousStables.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\TagTeams\\TagTeamWrestler\>\) of method App\\Livewire\\Wrestlers\\Tables\\PreviousTagTeams\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
-
-		-
-			message: '#^Return type \(Illuminate\\Database\\Eloquent\\Builder\<App\\Models\\Titles\\TitleChampionship\>\) of method App\\Livewire\\Wrestlers\\Tables\\PreviousTitleChampionships\:\:builder\(\) should be compatible with return type \(Illuminate\\Database\\Eloquent\\Builder\<Illuminate\\Database\\Eloquent\\Model\>\) of method App\\Livewire\\Table\\DataTableComponent\:\:builder\(\)$#'
-			identifier: method.childReturnType
-			count: 1
-			path: app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php


### PR DESCRIPTION
## Summary
- make DataTableComponent generic over its Eloquent row model
- carry concrete row types through base and domain table components
- type search, filters, sorting, and pagination without widening Builders to Model
- replace the stale columns compatibility property access with the actual configured columns
- remove 30 obsolete PHPStan return-type suppressions and document the table boundary

## Verification
- 386 table tests passed with 907 assertions before rebase
- 119 stable and tag-team tests passed with 298 assertions after rebase
- application and Pest PHPStan passed after rebase
- Rector passed
- changed PHP files passed Pint with Blade formatting
- git diff checks passed