### PR TITLE
refactor: reject partial match assignments

### DIFF
--- a/app/Actions/Matches/AddRefereesToMatchAction.php
+++ b/app/Actions/Matches/AddRefereesToMatchAction.php
@@ -9,7 +9,7 @@ use App\Lifecycle\RosterBookingEligibility;
 use App\Models\Matches\EventMatch;
 use App\Models\Referees\Referee;
 use App\Services\MatchAssignmentConflictService;
-use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
 class AddRefereesToMatchAction
@@ -46,47 +46,22 @@ class AddRefereesToMatchAction
      * @param  EventMatch  $eventMatch  The match to add referees to
      * @param  Collection<int, Referee>  $referees  The referees to assign for officiating
      */
-    public function handle(EventMatch $eventMatch, \Illuminate\Support\Collection $referees): void
+    public function handle(EventMatch $eventMatch, Collection $referees): void
     {
-        // Pre-filter referees to ensure only eligible officials are processed
-        $eligibleReferees = $referees->filter(
-            fn (Referee $referee) => $this->isRefereeEligibleForMatch($referee, $eventMatch)
-        )->unique('id')->values();
+        $requestedReferees = $referees->unique('id')->values();
 
-        // Validate we have referees to add after filtering
-        if ($eligibleReferees->isEmpty()) {
+        if ($requestedReferees->isEmpty() || $requestedReferees->contains(
+            fn (Referee $referee): bool => ! RosterBookingEligibility::allows($referee)
+        )) {
             throw EntityNotAvailableException::forMatchAssignment('referees');
         }
 
-        DB::transaction(function () use ($eventMatch, $eligibleReferees): void {
-            $this->conflictService->ensureRefereesCanBeAssigned($eventMatch, $eligibleReferees);
+        DB::transaction(function () use ($eventMatch, $requestedReferees): void {
+            $this->conflictService->ensureRefereesCanBeAssigned($eventMatch, $requestedReferees);
 
-            // Add each eligible referee to officiate the match
-            $eligibleReferees->each(function (Referee $referee) use ($eventMatch) {
+            $requestedReferees->each(function (Referee $referee) use ($eventMatch): void {
                 $eventMatch->referees()->attach($referee->id);
             });
         });
-    }
-
-    /**
-     * Check if a referee is eligible to officiate the match.
-     *
-     * @param  Referee  $referee  The referee to validate
-     * @param  EventMatch  $eventMatch  The match they would officiate
-     * @return bool True if the referee can officiate
-     */
-    private function isRefereeEligibleForMatch(Referee $referee, EventMatch $eventMatch): bool
-    {
-        // Basic availability checks - referee must be active and available
-        if (! RosterBookingEligibility::allows($referee)) {
-            return false;
-        }
-
-        // Check for conflicts with existing assignments
-        // Note: More complex conflict checking would be implemented here
-        // such as checking for double-booking on the same event date or conflicts of interest
-        // Could validate against $eventMatch->event->date for scheduling conflicts
-
-        return true;
     }
 }

--- a/app/Actions/Matches/AddTagTeamsToMatchAction.php
+++ b/app/Actions/Matches/AddTagTeamsToMatchAction.php
@@ -50,13 +50,11 @@ class AddTagTeamsToMatchAction
      */
     public function handle(EventMatch $eventMatch, Collection $tagTeams, int $sideNumber): void
     {
-        // Pre-filter tag teams to ensure only eligible teams are processed
-        $eligibleTagTeams = $tagTeams->filter(
-            fn (TagTeam $tagTeam) => $this->isTagTeamEligibleForMatch($tagTeam, $eventMatch)
-        )->unique('id')->values();
+        $requestedTagTeams = $tagTeams->unique('id')->values();
 
-        // Validate we have tag teams to add after filtering
-        if ($eligibleTagTeams->isEmpty()) {
+        if ($requestedTagTeams->isEmpty() || $requestedTagTeams->contains(
+            fn (TagTeam $tagTeam): bool => ! RosterBookingEligibility::allows($tagTeam)
+        )) {
             throw EntityNotAvailableException::forMatchAssignment('tag teams');
         }
 
@@ -65,12 +63,11 @@ class AddTagTeamsToMatchAction
             throw InvalidMatchConfigurationException::invalidSideNumber($sideNumber);
         }
 
-        DB::transaction(function () use ($eventMatch, $eligibleTagTeams, $sideNumber): void {
-            $this->conflictService->ensureTagTeamsCanBeAssigned($eventMatch, $eligibleTagTeams);
+        DB::transaction(function () use ($eventMatch, $requestedTagTeams, $sideNumber): void {
+            $this->conflictService->ensureTagTeamsCanBeAssigned($eventMatch, $requestedTagTeams);
             $side = $eventMatch->sides()->firstOrCreate(['position' => $sideNumber]);
 
-            // Add each eligible tag team to the specified side
-            $eligibleTagTeams->each(function (TagTeam $tagTeam) use ($eventMatch, $side) {
+            $requestedTagTeams->each(function (TagTeam $tagTeam) use ($eventMatch, $side): void {
                 $eventMatch->competitors()->create([
                     'competitor_id' => $tagTeam->id,
                     'competitor_type' => $tagTeam->getMorphClass(),
@@ -78,27 +75,5 @@ class AddTagTeamsToMatchAction
                 ]);
             });
         });
-    }
-
-    /**
-     * Check if a tag team is eligible to compete in the match.
-     *
-     * @param  TagTeam  $tagTeam  The tag team to validate
-     * @param  EventMatch  $eventMatch  The match they would compete in
-     * @return bool True if the tag team can compete
-     */
-    private function isTagTeamEligibleForMatch(TagTeam $tagTeam, EventMatch $eventMatch): bool
-    {
-        // Basic availability checks - tag team must be active and available
-        if (! RosterBookingEligibility::allows($tagTeam)) {
-            return false;
-        }
-
-        // Check for conflicts with existing match assignments
-        // Note: More complex conflict checking would be implemented here
-        // such as checking for double-booking on the same event date
-        // Could validate against $eventMatch->event->date for scheduling conflicts
-
-        return true;
     }
 }

--- a/app/Actions/Matches/AddTitlesToMatchAction.php
+++ b/app/Actions/Matches/AddTitlesToMatchAction.php
@@ -47,45 +47,20 @@ class AddTitlesToMatchAction
      */
     public function handle(EventMatch $eventMatch, Collection $titles): void
     {
-        // Pre-filter titles to ensure only eligible championships are processed
-        $eligibleTitles = $titles->filter(
-            fn (Title $title) => $this->isTitleEligibleForMatch($title, $eventMatch)
-        )->unique('id')->values();
+        $requestedTitles = $titles->unique('id')->values();
 
-        // Validate we have titles to add after filtering
-        if ($eligibleTitles->isEmpty()) {
+        if ($requestedTitles->isEmpty() || $requestedTitles->contains(
+            fn (Title $title): bool => ! $title->isCurrentlyActive()
+        )) {
             throw EntityNotAvailableException::forMatchAssignment('titles');
         }
 
-        DB::transaction(function () use ($eventMatch, $eligibleTitles): void {
-            $this->conflictService->ensureTitlesCanBeAssigned($eventMatch, $eligibleTitles);
+        DB::transaction(function () use ($eventMatch, $requestedTitles): void {
+            $this->conflictService->ensureTitlesCanBeAssigned($eventMatch, $requestedTitles);
 
-            // Add each eligible title as championship stakes
-            $eligibleTitles->each(function (Title $title) use ($eventMatch) {
+            $requestedTitles->each(function (Title $title) use ($eventMatch): void {
                 $eventMatch->titles()->attach($title->id);
             });
         });
-    }
-
-    /**
-     * Check if a title is eligible to be at stake in the match.
-     *
-     * @param  Title  $title  The title to validate
-     * @param  EventMatch  $eventMatch  The match where it would be at stake
-     * @return bool True if the title can be defended/competed for
-     */
-    private function isTitleEligibleForMatch(Title $title, EventMatch $eventMatch): bool
-    {
-        // Basic availability checks - title must be active and available
-        if (! $title->isCurrentlyActive()) {
-            return false;
-        }
-
-        // Check for conflicts with existing title defenses
-        // Note: More complex validation would be implemented here
-        // such as ensuring the current champion is participating in the match
-        // Could validate against $eventMatch->event->date for scheduling conflicts
-
-        return true;
     }
 }

--- a/app/Actions/Matches/AddWrestlersToMatchAction.php
+++ b/app/Actions/Matches/AddWrestlersToMatchAction.php
@@ -48,13 +48,11 @@ class AddWrestlersToMatchAction
      */
     public function handle(EventMatch $eventMatch, Collection $wrestlers, int $sideNumber): void
     {
-        // Pre-filter wrestlers to ensure only eligible competitors are processed
-        $eligibleWrestlers = $wrestlers->filter(
-            fn (Wrestler $wrestler) => $this->isWrestlerEligibleForMatch($wrestler, $eventMatch)
-        )->unique('id')->values();
+        $requestedWrestlers = $wrestlers->unique('id')->values();
 
-        // Validate we have wrestlers to add after filtering
-        if ($eligibleWrestlers->isEmpty()) {
+        if ($requestedWrestlers->isEmpty() || $requestedWrestlers->contains(
+            fn (Wrestler $wrestler): bool => ! RosterBookingEligibility::allows($wrestler)
+        )) {
             throw EntityNotAvailableException::forMatchAssignment('wrestlers');
         }
 
@@ -63,12 +61,11 @@ class AddWrestlersToMatchAction
             throw InvalidMatchConfigurationException::invalidSideNumber($sideNumber);
         }
 
-        DB::transaction(function () use ($eventMatch, $eligibleWrestlers, $sideNumber): void {
-            $this->conflictService->ensureWrestlersCanBeAssigned($eventMatch, $eligibleWrestlers);
+        DB::transaction(function () use ($eventMatch, $requestedWrestlers, $sideNumber): void {
+            $this->conflictService->ensureWrestlersCanBeAssigned($eventMatch, $requestedWrestlers);
             $side = $eventMatch->sides()->firstOrCreate(['position' => $sideNumber]);
 
-            // Add each eligible wrestler to the specified side
-            $eligibleWrestlers->each(function (Wrestler $wrestler) use ($eventMatch, $side) {
+            $requestedWrestlers->each(function (Wrestler $wrestler) use ($eventMatch, $side): void {
                 $eventMatch->competitors()->create([
                     'competitor_id' => $wrestler->id,
                     'competitor_type' => $wrestler->getMorphClass(),
@@ -76,27 +73,5 @@ class AddWrestlersToMatchAction
                 ]);
             });
         });
-    }
-
-    /**
-     * Check if a wrestler is eligible to compete in the match.
-     *
-     * @param  Wrestler  $wrestler  The wrestler to validate
-     * @param  EventMatch  $eventMatch  The match they would compete in
-     * @return bool True if the wrestler can compete
-     */
-    private function isWrestlerEligibleForMatch(Wrestler $wrestler, EventMatch $eventMatch): bool
-    {
-        // Basic availability checks - wrestler must be active and available
-        if (! RosterBookingEligibility::allows($wrestler)) {
-            return false;
-        }
-
-        // Check for conflicts with existing match assignments
-        // Note: More complex conflict checking would be implemented here
-        // such as checking for double-booking on the same event date
-        // Could validate against $eventMatch->event->date for scheduling conflicts
-
-        return true;
     }
 }

--- a/app/Exceptions/Scheduling/EntityNotAvailableException.php
+++ b/app/Exceptions/Scheduling/EntityNotAvailableException.php
@@ -10,6 +10,6 @@ final class EntityNotAvailableException extends BaseBusinessException
 {
     public static function forMatchAssignment(string $entityType): static
     {
-        return new self("No eligible {$entityType} were provided for match assignment.");
+        return new self("Selected {$entityType} must all be eligible for match assignment.");
     }
 }

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -44,6 +44,8 @@ Assignment actions lock the affected event rows and enforce these rules inside t
 
 Roster booking eligibility is evaluated by `RosterBookingEligibility`, not by Eloquent models or builders. The policy combines persisted employment, injury, suspension, future-employment, and tag-team membership state. A tag team must satisfy its own lifecycle state, have at least two current wrestlers, and have every current wrestler individually eligible. Models expose those relationships and state predicates; validation rules, assignment Actions, and collections invoke the policy when deciding whether a participant may be booked.
 
+Assignment Actions treat each requested collection as an atomic command. They reject the entire assignment when any selected wrestler, tag team, referee, or title is unavailable; they never silently discard unavailable selections and persist a partial request. Repeated selections of the same record are normalized before assignment.
+
 `MatchStipulation` is a persistence record containing its configured name, slug, description, active flag, and match relationship. Stipulation capabilities and match presentation must be implemented by the match domain when they are enforced; the model does not infer behavior from hard-coded slug lists.
 
 ## Winner/Loser System

--- a/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
@@ -14,7 +14,20 @@ test('it rejects match assignment when no referee is available', function () {
     $referees = Referee::factory()->retired()->count(2)->create();
 
     expect(fn () => resolve(AddRefereesToMatchAction::class)->handle($match, $referees))
-        ->toThrow(EntityNotAvailableException::class, 'No eligible referees were provided for match assignment.');
+        ->toThrow(EntityNotAvailableException::class, 'Selected referees must all be eligible for match assignment.');
+});
+
+test('it rejects the entire assignment when any referee is unavailable', function () {
+    $match = EventMatch::factory()->create();
+    $availableReferee = Referee::factory()->bookable()->create();
+    $unavailableReferee = Referee::factory()->retired()->create();
+
+    expect(fn () => resolve(AddRefereesToMatchAction::class)->handle(
+        $match,
+        collect([$availableReferee, $unavailableReferee]),
+    ))->toThrow(EntityNotAvailableException::class);
+
+    expect($match->referees()->count())->toBe(0);
 });
 
 test('it allows a referee to officiate multiple matches on one event card', function () {

--- a/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
@@ -34,7 +34,22 @@ test('it rejects match assignment when no tag team is available', function () {
     $tagTeams = TagTeam::factory()->retired()->count(2)->create();
 
     expect(fn () => resolve(AddTagTeamsToMatchAction::class)->handle($match, $tagTeams, 1))
-        ->toThrow(EntityNotAvailableException::class, 'No eligible tag teams were provided for match assignment.');
+        ->toThrow(EntityNotAvailableException::class, 'Selected tag teams must all be eligible for match assignment.');
+});
+
+test('it rejects the entire assignment when any tag team is unavailable', function () {
+    $match = EventMatch::factory()->create();
+    $availableTagTeam = TagTeam::factory()->bookable()->create();
+    $unavailableTagTeam = TagTeam::factory()->retired()->create();
+
+    expect(fn () => resolve(AddTagTeamsToMatchAction::class)->handle(
+        $match,
+        collect([$availableTagTeam, $unavailableTagTeam]),
+        1,
+    ))->toThrow(EntityNotAvailableException::class);
+
+    expect($match->competitors()->count())->toBe(0)
+        ->and($match->sides()->count())->toBe(0);
 });
 
 test('it rejects a tag team already booked on the event card', function () {

--- a/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
@@ -59,28 +59,17 @@ test('it adds multiple titles to a match', function () {
     expect($match->refresh()->titles->pluck('id'))->toContain($title1->id, $title2->id);
 });
 
-test('it filters out inactive titles', function () {
+test('it rejects the entire assignment when any title is inactive', function () {
     $match = EventMatch::factory()->create();
     $activeTitle = Title::factory()->active()->create();
     $inactiveTitle = Title::factory()->inactive()->create();
 
     $titles = collect([$activeTitle, $inactiveTitle]);
 
-    resolve(AddTitlesToMatchAction::class)->handle($match, $titles);
+    expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($match, $titles))
+        ->toThrow(EntityNotAvailableException::class, 'Selected titles must all be eligible for match assignment.');
 
-    // Should only add the active title
-    $this->assertDatabaseHas('events_matches_titles', [
-        'match_id' => $match->id,
-        'title_id' => $activeTitle->id,
-    ]);
-
-    $this->assertDatabaseMissing('events_matches_titles', [
-        'match_id' => $match->id,
-        'title_id' => $inactiveTitle->id,
-    ]);
-
-    expect($match->refresh()->titles)->toHaveCount(1);
-    expect($match->refresh()->titles->firstOrFail()->id)->toBe($activeTitle->id);
+    expect($match->titles()->count())->toBe(0);
 });
 
 test('it throws exception when no eligible titles provided', function () {
@@ -90,7 +79,7 @@ test('it throws exception when no eligible titles provided', function () {
     $titles = collect([$inactiveTitle]);
 
     expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($match, $titles))
-        ->toThrow(EntityNotAvailableException::class, 'No eligible titles were provided for match assignment.');
+        ->toThrow(EntityNotAvailableException::class, 'Selected titles must all be eligible for match assignment.');
 });
 
 test('it handles empty collection', function () {
@@ -98,7 +87,7 @@ test('it handles empty collection', function () {
     $titles = Title::query()->whereKey([])->get();
 
     expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($match, $titles))
-        ->toThrow(EntityNotAvailableException::class, 'No eligible titles were provided for match assignment.');
+        ->toThrow(EntityNotAvailableException::class, 'Selected titles must all be eligible for match assignment.');
 });
 
 test('it creates championship match correctly', function () {

--- a/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
@@ -102,7 +102,7 @@ test('it adds wrestlers to different sides', function () {
     expect($match->refresh()->competitors()->count())->toBe(2);
 });
 
-test('it filters out ineligible wrestlers', function () {
+test('it rejects the entire assignment when any wrestler is ineligible', function () {
     $match = EventMatch::factory()->create();
     $eligibleWrestler = Wrestler::factory()->employed()->create();
     $ineligibleWrestler = Wrestler::factory()->retired()->create(); // Not bookable
@@ -110,23 +110,11 @@ test('it filters out ineligible wrestlers', function () {
     $wrestlers = collect([$eligibleWrestler, $ineligibleWrestler]);
     $sideNumber = 1;
 
-    resolve(AddWrestlersToMatchAction::class)->handle($match, $wrestlers, $sideNumber);
+    expect(fn () => resolve(AddWrestlersToMatchAction::class)->handle($match, $wrestlers, $sideNumber))
+        ->toThrow(EntityNotAvailableException::class, 'Selected wrestlers must all be eligible for match assignment.');
 
-    // Should only add the eligible wrestler
-    $this->assertDatabaseHas('events_matches_competitors', [
-        'match_id' => $match->id,
-        'competitor_id' => $eligibleWrestler->id,
-        'competitor_type' => $eligibleWrestler->getMorphClass(),
-        'match_side_id' => $match->sides()->where('position', $sideNumber)->firstOrFail()->id,
-    ]);
-
-    $this->assertDatabaseMissing('events_matches_competitors', [
-        'match_id' => $match->id,
-        'competitor_id' => $ineligibleWrestler->id,
-        'competitor_type' => $ineligibleWrestler->getMorphClass(),
-    ]);
-
-    expect($match->refresh()->competitors()->count())->toBe(1);
+    expect($match->competitors()->count())->toBe(0)
+        ->and($match->sides()->count())->toBe(0);
 });
 
 test('it throws exception when no eligible wrestlers provided', function () {
@@ -137,7 +125,7 @@ test('it throws exception when no eligible wrestlers provided', function () {
     $sideNumber = 1;
 
     expect(fn () => resolve(AddWrestlersToMatchAction::class)->handle($match, $wrestlers, $sideNumber))
-        ->toThrow(EntityNotAvailableException::class, 'No eligible wrestlers were provided for match assignment.');
+        ->toThrow(EntityNotAvailableException::class, 'Selected wrestlers must all be eligible for match assignment.');
 });
 
 test('it throws exception when side number is invalid', function () {


### PR DESCRIPTION
## Summary
- reject wrestler, tag team, referee, and title assignment collections when any selected record is unavailable
- preserve duplicate normalization without silently filtering requested records
- document and test atomic match-assignment behavior

## Verification
- composer lint -- affected PHP files
- php artisan test --compact tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
- composer test:push