### PR TITLE
refactor: centralize title championship history

### DIFF
--- a/app/Builders/Titles/TitleChampionshipBuilder.php
+++ b/app/Builders/Titles/TitleChampionshipBuilder.php
@@ -16,6 +16,13 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class TitleChampionshipBuilder extends Builder
 {
+    public function forTitleId(int $titleId): static
+    {
+        $this->where('title_id', $titleId);
+
+        return $this;
+    }
+
     public function current(): static
     {
         $this->whereNull('lost_at');
@@ -33,5 +40,19 @@ class TitleChampionshipBuilder extends Builder
     public function forChampion(Wrestler|TagTeam $champion): static
     {
         return $this->whereMorphedTo('champion', $champion);
+    }
+
+    public function earliestWonFirst(): static
+    {
+        $this->orderBy('won_at');
+
+        return $this;
+    }
+
+    public function mostRecentlyLostFirst(): static
+    {
+        $this->orderByDesc('lost_at');
+
+        return $this;
     }
 }

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -43,9 +43,9 @@ class PreviousTitleChampionships extends DataTableComponent
         }
 
         return TitleChampionship::query()
-            ->where('title_id', $this->titleId)
+            ->forTitleId($this->titleId)
             ->previous()
-            ->orderByDesc('lost_at');
+            ->mostRecentlyLostFirst();
     }
 
     /**

--- a/app/Models/Titles/TitleChampionship.php
+++ b/app/Models/Titles/TitleChampionship.php
@@ -40,7 +40,10 @@ use Illuminate\Support\Carbon;
  *
  * @method static \Database\Factories\Titles\TitleChampionshipFactory factory($count = null, $state = [])
  * @method static TitleChampionshipBuilder<static>|TitleChampionship current()
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship earliestWonFirst()
  * @method static TitleChampionshipBuilder<static>|TitleChampionship forChampion(Wrestler|TagTeam $champion)
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship forTitleId(int $titleId)
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship mostRecentlyLostFirst()
  * @method static TitleChampionshipBuilder<static>|TitleChampionship newModelQuery()
  * @method static TitleChampionshipBuilder<static>|TitleChampionship newQuery()
  * @method static TitleChampionshipBuilder<static>|TitleChampionship previous()

--- a/app/Queries/Titles/TitleChampionshipQuery.php
+++ b/app/Queries/Titles/TitleChampionshipQuery.php
@@ -23,9 +23,9 @@ final class TitleChampionshipQuery
     public static function previousChampionship(Title $title): ?TitleChampionship
     {
         return TitleChampionship::query()
-            ->whereBelongsTo($title)
+            ->forTitleId($title->id)
             ->previous()
-            ->latest('lost_at')
+            ->mostRecentlyLostFirst()
             ->first();
     }
 
@@ -36,7 +36,10 @@ final class TitleChampionshipQuery
 
     public static function firstChampionship(Title $title): ?TitleChampionship
     {
-        return $title->championships()->oldest('won_at')->first();
+        return TitleChampionship::query()
+            ->forTitleId($title->id)
+            ->earliestWonFirst()
+            ->first();
     }
 
     public static function firstChampion(Title $title): ?Model

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -36,7 +36,7 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `EventMatchBuilder` owns reusable match-history and persisted assignment queries for event identifiers, matches on past events, competitors, referees, titles, and ordering by the related event date. Scheduling policy and conflict exceptions remain in `MatchAssignmentConflictService`.
 
-`TitleChampionshipBuilder` owns current and previous reign constraints and the polymorphic champion constraint. Championship reporting and derived reign calculations remain in `TitleChampionshipQuery`.
+`TitleChampionshipBuilder` owns current and previous reign constraints, title and polymorphic champion filters, and persisted win/loss ordering. Championship reporting and derived reign calculations remain in `TitleChampionshipQuery`.
 
 `MatchCompetitorBuilder` owns persisted competitor-record filters by competitor model type, competitor identifiers, and event identifiers. Scheduling policy and conflict exceptions remain in `MatchAssignmentConflictService`.
 

--- a/tests/Integration/Livewire/Titles/Tables/PreviousTitleChampionshipsTest.php
+++ b/tests/Integration/Livewire/Titles/Tables/PreviousTitleChampionshipsTest.php
@@ -19,7 +19,14 @@ test('displays championship reign length from its dates', function () {
 
 test('only retrieves previous championships for the selected title', function () {
     $title = Title::factory()->create();
-    $previousChampionship = TitleChampionship::factory()->for($title)->ended()->create();
+    $olderChampionship = TitleChampionship::factory()->for($title)->ended()->create([
+        'won_at' => now()->subYears(4),
+        'lost_at' => now()->subYears(3),
+    ]);
+    $latestChampionship = TitleChampionship::factory()->for($title)->ended()->create([
+        'won_at' => now()->subYears(2),
+        'lost_at' => now()->subYear(),
+    ]);
     TitleChampionship::factory()->for($title)->current()->create();
     TitleChampionship::factory()->ended()->create();
     $table = new PreviousTitleChampionships();
@@ -27,6 +34,8 @@ test('only retrieves previous championships for the selected title', function ()
 
     $championships = $table->builder()->get();
 
-    expect($championships)->toHaveCount(1)
-        ->and($championships->firstOrFail()->is($previousChampionship))->toBeTrue();
+    expect($championships->modelKeys())->toBe([
+        $latestChampionship->id,
+        $olderChampionship->id,
+    ]);
 });

--- a/tests/Unit/Builders/Titles/TitleChampionshipBuilderTest.php
+++ b/tests/Unit/Builders/Titles/TitleChampionshipBuilderTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
 use App\Models\Wrestlers\Wrestler;
 
@@ -32,4 +33,39 @@ it('filters championships by supported champion type', function () {
         ->and($wrestlerChampionships->firstOrFail()->is($wrestlerChampionship))->toBeTrue()
         ->and($tagTeamChampionships)->toHaveCount(1)
         ->and($tagTeamChampionships->firstOrFail()->is($tagTeamChampionship))->toBeTrue();
+});
+
+it('filters and orders title championship history', function () {
+    $title = Title::factory()->create();
+    $otherTitle = Title::factory()->create();
+    $firstChampionship = TitleChampionship::factory()->for($title)->ended()->create([
+        'won_at' => now()->subYears(4),
+        'lost_at' => now()->subYears(3),
+    ]);
+    $latestChampionship = TitleChampionship::factory()->for($title)->ended()->create([
+        'won_at' => now()->subYears(2),
+        'lost_at' => now()->subYear(),
+    ]);
+    TitleChampionship::factory()->for($otherTitle)->ended()->create([
+        'won_at' => now()->subMonths(2),
+        'lost_at' => now()->subMonth(),
+    ]);
+
+    $championshipsByWinDate = TitleChampionship::query()
+        ->forTitleId($title->id)
+        ->earliestWonFirst()
+        ->get();
+    $championshipsByLossDate = TitleChampionship::query()
+        ->forTitleId($title->id)
+        ->previous()
+        ->mostRecentlyLostFirst()
+        ->get();
+
+    expect($championshipsByWinDate->modelKeys())->toBe([
+        $firstChampionship->id,
+        $latestChampionship->id,
+    ])->and($championshipsByLossDate->modelKeys())->toBe([
+        $latestChampionship->id,
+        $firstChampionship->id,
+    ]);
 });


### PR DESCRIPTION
## Summary
- add reusable title championship filtering and chronological ordering to the typed builder
- reuse those builder operations in title reporting queries and Livewire history tables
- document and test the centralized title championship query boundary

## Verification
- 11 focused tests passed with 35 assertions
- application and Pest PHPStan passed for touched files
- touched PHP files passed Pint with Blade formatting
- git diff --check passed