### PR TITLE
fix: restore stable manager history

### DIFF
--- a/app/Livewire/Managers/Tables/PreviousStables.php
+++ b/app/Livewire/Managers/Tables/PreviousStables.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Managers\Tables;
 use App\Livewire\Base\Tables\BasePreviousStablesTable;
 use App\Livewire\Table\Column;
 use App\Models\Stables\Stable;
+use App\Queries\Roster\StableManagerHistoryQuery;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
@@ -33,8 +34,7 @@ class PreviousStables extends BasePreviousStablesTable
             throw new LogicException('A manager was not provided.');
         }
 
-        // Simplified query - just return all stables for now to fix the test
-        return Stable::query();
+        return StableManagerHistoryQuery::previousStablesForManagerId($this->managerId);
     }
 
     public function columns(): array

--- a/app/Livewire/Stables/Tables/PreviousManagers.php
+++ b/app/Livewire/Stables/Tables/PreviousManagers.php
@@ -4,10 +4,11 @@ declare(strict_types=1);
 
 namespace App\Livewire\Stables\Tables;
 
+use App\Builders\Roster\ManagerBuilder;
 use App\Livewire\Base\Tables\BasePreviousManagersTable;
 use App\Livewire\Table\Column;
 use App\Models\Managers\Manager;
-use App\Models\Stables\Stable;
+use App\Queries\Roster\StableManagerHistoryQuery;
 use Illuminate\Database\Eloquent\Builder;
 use LogicException;
 
@@ -27,17 +28,10 @@ class PreviousManagers extends BasePreviousManagersTable
             throw new LogicException('A stable was not provided.');
         }
 
-        // Note: Stables do not directly have managers.
-        // Managers are associated with individual wrestlers and tag teams.
-        // This table would show managers who previously managed members of this stable.
-        // For now, return empty query since this is not a valid business relationship.
-        return Manager::query()->whereRaw('1 = 0'); // Empty result set
+        return StableManagerHistoryQuery::previousManagersForStableId($this->stableId);
     }
 
