### PR TITLE
refactor: modernize match creation

### DIFF
--- a/app/Actions/Matches/AddMatchForEventAction.php
+++ b/app/Actions/Matches/AddMatchForEventAction.php
@@ -9,111 +9,46 @@ use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
-use App\Models\TagTeams\TagTeam;
-use App\Models\Wrestlers\Wrestler;
-use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class AddMatchForEventAction
 {
-    /**
-     * Create a new add match for event action instance.
-     */
     public function __construct(
         protected AddRefereesToMatchAction $addRefereesToMatchAction,
         protected AddTitlesToMatchAction $addTitlesToMatchAction,
         protected AddCompetitorsToMatchAction $addCompetitorsToMatchAction
     ) {}
 
-    /**
-     * Create a complete match for an event.
-     *
-     * This handles the comprehensive match creation workflow for an event:
-     * - Validates match data integrity and business rule compliance
-     * - Creates the match record with proper type, rules, and event association
-     * - Assigns qualified referees to officiate with proper authority
-     * - Associates championship titles at stake for title matches
-     * - Adds all competitors (wrestlers and tag teams) with proper side allocation
-     * - Ensures all match components are properly integrated and validated
-     * - Maintains data consistency through transaction management
-     *
-     * BUSINESS RULES:
-     * - Events must be scheduled and not yet completed
-     * - Match types must be valid and supported by the system
-     * - Competitors must be available and not conflicted for the event date
-     * - Referees must be qualified and available for officiating
-     * - Championship titles must be active if assigned to the match
-     * - Matches must have proper competitor distribution for balance
-     *
-     * BUSINESS IMPACT:
-     * - Creates complete match cards for fan engagement and ticket sales
-     * - Establishes competition structure for storyline development
-     * - Enables proper event planning and resource allocation
-     * - Supports championship tracking and title change possibilities
-     * - Facilitates payroll calculations and appearance fee management
-     * - Drives revenue through match-based promotional marketing
-     *
-     * @param  Event  $event  The event to add the match to
-     * @param  EventMatchData  $eventMatchData  Complete match data including all participants
-     * @throws EntityNotAvailableException When an assigned referee or title is unavailable
-     * @throws InvalidMatchConfigurationException When required match data or side assignments are invalid
-     * @return EventMatch The newly created match with all components properly assigned
-     */
+    /** @throws EntityNotAvailableException|InvalidMatchConfigurationException */
     public function handle(Event $event, EventMatchData $eventMatchData): EventMatch
     {
-        // Validate match data completeness
         $this->validateMatchData($eventMatchData);
 
         return DB::transaction(function () use ($event, $eventMatchData): EventMatch {
-            // Create the base match record
-            $createdMatch = EventMatch::create([
-                'event_id' => $event->id,
-                'match_type_id' => $eventMatchData->matchType->id,
+            $lockedEvent = Event::query()
+                ->lockForUpdate()
+                ->findOrFail($event->getKey());
+            $lastMatchNumber = $lockedEvent->matches()
+                ->withTrashed()
+                ->max('match_number');
+
+            $createdMatch = EventMatch::query()->create([
+                'event_id' => $lockedEvent->id,
+                'match_number' => ($lastMatchNumber ?? 0) + 1,
+                'match_type' => $eventMatchData->matchType,
                 'preview' => $eventMatchData->preview,
             ]);
 
-            // Add referees for match officiating (required for all matches)
-            if ($eventMatchData->referees->isNotEmpty()) {
-                $this->addRefereesToMatchAction->handle($createdMatch, $eventMatchData->referees);
+            $this->addRefereesToMatchAction->handle($createdMatch, $eventMatchData->referees);
+
+            if ($eventMatchData->titles->isNotEmpty()) {
+                $this->addTitlesToMatchAction->handle($createdMatch, $eventMatchData->titles);
             }
 
-            // Add championship titles if this is a title match
-            $eventMatchData->titles->whenNotEmpty(function (Collection $titles) use ($createdMatch): void {
-                $this->addTitlesToMatchAction->handle($createdMatch, $titles);
-            });
-
-            // Add all competitors to complete the match setup
-            if ($eventMatchData->competitors->isNotEmpty()) {
-                // Transform competitors from type-grouped to side-grouped structure
-                $transformedCompetitors = $this->transformCompetitorsStructure($eventMatchData->competitors);
-                $this->addCompetitorsToMatchAction->handle($createdMatch, $transformedCompetitors);
-            }
+            $this->addCompetitorsToMatchAction->handle($createdMatch, $eventMatchData->sides);
 
             return $createdMatch;
         });
-    }
-
-    /**
-     * Transform competitors from type-grouped to side-grouped structure.
-     *
-     * @param  Collection<string, covariant array<int, Wrestler|TagTeam>>  $competitors
-     * @return Collection<int, array<string, array<int, Wrestler|TagTeam>>>
-     */
-    private function transformCompetitorsStructure(Collection $competitors): Collection
-    {
-        // For now, assume single side (side 1) for all competitors
-        // This is a simplified transformation - a more complex implementation
-        // would need to handle side assignment based on match type and strategy
-
-        /** @var array<int, array<string, array<int, Wrestler|TagTeam>>> $transformedData */
-        $transformedData = [
-            1 => [
-                'wrestlers' => $competitors->get('wrestlers', []),
-                'tag_teams' => $competitors->get('tag_teams', []),
-            ],
-        ];
-
-        return collect($transformedData);
     }
 
     /**
@@ -124,19 +59,12 @@ class AddMatchForEventAction
      */
     private function validateMatchData(EventMatchData $eventMatchData): void
     {
-        // Ensure we have competitors for the match
-        if ($eventMatchData->competitors->isEmpty()) {
+        if ($eventMatchData->sides->isEmpty()) {
             throw InvalidMatchConfigurationException::missingCompetitors();
         }
 
-        // Ensure we have at least one referee
         if ($eventMatchData->referees->isEmpty()) {
             throw InvalidMatchConfigurationException::missingReferees();
         }
-
-        // Additional validation could include:
-        // - Match type compatibility with competitors
-        // - Title match requirements validation
-        // - Competitor availability checking
     }
 }

--- a/app/Data/Matches/EventMatchData.php
+++ b/app/Data/Matches/EventMatchData.php
@@ -19,13 +19,13 @@ readonly class EventMatchData
      *
      * @param  EloquentCollection<int, Referee>  $referees
      * @param  EloquentCollection<int, Title>  $titles
-     * @param  Collection<string, covariant array<int, Wrestler|TagTeam>>  $competitors
+     * @param  Collection<int, covariant array{wrestlers?: array<int, Wrestler>, tag_teams?: array<int, TagTeam>}>  $sides
      */
     public function __construct(
         public MatchType $matchType,
         public EloquentCollection $referees,
         public EloquentCollection $titles,
-        public Collection $competitors,
+        public Collection $sides,
         public ?string $preview
     ) {}
 }

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -46,6 +46,8 @@ Roster booking eligibility is evaluated by `RosterBookingEligibility`, not by El
 
 `MatchStipulation` is a persistence record containing its configured name, slug, description, active flag, and match relationship. Stipulation capabilities and match presentation must be implemented by the match domain when they are enforced; the model does not infer behavior from hard-coded slug lists.
 
+`AddMatchForEventAction` receives side-based `EventMatchData`, locks the owning event, allocates the next card position without reusing soft-deleted match numbers, and persists the match, officials, championship stakes, sides, and competitors in one transaction. Assignment Actions retain eligibility and scheduling-conflict enforcement for their respective relationships.
+
 ## Winner/Loser System
 
 ### Multiple Winners and Losers

--- a/docs/testing-audit.md
+++ b/docs/testing-audit.md
@@ -88,7 +88,6 @@ Notable missing 1:1 areas by production path:
 
 Representative missing/high-value paths:
 
-- `app/Actions/Matches/AddMatchForEventAction.php`
 - `app/Actions/Matches/AddRefereesToMatchAction.php`
 - `app/Actions/Matches/AddTagTeamsToMatchAction.php`
 - Most `app/Actions/Stables/*` beyond lifecycle/retire/split coverage
@@ -150,7 +149,7 @@ Strengths:
 
 Gaps:
 
-- Matches coverage lacks full parity: `AddCompetitorsToMatchAction`, `AddTitlesToMatchAction`, and `AddWrestlersToMatchAction` are covered, but `AddMatchForEventAction`, `AddRefereesToMatchAction`, and `AddTagTeamsToMatchAction` are not mirrored.
+- Matches coverage lacks full parity: match creation, competitor assignment, title assignment, and wrestler assignment are covered, but `AddRefereesToMatchAction` and `AddTagTeamsToMatchAction` are not mirrored.
 - Events, Venues, Titles, and Stables action coverage is incomplete compared with production action surface.
 - Service classes are untested despite encoding membership/lifecycle/validation behavior.
 - There is no clear integration suite for contracts, booking constraints across bookable competitors/officials, or computed status interactions spanning promotions/events/matches/titles.
@@ -317,7 +316,6 @@ High-value Ringside candidates:
 
 4. **INF-56-P0-D: Close critical domain action parity gaps**
    - Add mirrored integration tests for match/event/title/stable/venue actions that currently lack 1:1 coverage, especially:
-     - `Actions\Matches\AddMatchForEventAction`
      - `Actions\Matches\AddRefereesToMatchAction`
      - `Actions\Matches\AddTagTeamsToMatchAction`
      - missing `Actions\Titles\*` lifecycle actions

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,12 +1,6 @@
 parameters:
 	ignoreErrors:
 		-
-			message: '#^Access to an undefined property App\\Enums\\MatchType\:\:\$id\.$#'
-			identifier: property.notFound
-			count: 1
-			path: app/Actions/Matches/AddMatchForEventAction.php
-
-		-
 			message: '#^Parameter \#1 \$callback of method Illuminate\\Database\\Eloquent\\Collection\<int,App\\Models\\Matches\\MatchCompetitor\>\:\:map\(\) expects callable\(App\\Models\\Matches\\MatchCompetitor, int\)\: Illuminate\\Support\\Collection\<int, App\\Models\\TagTeams\\TagTeam\|App\\Models\\Wrestlers\\Wrestler\>, Closure\(App\\Collections\\MatchCompetitorsCollection\)\: Illuminate\\Support\\Collection\<int, App\\Models\\TagTeams\\TagTeam\|App\\Models\\Wrestlers\\Wrestler\> given\.$#'
 			identifier: argument.type
 			count: 1

--- a/tests/Integration/Actions/Matches/AddMatchForEventActionTest.php
+++ b/tests/Integration/Actions/Matches/AddMatchForEventActionTest.php
@@ -6,7 +6,9 @@ use App\Actions\Matches\AddMatchForEventAction;
 use App\Data\Matches\EventMatchData;
 use App\Enums\MatchType;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Events\Event;
+use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
@@ -27,18 +29,95 @@ test('it rejects a match without competitors', function () {
 
 test('it rejects a match without referees', function () {
     $event = Event::factory()->create();
-    $wrestlers = [
-        Wrestler::factory()->bookable()->create(),
-        Wrestler::factory()->bookable()->create(),
-    ];
+    $firstWrestler = Wrestler::factory()->bookable()->create();
+    $secondWrestler = Wrestler::factory()->bookable()->create();
     $matchData = new EventMatchData(
         MatchType::Singles,
         Referee::query()->whereKey([])->get(),
         Title::query()->whereKey([])->get(),
-        collect(['wrestlers' => $wrestlers]),
+        collect([
+            1 => ['wrestlers' => [$firstWrestler]],
+            2 => ['wrestlers' => [$secondWrestler]],
+        ]),
         null,
     );
 
     expect(fn () => resolve(AddMatchForEventAction::class)->handle($event, $matchData))
         ->toThrow(InvalidMatchConfigurationException::class, 'A match must have at least one referee assigned.');
+});
+
+test('it creates a complete side-based match', function () {
+    $event = Event::factory()->create();
+    $referee = Referee::factory()->bookable()->create();
+    $title = Title::factory()->active()->create();
+    $firstWrestler = Wrestler::factory()->bookable()->create();
+    $secondWrestler = Wrestler::factory()->bookable()->create();
+    $matchData = new EventMatchData(
+        MatchType::Singles,
+        Referee::query()->whereKey($referee)->get(),
+        Title::query()->whereKey($title)->get(),
+        collect([
+            1 => ['wrestlers' => [$firstWrestler]],
+            2 => ['wrestlers' => [$secondWrestler]],
+        ]),
+        'Opening contest',
+    );
+
+    $match = resolve(AddMatchForEventAction::class)->handle($event, $matchData);
+
+    expect($match->event->is($event))->toBeTrue()
+        ->and($match->match_number)->toBe(1)
+        ->and($match->match_type)->toBe(MatchType::Singles)
+        ->and($match->preview)->toBe('Opening contest')
+        ->and($match->referees->modelKeys())->toBe([$referee->id])
+        ->and($match->titles->modelKeys())->toBe([$title->id])
+        ->and($match->sides()->pluck('position')->all())->toBe([1, 2])
+        ->and($match->competitors()->pluck('competitor_id')->all())->toEqualCanonicalizing([
+            $firstWrestler->id,
+            $secondWrestler->id,
+        ]);
+});
+
+test('it does not reuse match numbers from soft-deleted matches', function () {
+    $event = Event::factory()->create();
+    EventMatch::factory()->for($event)->create(['match_number' => 4])->delete();
+    $referee = Referee::factory()->bookable()->create();
+    $firstWrestler = Wrestler::factory()->bookable()->create();
+    $secondWrestler = Wrestler::factory()->bookable()->create();
+    $matchData = new EventMatchData(
+        MatchType::Singles,
+        Referee::query()->whereKey($referee)->get(),
+        Title::query()->whereKey([])->get(),
+        collect([
+            1 => ['wrestlers' => [$firstWrestler]],
+            2 => ['wrestlers' => [$secondWrestler]],
+        ]),
+        null,
+    );
+
+    $match = resolve(AddMatchForEventAction::class)->handle($event, $matchData);
+
+    expect($match->match_number)->toBe(5);
+});
+
+test('it rolls back the match when a side contains no eligible competitors', function () {
+    $event = Event::factory()->create();
+    $referee = Referee::factory()->bookable()->create();
+    $bookableWrestler = Wrestler::factory()->bookable()->create();
+    $unemployedWrestler = Wrestler::factory()->unemployed()->create();
+    $matchData = new EventMatchData(
+        MatchType::Singles,
+        Referee::query()->whereKey($referee)->get(),
+        Title::query()->whereKey([])->get(),
+        collect([
+            1 => ['wrestlers' => [$bookableWrestler]],
+            2 => ['wrestlers' => [$unemployedWrestler]],
+        ]),
+        null,
+    );
+
+    expect(fn () => resolve(AddMatchForEventAction::class)->handle($event, $matchData))
+        ->toThrow(EntityNotAvailableException::class);
+
+    expect(EventMatch::query()->whereBelongsTo($event)->exists())->toBeFalse();
 });


### PR DESCRIPTION
## Summary
- replace the obsolete type-grouped competitor transformation with side-based match input
- lock the owning event and allocate card positions without reusing soft-deleted match numbers
- persist match type through the current enum column and keep the complete workflow atomic
- add happy-path, numbering, validation, and rollback coverage
- remove the resolved PHPStan baseline entry and update architecture/testing documentation

## Verification
- composer test:push
- php artisan test --compact tests/Integration/Actions/Matches/AddMatchForEventActionTest.php