### PR TITLE
refactor: remove stale model metadata

### DIFF
--- a/app/Models/Managers/Manager.php
+++ b/app/Models/Managers/Manager.php
@@ -78,19 +78,15 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, TagTeam> $currentTagTeams
  * @property-read Collection<int, TagTeam> $previousTagTeams
  *
- * @method static ManagerBuilder<static>|Manager available()
  * @method static ManagerBuilder<static>|Manager employed()
  * @method static \Database\Factories\Managers\ManagerFactory factory($count = null, $state = [])
  * @method static ManagerBuilder<static>|Manager futureEmployed()
- * @method static ManagerBuilder<static>|Manager injured()
  * @method static ManagerBuilder<static>|Manager newModelQuery()
  * @method static ManagerBuilder<static>|Manager newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Manager onlyTrashed()
  * @method static ManagerBuilder<static>|Manager query()
  * @method static ManagerBuilder<static>|Manager released()
  * @method static ManagerBuilder<static>|Manager retired()
- * @method static ManagerBuilder<static>|Manager suspended()
- * @method static ManagerBuilder<static>|Manager unavailable()
  * @method static ManagerBuilder<static>|Manager unemployed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Manager withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Manager withoutTrashed()

--- a/app/Models/Referees/Referee.php
+++ b/app/Models/Referees/Referee.php
@@ -72,19 +72,15 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, EventMatch> $matches
  * @property-read Collection<int, EventMatch> $previousMatches
  *
- * @method static RefereeBuilder<static>|Referee available()
  * @method static RefereeBuilder<static>|Referee employed()
  * @method static \Database\Factories\Referees\RefereeFactory factory($count = null, $state = [])
  * @method static RefereeBuilder<static>|Referee futureEmployed()
- * @method static RefereeBuilder<static>|Referee injured()
  * @method static RefereeBuilder<static>|Referee newModelQuery()
  * @method static RefereeBuilder<static>|Referee newQuery()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Referee onlyTrashed()
  * @method static RefereeBuilder<static>|Referee query()
  * @method static RefereeBuilder<static>|Referee released()
  * @method static RefereeBuilder<static>|Referee retired()
- * @method static RefereeBuilder<static>|Referee suspended()
- * @method static RefereeBuilder<static>|Referee unavailable()
  * @method static RefereeBuilder<static>|Referee unemployed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Referee withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|Referee withoutTrashed()
@@ -129,7 +125,4 @@ class Referee extends Model implements Employable, Injurable, Retirable, SoftDel
             $eventQuery->where('date', '<', now());
         });
     }
-
-    // full_name is handled by virtual column in database
-
 }

--- a/app/Models/TagTeams/TagTeam.php
+++ b/app/Models/TagTeams/TagTeam.php
@@ -87,8 +87,6 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, TitleChampionship> $currentChampionships
  * @property-read Collection<int, TitleChampionship> $previousTitleChampionships
  *
- * @method static TagTeamBuilder<static>|TagTeam available()
- * @method static TagTeamBuilder<static>|TagTeam belowMinimumWrestlers(int $count = 2)
  * @method static TagTeamBuilder<static>|TagTeam employed()
  * @method static \Database\Factories\TagTeams\TagTeamFactory factory($count = null, $state = [])
  * @method static TagTeamBuilder<static>|TagTeam futureEmployed()
@@ -98,10 +96,7 @@ use Illuminate\Support\Carbon;
  * @method static TagTeamBuilder<static>|TagTeam query()
  * @method static TagTeamBuilder<static>|TagTeam released()
  * @method static TagTeamBuilder<static>|TagTeam retired()
- * @method static TagTeamBuilder<static>|TagTeam suspended()
- * @method static TagTeamBuilder<static>|TagTeam unavailable()
  * @method static TagTeamBuilder<static>|TagTeam unemployed()
- * @method static TagTeamBuilder<static>|TagTeam withMinimumWrestlers(int $count = 2)
  * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeam withTrashed()
  * @method static \Illuminate\Database\Eloquent\Builder<static>|TagTeam withoutTrashed()
  *

--- a/app/Models/Wrestlers/Wrestler.php
+++ b/app/Models/Wrestlers/Wrestler.php
@@ -102,8 +102,6 @@ use Illuminate\Support\Carbon;
  * @property-read Collection<int, TitleChampionship> $titleChampionships
  * @property-read Collection<int, TitleChampionship> $currentChampionships
  * @property-read Collection<int, TitleChampionship> $previousTitleChampionships
- *
- * @method string getNameLabel()
  */
 #[Fillable('name', 'height', 'weight', 'hometown', 'signature_move')]
 #[Appends('status')]


### PR DESCRIPTION
## Summary

- remove model `@method` annotations for builder methods that no longer exist
- remove an obsolete wrestler display-name annotation
- remove a stale referee virtual-column comment

## Verification

- `composer lint`
- focused model Pest suite: 32 tests, 75 assertions
- `composer test:types`
- `composer test:rector`
- `composer test:type-coverage`
