### PR TITLE
chore: install Laravel Doctor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,7 @@
         "larastan/larastan": "^3.9",
         "laravel/boost": "^2.2",
         "laravel/breeze": "^2.4",
+        "laravel/doctor": "^0.1.0",
         "laravel/pail": "^1.2.5",
         "laravel/pao": "^1.1",
         "laravel/pint": "^1.30",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ffb2c9c3db277501e70c1ad88b1604d",
+    "content-hash": "28f7a61b45364865b6099bbf2f899bf3",
     "packages": [
         {
             "name": "blade-ui-kit/blade-heroicons",
@@ -9127,6 +9127,76 @@
                 "source": "https://github.com/laravel/breeze"
             },
             "time": "2026-03-10T19:59:01+00:00"
+        },
+        {
+            "name": "laravel/doctor",
+            "version": "v0.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/doctor.git",
+                "reference": "6e634a0746f70f9dd9abaf4d9c8a4b81ceebdd4c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/doctor/zipball/6e634a0746f70f9dd9abaf4d9c8a4b81ceebdd4c",
+                "reference": "6e634a0746f70f9dd9abaf4d9c8a4b81ceebdd4c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.0",
+                "composer/semver": "^3.0",
+                "illuminate/console": "^12.0|^13.0",
+                "illuminate/contracts": "^12.0|^13.0",
+                "illuminate/process": "^12.0|^13.0",
+                "illuminate/support": "^12.0|^13.0",
+                "laravel/agent-detector": "^2.0.1",
+                "laravel/prompts": "^0.3.21",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.28.0",
+                "orchestra/testbench": "^10.0|^11.0",
+                "pestphp/pest": "^4.0",
+                "phpstan/phpstan": "^2.0",
+                "rector/rector": "^2.3"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Doctor\\DoctorServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Doctor\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                }
+            ],
+            "description": "First-party diagnostics for Laravel applications",
+            "homepage": "https://github.com/laravel/doctor",
+            "keywords": [
+                "configuration",
+                "diagnostics",
+                "doctor",
+                "health",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/doctor/issues",
+                "source": "https://github.com/laravel/doctor"
+            },
+            "time": "2026-07-22T17:39:59+00:00"
         },
         {
             "name": "laravel/mcp",


### PR DESCRIPTION
## Summary
- install the official first-party laravel/doctor development package
- register the php artisan doctor diagnostic command through package discovery

## Verification
- php artisan doctor executes and reports application diagnostics
- composer validate --strict passed
- application and Pest PHPStan passed
- Rector passed
- type coverage passed at 100%

## Diagnostic findings
- Doctor surfaced existing PSR-4 warnings in test helper classes for a separate cleanup
- temporary-worktree environment checks fail where this worktree has no .env, SQLite database, or local storage setup

## Local suite note
- composer test:push reaches the repository-wide Blade formatting check, which fails on pre-existing unrelated Blade files; this PR only modifies composer.json and composer.lock.