-    public function configure(): void
-    {
-        // No additional selects needed for direct manager query
-    }
+    public function configure(): void {}
 
     /**
      * @return array<int, Column>
@@ -46,9 +40,11 @@ class PreviousManagers extends BasePreviousManagersTable
     {
         return [
             Column::make(__('managers.name'), 'full_name')
-                ->searchable(),
+                ->searchable(function (ManagerBuilder $builder, string $searchTerm): void {
+                    $builder->whereNameMatches($searchTerm);
+                }),
             Column::make(__('managers.status'), 'status')
-                ->searchable(),
+                ->label(fn (Manager $manager) => $manager->status->label()),
         ];
     }
 }

--- a/app/Queries/Roster/StableManagerHistoryQuery.php
+++ b/app/Queries/Roster/StableManagerHistoryQuery.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Queries\Roster;
+
+use App\Models\Managers\Manager;
+use App\Models\Stables\Stable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+
+final class StableManagerHistoryQuery
+{
+    /** @return Builder<Stable> */
+    public static function previousStablesForManagerId(int $managerId): Builder
+    {
+        return Stable::query()
+            ->where(function (Builder $stableQuery) use ($managerId): void {
+                $stableQuery
+                    ->whereExists(function (QueryBuilder $associationQuery) use ($managerId): void {
+                        self::previousWrestlerAssociation($associationQuery)
+                            ->where('wrestlers_managers.manager_id', $managerId)
+                            ->whereColumn('stables_wrestlers.stable_id', 'stables.id');
+                    })
+                    ->orWhereExists(function (QueryBuilder $associationQuery) use ($managerId): void {
+                        self::previousTagTeamAssociation($associationQuery)
+                            ->where('tag_teams_managers.manager_id', $managerId)
+                            ->whereColumn('stables_tag_teams.stable_id', 'stables.id');
+                    });
+            })
+            ->whereNotExists(function (QueryBuilder $associationQuery) use ($managerId): void {
+                self::currentWrestlerAssociation($associationQuery)
+                    ->where('wrestlers_managers.manager_id', $managerId)
+                    ->whereColumn('stables_wrestlers.stable_id', 'stables.id');
+            })
+            ->whereNotExists(function (QueryBuilder $associationQuery) use ($managerId): void {
+                self::currentTagTeamAssociation($associationQuery)
+                    ->where('tag_teams_managers.manager_id', $managerId)
+                    ->whereColumn('stables_tag_teams.stable_id', 'stables.id');
+            })
+            ->orderBy('stables.name');
+    }
+
+    /** @return Builder<Manager> */
+    public static function previousManagersForStableId(int $stableId): Builder
+    {
+        return Manager::query()
+            ->where(function (Builder $managerQuery) use ($stableId): void {
+                $managerQuery
+                    ->whereExists(function (QueryBuilder $associationQuery) use ($stableId): void {
+                        self::previousWrestlerAssociation($associationQuery)
+                            ->where('stables_wrestlers.stable_id', $stableId)
+                            ->whereColumn('wrestlers_managers.manager_id', 'managers.id');
+                    })
+                    ->orWhereExists(function (QueryBuilder $associationQuery) use ($stableId): void {
+                        self::previousTagTeamAssociation($associationQuery)
+                            ->where('stables_tag_teams.stable_id', $stableId)
+                            ->whereColumn('tag_teams_managers.manager_id', 'managers.id');
+                    });
+            })
+            ->whereNotExists(function (QueryBuilder $associationQuery) use ($stableId): void {
+                self::currentWrestlerAssociation($associationQuery)
+                    ->where('stables_wrestlers.stable_id', $stableId)
+                    ->whereColumn('wrestlers_managers.manager_id', 'managers.id');
+            })
+            ->whereNotExists(function (QueryBuilder $associationQuery) use ($stableId): void {
+                self::currentTagTeamAssociation($associationQuery)
+                    ->where('stables_tag_teams.stable_id', $stableId)
+                    ->whereColumn('tag_teams_managers.manager_id', 'managers.id');
+            })
+            ->orderBy('managers.last_name')
+            ->orderBy('managers.first_name');
+    }
+
+    private static function previousWrestlerAssociation(QueryBuilder $query): QueryBuilder
+    {
+        return self::wrestlerAssociation($query)
+            ->where(function (QueryBuilder $endedAssociationQuery): void {
+                $endedAssociationQuery
+                    ->whereNotNull('wrestlers_managers.fired_at')
+                    ->orWhereNotNull('stables_wrestlers.left_at');
+            });
+    }
+
+    private static function currentWrestlerAssociation(QueryBuilder $query): QueryBuilder
+    {
+        return self::wrestlerAssociation($query)
+            ->whereNull('wrestlers_managers.fired_at')
+            ->whereNull('stables_wrestlers.left_at');
+    }
+
+    private static function wrestlerAssociation(QueryBuilder $query): QueryBuilder
+    {
+        return $query
+            ->selectRaw('1')
+            ->from('wrestlers_managers')
+            ->join(
+                'stables_wrestlers',
+                'stables_wrestlers.wrestler_id',
+                '=',
+                'wrestlers_managers.wrestler_id',
+            )
+            ->where(function (QueryBuilder $membershipEndQuery): void {
+                $membershipEndQuery
+                    ->whereNull('stables_wrestlers.left_at')
+                    ->orWhereColumn('wrestlers_managers.hired_at', '<=', 'stables_wrestlers.left_at');
+            })
+            ->where(function (QueryBuilder $assignmentEndQuery): void {
+                $assignmentEndQuery
+                    ->whereNull('wrestlers_managers.fired_at')
+                    ->orWhereColumn('stables_wrestlers.joined_at', '<=', 'wrestlers_managers.fired_at');
+            });
+    }
+
+    private static function previousTagTeamAssociation(QueryBuilder $query): QueryBuilder
+    {
+        return self::tagTeamAssociation($query)
+            ->where(function (QueryBuilder $endedAssociationQuery): void {
+                $endedAssociationQuery
+                    ->whereNotNull('tag_teams_managers.fired_at')
+                    ->orWhereNotNull('stables_tag_teams.left_at');
+            });
+    }
+
+    private static function currentTagTeamAssociation(QueryBuilder $query): QueryBuilder
+    {
+        return self::tagTeamAssociation($query)
+            ->whereNull('tag_teams_managers.fired_at')
+            ->whereNull('stables_tag_teams.left_at');
+    }
+
+    private static function tagTeamAssociation(QueryBuilder $query): QueryBuilder
+    {
+        return $query
+            ->selectRaw('1')
+            ->from('tag_teams_managers')
+            ->join(
+                'stables_tag_teams',
+                'stables_tag_teams.tag_team_id',
+                '=',
+                'tag_teams_managers.tag_team_id',
+            )
+            ->where(function (QueryBuilder $membershipEndQuery): void {
+                $membershipEndQuery
+                    ->whereNull('stables_tag_teams.left_at')
+                    ->orWhereColumn('tag_teams_managers.hired_at', '<=', 'stables_tag_teams.left_at');
+            })
+            ->where(function (QueryBuilder $assignmentEndQuery): void {
+                $assignmentEndQuery
+                    ->whereNull('tag_teams_managers.fired_at')
+                    ->orWhereColumn('stables_tag_teams.joined_at', '<=', 'tag_teams_managers.fired_at');
+            });
+    }
+}

