### PR TITLE
refactor: centralize match updates

### DIFF
--- a/app/Actions/Matches/AddMatchForEventAction.php
+++ b/app/Actions/Matches/AddMatchForEventAction.php
@@ -36,6 +36,7 @@ class AddMatchForEventAction
                 'event_id' => $lockedEvent->id,
                 'match_number' => ($lastMatchNumber ?? 0) + 1,
                 'match_type' => $eventMatchData->matchType,
+                'match_stipulation_id' => $eventMatchData->matchStipulation?->id,
                 'preview' => $eventMatchData->preview,
             ]);
 

--- a/app/Actions/Matches/AddWrestlersToMatchAction.php
+++ b/app/Actions/Matches/AddWrestlersToMatchAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
+use App\Enums\MatchType;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Lifecycle\RosterBookingEligibility;
@@ -66,11 +67,15 @@ class AddWrestlersToMatchAction
             $side = $eventMatch->sides()->firstOrCreate(['position' => $sideNumber]);
 
             $requestedWrestlers->each(function (Wrestler $wrestler) use ($eventMatch, $side): void {
-                $eventMatch->competitors()->create([
+                $competitor = $eventMatch->competitors()->create([
                     'competitor_id' => $wrestler->id,
                     'competitor_type' => $wrestler->getMorphClass(),
                     'match_side_id' => $side->id,
                 ]);
+
+                if ($eventMatch->match_type === MatchType::RoyalRumble) {
+                    $competitor->forceFill(['entry_order' => $side->position])->save();
+                }
             });
         });
     }

--- a/app/Actions/Matches/UpdateMatchAction.php
+++ b/app/Actions/Matches/UpdateMatchAction.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Matches;
+
+use App\Data\Matches\EventMatchData;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Models\Matches\EventMatch;
+use Illuminate\Support\Facades\DB;
+
+class UpdateMatchAction
+{
+    public function __construct(
+        private AddRefereesToMatchAction $addRefereesToMatchAction,
+        private AddTitlesToMatchAction $addTitlesToMatchAction,
+        private AddCompetitorsToMatchAction $addCompetitorsToMatchAction,
+    ) {}
+
+    public function handle(EventMatch $match, EventMatchData $data): EventMatch
+    {
+        $this->ensureComplete($data);
+
+        return DB::transaction(function () use ($match, $data): EventMatch {
+            $lockedMatch = EventMatch::query()
+                ->lockForUpdate()
+                ->findOrFail($match->id);
+
+            if ($lockedMatch->match_finish !== null) {
+                throw InvalidMatchConfigurationException::resultAlreadyRecorded();
+            }
+
+            $lockedMatch->update([
+                'match_type' => $data->matchType,
+                'match_stipulation_id' => $data->matchStipulation?->id,
+                'preview' => $data->preview,
+            ]);
+
+            $lockedMatch->referees()->detach();
+            $lockedMatch->titles()->detach();
+            $lockedMatch->competitors()->delete();
+            $lockedMatch->sides()->delete();
+
+            $this->addRefereesToMatchAction->handle($lockedMatch, $data->referees);
+
+            if ($data->titles->isNotEmpty()) {
+                $this->addTitlesToMatchAction->handle($lockedMatch, $data->titles);
+            }
+
+            $this->addCompetitorsToMatchAction->handle($lockedMatch, $data->sides);
+
+            return $lockedMatch->refresh();
+        });
+    }
+
+    private function ensureComplete(EventMatchData $data): void
+    {
+        if ($data->sides->isEmpty()) {
+            throw InvalidMatchConfigurationException::missingCompetitors();
+        }
+
+        if ($data->referees->isEmpty()) {
+            throw InvalidMatchConfigurationException::missingReferees();
+        }
+    }
+}

--- a/app/Data/Matches/EventMatchData.php
+++ b/app/Data/Matches/EventMatchData.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Data\Matches;
 
 use App\Enums\MatchType;
+use App\Models\Matches\MatchStipulation;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
@@ -26,6 +27,7 @@ readonly class EventMatchData
         public EloquentCollection $referees,
         public EloquentCollection $titles,
         public Collection $sides,
-        public ?string $preview
+        public ?string $preview,
+        public ?MatchStipulation $matchStipulation = null,
     ) {}
 }

