### PR TITLE
feat: integrate match stipulations

### DIFF
--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -11,6 +11,7 @@ use App\Livewire\Concerns\HasStandardValidationAttributes;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
+use App\Models\Matches\MatchStipulation;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
@@ -18,6 +19,7 @@ use App\Rules\Matches\CompetitorsNotDuplicated;
 use App\Rules\Matches\CorrectNumberOfSides;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 
 /**
@@ -93,6 +95,8 @@ class CreateEditForm extends BaseForm
      */
     public ?MatchType $matchType = null;
 
+    public ?int $matchStipulationId = null;
+
     /**
      * Array of competitors organized by sides in the match.
      *
@@ -163,6 +167,7 @@ class CreateEditForm extends BaseForm
 
         // Load match type from enum property
         $this->matchType = $this->formModel->match_type;
+        $this->matchStipulationId = $this->formModel->match_stipulation_id;
 
         $this->referees = $this->formModel->referees->pluck('id')->toArray();
         $this->titles = $this->formModel->titles->pluck('id')->toArray();
@@ -289,6 +294,7 @@ class CreateEditForm extends BaseForm
             'match_number' => $this->getNextMatchNumber(),
             'preview' => $this->preview,
             'match_type' => $this->matchType,
+            'match_stipulation_id' => $this->matchStipulationId,
         ];
         // Note: relationships (competitors, referees, titles) are handled
         // separately through the relationship synchronization system
@@ -343,6 +349,11 @@ class CreateEditForm extends BaseForm
         $baseRules = [
             // eventId removed - it's context from route model binding, not user input
             'matchType' => ['required', new Enum(MatchType::class)],
+            'matchStipulationId' => [
+                'nullable',
+                'integer',
+                Rule::exists(MatchStipulation::class, 'id')->where('is_active', true),
+            ],
             'preview' => ['sometimes', 'string'],
             'referees' => ['sometimes', 'array'],
             'referees.*' => ['integer', 'exists:referees,id'],
@@ -495,6 +506,7 @@ class CreateEditForm extends BaseForm
         return [
             'preview' => 'match preview',
             'matchType' => 'match type',
+            'matchStipulationId' => 'match stipulation',
             'competitors' => 'competitors',
             'referees' => 'referees',
             'titles' => 'championship titles',

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -13,11 +13,13 @@ use App\Livewire\Concerns\Data\PresentsTitlesList;
 use App\Livewire\Concerns\Data\PresentsWrestlersList;
 use App\Livewire\Matches\Forms\CreateEditForm;
 use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchStipulation;
 use App\Models\Referees\Referee;
 use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
+use Livewire\Attributes\Computed;
 use Log;
 
 /**
@@ -98,6 +100,19 @@ class FormModal extends BaseFormModal
     protected function getModalPath(): string
     {
         return 'livewire.matches.modals.form-modal';
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    #[Computed(cache: true, key: 'active-match-stipulations-list', seconds: 180)]
+    public function getMatchStipulations(): array
+    {
+        return MatchStipulation::query()
+            ->where('is_active', true)
+            ->orderBy('name')
+            ->pluck('name', 'id')
+            ->all();
     }
 
     /**

--- a/database/migrations/2026_08_15_190102_create_matches_stipulations_table.php
+++ b/database/migrations/2026_08_15_190102_create_matches_stipulations_table.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('matches_stipulations', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug');
+            $table->text('description')->nullable();
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+        });
+    }
+};

--- a/database/migrations/2026_08_15_190106_add_match_stipulation_id_to_events_matches_table.php
+++ b/database/migrations/2026_08_15_190106_add_match_stipulation_id_to_events_matches_table.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Matches\MatchStipulation;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('events_matches', function (Blueprint $table) {
+            $table->foreignIdFor(MatchStipulation::class)
+                ->nullable()
+                ->constrained();
+        });
+    }
+};

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -44,7 +44,7 @@ Assignment actions lock the affected event rows and enforce these rules inside t
 
 Roster booking eligibility is evaluated by `RosterBookingEligibility`, not by Eloquent models or builders. The policy combines persisted employment, injury, suspension, future-employment, and tag-team membership state. A tag team must satisfy its own lifecycle state, have at least two current wrestlers, and have every current wrestler individually eligible. Models expose those relationships and state predicates; validation rules, assignment Actions, and collections invoke the policy when deciding whether a participant may be booked.
 
-`MatchStipulation` is a persistence record containing its configured name, slug, description, active flag, and match relationship. Stipulation capabilities and match presentation must be implemented by the match domain when they are enforced; the model does not infer behavior from hard-coded slug lists.
+`MatchStipulation` is an optional match configuration selected from active definitions when a match is created or edited. The match retains that relationship as historical configuration even if the definition is later made inactive. Stipulation capabilities and match presentation must be implemented by the match domain when they are enforced; the model does not infer behavior from hard-coded slug lists.
 
 ## Winner/Loser System
 

--- a/resources/views/livewire/matches/modals/form-modal.blade.php
+++ b/resources/views/livewire/matches/modals/form-modal.blade.php
@@ -3,6 +3,15 @@
         <x-form.inputs.select label="Match Type" wire:model.live="form.matchType" :options="$this->getMatchTypes" />
     </x-form-modal.modal-input>
 
+    <x-form-modal.modal-input>
+        <x-form.inputs.select
+            label="Match Stipulation"
+            wire:model="form.matchStipulationId"
+            :options="$this->getMatchStipulations"
+            placeholder="Standard match"
+        />
+    </x-form-modal.modal-input>
+
     {{-- Dynamic Competitor Selection Based on Match Type --}}
     @if ($form->matchType)
         <div class="space-y-4">

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -9,6 +9,7 @@ use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
+use App\Models\Matches\MatchStipulation;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
@@ -101,6 +102,65 @@ describe('FormModal Rendering', function () {
 
         // Match types are now enums, so they should all be listed
         $component->assertSee('Singles');
+    });
+});
+
+describe('FormModal Match Stipulation Integration', function () {
+    it('presents only active stipulations', function () {
+        $activeStipulation = MatchStipulation::factory()->active()->create(['name' => 'Steel Cage']);
+        $inactiveStipulation = MatchStipulation::factory()->inactive()->create(['name' => 'Retired Rules']);
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->assertSee($activeStipulation->name)
+            ->assertDontSee($inactiveStipulation->name);
+    });
+
+    it('persists an active stipulation when creating a match', function () {
+        $stipulation = MatchStipulation::factory()->active()->create();
+        $wrestlers = Wrestler::factory()->count(2)->bookable()->create();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->set('form.matchType', MatchType::Singles)
+            ->set('form.matchStipulationId', $stipulation->id)
+            ->set('form.competitors', [
+                ['wrestlers' => [$wrestlers[0]->id]],
+                ['wrestlers' => [$wrestlers[1]->id]],
+            ])
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $match = EventMatch::query()->whereBelongsTo($this->event)->sole();
+
+        expect($match->matchStipulation->is($stipulation))->toBeTrue();
+    });
+
+    it('rejects inactive stipulations', function () {
+        $stipulation = MatchStipulation::factory()->inactive()->create();
+        $wrestlers = Wrestler::factory()->count(2)->bookable()->create();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->set('form.matchType', MatchType::Singles)
+            ->set('form.matchStipulationId', $stipulation->id)
+            ->set('form.competitors', [
+                ['wrestlers' => [$wrestlers[0]->id]],
+                ['wrestlers' => [$wrestlers[1]->id]],
+            ])
+            ->call('save')
+            ->assertHasErrors(['form.matchStipulationId']);
+    });
+
+    it('loads the existing stipulation when editing a match', function () {
+        $stipulation = MatchStipulation::factory()->active()->create();
+        $match = EventMatch::factory()->for($this->event)->create([
+            'match_stipulation_id' => $stipulation->id,
+        ]);
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal', $match->id)
+            ->assertSet('form.matchStipulationId', $stipulation->id);
     });
 });
 

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -118,35 +118,37 @@ describe('FormModal Match Stipulation Integration', function () {
 
     it('persists an active stipulation when creating a match', function () {
         $stipulation = MatchStipulation::factory()->active()->create();
-        $wrestlers = Wrestler::factory()->count(2)->bookable()->create();
+        $firstWrestler = Wrestler::factory()->bookable()->create();
+        $secondWrestler = Wrestler::factory()->bookable()->create();
 
         livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.matchStipulationId', $stipulation->id)
             ->set('form.competitors', [
-                ['wrestlers' => [$wrestlers[0]->id]],
-                ['wrestlers' => [$wrestlers[1]->id]],
+                ['wrestlers' => [$firstWrestler->id]],
+                ['wrestlers' => [$secondWrestler->id]],
             ])
             ->call('save')
             ->assertHasNoErrors();
 
         $match = EventMatch::query()->whereBelongsTo($this->event)->sole();
 
-        expect($match->matchStipulation->is($stipulation))->toBeTrue();
+        expect($match->matchStipulation()->sole()->is($stipulation))->toBeTrue();
     });
 
     it('rejects inactive stipulations', function () {
         $stipulation = MatchStipulation::factory()->inactive()->create();
-        $wrestlers = Wrestler::factory()->count(2)->bookable()->create();
+        $firstWrestler = Wrestler::factory()->bookable()->create();
+        $secondWrestler = Wrestler::factory()->bookable()->create();
 
         livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.matchStipulationId', $stipulation->id)
             ->set('form.competitors', [
-                ['wrestlers' => [$wrestlers[0]->id]],
-                ['wrestlers' => [$wrestlers[1]->id]],
+                ['wrestlers' => [$firstWrestler->id]],
+                ['wrestlers' => [$secondWrestler->id]],
             ])
             ->call('save')
             ->assertHasErrors(['form.matchStipulationId']);


### PR DESCRIPTION
## Summary
- add the missing match stipulation definition table and optional match foreign key
- present active stipulations in the match form and persist the selected definition
- reject inactive definitions while preserving existing selections for historical matches
- document and test the stipulation boundary

## Verification
- composer test:push
- php artisan test --compact tests/Integration/Livewire/Matches/Modals/FormModalTest.php tests/Unit/Models/Matches/MatchStipulationTest.php tests/Unit/Models/Matches/EventMatchTest.php