### PR TITLE
refactor: centralize tag team membership requirements

### DIFF
--- a/app/Lifecycle/RosterBookingEligibility.php
+++ b/app/Lifecycle/RosterBookingEligibility.php
@@ -24,9 +24,10 @@ final class RosterBookingEligibility
 
             $currentWrestlers = $rosterMember->currentWrestlers;
 
-            return $currentWrestlers->count() >= 2 && $currentWrestlers->every(
-                fn (Wrestler $wrestler): bool => self::allows($wrestler),
-            );
+            return TagTeamMembershipRequirements::hasMinimumCurrentWrestlers($currentWrestlers)
+                && $currentWrestlers->every(
+                    fn (Wrestler $wrestler): bool => self::allows($wrestler),
+                );
         }
 
         return ! (

--- a/app/Lifecycle/TagTeamMembershipRequirements.php
+++ b/app/Lifecycle/TagTeamMembershipRequirements.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
+
+final class TagTeamMembershipRequirements
+{
+    public const int MINIMUM_CURRENT_WRESTLERS = 2;
+
+    /** @param Collection<int, Wrestler> $wrestlers */
+    public static function hasMinimumCurrentWrestlers(Collection $wrestlers): bool
+    {
+        return $wrestlers->count() >= self::MINIMUM_CURRENT_WRESTLERS;
+    }
+}

--- a/app/Lifecycle/TagTeamRetirementEligibility.php
+++ b/app/Lifecycle/TagTeamRetirementEligibility.php
@@ -71,9 +71,9 @@ final class TagTeamRetirementEligibility
             throw CannotBeUnretiredException::noAvailablePartners($tagTeam);
         }
 
-        $minimumPartners = TagTeam::NUMBER_OF_WRESTLERS_ON_TEAM;
+        $minimumPartners = TagTeamMembershipRequirements::MINIMUM_CURRENT_WRESTLERS;
 
-        if ($currentPartners->count() < $minimumPartners) {
+        if (! TagTeamMembershipRequirements::hasMinimumCurrentWrestlers($currentPartners)) {
             throw CannotBeUnretiredException::insufficientPartners(
                 $tagTeam,
                 $currentPartners->count(),

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -206,9 +206,4 @@ class TagTeam extends Model implements CanBeAStableMember, CanBeChampion, Employ
     {
         return $this->stables()->wherePivotNotNull('left_at');
     }
-
-    /**
-     * The number of the wrestlers allowed on a tag team.
-     */
-    public const int NUMBER_OF_WRESTLERS_ON_TEAM = 2;
 }

--- a/tests/Unit/Lifecycle/TagTeamMembershipRequirementsTest.php
+++ b/tests/Unit/Lifecycle/TagTeamMembershipRequirementsTest.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Lifecycle\TagTeamMembershipRequirements;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
+
+test('a tag team requires at least two current wrestlers', function (int $wrestlerCount, bool $satisfiesRequirement): void {
+    $wrestlers = new Collection(
+        Wrestler::factory()->count($wrestlerCount)->make()->all(),
+    );
+
+    expect(TagTeamMembershipRequirements::hasMinimumCurrentWrestlers($wrestlers))
+        ->toBe($satisfiesRequirement);
+})->with([
+    'no wrestlers' => [0, false],
+    'one wrestler' => [1, false],
+    'two wrestlers' => [2, true],
+    'more than two wrestlers' => [3, true],
+]);

--- a/tests/Unit/Models/TagTeams/TagTeamTest.php
+++ b/tests/Unit/Models/TagTeams/TagTeamTest.php
@@ -102,8 +102,7 @@ describe('TagTeam Model Unit Tests', function () {
                 return $constant && $constant->getDeclaringClass()->getName() === TagTeam::class;
             }, ARRAY_FILTER_USE_BOTH);
 
-            expect($modelConstants)->toHaveKey('NUMBER_OF_WRESTLERS_ON_TEAM');
-            expect($modelConstants['NUMBER_OF_WRESTLERS_ON_TEAM'])->toBe(2);
+            expect($modelConstants)->not->toHaveKey('NUMBER_OF_WRESTLERS_ON_TEAM');
         });
     });
 


### PR DESCRIPTION
## Summary

- centralize the minimum current-wrestler requirement for tag teams
- reuse the requirement for booking and unretirement eligibility
- remove the domain rule constant from the Eloquent model
- add focused boundary coverage for the shared requirement

## Verification

- `composer lint`
- focused Pest suite: 28 tests, 47 assertions
- `composer test:types`
- `composer test:rector`
- `composer test:type-coverage`
- `composer test:push` passed type coverage, Rector, Pint/Blade, and both PHPStan suites; the final browser suite could not start because Playwright installation stalled in the isolated worktree
