### PR TITLE
feat: align match sides and entrant outcomes

### DIFF
--- a/app/Collections/MatchCompetitorsCollection.php
+++ b/app/Collections/MatchCompetitorsCollection.php
@@ -22,7 +22,7 @@ use Illuminate\Support\Collection as BaseCollection;
  * @example
  * ```php
  * $competitors = new MatchCompetitorsCollection($matchCompetitors);
- * $sides = $competitors->sides();
+ * $sidePositions = $competitors->sidePositions();
  * $wrestlersOnly = $competitors->onlyWrestlers();
  * ```
  */
@@ -35,10 +35,10 @@ class MatchCompetitorsCollection extends Collection
      *
      * @example
      * ```php
-     * $sortedCompetitors = $competitors->sortBySideNumber();
+     * $sortedCompetitors = $competitors->sortBySidePosition();
      * ```
      */
-    public function sortBySideNumber(): static
+    public function sortBySidePosition(): static
     {
         return $this->sortBy(fn (MatchCompetitor $competitor): int => $competitor->side->position)->values();
     }
@@ -50,10 +50,10 @@ class MatchCompetitorsCollection extends Collection
      *
      * @example
      * ```php
-     * $sides = $competitors->sides(); // [1, 2]
+     * $sidePositions = $competitors->sidePositions(); // [1, 2]
      * ```
      */