--- a/docs/architecture/stable-membership.md
+++ b/docs/architecture/stable-membership.md
@@ -12,6 +12,7 @@ Stable membership defines how wrestlers and tag teams can belong to stables.
 - **Wrestler Membership**: Individual wrestlers can belong to stables
 - **Tag Team Membership**: Tag teams can belong to stables
 - **Manager Exclusion**: Managers do NOT belong to stables directly (they manage individual wrestlers/tag teams)
+- **Derived Manager History**: A manager is historically associated with a stable only when their wrestler or tag-team assignment overlaps that member's stable-membership period; this reporting association does not create stable membership for the manager
 - **Single Current Stable**: Wrestlers and tag teams can belong to only one stable at a time
 - **Database Enforcement**: Membership history tables enforce one open membership per wrestler or tag team while allowing unlimited ended memberships
 - **Membership History**: Wrestlers and tag teams can belong to multiple stables across non-overlapping historical periods

--- a/tests/Feature/Http/Controllers/Managers/ManagersControllerShowTest.php
+++ b/tests/Feature/Http/Controllers/Managers/ManagersControllerShowTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Managers\ManagersController;
+use App\Livewire\Managers\Tables\PreviousStables;
 use App\Livewire\Managers\Tables\PreviousTagTeams;
 use App\Livewire\Managers\Tables\PreviousWrestlers;
 use App\Models\Managers\Manager;
