### PR TITLE
refactor: centralize match side ordering

### DIFF
--- a/app/Builders/Matches/MatchSideBuilder.php
+++ b/app/Builders/Matches/MatchSideBuilder.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Matches;
+
+use App\Models\Matches\MatchSide;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @extends Builder<MatchSide>
+ */
+class MatchSideBuilder extends Builder
+{
+    public function inPositionOrder(): static
+    {
+        self::constrainToPositionOrder($this);
+
+        return $this;
+    }
+
+    /**
+     * @template TModel of Model
+     *
+     * @param  Builder<TModel>  $query
+     */
+    public static function constrainToPositionOrder(Builder $query): void
+    {
+        $query->orderBy('position');
+    }
+}

--- a/app/Models/Matches/EventMatch.php
+++ b/app/Models/Matches/EventMatch.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models\Matches;
 
 use App\Builders\Matches\EventMatchBuilder;
+use App\Builders\Matches\MatchSideBuilder;
 use App\Collections\MatchCompetitorsCollection;
 use App\Enums\MatchFinish;
 use App\Enums\MatchType;
@@ -173,7 +174,10 @@ class EventMatch extends Model implements SoftDeletable
     /** @return HasMany<MatchSide, $this> */
     public function sides(): HasMany
     {
-        return $this->hasMany(MatchSide::class, 'match_id')->orderBy('position');
+        $relation = $this->hasMany(MatchSide::class, 'match_id');
+        MatchSideBuilder::constrainToPositionOrder($relation->getQuery());
+
+        return $relation;
     }
 
     /** @return BelongsTo<MatchSide, $this> */

--- a/app/Models/Matches/MatchSide.php
+++ b/app/Models/Matches/MatchSide.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Models\Matches;
 
+use App\Builders\Matches\MatchSideBuilder;
 use Database\Factories\Matches\MatchSideFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -32,6 +34,7 @@ use Illuminate\Support\Carbon;
 #[Table('events_matches_sides')]
 #[Fillable('match_id', 'position')]
 #[UseFactory(MatchSideFactory::class)]
+#[UseEloquentBuilder(MatchSideBuilder::class)]
 class MatchSide extends Model
 {
     /** @use HasFactory<MatchSideFactory> */

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -40,6 +40,8 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 
 `MatchCompetitorBuilder` owns persisted competitor-record filters by competitor model type, competitor identifiers, and event identifiers. Scheduling policy and conflict exceptions remain in `MatchAssignmentConflictService`.
 
+`MatchSideBuilder` owns canonical match-side ordering by persisted position. `EventMatch::sides()` applies the same ordering so side collections remain deterministic regardless of insertion order.
+
 ## Boundaries
 
 Builders express database queries over relationships and stored lifecycle periods. They may:

--- a/tests/Unit/Builders/Matches/MatchSideBuilderTest.php
+++ b/tests/Unit/Builders/Matches/MatchSideBuilderTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Builders\Matches\MatchSideBuilder;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchSide;
+
+test('match sides use the typed builder', function () {
+    expect(MatchSide::query())->toBeInstanceOf(MatchSideBuilder::class);
+});
+
+test('match sides can be ordered by their position', function () {
+    $eventMatch = EventMatch::factory()->create();
+
+    $thirdSide = MatchSide::factory()->for($eventMatch, 'match')->create(['position' => 3]);
+    $firstSide = MatchSide::factory()->for($eventMatch, 'match')->create(['position' => 1]);
+    $secondSide = MatchSide::factory()->for($eventMatch, 'match')->create(['position' => 2]);
+
+    expect(MatchSide::query()
+        ->whereBelongsTo($eventMatch, 'match')
+        ->inPositionOrder()
+        ->pluck('id')
+        ->all())->toBe([
+            $firstSide->id,
+            $secondSide->id,
+            $thirdSide->id,
+        ])->and($eventMatch->sides()->pluck('id')->all())->toBe([
+            $firstSide->id,
+            $secondSide->id,
+            $thirdSide->id,
+        ]);
+});


### PR DESCRIPTION
## Summary

- add a typed builder for match-side persistence queries
- centralize canonical ordering by side position
- apply the same ordering through the `EventMatch::sides()` relationship
- document and test deterministic side ordering

## Verification

- focused Pest suite: 36 tests, 72 assertions
- `composer lint`
- `composer test:types`
- `composer test:rector`
- `composer test:type-coverage`
- `git diff --check`

`composer test:push` completed type coverage, Rector, Pint, and PHPStan successfully; its final Pest stage could not start browser tests because Playwright is not installed in the isolated worktree.
