### PR TITLE
refactor: order matches by event chronology

### DIFF
--- a/app/Builders/Matches/EventMatchBuilder.php
+++ b/app/Builders/Matches/EventMatchBuilder.php
@@ -92,7 +92,9 @@ class EventMatchBuilder extends Builder
                     $event->qualifyColumn('id'),
                     $this->getModel()->qualifyColumn('event_id'),
                 )
-        );
+        )
+            ->orderByDesc($this->qualifyColumn('event_id'))
+            ->orderBy($this->qualifyColumn('match_number'));
 
         return $this;
     }

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -5,12 +5,12 @@ declare(strict_types=1);
 namespace App\Livewire\Matches\Tables;
 
 use App\Actions\Matches\DeleteAction;
+use App\Builders\Matches\EventMatchBuilder;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 
 /** @extends BaseTable<EventMatch> */
@@ -25,13 +25,13 @@ class Main extends BaseTable
     protected string $resourceName = 'matches';
 
     /**
-     * @return Builder<EventMatch>
+     * @return EventMatchBuilder<EventMatch>
      */
-    public function builder(): Builder
+    public function builder(): EventMatchBuilder
     {
         return EventMatch::query()
-            ->with(['event', 'competitors', 'result.winner'])
-            ->orderBy('events_matches.created_at', 'desc');
+            ->latestEventFirst()
+            ->with(['event', 'competitors', 'result.winner']);
     }
 
     public function configure(): void

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -34,7 +34,7 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 - `FiltersByRetirementStatus` provides the shared `retired()` filter for individual roster members and tag teams.
 - `HasNameSearch` provides first-name and last-name matching for models that store those columns.
 
-`EventMatchBuilder` owns reusable match-history and persisted assignment queries for event identifiers, matches on past events, competitors, referees, titles, and ordering by the related event date. Scheduling policy and conflict exceptions remain in `MatchAssignmentConflictService`.
+`EventMatchBuilder` owns reusable match-history and persisted assignment queries for event identifiers, matches on past events, competitors, referees, titles, and deterministic ordering by event date, card, and match number. Scheduling policy and conflict exceptions remain in `MatchAssignmentConflictService`.
 
 `TitleChampionshipBuilder` owns current and previous reign constraints and the polymorphic champion constraint. Championship reporting and derived reign calculations remain in `TitleChampionshipQuery`.
 

--- a/tests/Integration/Livewire/Matches/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MainTest.php
@@ -108,6 +108,26 @@ describe('Matches Main Table Component Integration', function () {
     });
 
     describe('query optimization and performance', function () {
+        test('orders matches by event chronology instead of creation chronology', function () {
+            EventMatch::query()->forceDelete();
+
+            $latestEvent = Event::factory()->create(['date' => now()->addDay()]);
+            $earliestEvent = Event::factory()->create(['date' => now()->subDay()]);
+            $latestEventMatch = EventMatch::factory()->forEvent($latestEvent)->create([
+                'created_at' => now()->subDay(),
+            ]);
+            $earliestEventMatch = EventMatch::factory()->forEvent($earliestEvent)->create([
+                'created_at' => now(),
+            ]);
+
+            $table = new Main();
+
+            expect($table->builder()->pluck('id')->all())->toBe([
+                $latestEventMatch->id,
+                $earliestEventMatch->id,
+            ]);
+        });
+
         test('component loads efficiently with many matches', function () {
             EventMatch::factory()->count(10)->create([
                 'event_id' => $this->event->id,

--- a/tests/Unit/Builders/Matches/EventMatchBuilderTest.php
+++ b/tests/Unit/Builders/Matches/EventMatchBuilderTest.php
@@ -112,18 +112,23 @@ it('retrieves matches assigned to any selected title', function () {
         ->and($matches->firstOrFail()->is($selectedMatch))->toBeTrue();
 });
 
-it('orders matches by their event date with the latest event first', function () {
+it('orders matches by event date, card, and match number', function () {
     $oldestEvent = Event::factory()->past()->create(['date' => now()->subDays(3)]);
     $latestEvent = Event::factory()->past()->create(['date' => now()->subDay()]);
+    $otherLatestEvent = Event::factory()->past()->create(['date' => $latestEvent->date]);
     $middleEvent = Event::factory()->past()->create(['date' => now()->subDays(2)]);
     $oldestMatch = EventMatch::factory()->forEvent($oldestEvent)->create();
-    $latestMatch = EventMatch::factory()->forEvent($latestEvent)->create();
+    $latestSecondMatch = EventMatch::factory()->forEvent($latestEvent)->create(['match_number' => 2]);
+    $latestFirstMatch = EventMatch::factory()->forEvent($latestEvent)->create(['match_number' => 1]);
+    $otherLatestMatch = EventMatch::factory()->forEvent($otherLatestEvent)->create(['match_number' => 1]);
     $middleMatch = EventMatch::factory()->forEvent($middleEvent)->create();
 
     $matches = EventMatch::query()->latestEventFirst()->get();
 
     expect($matches->modelKeys())->toBe([
-        $latestMatch->id,
+        $otherLatestMatch->id,
+        $latestFirstMatch->id,
+        $latestSecondMatch->id,
         $middleMatch->id,
         $oldestMatch->id,
     ]);


### PR DESCRIPTION
## Summary
- order the main match table by its related event date instead of match creation time
- make EventMatchBuilder ordering deterministic across same-date cards and match positions
- document the canonical match ordering and cover it at the Builder and Livewire boundaries

## Verification
- 18 focused tests passed with 39 assertions
- application and Pest PHPStan passed for touched files
- Rector passed
- touched PHP files passed Pint with Blade formatting
- git diff --check passed
- composer test:push reached only the known repository-wide local Blade formatter mismatch; GitHub CI remains authoritative for the full style check