### PR TITLE
refactor: centralize historical match queries

### DIFF
--- a/app/Builders/Matches/EventMatchBuilder.php
+++ b/app/Builders/Matches/EventMatchBuilder.php
@@ -10,6 +10,7 @@ use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Collection;
 
@@ -32,11 +33,22 @@ class EventMatchBuilder extends Builder
 
     public function forPastEvents(): static
     {
-        $this->withWhereHas('event', function (Builder|Relation $query): void {
-            $query->where('date', '<', now());
-        });
+        self::constrainToPastEvents($this);
+        $this->with('event');
 
         return $this;
+    }
+
+    /**
+     * @template TRelatedModel of Model
+     *
+     * @param  Builder<TRelatedModel>  $query
+     */
+    public static function constrainToPastEvents(Builder $query): void
+    {
+        $query->whereHas('event', function (Builder|Relation $query): void {
+            $query->where('date', '<', now());
+        });
     }
 
     public function forCompetitor(Wrestler|TagTeam $competitor): static

--- a/app/Models/Concerns/HasMatchParticipations.php
+++ b/app/Models/Concerns/HasMatchParticipations.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Concerns;
 
+use App\Builders\Matches\EventMatchBuilder;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
@@ -20,7 +21,13 @@ trait HasMatchParticipations
      */
     public function matches(): MorphToMany
     {
-        return $this->morphToMany(EventMatch::class, 'competitor', 'event_match_competitors')
+        return $this->morphToMany(
+            EventMatch::class,
+            'competitor',
+            'events_matches_competitors',
+            'competitor_id',
+            'match_id',
+        )
             ->using(MatchCompetitor::class);
     }
 
@@ -31,8 +38,9 @@ trait HasMatchParticipations
      */
     public function previousMatches(): MorphToMany
     {
-        return $this->matches()->whereHas('event', function ($query) {
-            $query->where('date', '<', now());
-        });
+        $relation = $this->matches();
+        EventMatchBuilder::constrainToPastEvents($relation->getQuery());
+
+        return $relation;
     }
 }

--- a/app/Models/Referees/Referee.php
+++ b/app/Models/Referees/Referee.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models\Referees;
 
+use App\Builders\Matches\EventMatchBuilder;
 use App\Builders\Roster\RefereeBuilder;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\HasComputedEmploymentStatus;
@@ -26,7 +27,6 @@ use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -115,14 +115,20 @@ class Referee extends Model implements Employable, Injurable, Retirable, SoftDel
     /** @return BelongsToMany<EventMatch, $this> */
     public function matches(): BelongsToMany
     {
-        return $this->belongsToMany(EventMatch::class, 'events_matches_referees');
+        return $this->belongsToMany(
+            EventMatch::class,
+            'events_matches_referees',
+            'referee_id',
+            'match_id',
+        );
     }
 
     /** @return BelongsToMany<EventMatch, $this> */
     public function previousMatches(): BelongsToMany
     {
-        return $this->matches()->whereHas('event', function (Builder $eventQuery): void {
-            $eventQuery->where('date', '<', now());
-        });
+        $relation = $this->matches();
+        EventMatchBuilder::constrainToPastEvents($relation->getQuery());
+
+        return $relation;
     }
 }

--- a/docs/architecture/builders.md
+++ b/docs/architecture/builders.md
@@ -34,7 +34,7 @@ Builders are grouped by technical layer first and wrestling entity second. A con
 - `FiltersByRetirementStatus` provides the shared `retired()` filter for individual roster members and tag teams.
 - `HasNameSearch` provides first-name and last-name matching for models that store those columns.
 
-`EventMatchBuilder` owns reusable match-history and persisted assignment queries for event identifiers, matches on past events, competitors, referees, titles, and deterministic ordering by event date, card, and match number. Scheduling policy and conflict exceptions remain in `MatchAssignmentConflictService`.
+`EventMatchBuilder` owns reusable match-history and persisted assignment queries for event identifiers, matches on past events, competitors, referees, titles, and deterministic ordering by event date, card, and match number. Competitor and referee history relationships reuse its persisted past-event constraint rather than defining their own date comparisons. Scheduling policy and conflict exceptions remain in `MatchAssignmentConflictService`.
 
 `TitleChampionshipBuilder` owns current and previous reign constraints, title and polymorphic champion filters, and persisted win/loss ordering. Championship reporting and derived reign calculations remain in `TitleChampionshipQuery`.
 

--- a/tests/Unit/Models/Concerns/HasMatchParticipationsTest.php
+++ b/tests/Unit/Models/Concerns/HasMatchParticipationsTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Events\Event;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
+use App\Models\Referees\Referee;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
+
+test('competitor and referee relationships share the canonical past event constraint', function () {
+    $pastMatch = EventMatch::factory()
+        ->forEvent(Event::factory()->past()->create())
+        ->create();
+    $scheduledMatch = EventMatch::factory()
+        ->forEvent(Event::factory()->scheduled()->create())
+        ->create();
+    $wrestler = Wrestler::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+    $referee = Referee::factory()->create();
+
+    foreach ([$pastMatch, $scheduledMatch] as $match) {
+        $side = MatchSide::factory()->for($match, 'match')->create();
+
+        foreach ([$wrestler, $tagTeam] as $competitor) {
+            MatchCompetitor::factory()->create([
+                'match_id' => $match->id,
+                'match_side_id' => $side->id,
+                'competitor_type' => $competitor->getMorphClass(),
+                'competitor_id' => $competitor->id,
+            ]);
+        }
+
+        $match->referees()->attach($referee);
+    }
+
+    expect($wrestler->previousMatches()->pluck('events_matches.id')->all())
+        ->toBe([$pastMatch->id])
+        ->and($tagTeam->previousMatches()->pluck('events_matches.id')->all())
+        ->toBe([$pastMatch->id])
+        ->and($referee->previousMatches()->pluck('events_matches.id')->all())
+        ->toBe([$pastMatch->id]);
+});


### PR DESCRIPTION
## Summary

- centralize persisted past-event filtering in `EventMatchBuilder`
- reuse the constraint for wrestler, tag-team, and referee history relationships
- correct inverse competitor and referee pivot mappings to use their actual `match_id` columns
- add focused relationship regression coverage and update builder architecture documentation

## Verification

- focused Pest suite: 17 tests, 43 assertions
- `composer lint`
- `composer test:types`
- `composer test:rector`
- `composer test:type-coverage`
- `git diff --check`

`composer test:push` completed type coverage, Rector, Pint, and PHPStan successfully; its final Pest stage could not start browser tests because Playwright is not installed in the isolated worktree.