--- a/app/Exceptions/Matches/InvalidMatchConfigurationException.php
+++ b/app/Exceptions/Matches/InvalidMatchConfigurationException.php
@@ -28,6 +28,11 @@ final class InvalidMatchConfigurationException extends BaseBusinessException
         return new self('A match must have at least one referee assigned.');
     }
 
+    public static function resultAlreadyRecorded(): static
+    {
+        return new self('A match cannot be reconfigured after its result has been recorded.');
+    }
+
     public static function missingWinningSide(): static
     {
         return new self('This match finish requires a winning side.');

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -4,14 +4,19 @@ declare(strict_types=1);
 
 namespace App\Livewire\Matches\Forms;
 
+use App\Actions\Matches\AddMatchForEventAction;
+use App\Actions\Matches\UpdateMatchAction;
+use App\Data\Matches\EventMatchData;
 use App\Enums\MatchType;
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\Concerns\HasStandardValidationAttributes;
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
 use App\Models\Matches\MatchStipulation;
+use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
@@ -136,13 +141,21 @@ class CreateEditForm extends BaseForm
      */
     public function store(): bool
     {
-        $result = parent::store();
+        $this->validate();
 
-        if ($result) {
-            $this->syncRelationships();
+        $data = $this->toData();
+
+        if ($this->isCreating()) {
+            $event = Event::query()->findOrFail($this->eventId);
+            $this->formModel = resolve(AddMatchForEventAction::class)->handle($event, $data);
+        } else {
+            $match = EventMatch::query()->findOrFail($this->modelId);
+            $this->formModel = resolve(UpdateMatchAction::class)->handle($match, $data);
         }
 
-        return $result;
+        $this->modelId = $this->formModel->getKey();
+
+        return true;
     }
 
     /**
@@ -200,85 +213,6 @@ class CreateEditForm extends BaseForm
     }
 
     /**
-     * Synchronize all event match relationships.
-     *
-     * Updates the relationships for referees, titles, and competitors
-     * to match the current form state. Handles both many-to-many
-     * and one-to-many relationships appropriately.
-     */
-    private function syncRelationships(): void
-    {
-        if (! $this->formModel instanceof EventMatch) {
-            return;
-        }
-
-        // Sync many-to-many relationships (assuming referees and titles are BelongsToMany)
-        $this->formModel->referees()->sync($this->referees);
-        $this->formModel->titles()->sync($this->titles);
-
-        // Handle competitors - assuming it's a HasMany relationship
-        $this->syncCompetitors();
-    }
-
-    /**
-     * Sync competitors for HasMany relationship.
-     *
-     * Removes existing competitors and creates new ones based on
-     * the current form state.
-     */
-    private function syncCompetitors(): void
-    {
-        if (! $this->formModel instanceof EventMatch) {
-            return;
-        }
-
-        // Delete existing competitors
-        $this->formModel->competitors()->delete();
-        $this->formModel->sides()->delete();
-
-        if ($this->matchType->usesIndividualCompetitorSides()) {
-            foreach ($this->competitors[0]['wrestlers'] ?? [] as $sideIndex => $wrestlerId) {
-                $side = $this->formModel->sides()->create(['position' => $sideIndex + 1]);
-
-                $competitor = $this->formModel->competitors()->create([
-                    'competitor_type' => (new Wrestler())->getMorphClass(),
-                    'competitor_id' => $wrestlerId,
-                    'match_side_id' => $side->id,
-                ]);
-
-                if ($this->matchType === MatchType::RoyalRumble) {
-                    $competitor->forceFill(['entry_order' => $sideIndex + 1])->save();
-                }
-            }
-
-            return;
-        }
-
-        // Create new competitor records using the side-based structure
-        foreach ($this->competitors as $sideIndex => $sideCompetitors) {
-            $side = $this->formModel->sides()->create(['position' => $sideIndex + 1]);
-
-            // Handle wrestlers for this side
-            foreach ($sideCompetitors['wrestlers'] ?? [] as $wrestlerId) {
-                $this->formModel->competitors()->create([
-                    'competitor_type' => (new Wrestler())->getMorphClass(),
-                    'competitor_id' => $wrestlerId,
-                    'match_side_id' => $side->id,
-                ]);
-            }
-
-            // Handle tag teams for this side (when implemented)
-            foreach ($sideCompetitors['tag_teams'] ?? [] as $tagTeamId) {
-                $this->formModel->competitors()->create([
-                    'competitor_type' => (new TagTeam())->getMorphClass(),
-                    'competitor_id' => $tagTeamId,
-                    'match_side_id' => $side->id,
-                ]);
-            }
-        }
-    }
-
-    /**
      * Prepare event match data for model storage.
      *
      * Transforms form fields into model-compatible data structure.
@@ -291,28 +225,43 @@ class CreateEditForm extends BaseForm
     {
         return [
             'event_id' => $this->eventId,
-            'match_number' => $this->getNextMatchNumber(),
             'preview' => $this->preview,
             'match_type' => $this->matchType,
             'match_stipulation_id' => $this->matchStipulationId,
         ];
-        // Note: relationships (competitors, referees, titles) are handled
-        // separately through the relationship synchronization system
     }
 
-    /**
-     * Get the next match number for the event.
-     *
-     * Calculates the next sequential match number based on existing matches
-     * for the specified event. Match numbers start from 1.
-     *
-     * @return int Next match number (1-based)
-     */
-    private function getNextMatchNumber(): int
+    private function toData(): EventMatchData
     {
-        $maxMatchNumber = EventMatch::where('event_id', $this->eventId)->max('match_number');
+        $matchType = $this->matchType;
+        $sides = $matchType->usesIndividualCompetitorSides()
+            ? collect($this->competitors[0]['wrestlers'] ?? [])
+                ->values()
+                ->mapWithKeys(fn (int $wrestlerId, int $index): array => [
+                    $index + 1 => [
+                        'wrestlers' => Wrestler::query()->whereKey($wrestlerId)->get()->all(),
+                        'tag_teams' => [],
+                    ],
+                ])
+            : collect($this->competitors)
+                ->values()
+                ->mapWithKeys(fn (array $side, int $index): array => [
+                    $index + 1 => [
+                        'wrestlers' => Wrestler::query()->whereKey($side['wrestlers'] ?? [])->get()->all(),
+                        'tag_teams' => TagTeam::query()->whereKey($side['tag_teams'] ?? [])->get()->all(),
+                    ],
+                ]);
 
-        return ($maxMatchNumber ?? 0) + 1;
+        return new EventMatchData(
+            matchType: $matchType,
+            referees: Referee::query()->whereKey($this->referees)->get(),
+            titles: Title::query()->whereKey($this->titles)->get(),
+            sides: $sides,
+            preview: $this->preview,
+            matchStipulation: $this->matchStipulationId === null
+                ? null
+                : MatchStipulation::query()->findOrFail($this->matchStipulationId),
+        );
     }
 
     /**
@@ -355,7 +304,7 @@ class CreateEditForm extends BaseForm
                 Rule::exists(MatchStipulation::class, 'id')->where('is_active', true),
             ],
             'preview' => ['sometimes', 'string'],
-            'referees' => ['sometimes', 'array'],
+            'referees' => ['required', 'array', 'min:1'],
             'referees.*' => ['integer', 'exists:referees,id'],
             'titles' => ['sometimes', 'array'],
             'titles.*' => [

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -50,6 +50,8 @@ Assignment Actions treat each requested collection as an atomic command. They re
 
 `AddMatchForEventAction` receives side-based `EventMatchData`, locks the owning event, allocates the next card position without reusing soft-deleted match numbers, and persists the match, officials, championship stakes, sides, and competitors in one transaction. Assignment Actions retain eligibility and scheduling-conflict enforcement for their respective relationships.
 
+`UpdateMatchAction` receives the same typed data, locks the match, and replaces its configuration and assignments in one transaction. Any unavailable replacement rolls the entire edit back to the previous configuration. Once a result has been recorded, the match configuration is immutable so its sides and competitors continue to describe that result.
+
 ## Winner/Loser System
 
 ### Multiple Winners and Losers

--- a/tests/Integration/Actions/Matches/UpdateMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/UpdateMatchActionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Matches\UpdateMatchAction;
+use App\Data\Matches\EventMatchData;
+use App\Enums\MatchFinish;
+use App\Enums\MatchType;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
+use App\Models\Referees\Referee;
+use App\Models\Titles\Title;
+use App\Models\Wrestlers\Wrestler;
+
+test('it atomically replaces a match configuration', function () {
+    $match = EventMatch::factory()->create([
+        'match_type' => MatchType::Singles,
+        'preview' => 'Original preview',
+    ]);
+    $originalReferee = Referee::factory()->bookable()->create();
+    $originalTitle = Title::factory()->active()->create();
+    $originalWrestler = Wrestler::factory()->bookable()->create();
+    $originalSide = MatchSide::factory()->for($match, 'match')->create(['position' => 1]);
+    MatchCompetitor::factory()->for($match, 'eventMatch')->for($originalSide, 'side')->create([
+        'competitor_id' => $originalWrestler->id,
+        'competitor_type' => $originalWrestler->getMorphClass(),
+    ]);
+    $match->referees()->attach($originalReferee);
+    $match->titles()->attach($originalTitle);
+
+    $newReferee = Referee::factory()->bookable()->create();
+    $newTitle = Title::factory()->active()->create();
+    $firstWrestler = Wrestler::factory()->bookable()->create();
+    $secondWrestler = Wrestler::factory()->bookable()->create();
+    $data = new EventMatchData(
+        MatchType::TagTeam,
+        Referee::query()->whereKey($newReferee)->get(),
+        Title::query()->whereKey($newTitle)->get(),
+        collect([
+            1 => ['wrestlers' => [$firstWrestler]],
+            2 => ['wrestlers' => [$secondWrestler]],
+        ]),
+        'Updated preview',
+    );
+
+    $updatedMatch = resolve(UpdateMatchAction::class)->handle($match, $data);
+
+    expect($updatedMatch->match_type)->toBe(MatchType::TagTeam)
+        ->and($updatedMatch->preview)->toBe('Updated preview')
+        ->and($updatedMatch->match_number)->toBe($match->match_number)
+        ->and($updatedMatch->referees->modelKeys())->toBe([$newReferee->id])
+        ->and($updatedMatch->titles->modelKeys())->toBe([$newTitle->id])
+        ->and($updatedMatch->competitors()->pluck('competitor_id')->all())->toEqualCanonicalizing([
+            $firstWrestler->id,
+            $secondWrestler->id,
+        ]);
+});
+
+test('it rolls back the original configuration when a replacement is unavailable', function () {
+    $match = EventMatch::factory()->create(['preview' => 'Original preview']);
+    $originalReferee = Referee::factory()->bookable()->create();
+    $originalWrestler = Wrestler::factory()->bookable()->create();
+    $originalSide = MatchSide::factory()->for($match, 'match')->create(['position' => 1]);
+    MatchCompetitor::factory()->for($match, 'eventMatch')->for($originalSide, 'side')->create([
+        'competitor_id' => $originalWrestler->id,
+        'competitor_type' => $originalWrestler->getMorphClass(),
+    ]);
+    $match->referees()->attach($originalReferee);
+
+    $newReferee = Referee::factory()->bookable()->create();
+    $availableWrestler = Wrestler::factory()->bookable()->create();
+    $unavailableWrestler = Wrestler::factory()->retired()->create();
+    $data = new EventMatchData(
+        MatchType::Singles,
+        Referee::query()->whereKey($newReferee)->get(),
+        Title::query()->whereKey([])->get(),
+        collect([
+            1 => ['wrestlers' => [$availableWrestler]],
+            2 => ['wrestlers' => [$unavailableWrestler]],
+        ]),
+        'Updated preview',
+    );
+
+    expect(fn () => resolve(UpdateMatchAction::class)->handle($match, $data))
+        ->toThrow(EntityNotAvailableException::class);
+
+    $match->refresh();
+
+    expect($match->preview)->toBe('Original preview')
+        ->and($match->referees->modelKeys())->toBe([$originalReferee->id])
+        ->and($match->competitors()->pluck('competitor_id')->all())->toBe([$originalWrestler->id]);
+});
+
+test('it rejects reconfiguring a match after its result is recorded', function () {
+    $match = EventMatch::factory()->create(['match_finish' => MatchFinish::TimeLimitDraw]);
+    $referee = Referee::factory()->bookable()->create();
+    $firstWrestler = Wrestler::factory()->bookable()->create();
+    $secondWrestler = Wrestler::factory()->bookable()->create();
+    $data = new EventMatchData(
+        MatchType::Singles,
+        Referee::query()->whereKey($referee)->get(),
+        Title::query()->whereKey([])->get(),
+        collect([
+            1 => ['wrestlers' => [$firstWrestler]],
+            2 => ['wrestlers' => [$secondWrestler]],
+        ]),
+        null,
+    );
+
+    expect(fn () => resolve(UpdateMatchAction::class)->handle($match, $data))
+        ->toThrow(
+            InvalidMatchConfigurationException::class,
+            'A match cannot be reconfigured after its result has been recorded.',
+        );
+});

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -120,11 +120,13 @@ describe('FormModal Match Stipulation Integration', function () {
         $stipulation = MatchStipulation::factory()->active()->create();
         $firstWrestler = Wrestler::factory()->bookable()->create();
         $secondWrestler = Wrestler::factory()->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
 
         livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
             ->set('form.matchStipulationId', $stipulation->id)
+            ->set('form.referees', [$referee->id])
             ->set('form.competitors', [
                 ['wrestlers' => [$firstWrestler->id]],
                 ['wrestlers' => [$secondWrestler->id]],
@@ -261,10 +263,12 @@ describe('FormModal Create Operations', function () {
 
     it('persists each battle royal entrant on an individual side', function () {
         $wrestlers = Wrestler::factory()->count(3)->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
 
         livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::BattleRoyal)
+            ->set('form.referees', [$referee->id])
             ->set('form.competitors.0.wrestlers', $wrestlers->modelKeys())
             ->call('save')
             ->assertHasNoErrors()
@@ -279,10 +283,12 @@ describe('FormModal Create Operations', function () {
 
     it('records royal rumble selection order as entrant order', function () {
         $wrestlers = Wrestler::factory()->count(10)->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
 
         livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::RoyalRumble)
+            ->set('form.referees', [$referee->id])
             ->set('form.competitors.0.wrestlers', $wrestlers->modelKeys())
             ->call('save')
             ->assertHasNoErrors();
@@ -320,10 +326,12 @@ describe('FormModal Edit Operations', function () {
         $wrestler2 = Wrestler::factory()->bookable()->create();
         $wrestler3 = Wrestler::factory()->bookable()->create();
         $wrestler4 = Wrestler::factory()->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
 
         $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal', $match->id)
             ->set('form.matchType', MatchType::TagTeam)
+            ->set('form.referees', [$referee->id])
             ->set('form.competitors', [
                 0 => ['wrestlers' => [$wrestler1->id, $wrestler2->id]],
                 1 => ['wrestlers' => [$wrestler3->id, $wrestler4->id]],
@@ -425,10 +433,12 @@ describe('FormModal Title Championship Integration', function () {
         $title = Title::factory()->active()->create();
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
 
         $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
+            ->set('form.referees', [$referee->id])
             ->set('form.competitors', [
                 0 => ['wrestlers' => [$wrestler1->id]],
                 1 => ['wrestlers' => [$wrestler2->id]],
@@ -475,10 +485,12 @@ describe('FormModal Tag Team Integration', function () {
     it('can create tag team match', function () {
         $tagTeam1 = TagTeam::factory()->bookable()->create();
         $tagTeam2 = TagTeam::factory()->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
 
         $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::TagTeam)
+            ->set('form.referees', [$referee->id])
             ->set('form.competitors', [
                 0 => ['tag_teams' => [$tagTeam1->id]],
                 1 => ['tag_teams' => [$tagTeam2->id]],
@@ -517,10 +529,12 @@ describe('FormModal State Management', function () {
     it('closes modal after successful save', function () {
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
 
         $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal')
             ->set('form.matchType', MatchType::Singles)
+            ->set('form.referees', [$referee->id])
             ->set('form.competitors', [
                 0 => ['wrestlers' => [$wrestler1->id]],
                 1 => ['wrestlers' => [$wrestler2->id]],


### PR DESCRIPTION
## Summary
- route Livewire match creation and editing through typed action workflows
- add an atomic update action with rollback protection and result immutability
- preserve match stipulations and Royal Rumble entry ordering in the action layer

## Verification
- focused match tests: 46 tests, 104 assertions
- composer test:types
- composer test:push