-    public function sides(): array
+    public function sidePositions(): array
     {
         return $this->map(fn (MatchCompetitor $competitor): int => $competitor->side->position)
             ->unique()
@@ -68,10 +68,10 @@ class MatchCompetitorsCollection extends Collection
      *
      * @example
      * ```php
-     * $counts = $competitors->countPerSide(); // [1 => 2, 2 => 1]
+     * $counts = $competitors->countBySidePosition(); // [1 => 2, 2 => 1]
      * ```
      */
-    public function countPerSide(): BaseCollection
+    public function countBySidePosition(): BaseCollection
     {
         // @phpstan-ignore-next-line return.type
         return $this->groupBy(fn (MatchCompetitor $competitor): int => $competitor->side->position)
@@ -82,48 +82,36 @@ class MatchCompetitorsCollection extends Collection
     }
 
     /**
-     * Get all distinct side numbers present in the collection.
-     *
-     * Alias for sides() method for backward compatibility.
-     *
-     * @return array<int> Array of unique side numbers
-     */
-    public function getSides(): array
-    {
-        return $this->sides();
-    }
-
-    /**
      * Count how many competitors exist for a given side.
      *
-     * @param  int  $side  The side number to count
+     * @param  int  $position  The side position to count
      * @return int Number of competitors on the specified side
      *
      * @example
      * ```php
-     * $count = $competitors->countCompetitorsForSide(1); // 2
+     * $count = $competitors->competitorCountForSidePosition(1); // 2
      * ```
      */
-    public function countCompetitorsForSide(int $side): int
+    public function competitorCountForSidePosition(int $position): int
     {
-        return $this->filterBySide($side)->count();
+        return $this->forSidePosition($position)->count();
     }
 
     /**
      * Determine if any competitor on the given side is a tag team.
      *
-     * @param  int  $side  The side number to check
+     * @param  int  $position  The side position to check
      * @return bool True if any competitor on the side is a tag team
      *
      * @example
      * ```php
-     * $hasTagTeams = $competitors->hasTagTeamsOnSide(1);
+     * $hasTagTeams = $competitors->hasTagTeamsOnSidePosition(1);
      * ```
      */
-    public function hasTagTeamsOnSide(int $side): bool
+    public function hasTagTeamsOnSidePosition(int $position): bool
     {
-        return $this->getCompetitorsForSide($side)
-            ->contains(fn (Wrestler|TagTeam $competitor) => $competitor instanceof TagTeam);
+        return $this->competitorsForSidePosition($position)
+            ->contains(fn (Wrestler|TagTeam $competitor): bool => $competitor instanceof TagTeam);
     }
 
     /**
@@ -150,11 +138,11 @@ class MatchCompetitorsCollection extends Collection
      *
      * @example
      * ```php
-     * $grouped = $competitors->groupBySide();
+     * $grouped = $competitors->groupBySidePosition();
      * // [1 => Collection[...], 2 => Collection[...]]
      * ```
      */
-    public function groupBySide(): BaseCollection
+    public function groupBySidePosition(): BaseCollection
     {
         return $this->groupBy(fn (MatchCompetitor $competitor): int => $competitor->side->position);
     }
@@ -209,17 +197,17 @@ class MatchCompetitorsCollection extends Collection
     /**
      * Get all competitors belonging to a specific side.
      *
-     * @param  int  $side  The side number to filter by
+     * @param  int  $position  The side position to filter by
      * @return static Collection of competitors on the specified side
      *
      * @example
      * ```php
-     * $sideOneCompetitors = $competitors->filterBySide(1);
+     * $sideOneCompetitors = $competitors->forSidePosition(1);
      * ```
      */
-    public function filterBySide(int $side): static
+    public function forSidePosition(int $position): static
     {
-        return $this->filter(fn (MatchCompetitor $competitor) => $competitor->side->position === $side);
+        return $this->filter(fn (MatchCompetitor $competitor): bool => $competitor->side->position === $position);
     }
 
     /**
@@ -276,11 +264,11 @@ class MatchCompetitorsCollection extends Collection
      *
      * @example
      * ```php
-     * $competitorsBySide = $competitors->pluckCompetitorsBySide();
+     * $competitorsBySide = $competitors->competitorsBySidePosition();
      * // [1 => Collection[Wrestler, TagTeam], 2 => Collection[Wrestler]]
      * ```
      */
-    public function pluckCompetitorsBySide(): BaseCollection
+    public function competitorsBySidePosition(): BaseCollection
     {
         return $this->groupBy(fn (MatchCompetitor $competitor): int => $competitor->side->position)
             ->map(function (MatchCompetitorsCollection $competitorsOnSide) {
@@ -293,18 +281,18 @@ class MatchCompetitorsCollection extends Collection
     /**
      * Get all Bookable competitors for a given side number.
      *
-     * @param  int  $side  The side number to get competitors for
+     * @param  int  $position  The side position to get competitors for
      * @return BaseCollection<int, Wrestler|TagTeam> Collection of competitor models
      *
      * @example
      * ```php
-     * $sideCompetitors = $competitors->getCompetitorsForSide(1);
+     * $sideCompetitors = $competitors->competitorsForSidePosition(1);
      * ```
      */
-    public function getCompetitorsForSide(int $side): BaseCollection
+    public function competitorsForSidePosition(int $position): BaseCollection
     {
-        return $this->filterBySide($side)
-            ->map(fn (MatchCompetitor $competitor) => $competitor->competitor)
+        return $this->forSidePosition($position)
+            ->map(fn (MatchCompetitor $competitor): Wrestler|TagTeam => $competitor->competitor)
             ->values();
     }
 }

--- a/app/Enums/MatchType.php
+++ b/app/Enums/MatchType.php
@@ -69,9 +69,14 @@ enum MatchType: string
         return match ($this) {
             self::TagTeam, self::TornadoTagTeam, self::SixManTagTeam,
             self::EightManTagTeam, self::TenManTagTeam => ['wrestler', 'tag_team'],
-            self::TripleThreat, self::Fatal4Way, self::BattleRoyal, self::RoyalRumble => ['wrestler', 'tag_team'],
+            self::TripleThreat, self::Fatal4Way => ['wrestler', 'tag_team'],
             default => ['wrestler'], // Singles and other types default to wrestler-only
         };
+    }
+
+    public function usesIndividualCompetitorSides(): bool
+    {
+        return in_array($this, [self::BattleRoyal, self::RoyalRumble], true);
     }
 
     /**
@@ -103,16 +108,23 @@ enum MatchType: string
      */
     public function getMinimumCompetitors(): int
     {
-        return $this->numberOfSides() ?? 2;
+        return match ($this) {
+            self::BattleRoyal => 3,
+            self::RoyalRumble => 10,
+            default => $this->numberOfSides() ?? 2,
+        };
     }
 
     /**
      * Get the maximum number of competitors allowed for this match type.
      */
-    public function getMaximumCompetitors(): int
+    public function getMaximumCompetitors(): ?int
     {
-        // For now, assume same as minimum unless specified otherwise
-        return $this->getMinimumCompetitors();
+        return match ($this) {
+            self::BattleRoyal => null,
+            self::RoyalRumble => 30,
+            default => $this->getMinimumCompetitors(),
+        };
     }
 
     /**

--- a/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
@@ -13,7 +13,10 @@ use App\Livewire\Table\DataTableComponent;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Referees\Referee;
+use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Support\Collection;
 
 /**
  * @extends DataTableComponent<EventMatch>
@@ -55,15 +58,16 @@ abstract class BasePreviousMatchesTable extends DataTableComponent
                 })
                 ->separator(', ')
                 ->emptyValue('N/A'),
-            ArrayColumn::make(__('event-matches.competitors'))
-                ->data(fn (mixed $value, EventMatch $row) => ($row->competitors))
-                ->outputFormat(function (int $index, MatchCompetitor $value): string {
-                    $competitor = $value->competitor;
-                    $type = str($competitor->getMorphClass())->kebab()->plural();
+            Column::make(__('event-matches.competitors'))
+                ->label(fn (EventMatch $row): string => $row->competitors
+                    ->competitorsBySidePosition()
+                    ->map(fn (Collection $side): string => $side->map(function (Wrestler|TagTeam $competitor): string {
+                        $type = str($competitor->getMorphClass())->kebab()->plural();
 
-                    return '<a href="'.route($type.'.show', $competitor->id).'">'.$competitor->name.'</a>';
-                })
-                ->separator('<br />'),
+                        return '<a href="'.route($type.'.show', $competitor->id).'">'.$competitor->name.'</a>';
+                    })->join(' & '))
+                    ->join(' vs '))
+                ->html(),
             ArrayColumn::make(__('event-matches.titles'))
                 ->data(fn (mixed $value, EventMatch $row) => ($row->titles))
                 ->outputFormat(fn (int $index, Title $value): string => '<a href="'.route('titles.show', $value->id).'">'.$value->name.'</a>')

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -166,7 +166,7 @@ class CreateEditForm extends BaseForm
 
         $this->referees = $this->formModel->referees->pluck('id')->toArray();
         $this->titles = $this->formModel->titles->pluck('id')->toArray();
-        $this->competitors = $this->formModel->sides()
+        $competitorsBySide = $this->formModel->sides()
             ->with('competitors.competitor')
             ->get()
             ->map(function (MatchSide $side): array {
@@ -185,6 +185,13 @@ class CreateEditForm extends BaseForm
             })
             ->values()
             ->all();
+
+        $this->competitors = $this->matchType->usesIndividualCompetitorSides()
+            ? [[
+                'wrestlers' => collect($competitorsBySide)->pluck('wrestlers')->flatten()->values()->all(),
+                'tag_teams' => [],
+            ]]
+            : $competitorsBySide;
     }
 
     /**
@@ -223,6 +230,20 @@ class CreateEditForm extends BaseForm
         // Delete existing competitors
         $this->formModel->competitors()->delete();
         $this->formModel->sides()->delete();
+
+        if ($this->matchType->usesIndividualCompetitorSides()) {
+            foreach ($this->competitors[0]['wrestlers'] ?? [] as $sideIndex => $wrestlerId) {
+                $side = $this->formModel->sides()->create(['position' => $sideIndex + 1]);
+
+                $this->formModel->competitors()->create([
+                    'competitor_type' => (new Wrestler())->getMorphClass(),
+                    'competitor_id' => $wrestlerId,
+                    'match_side_id' => $side->id,
+                ]);
+            }
+
+            return;
+        }
 
         // Create new competitor records using the side-based structure
         foreach ($this->competitors as $sideIndex => $sideCompetitors) {
@@ -431,12 +452,18 @@ class CreateEditForm extends BaseForm
             ];
         }
 
-        // Battle Royal / Rumble: Multiple sides, 1 wrestler each
-        if (in_array($matchType, [MatchType::BattleRoyal, MatchType::RoyalRumble], true)) {
+        if ($matchType->usesIndividualCompetitorSides()) {
+            $maximumCompetitors = $matchType->getMaximumCompetitors();
+            $wrestlerRules = ['required', 'array', 'min:'.$matchType->getMinimumCompetitors()];
+
+            if ($maximumCompetitors !== null) {
+                $wrestlerRules[] = 'max:'.$maximumCompetitors;
+            }
+
             return [
-                'competitors' => ['required', 'array', 'min:6'], // Minimum 6 for battle royal
-                'competitors.*.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
+                'competitors' => ['required', 'array', 'size:1'],
+                'competitors.0.wrestlers' => $wrestlerRules,
+                'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
             ];
         }
 

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -9,9 +9,13 @@ use App\Livewire\Base\BaseForm;
 use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\Concerns\HasStandardValidationAttributes;
 use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
+use App\Rules\Matches\CompetitorsNotDuplicated;
+use App\Rules\Matches\CorrectNumberOfSides;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rules\Enum;
@@ -41,7 +45,7 @@ use Illuminate\Validation\Rules\Enum;
  *
  * @property string $preview Match promotional preview content
  * @property MatchType $matchType Match type enum
- * @property array<int> $competitors Array of competitor IDs (wrestlers/tag teams)
+ * @property array<int, array{wrestlers?: array<int>, tag_teams?: array<int>}> $competitors Competitors grouped by side
  * @property array<int> $referees Array of referee IDs for match officials
  * @property array<int> $titles Array of title IDs at stake in the match
  */
@@ -95,7 +99,7 @@ class CreateEditForm extends BaseForm
      * Each side contains wrestlers and potentially tag teams for that side.
      * Structure: [0 => ['wrestlers' => [1, 2]], 1 => ['wrestlers' => [3, 4]]]
      *
-     * @var array<int, array{wrestlers: array<int>}> Competitors grouped by side
+     * @var array<int, array{wrestlers?: array<int>, tag_teams?: array<int>}> Competitors grouped by side
      */
     public array $competitors = [];
 
@@ -160,10 +164,27 @@ class CreateEditForm extends BaseForm
         // Load match type from enum property
         $this->matchType = $this->formModel->match_type;
 
-        // Load competitor IDs from relationships
         $this->referees = $this->formModel->referees->pluck('id')->toArray();
         $this->titles = $this->formModel->titles->pluck('id')->toArray();
-        $this->competitors = $this->formModel->competitors->pluck('wrestler_id')->toArray(); // Assuming wrestler_id is the foreign key
+        $this->competitors = $this->formModel->sides()
+            ->with('competitors.competitor')
+            ->get()
+            ->map(function (MatchSide $side): array {
+                return [
+                    'wrestlers' => $side->competitors
+                        ->filter(fn (MatchCompetitor $competitor): bool => $competitor->competitor instanceof Wrestler)
+                        ->pluck('competitor_id')
+                        ->values()
+                        ->all(),
+                    'tag_teams' => $side->competitors
+                        ->filter(fn (MatchCompetitor $competitor): bool => $competitor->competitor instanceof TagTeam)
+                        ->pluck('competitor_id')
+                        ->values()
+                        ->all(),
+                ];
+            })
+            ->values()
+            ->all();
     }
 
     /**
@@ -204,29 +225,25 @@ class CreateEditForm extends BaseForm
         $this->formModel->sides()->delete();
 
         // Create new competitor records using the side-based structure
-        foreach ($this->competitors as $sideNumber => $sideCompetitors) {
-            $side = $this->formModel->sides()->create(['position' => (int) $sideNumber]);
+        foreach ($this->competitors as $sideIndex => $sideCompetitors) {
+            $side = $this->formModel->sides()->create(['position' => $sideIndex + 1]);
 
             // Handle wrestlers for this side
-            if (isset($sideCompetitors['wrestlers'])) {
-                foreach ($sideCompetitors['wrestlers'] as $wrestlerId) {
-                    $this->formModel->competitors()->create([
-                        'competitor_type' => (new Wrestler())->getMorphClass(),
-                        'competitor_id' => $wrestlerId,
-                        'match_side_id' => $side->id,
-                    ]);
-                }
+            foreach ($sideCompetitors['wrestlers'] ?? [] as $wrestlerId) {
+                $this->formModel->competitors()->create([
+                    'competitor_type' => (new Wrestler())->getMorphClass(),
+                    'competitor_id' => $wrestlerId,
+                    'match_side_id' => $side->id,
+                ]);
             }
 
             // Handle tag teams for this side (when implemented)
-            if (isset($sideCompetitors['tag_teams'])) {
-                foreach ($sideCompetitors['tag_teams'] as $tagTeamId) {
-                    $this->formModel->competitors()->create([
-                        'competitor_type' => (new TagTeam())->getMorphClass(),
-                        'competitor_id' => $tagTeamId,
-                        'match_side_id' => $side->id,
-                    ]);
-                }
+            foreach ($sideCompetitors['tag_teams'] ?? [] as $tagTeamId) {
+                $this->formModel->competitors()->create([
+                    'competitor_type' => (new TagTeam())->getMorphClass(),
+                    'competitor_id' => $tagTeamId,
+                    'match_side_id' => $side->id,
+                ]);
             }
         }
     }
@@ -319,6 +336,11 @@ class CreateEditForm extends BaseForm
 
         // Add dynamic competitor validation based on match type
         $competitorRules = $this->getCompetitorValidationRules();
+        $competitorRules['competitors'] = [
+            ...$competitorRules['competitors'],
+            new CorrectNumberOfSides(),
+            new CompetitorsNotDuplicated(),
+        ];
 
         return array_merge($baseRules, $competitorRules);
     }

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -235,11 +235,15 @@ class CreateEditForm extends BaseForm
             foreach ($this->competitors[0]['wrestlers'] ?? [] as $sideIndex => $wrestlerId) {
                 $side = $this->formModel->sides()->create(['position' => $sideIndex + 1]);
 
-                $this->formModel->competitors()->create([
+                $competitor = $this->formModel->competitors()->create([
                     'competitor_type' => (new Wrestler())->getMorphClass(),
                     'competitor_id' => $wrestlerId,
                     'match_side_id' => $side->id,
                 ]);
+
+                if ($this->matchType === MatchType::RoyalRumble) {
+                    $competitor->forceFill(['entry_order' => $sideIndex + 1])->save();
+                }
             }
 
             return;

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -370,7 +370,7 @@ class FormModal extends BaseFormModal
     {
         $matchType = $this->getSelectedMatchType();
 
-        return $matchType ? $matchType->getMinimumCompetitors() : 2;
+        return $matchType?->numberOfSides() ?? 1;
     }
 
     /**
@@ -388,14 +388,10 @@ class FormModal extends BaseFormModal
      */
     private function initializeCompetitorStructure(MatchType $matchType): void
     {
-        $numberOfSides = $matchType->getMinimumCompetitors();
+        $numberOfSides = $matchType->numberOfSides() ?? 1;
         $competitors = [];
 
-        $matchTypeName = mb_strtolower($matchType->name);
-
-        // Initialize competitor structure based on match type specifics
-        if (str_contains($matchTypeName, 'battle') || str_contains($matchTypeName, 'rumble') || str_contains($matchTypeName, 'royal')) {
-            // Battle Royal: Single array for multiple wrestlers
+        if ($matchType->usesIndividualCompetitorSides()) {
             $competitors[0] = [
                 'wrestlers' => [],
                 'tag_teams' => [],

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -11,6 +11,7 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 
 /** @extends BaseTable<EventMatch> */
@@ -31,7 +32,7 @@ class Main extends BaseTable
     {
         return EventMatch::query()
             ->latestEventFirst()
-            ->with(['event', 'competitors.competitor', 'winningSide.competitors.competitor']);
+            ->with(['event', 'competitors.competitor', 'competitors.side', 'winningSide.competitors.competitor']);
     }
 
     public function configure(): void
@@ -59,7 +60,10 @@ class Main extends BaseTable
                 ->label(fn (EventMatch $row) => $row->match_type->label())
                 ->searchable(),
             Column::make(__('event-matches.competitors'))
-                ->label(fn (EventMatch $row) => $row->competitors->map(fn (MatchCompetitor $competitor) => $competitor->competitor->name)->join(' vs ')),
+                ->label(fn (EventMatch $row): string => $row->competitors
+                    ->competitorsBySidePosition()
+                    ->map(fn (Collection $side): string => $side->pluck('name')->join(' & '))
+                    ->join(' vs ')),
             Column::make(__('event-matches.result'))
                 ->label(function (EventMatch $row): string {
                     if ($row->match_finish === null) {

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -11,8 +11,11 @@ use App\Livewire\Table\DataTableComponent;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Referees\Referee;
+use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
+use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
 use LogicException;
 
@@ -40,7 +43,7 @@ class MatchesTable extends DataTableComponent
         }
 
         return EventMatch::query()
-            ->with(['event', 'titles', 'competitors.competitor', 'winningSide.competitors.competitor'])
+            ->with(['event', 'titles', 'competitors.competitor', 'competitors.side', 'winningSide.competitors.competitor'])
             ->where('event_id', $this->eventId);
     }
 
@@ -64,15 +67,16 @@ class MatchesTable extends DataTableComponent
             Column::make(__('matches.match_type'), 'match_type')
                 ->label(fn (EventMatch $row) => $row->match_type->label())
                 ->searchable(),
-            ArrayColumn::make(__('matches.competitors'))
-                ->data(fn (mixed $value, EventMatch $row) => ($row->competitors))
-                ->outputFormat(function (int $index, MatchCompetitor $value): string {
-                    $competitor = $value->competitor;
-                    $type = str($competitor->getMorphClass())->kebab()->plural();
+            Column::make(__('matches.competitors'))
+                ->label(fn (EventMatch $row): string => $row->competitors
+                    ->competitorsBySidePosition()
+                    ->map(fn (Collection $side): string => $side->map(function (Wrestler|TagTeam $competitor): string {
+                        $type = str($competitor->getMorphClass())->kebab()->plural();
 
-                    return '<a href="'.route($type.'.show', $competitor->id).'">'.$competitor->name.'</a>';
-                })
-                ->separator(' vs '),
+                        return '<a href="'.route($type.'.show', $competitor->id).'">'.$competitor->name.'</a>';
+                    })->join(' & '))
+                    ->join(' vs '))
+                ->html(),
             ArrayColumn::make(__('matches.referees'))
                 ->data(fn (mixed $value, EventMatch $row) => ($row->referees))
                 ->outputFormat(function (int $index, Referee $value): string {

--- a/app/Livewire/Referees/Tables/PreviousMatches.php
+++ b/app/Livewire/Referees/Tables/PreviousMatches.php
@@ -34,7 +34,7 @@ class PreviousMatches extends BasePreviousMatchesTable
 
         return EventMatch::query()
             ->forPastEvents()
-            ->with(['titles', 'competitors.competitor', 'winningSide.competitors.competitor'])
+            ->with(['titles', 'competitors.competitor', 'competitors.side', 'winningSide.competitors.competitor'])
             ->forReferee($referee)
             ->latestEventFirst();
     }

--- a/app/Livewire/TagTeams/Tables/PreviousMatches.php
+++ b/app/Livewire/TagTeams/Tables/PreviousMatches.php
@@ -34,7 +34,7 @@ class PreviousMatches extends BasePreviousMatchesTable
 
         return EventMatch::query()
             ->forPastEvents()
-            ->with(['titles', 'competitors.competitor', 'winningSide.competitors.competitor'])
+            ->with(['titles', 'competitors.competitor', 'competitors.side', 'winningSide.competitors.competitor'])
             ->forCompetitor($tagTeam)
             ->latestEventFirst();
     }

--- a/app/Livewire/Wrestlers/Tables/PreviousMatches.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousMatches.php
@@ -32,7 +32,7 @@ class PreviousMatches extends BasePreviousMatchesTable
 
         return EventMatch::query()
             ->forPastEvents()
-            ->with(['titles', 'competitors.competitor', 'winningSide.competitors.competitor'])
+            ->with(['titles', 'competitors.competitor', 'competitors.side', 'winningSide.competitors.competitor'])
             ->forCompetitor($wrestler)
             ->latestEventFirst();
     }

--- a/app/Models/Matches/MatchCompetitor.php
+++ b/app/Models/Matches/MatchCompetitor.php
@@ -13,9 +13,11 @@ use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\MorphPivot;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Illuminate\Support\Carbon;
@@ -26,11 +28,16 @@ use Illuminate\Support\Carbon;
  * @property string $competitor_type
  * @property int $competitor_id
  * @property int $match_side_id
+ * @property int|null $entry_order
+ * @property int|null $elimination_order
+ * @property int|null $eliminated_by_match_competitor_id
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  *
  * @property-read Wrestler|TagTeam $competitor
  * @property-read MatchSide $side
+ * @property-read MatchCompetitor|null $eliminatedBy
+ * @property-read Collection<int, MatchCompetitor> $eliminations
  *
  * @method static MatchCompetitorsCollection<int, static> all($columns = ['*'])
  * @method static MatchCompetitorsCollection<int, static> get($columns = ['*'])
@@ -68,12 +75,36 @@ class MatchCompetitor extends MorphPivot
         return $this->belongsTo(MatchSide::class, 'match_side_id');
     }
 
+    /** @return BelongsTo<MatchCompetitor, $this> */
+    public function eliminatedBy(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'eliminated_by_match_competitor_id');
+    }
+
+    /** @return HasMany<MatchCompetitor, $this> */
+    public function eliminations(): HasMany
+    {
+        return $this->hasMany(self::class, 'eliminated_by_match_competitor_id');
+    }
+
     /**
      * The table associated with the model.
      *
      * @var string
      */
     protected $table = 'events_matches_competitors';
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'entry_order' => 'integer',
+            'elimination_order' => 'integer',
+            'eliminated_by_match_competitor_id' => 'integer',
+        ];
+    }
 
     /**
      * Get the competitor for the match (Wrestler or TagTeam).

--- a/app/Rules/Matches/CompetitorsNotDuplicated.php
+++ b/app/Rules/Matches/CompetitorsNotDuplicated.php
@@ -19,16 +19,14 @@ class CompetitorsNotDuplicated implements ValidationRule
 
         $wrestlers = [];
         $tagTeams = [];
-        $matchCompetitors = (array) $value;
 
-        foreach ($matchCompetitors as $competitors) {
-            if (Arr::has($competitors, 'wrestlers')) {
-                $wrestlers[] = $competitors['wrestlers'];
+        foreach ($value as $side) {
+            if (! is_array($side)) {
+                continue;
             }
 
-            if (Arr::has($competitors, 'tagteams')) {
-                $tagTeams[] = $competitors['tagteams'];
-            }
+            $wrestlers[] = Arr::wrap(Arr::get($side, 'wrestlers', []));
+            $tagTeams[] = Arr::wrap(Arr::get($side, 'tag_teams', []));
         }
 
         $wrestlers = Arr::flatten($wrestlers);

--- a/app/Rules/Matches/CorrectNumberOfSides.php
+++ b/app/Rules/Matches/CorrectNumberOfSides.php
@@ -24,15 +24,17 @@ class CorrectNumberOfSides implements DataAwareRule, ValidationRule
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! isset($this->data['match_type'])) {
-            return; // No match type to validate against
+        if (! is_array($value)) {
+            return;
         }
 
-        $matchType = $this->data['match_type'] instanceof MatchType
-            ? $this->data['match_type']
-            : MatchType::tryFrom($this->data['match_type']);
+        $matchTypeValue = $this->data['matchType'] ?? $this->data['match_type'] ?? null;
+        $matchType = $matchTypeValue instanceof MatchType
+            ? $matchTypeValue
+            : (is_string($matchTypeValue) ? MatchType::tryFrom($matchTypeValue) : null);
+        $requiredSides = $matchType?->numberOfSides();
 
-        if ($matchType && $matchType->numberOfSides() !== count((array) $value)) {
+        if ($requiredSides !== null && $requiredSides !== count($value)) {
             $fail('This match does not have the required number of competitor sides.');
         }
     }

--- a/database/migrations/2026_08_15_145235_add_entry_and_elimination_metadata_to_events_matches_competitors_table.php
+++ b/database/migrations/2026_08_15_145235_add_entry_and_elimination_metadata_to_events_matches_competitors_table.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events_matches_competitors', function (Blueprint $table) {
+            $table->unsignedInteger('entry_order')->nullable()->after('match_side_id');
+            $table->unsignedInteger('elimination_order')->nullable()->after('entry_order');
+            $table->foreignId('eliminated_by_match_competitor_id')
+                ->nullable()
+                ->after('elimination_order')
+                ->constrained('events_matches_competitors')
+                ->nullOnDelete();
+
+            $table->unique(['match_id', 'entry_order']);
+            $table->unique(['match_id', 'elimination_order']);
+        });
+    }
+};

--- a/docs/architecture/factory-capabilities.md
+++ b/docs/architecture/factory-capabilities.md
@@ -211,7 +211,7 @@ The factory enforces business rules:
 
 - **Royal Rumble**: Only allows wrestlers (no tag teams)
 - **Singles**: Only allows wrestlers (no tag teams)
-- **Other types**: Allow both wrestlers and tag teams based on `MatchType::getAllowedCompetitorTypes()`
+- **Other types**: Use the competitor types exposed by `MatchType::getAllowedCompetitorTypes()`
 
 ### Championship Integration
 

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -66,6 +66,10 @@ Roster booking eligibility is evaluated by `RosterBookingEligibility`, not by El
 - **MatchCompetitor**: Polymorphic competitor entry belonging to a match side
 - **MatchFinish**: Determines whether a winning side must be recorded
 
+### Entrant and Elimination Metadata
+
+Royal Rumble competitors record a unique `entry_order` within the match. Battle Royal competitors may leave entry order unset because they begin simultaneously. Eliminated competitors record a unique `elimination_order`; the winner remains without one. `eliminated_by_match_competitor_id` optionally identifies the competitor responsible for the elimination and remains nullable for joint, external, or indeterminate eliminations.
+
 ## Related Documentation
 - [Business Rules](business-rules.md)
 - [Core Capabilities](core-capabilities.md)

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -13,6 +13,7 @@ The match system handles complex wrestling match scenarios with flexible competi
 
 #### Wrestler-Only Match Types
 - **Singles**: Only wrestler vs wrestler
+- **Battle Royal**: Individual wrestlers, with at least three entrants and no configured maximum
 - **Royal Rumble**: Only individual wrestlers
 - **Rationale**: These match types require individual competitor mechanics
 
@@ -22,7 +23,6 @@ The match system handles complex wrestling match scenarios with flexible competi
 - **Fatal 4-Way**: Can be wrestlers, tag teams, or mixed
 - **6/8/10 Man Tag Team**: Can be wrestlers, tag teams, or mixed
 - **Handicap Matches**: Can be wrestlers, tag teams, or mixed
-- **Battle Royal**: Can be wrestlers, tag teams, or mixed
 - **Tornado Tag Team**: Can be wrestlers, tag teams, or mixed
 - **Gauntlet**: Can be wrestlers, tag teams, or mixed
 - **Rationale**: These match types support flexible competitor configurations

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -127,12 +127,6 @@ parameters:
 			path: app/Livewire/Matches/Forms/CreateEditForm.php
 
 		-
-			message: '#^Property App\\Livewire\\Matches\\Forms\\CreateEditForm\:\:\$competitors \(array\<int\>\) does not accept array\<int\<0, max\>, array\<string, array\>\>\.$#'
-			identifier: assign.propertyType
-			count: 1
-			path: app/Livewire/Matches/Modals/FormModal.php
-
-		-
 			message: '#^Right side of && is always true\.$#'
 			identifier: booleanAnd.rightAlwaysTrue
 			count: 1

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -196,6 +196,38 @@ describe('FormModal Create Operations', function () {
 
         $component->assertHasErrors(['form.referees.0']);
     });
+
+    it('persists each battle royal entrant on an individual side', function () {
+        $wrestlers = Wrestler::factory()->count(3)->bookable()->create();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->set('form.matchType', MatchType::BattleRoyal)
+            ->set('form.competitors.0.wrestlers', $wrestlers->modelKeys())
+            ->call('save')
+            ->assertHasNoErrors()
+            ->assertDispatched('matchCreated');
+
+        $match = EventMatch::query()->whereBelongsTo($this->event)->sole();
+
+        expect($match->sides()->pluck('position')->all())->toBe([1, 2, 3])
+            ->and($match->competitors)->toHaveCount(3)
+            ->and($match->competitors->pluck('match_side_id')->unique())->toHaveCount(3);
+    });
+
+    it('requires the configured minimum number of individual entrants', function (MatchType $matchType, int $entrantCount) {
+        $wrestlers = Wrestler::factory()->count($entrantCount)->bookable()->create();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->set('form.matchType', $matchType)
+            ->set('form.competitors.0.wrestlers', $wrestlers->modelKeys())
+            ->call('save')
+            ->assertHasErrors(['form.competitors.0.wrestlers' => 'min']);
+    })->with([
+        'battle royal' => [MatchType::BattleRoyal, 2],
+        'royal rumble' => [MatchType::RoyalRumble, 9],
+    ]);
 });
 
 describe('FormModal Edit Operations', function () {
@@ -267,6 +299,26 @@ describe('FormModal Edit Operations', function () {
             ->assertSet('form.competitors', [
                 ['wrestlers' => [$wrestler->id], 'tag_teams' => []],
                 ['wrestlers' => [], 'tag_teams' => [$tagTeam->id]],
+            ]);
+    });
+
+    it('loads individual entrant sides into one selection bucket', function () {
+        $match = EventMatch::factory()
+            ->for($this->event)
+            ->battleRoyal(3)
+            ->create();
+        $wrestlerIds = $match->competitors()
+            ->with('side')
+            ->get()
+            ->sortBy('side.position')
+            ->pluck('competitor_id')
+            ->values()
+            ->all();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal', $match->id)
+            ->assertSet('form.competitors', [
+                ['wrestlers' => $wrestlerIds, 'tag_teams' => []],
             ]);
     });
 

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -7,6 +7,8 @@ use App\Livewire\Matches\Forms\CreateEditForm;
 use App\Livewire\Matches\Modals\FormModal;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
@@ -127,6 +129,9 @@ describe('FormModal Create Operations', function () {
             'match_type' => MatchType::Singles->value,
             'preview' => 'Epic wrestling match preview',
         ]);
+
+        $match = EventMatch::query()->whereBelongsTo($this->event)->sole();
+        expect($match->sides()->pluck('position')->all())->toBe([1, 2]);
     });
 
     it('validates required fields when creating', function () {
@@ -233,6 +238,50 @@ describe('FormModal Edit Operations', function () {
         $component->assertSet('form.eventId', $this->event->id);
         $component->assertSet('form.matchType', MatchType::Singles);
         $component->assertSet('form.preview', 'Original preview');
+    });
+
+    it('loads existing competitors grouped by their ordered sides', function () {
+        $match = EventMatch::factory()
+            ->for($this->event)
+            ->state(['match_type' => MatchType::TagTeam])
+            ->create();
+        $wrestler = Wrestler::factory()->bookable()->create();
+        $tagTeam = TagTeam::factory()->bookable()->create();
+        $firstSide = MatchSide::factory()->for($match, 'match')->create(['position' => 1]);
+        $secondSide = MatchSide::factory()->for($match, 'match')->create(['position' => 2]);
+        MatchCompetitor::factory()->create([
+            'match_id' => $match->id,
+            'match_side_id' => $firstSide->id,
+            'competitor_type' => $wrestler->getMorphClass(),
+            'competitor_id' => $wrestler->id,
+        ]);
+        MatchCompetitor::factory()->create([
+            'match_id' => $match->id,
+            'match_side_id' => $secondSide->id,
+            'competitor_type' => $tagTeam->getMorphClass(),
+            'competitor_id' => $tagTeam->id,
+        ]);
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal', $match->id)
+            ->assertSet('form.competitors', [
+                ['wrestlers' => [$wrestler->id], 'tag_teams' => []],
+                ['wrestlers' => [], 'tag_teams' => [$tagTeam->id]],
+            ]);
+    });
+
+    it('rejects a competitor selected on multiple sides', function () {
+        $wrestler = Wrestler::factory()->bookable()->create();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->set('form.matchType', MatchType::Singles)
+            ->set('form.competitors', [
+                ['wrestlers' => [$wrestler->id]],
+                ['wrestlers' => [$wrestler->id]],
+            ])
+            ->call('save')
+            ->assertHasErrors(['form.competitors']);
     });
 });
 

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -215,6 +215,27 @@ describe('FormModal Create Operations', function () {
             ->and($match->competitors->pluck('match_side_id')->unique())->toHaveCount(3);
     });
 
+    it('records royal rumble selection order as entrant order', function () {
+        $wrestlers = Wrestler::factory()->count(10)->bookable()->create();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->set('form.matchType', MatchType::RoyalRumble)
+            ->set('form.competitors.0.wrestlers', $wrestlers->modelKeys())
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $entryOrder = EventMatch::query()
+            ->whereBelongsTo($this->event)
+            ->sole()
+            ->competitors()
+            ->orderBy('entry_order')
+            ->pluck('entry_order')
+            ->all();
+
+        expect($entryOrder)->toBe(range(1, 10));
+    });
+
     it('requires the configured minimum number of individual entrants', function (MatchType $matchType, int $entrantCount) {
         $wrestlers = Wrestler::factory()->count($entrantCount)->bookable()->create();
 

--- a/tests/Integration/Livewire/Matches/Tables/MatchesTableTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MatchesTableTest.php
@@ -7,7 +7,6 @@ use App\Livewire\Matches\Tables\MatchesTable;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
-use App\Models\Matches\MatchSide;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
@@ -29,7 +28,7 @@ beforeEach(function () {
 
 function attachTableCompetitor(EventMatch $match, Wrestler|TagTeam $competitor, int $position): void
 {
-    $side = MatchSide::factory()->for($match, 'match')->create(compact('position'));
+    $side = $match->sides()->firstOrCreate(compact('position'));
 
     MatchCompetitor::factory()->create([
         'match_id' => $match->id,

--- a/tests/Unit/Collections/MatchCompetitorsCollectionTest.php
+++ b/tests/Unit/Collections/MatchCompetitorsCollectionTest.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
+use App\Models\Wrestlers\Wrestler;
+
+it('groups competitor models by ordered side position', function () {
+    $match = EventMatch::factory()->create();
+    $firstSide = MatchSide::factory()->for($match, 'match')->create(['position' => 1]);
+    $secondSide = MatchSide::factory()->for($match, 'match')->create(['position' => 2]);
+    $partners = Wrestler::factory()->count(2)->create();
+    $opponent = Wrestler::factory()->create();
+
+    foreach ($partners as $partner) {
+        MatchCompetitor::factory()->create([
+            'match_id' => $match->id,
+            'match_side_id' => $firstSide->id,
+            'competitor_type' => $partner->getMorphClass(),
+            'competitor_id' => $partner->id,
+        ]);
+    }
+
+    MatchCompetitor::factory()->create([
+        'match_id' => $match->id,
+        'match_side_id' => $secondSide->id,
+        'competitor_type' => $opponent->getMorphClass(),
+        'competitor_id' => $opponent->id,
+    ]);
+
+    $competitorsBySide = $match->competitors()
+        ->with(['side', 'competitor'])
+        ->get()
+        ->competitorsBySidePosition();
+
+    expect($competitorsBySide->keys()->all())->toBe([1, 2])
+        ->and($competitorsBySide->get(1)?->pluck('id')->all())->toBe($partners->pluck('id')->all())
+        ->and($competitorsBySide->get(2)?->pluck('id')->all())->toBe([$opponent->id]);
+});

--- a/tests/Unit/Models/Matches/MatchCompetitorEliminationTest.php
+++ b/tests/Unit/Models/Matches/MatchCompetitorEliminationTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
+use Illuminate\Database\QueryException;
+
+function createMatchEntrant(EventMatch $match, int $position): MatchCompetitor
+{
+    $side = MatchSide::factory()->for($match, 'match')->create(['position' => $position]);
+
+    return MatchCompetitor::factory()->create([
+        'match_id' => $match->id,
+        'match_side_id' => $side->id,
+    ]);
+}
+
+it('records entry and elimination order with the eliminating competitor', function () {
+    $match = EventMatch::factory()->create();
+    $eliminator = createMatchEntrant($match, 1);
+    $eliminated = createMatchEntrant($match, 2);
+
+    $eliminator->forceFill(['entry_order' => 1])->save();
+    $eliminated->forceFill([
+        'entry_order' => 2,
+        'elimination_order' => 1,
+        'eliminated_by_match_competitor_id' => $eliminator->id,
+    ])->save();
+    $eliminated->refresh();
+    $eliminator->refresh();
+
+    expect($eliminated->eliminatedBy?->is($eliminator))->toBeTrue()
+        ->and($eliminator->eliminations->sole()->is($eliminated))->toBeTrue();
+});
+
+it('keeps entry and elimination order unique within a match', function (string $attribute) {
+    $match = EventMatch::factory()->create();
+    createMatchEntrant($match, 1)->forceFill([$attribute => 1])->save();
+    $otherEntrant = createMatchEntrant($match, 2);
+
+    expect(fn () => $otherEntrant->forceFill([$attribute => 1])->save())
+        ->toThrow(QueryException::class);
+})->with(['entry_order', 'elimination_order']);
+
+it('retains elimination history when the eliminating competitor is removed', function () {
+    $match = EventMatch::factory()->create();
+    $eliminator = createMatchEntrant($match, 1);
+    $eliminated = createMatchEntrant($match, 2);
+    $eliminated->forceFill([
+        'elimination_order' => 1,
+        'eliminated_by_match_competitor_id' => $eliminator->id,
+    ])->save();
+
+    $eliminator->delete();
+    $eliminated->refresh();
+
+    expect($eliminated->eliminated_by_match_competitor_id)->toBeNull();
+});

--- a/tests/Unit/Rules/Matches/CompetitorsNotDuplicatedUnitTest.php
+++ b/tests/Unit/Rules/Matches/CompetitorsNotDuplicatedUnitTest.php
@@ -93,8 +93,8 @@ describe('CompetitorsNotDuplicated Validation Rule Unit Tests', function () {
             // Arrange
             $rule = new CompetitorsNotDuplicated();
             $competitors = [
-                ['tagteams' => [1, 2]],
-                ['tagteams' => [3, 4]],
+                ['tag_teams' => [1, 2]],
+                ['tag_teams' => [3, 4]],
             ];
 
             $failCalled = false;
@@ -113,8 +113,8 @@ describe('CompetitorsNotDuplicated Validation Rule Unit Tests', function () {
             // Arrange
             $rule = new CompetitorsNotDuplicated();
             $competitors = [
-                ['tagteams' => [1, 2]],
-                ['tagteams' => [2, 3]], // Tag team 2 appears twice
+                ['tag_teams' => [1, 2]],
+                ['tag_teams' => [2, 3]], // Tag team 2 appears twice
             ];
 
             $failCalled = false;
@@ -138,8 +138,8 @@ describe('CompetitorsNotDuplicated Validation Rule Unit Tests', function () {
             // Arrange
             $rule = new CompetitorsNotDuplicated();
             $competitors = [
-                ['wrestlers' => [1, 2], 'tagteams' => [1]],
-                ['wrestlers' => [3], 'tagteams' => [2, 3]],
+                ['wrestlers' => [1, 2], 'tag_teams' => [1]],
+                ['wrestlers' => [3], 'tag_teams' => [2, 3]],
             ];
 
             $failCalled = false;
@@ -158,8 +158,8 @@ describe('CompetitorsNotDuplicated Validation Rule Unit Tests', function () {
             // Arrange
             $rule = new CompetitorsNotDuplicated();
             $competitors = [
-                ['wrestlers' => [1], 'tagteams' => [1]],
-                ['wrestlers' => [2], 'tagteams' => [2]],
+                ['wrestlers' => [1], 'tag_teams' => [1]],
+                ['wrestlers' => [2], 'tag_teams' => [2]],
             ];
             // Wrestler 1 and tag team 1 can coexist (different types)
 
@@ -219,8 +219,8 @@ describe('CompetitorsNotDuplicated Validation Rule Unit Tests', function () {
             // Arrange
             $rule = new CompetitorsNotDuplicated();
             $competitors = [
-                ['tagteams' => [1, 2]],
-                ['tagteams' => [3, 4]],
+                ['tag_teams' => [1, 2]],
+                ['tag_teams' => [3, 4]],
                 // No wrestlers key
             ];
 
@@ -240,8 +240,8 @@ describe('CompetitorsNotDuplicated Validation Rule Unit Tests', function () {
             // Arrange
             $rule = new CompetitorsNotDuplicated();
             $competitors = [
-                ['wrestlers' => [], 'tagteams' => []],
-                ['wrestlers' => [], 'tagteams' => []],
+                ['wrestlers' => [], 'tag_teams' => []],
+                ['wrestlers' => [], 'tag_teams' => []],
             ];
 
             $failCalled = false;

--- a/tests/Unit/Rules/Matches/CorrectNumberOfSidesUnitTest.php
+++ b/tests/Unit/Rules/Matches/CorrectNumberOfSidesUnitTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\MatchType;
 use App\Rules\Matches\CorrectNumberOfSides;
 use Illuminate\Contracts\Validation\DataAwareRule;
 use Illuminate\Contracts\Validation\ValidationRule;
@@ -22,6 +23,39 @@ use Illuminate\Contracts\Validation\ValidationRule;
  * @see CorrectNumberOfSides
  */
 describe('CorrectNumberOfSides Validation Rule Unit Tests', function () {
+    test('accepts the required number of sides for a fixed match type', function () {
+        $failed = false;
+        $rule = (new CorrectNumberOfSides())->setData(['matchType' => MatchType::Singles]);
+
+        $rule->validate('competitors', [[], []], validationFailureCallback(function () use (&$failed): void {
+            $failed = true;
+        }));
+
+        expect($failed)->toBeFalse();
+    });
+
+    test('rejects the wrong number of sides for a fixed match type', function () {
+        $failureMessage = null;
+        $rule = (new CorrectNumberOfSides())->setData(['matchType' => MatchType::TripleThreat]);
+
+        $rule->validate('competitors', [[], []], validationFailureCallback(function (string $message) use (&$failureMessage): void {
+            $failureMessage = $message;
+        }));
+
+        expect($failureMessage)->toBe('This match does not have the required number of competitor sides.');
+    });
+
+    test('allows variable side counts for open match types', function () {
+        $failed = false;
+        $rule = (new CorrectNumberOfSides())->setData(['matchType' => MatchType::BattleRoyal]);
+
+        $rule->validate('competitors', [[], [], [], [], [], []], validationFailureCallback(function () use (&$failed): void {
+            $failed = true;
+        }));
+
+        expect($failed)->toBeFalse();
+    });
+
     describe('DataAwareRule implementation', function () {
         test('implements DataAwareRule interface correctly', function () {
             // Arrange

--- a/tests/Unit/database/Factories/Matches/MatchFactoryTest.php
+++ b/tests/Unit/database/Factories/Matches/MatchFactoryTest.php
@@ -328,7 +328,12 @@ describe('MatchFactory', function () {
         test('match type has correct competitor limits', function () {
             expect(MatchType::Singles->getMinimumCompetitors())->toBe(2);
             expect(MatchType::TripleThreat->getMinimumCompetitors())->toBe(3);
-            expect(MatchType::BattleRoyal->getMinimumCompetitors())->toBe(2);
+            expect(MatchType::BattleRoyal->getMinimumCompetitors())->toBe(3);
+            expect(MatchType::BattleRoyal->getMaximumCompetitors())->toBeNull();
+            expect(MatchType::RoyalRumble->getMinimumCompetitors())->toBe(10);
+            expect(MatchType::RoyalRumble->getMaximumCompetitors())->toBe(30);
+            expect(MatchType::BattleRoyal->allowsTagTeams())->toBeFalse();
+            expect(MatchType::RoyalRumble->allowsTagTeams())->toBeFalse();
         });
     });
 });


### PR DESCRIPTION
## Summary
- make match sides the canonical grouping boundary across forms, validation, collections, and tables
- persist Battle Royal and Royal Rumble entrants on individual sides with type-specific limits
- track Royal Rumble entry order and competitor elimination metadata
- add self-referencing eliminator relationships and database uniqueness constraints

## Verification
- 64 focused tests passed with 211 assertions
- application and Pest PHPStan passed
- Rector passed
- type coverage passed at 100%
- targeted Pint with Blade passed
- git diff checks passed

## Local suite note
- composer test:push reaches the repository-wide Blade formatting check, which fails on pre-existing unrelated Blade files; this PR does not modify those files.