@@ -30,7 +31,8 @@ describe('Managers Controller', function () {
             ->assertViewIs('managers.show')
             ->assertViewHas('manager', $this->manager)
             ->assertSeeLivewire(PreviousWrestlers::class)
-            ->assertSeeLivewire(PreviousTagTeams::class);
+            ->assertSeeLivewire(PreviousTagTeams::class)
+            ->assertSeeLivewire(PreviousStables::class);
     });
 
     /**

--- a/tests/Feature/Http/Controllers/Stables/StablesControllerShowTest.php
+++ b/tests/Feature/Http/Controllers/Stables/StablesControllerShowTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Http\Controllers\Stables\StablesController;
+use App\Livewire\Stables\Tables\PreviousManagers;
 use App\Livewire\Stables\Tables\PreviousTagTeams;
 use App\Livewire\Stables\Tables\PreviousWrestlers;
 use App\Models\Stables\Stable;
@@ -31,7 +32,8 @@ describe('Stables Controller', function () {
         $response->assertViewIs('stables.show')
             ->assertViewHas('stable', $this->stable)
             ->assertSeeLivewire(PreviousWrestlers::class)
-            ->assertSeeLivewire(PreviousTagTeams::class);
+            ->assertSeeLivewire(PreviousTagTeams::class)
+            ->assertSeeLivewire(PreviousManagers::class);
     });
 
     /**

--- a/tests/Feature/Livewire/Managers/Tables/PreviousStablesTest.php
+++ b/tests/Feature/Livewire/Managers/Tables/PreviousStablesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Managers\Tables\PreviousStables;
+use App\Models\Managers\Manager;
+use App\Models\Stables\Stable;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Users\User;
+use App\Models\Wrestlers\Wrestler;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->administrator()->create());
+});
+
+it('requires a manager', function () {
+    expect(fn () => (new PreviousStables())->builder())
+        ->toThrow(LogicException::class, 'A manager was not provided.');
+});
+
+it('shows distinct previous stables associated through managed roster members', function () {
+    $manager = Manager::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+    $previousWrestlerStable = Stable::factory()->create();
+    $previousTagTeamStable = Stable::factory()->create();
+    $nonOverlappingStable = Stable::factory()->create();
+    $currentStable = Stable::factory()->create();
+
+    $wrestler->managers()->attach($manager, [
+        'hired_at' => now()->subYears(3),
+        'fired_at' => now()->subYears(2),
+    ]);
+    $previousWrestlerStable->wrestlers()->attach($wrestler, [
+        'joined_at' => now()->subYears(3)->addMonth(),
+        'left_at' => now()->subYears(2)->addMonth(),
+    ]);
+    $nonOverlappingStable->wrestlers()->attach($wrestler, [
+        'joined_at' => now()->subYear(),
+        'left_at' => now()->subMonths(6),
+    ]);
+
+    $tagTeam->managers()->attach($manager, [
+        'hired_at' => now()->subYears(2),
+        'fired_at' => now()->subYear(),
+    ]);
+    $previousTagTeamStable->tagTeams()->attach($tagTeam, [
+        'joined_at' => now()->subYears(2)->addMonth(),
+        'left_at' => now()->subYear()->addMonth(),
+    ]);
+    $currentStable->tagTeams()->attach($tagTeam, [
+        'joined_at' => now()->subMonths(6),
+    ]);
+    $tagTeam->managers()->attach($manager, [
+        'hired_at' => now()->subMonths(5),
+    ]);
+
+    $stables = testLivewire(PreviousStables::class, ['managerId' => $manager->id])
+        ->instance()
+        ->builder()
+        ->get();
+
+    expect($stables->modelKeys())->toEqualCanonicalizing([
+        $previousWrestlerStable->id,
+        $previousTagTeamStable->id,
+    ]);
+});
+
+it('renders for an administrator', function () {
+    $manager = Manager::factory()->create();
+
+    testLivewire(PreviousStables::class, ['managerId' => $manager->id])
+        ->assertSuccessful();
+});

--- a/tests/Feature/Livewire/Stables/Tables/PreviousManagersTest.php
+++ b/tests/Feature/Livewire/Stables/Tables/PreviousManagersTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Stables\Tables\PreviousManagers;
+use App\Models\Managers\Manager;
+use App\Models\Stables\Stable;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Users\User;
+use App\Models\Wrestlers\Wrestler;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->administrator()->create());
+});
+
+it('requires a stable', function () {
+    expect(fn () => (new PreviousManagers())->builder())
+        ->toThrow(LogicException::class, 'A stable was not provided.');
+});
+
+it('shows distinct previous managers associated through stable roster members', function () {
+    $stable = Stable::factory()->create();
+    $wrestler = Wrestler::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+    $previousWrestlerManager = Manager::factory()->create([
+        'first_name' => 'Historic',
+        'last_name' => 'Manager',
+    ]);
+    $previousTagTeamManager = Manager::factory()->create([
+        'first_name' => 'Former',
+        'last_name' => 'Advisor',
+    ]);
+    $nonOverlappingManager = Manager::factory()->create();
+    $currentManager = Manager::factory()->create();
+
+    $stable->wrestlers()->attach($wrestler, [
+        'joined_at' => now()->subYears(3),
+        'left_at' => now()->subYear(),
+    ]);
+    $wrestler->managers()->attach($previousWrestlerManager, [
+        'hired_at' => now()->subYears(2),
+        'fired_at' => now()->subMonths(18),
+    ]);
+    $wrestler->managers()->attach($nonOverlappingManager, [
+        'hired_at' => now()->subMonths(6),
+        'fired_at' => now()->subMonths(3),
+    ]);
+
+    $stable->tagTeams()->attach($tagTeam, [
+        'joined_at' => now()->subYears(2),
+        'left_at' => now()->subMonths(6),
+    ]);
+    $tagTeam->managers()->attach($previousTagTeamManager, [
+        'hired_at' => now()->subYear(),
+        'fired_at' => now()->subMonths(9),
+    ]);
+
+    $currentWrestler = Wrestler::factory()->create();
+    $stable->wrestlers()->attach($currentWrestler, [
+        'joined_at' => now()->subMonths(3),
+    ]);
+    $currentWrestler->managers()->attach($currentManager, [
+        'hired_at' => now()->subMonths(2),
+    ]);
+
+    $managers = testLivewire(PreviousManagers::class, ['stableId' => $stable->id])
+        ->instance()
+        ->builder()
+        ->get();
+
+    expect($managers->modelKeys())->toEqualCanonicalizing([
+        $previousWrestlerManager->id,
+        $previousTagTeamManager->id,
+    ]);
+
+    testLivewire(PreviousManagers::class, ['stableId' => $stable->id])
+        ->set('search', 'Historic')
+        ->assertSee('Historic Manager')
+        ->assertDontSee('Former Advisor');
+});
+
+it('renders for an administrator', function () {
+    $stable = Stable::factory()->create();
+
+    testLivewire(PreviousManagers::class, ['stableId' => $stable->id])
+        ->assertSuccessful();
+});


### PR DESCRIPTION
## Summary

- restore previous manager and stable tables using historical assignment overlap
- exclude associations that are still current
- support manager-name searching and rendered status labels
- document that manager-to-stable history is derived rather than direct membership

## Verification

- `php artisan test --compact` on four focused feature files: 14 tests, 30 assertions
- `composer test:push`
- Rector passed
- Pint with Blade passed
- PHPStan passed
- type coverage remains 100%
