### PR TITLE
refactor: record complete match outcomes

### DIFF
--- a/app/Actions/Matches/RecordResultAction.php
+++ b/app/Actions/Matches/RecordResultAction.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
-use App\Enums\MatchFinish;
+use App\Data\Matches\MatchEliminationData;
+use App\Data\Matches\MatchResultData;
 use App\Lifecycle\MatchOutcomeRequirements;
 use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
 use Illuminate\Support\Facades\DB;
 
@@ -14,20 +16,45 @@ class RecordResultAction
 {
     public function __construct(private MatchOutcomeRequirements $requirements) {}
 
-    public function handle(EventMatch $match, MatchFinish $finish, ?MatchSide $winningSide): EventMatch
+    public function handle(EventMatch $match, MatchResultData $result): EventMatch
     {
-        return DB::transaction(function () use ($match, $finish, $winningSide): EventMatch {
+        return DB::transaction(function () use ($match, $result): EventMatch {
             $lockedMatch = EventMatch::query()->lockForUpdate()->findOrFail($match->id);
-            $lockedWinningSide = $winningSide === null
+            $lockedWinningSide = $result->winningSide === null
                 ? null
-                : MatchSide::query()->lockForUpdate()->findOrFail($winningSide->id);
+                : MatchSide::query()->lockForUpdate()->findOrFail($result->winningSide->id);
+            $lockedCompetitors = MatchCompetitor::query()
+                ->whereBelongsTo($lockedMatch, 'eventMatch')
+                ->lockForUpdate()
+                ->get();
+            $lockedResult = new MatchResultData(
+                finish: $result->finish,
+                winningSide: $lockedWinningSide,
+                eliminations: $result->eliminations,
+            );
 
-            $this->requirements->ensureSatisfied($lockedMatch, $finish, $lockedWinningSide);
+            $this->requirements->ensureSatisfied($lockedMatch, $lockedResult, $lockedCompetitors);
 
             $lockedMatch->update([
-                'match_finish' => $finish,
+                'match_finish' => $result->finish,
                 'winning_side_id' => $lockedWinningSide?->id,
             ]);
+
+            MatchCompetitor::query()
+                ->whereBelongsTo($lockedMatch, 'eventMatch')
+                ->update([
+                    'elimination_order' => null,
+                    'eliminated_by_match_competitor_id' => null,
+                ]);
+
+            $result->eliminations->each(function (MatchEliminationData $elimination) use ($lockedCompetitors): void {
+                $lockedCompetitor = $lockedCompetitors->sole('id', $elimination->competitor->id);
+
+                $lockedCompetitor->forceFill([
+                    'elimination_order' => $elimination->order,
+                    'eliminated_by_match_competitor_id' => $elimination->eliminatedBy?->id,
+                ])->save();
+            });
 
             return $lockedMatch->refresh();
         });

--- a/app/Data/Matches/MatchEliminationData.php
+++ b/app/Data/Matches/MatchEliminationData.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Matches;
+
+use App\Models\Matches\MatchCompetitor;
+
+readonly class MatchEliminationData
+{
+    public function __construct(
+        public MatchCompetitor $competitor,
+        public int $order,
+        public ?MatchCompetitor $eliminatedBy = null,
+    ) {}
+}

--- a/app/Data/Matches/MatchResultData.php
+++ b/app/Data/Matches/MatchResultData.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Data\Matches;
+
+use App\Enums\MatchFinish;
+use App\Models\Matches\MatchSide;
+use Illuminate\Support\Collection;
+
+readonly class MatchResultData
+{
+    /**
+     * @param  Collection<int, MatchEliminationData>  $eliminations
+     */
+    public function __construct(
+        public MatchFinish $finish,
+        public ?MatchSide $winningSide,
+        public Collection $eliminations,
+    ) {}
+}

--- a/app/Enums/MatchType.php
+++ b/app/Enums/MatchType.php
@@ -79,6 +79,11 @@ enum MatchType: string
         return in_array($this, [self::BattleRoyal, self::RoyalRumble], true);
     }
 
+    public function recordsIndividualEliminations(): bool
+    {
+        return in_array($this, [self::BattleRoyal, self::RoyalRumble], true);
+    }
+
     /**
      * Check if this match type allows wrestler competitors.
      */

--- a/app/Exceptions/Matches/InvalidMatchConfigurationException.php
+++ b/app/Exceptions/Matches/InvalidMatchConfigurationException.php
@@ -32,24 +32,4 @@ final class InvalidMatchConfigurationException extends BaseBusinessException
     {
         return new self('A match cannot be reconfigured after its result has been recorded.');
     }
-
-    public static function missingWinningSide(): static
-    {
-        return new self('This match finish requires a winning side.');
-    }
-
-    public static function unexpectedWinningSide(): static
-    {
-        return new self('This match finish cannot have a winning side.');
-    }
-
-    public static function winningSideFromAnotherMatch(): static
-    {
-        return new self('The winning side must belong to the match being resulted.');
-    }
-
-    public static function winningSideWithoutCompetitors(): static
-    {
-        return new self('The winning side must contain at least one competitor.');
-    }
 }

--- a/app/Exceptions/Matches/InvalidMatchOutcomeException.php
+++ b/app/Exceptions/Matches/InvalidMatchOutcomeException.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Matches;
+
+use App\Exceptions\BaseBusinessException;
+
+final class InvalidMatchOutcomeException extends BaseBusinessException
+{
+    public static function missingWinningSide(): self
+    {
+        return new self('This match finish requires a winning side.');
+    }
+
+    public static function unexpectedWinningSide(): self
+    {
+        return new self('This match finish cannot have a winning side.');
+    }
+
+    public static function winningSideFromAnotherMatch(): self
+    {
+        return new self('The winning side must belong to the match being resulted.');
+    }
+
+    public static function winningSideWithoutCompetitors(): self
+    {
+        return new self('The winning side must contain at least one competitor.');
+    }
+
+    public static function eliminationsNotSupported(): self
+    {
+        return new self('Elimination details may only be recorded for Battle Royal and Royal Rumble matches.');
+    }
+
+    public static function competitorFromAnotherMatch(): self
+    {
+        return new self('Every eliminated competitor must belong to the match being resulted.');
+    }
+
+    public static function eliminatorFromAnotherMatch(): self
+    {
+        return new self('Every eliminating competitor must belong to the match being resulted.');
+    }
+
+    public static function selfElimination(): self
+    {
+        return new self('A competitor cannot eliminate itself.');
+    }
+
+    public static function duplicateEliminatedCompetitor(): self
+    {
+        return new self('A competitor may be eliminated only once.');
+    }
+
+    public static function invalidEliminationOrder(): self
+    {
+        return new self('Elimination order must be unique, positive, and consecutive.');
+    }
+
+    public static function incompleteEliminationHistory(): self
+    {
+        return new self('A decisive elimination match must record every losing competitor exactly once.');
+    }
+
+    public static function winnerEliminated(): self
+    {
+        return new self('A competitor on the winning side cannot be eliminated.');
+    }
+
+    public static function eliminationAfterEliminatorExited(): self
+    {
+        return new self('A competitor cannot eliminate another competitor after being eliminated.');
+    }
+
+    public static function invalidEntryOrder(): self
+    {
+        return new self('Royal Rumble entry order must be unique, positive, and consecutive.');
+    }
+}

--- a/app/Lifecycle/MatchOutcomeRequirements.php
+++ b/app/Lifecycle/MatchOutcomeRequirements.php
@@ -4,33 +4,180 @@ declare(strict_types=1);
 
 namespace App\Lifecycle;
 
-use App\Enums\MatchFinish;
-use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Data\Matches\MatchEliminationData;
+use App\Data\Matches\MatchResultData;
+use App\Enums\MatchType;
+use App\Exceptions\Matches\InvalidMatchOutcomeException;
 use App\Models\Matches\EventMatch;
-use App\Models\Matches\MatchSide;
+use App\Models\Matches\MatchCompetitor;
+use Illuminate\Database\Eloquent\Collection;
 
 class MatchOutcomeRequirements
 {
-    public function ensureSatisfied(EventMatch $match, MatchFinish $finish, ?MatchSide $winningSide): void
+    /**
+     * @param  Collection<int, MatchCompetitor>  $competitors
+     */
+    public function ensureSatisfied(EventMatch $match, MatchResultData $result, Collection $competitors): void
     {
-        if ($finish->requiresWinningSide() && $winningSide === null) {
-            throw InvalidMatchConfigurationException::missingWinningSide();
+        $this->ensureWinningSideIsValid($match, $result);
+        $this->ensureEntryOrderIsValid($match, $competitors);
+        $this->ensureEliminationsAreValid($match, $result, $competitors);
+    }
+
+    private function ensureWinningSideIsValid(EventMatch $match, MatchResultData $result): void
+    {
+        if ($result->finish->requiresWinningSide() && $result->winningSide === null) {
+            throw InvalidMatchOutcomeException::missingWinningSide();
         }
 
-        if (! $finish->requiresWinningSide() && $winningSide !== null) {
-            throw InvalidMatchConfigurationException::unexpectedWinningSide();
+        if (! $result->finish->requiresWinningSide() && $result->winningSide !== null) {
+            throw InvalidMatchOutcomeException::unexpectedWinningSide();
         }
 
-        if ($winningSide === null) {
+        if ($result->winningSide === null) {
             return;
         }
 
-        if ($winningSide->match_id !== $match->id) {
-            throw InvalidMatchConfigurationException::winningSideFromAnotherMatch();
+        if ($result->winningSide->match_id !== $match->id) {
+            throw InvalidMatchOutcomeException::winningSideFromAnotherMatch();
         }
 
-        if (! $winningSide->competitors()->exists()) {
-            throw InvalidMatchConfigurationException::winningSideWithoutCompetitors();
+        if (! $result->winningSide->competitors()->exists()) {
+            throw InvalidMatchOutcomeException::winningSideWithoutCompetitors();
         }
+    }
+
+    /**
+     * @param  Collection<int, MatchCompetitor>  $competitors
+     */
+    private function ensureEntryOrderIsValid(EventMatch $match, Collection $competitors): void
+    {
+        if ($match->match_type !== MatchType::RoyalRumble) {
+            return;
+        }
+
+        $entryOrders = $competitors->pluck('entry_order')->all();
+
+        if (! $this->isConsecutiveSequence($entryOrders, $competitors->count())) {
+            throw InvalidMatchOutcomeException::invalidEntryOrder();
+        }
+    }
+
+    /**
+     * @param  Collection<int, MatchCompetitor>  $competitors
+     */
+    private function ensureEliminationsAreValid(
+        EventMatch $match,
+        MatchResultData $result,
+        Collection $competitors,
+    ): void {
+        if (! $match->match_type->recordsIndividualEliminations()) {
+            if ($result->eliminations->isNotEmpty()) {
+                throw InvalidMatchOutcomeException::eliminationsNotSupported();
+            }
+
+            return;
+        }
+
+        $competitorsById = $competitors->keyBy('id');
+        $eliminatedCompetitorIds = $result->eliminations
+            ->map(fn (MatchEliminationData $elimination): int => $elimination->competitor->id);
+
+        if ($eliminatedCompetitorIds->unique()->count() !== $eliminatedCompetitorIds->count()) {
+            throw InvalidMatchOutcomeException::duplicateEliminatedCompetitor();
+        }
+
+        $orders = $result->eliminations
+            ->map(fn (MatchEliminationData $elimination): int => $elimination->order)
+            ->all();
+
+        if (! $this->isConsecutiveSequence($orders, $result->eliminations->count())) {
+            throw InvalidMatchOutcomeException::invalidEliminationOrder();
+        }
+
+        foreach ($result->eliminations as $elimination) {
+            $this->ensureEliminationParticipantsBelongToMatch($elimination, $competitorsById);
+        }
+
+        $this->ensureEliminationChronology($result);
+
+        if (! $result->finish->requiresWinningSide()) {
+            return;
+        }
+
+        $winningSideId = $result->winningSide?->id;
+        $winningCompetitorIds = collect($competitors
+            ->where('match_side_id', $winningSideId)
+            ->modelKeys());
+
+        if ($eliminatedCompetitorIds->intersect($winningCompetitorIds)->isNotEmpty()) {
+            throw InvalidMatchOutcomeException::winnerEliminated();
+        }
+
+        $expectedEliminatedCompetitorIds = collect($competitors
+            ->where('match_side_id', '!=', $winningSideId)
+            ->modelKeys());
+
+        if ($eliminatedCompetitorIds->sort()->values()->all() !== $expectedEliminatedCompetitorIds->sort()->values()->all()) {
+            throw InvalidMatchOutcomeException::incompleteEliminationHistory();
+        }
+    }
+
+    /**
+     * @param  Collection<int, MatchCompetitor>  $competitorsById
+     */
+    private function ensureEliminationParticipantsBelongToMatch(
+        MatchEliminationData $elimination,
+        Collection $competitorsById,
+    ): void {
+        if (! $competitorsById->has($elimination->competitor->id)) {
+            throw InvalidMatchOutcomeException::competitorFromAnotherMatch();
+        }
+
+        if ($elimination->eliminatedBy === null) {
+            return;
+        }
+
+        if (! $competitorsById->has($elimination->eliminatedBy->id)) {
+            throw InvalidMatchOutcomeException::eliminatorFromAnotherMatch();
+        }
+
+        if ($elimination->competitor->is($elimination->eliminatedBy)) {
+            throw InvalidMatchOutcomeException::selfElimination();
+        }
+    }
+
+    private function ensureEliminationChronology(MatchResultData $result): void
+    {
+        $eliminationOrders = $result->eliminations
+            ->mapWithKeys(fn (MatchEliminationData $elimination): array => [
+                $elimination->competitor->id => $elimination->order,
+            ]);
+
+        foreach ($result->eliminations as $elimination) {
+            if ($elimination->eliminatedBy === null) {
+                continue;
+            }
+
+            $eliminatorExitOrder = $eliminationOrders->get($elimination->eliminatedBy->id);
+
+            if (is_int($eliminatorExitOrder) && $eliminatorExitOrder <= $elimination->order) {
+                throw InvalidMatchOutcomeException::eliminationAfterEliminatorExited();
+            }
+        }
+    }
+
+    /**
+     * @param  array<int, int|null>  $values
+     */
+    private function isConsecutiveSequence(array $values, int $count): bool
+    {
+        if ($count === 0) {
+            return $values === [];
+        }
+
+        sort($values);
+
+        return $values === range(1, $count);
     }
 }

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -76,6 +76,8 @@ Assignment Actions treat each requested collection as an atomic command. They re
 
 Royal Rumble competitors record a unique `entry_order` within the match. Battle Royal competitors may leave entry order unset because they begin simultaneously. Eliminated competitors record a unique `elimination_order`; the winner remains without one. `eliminated_by_match_competitor_id` optionally identifies the competitor responsible for the elimination and remains nullable for joint, external, or indeterminate eliminations.
 
+`RecordResultAction` records the finish, winning side, and elimination history as one atomic outcome. A decisive Battle Royal or Royal Rumble result accounts for every losing competitor exactly once, never eliminates a winner, and preserves chronological elimination order. No-outcome finishes may retain a valid partial elimination history. Recording a corrected result replaces the previous outcome metadata in the same transaction.
+
 ## Related Documentation
 - [Business Rules](business-rules.md)
 - [Core Capabilities](core-capabilities.md)

--- a/tests/Integration/Actions/Matches/RecordResultActionTest.php
+++ b/tests/Integration/Actions/Matches/RecordResultActionTest.php
@@ -3,35 +3,69 @@
 declare(strict_types=1);
 
 use App\Actions\Matches\RecordResultAction;
+use App\Data\Matches\MatchEliminationData;
+use App\Data\Matches\MatchResultData;
 use App\Enums\MatchFinish;
-use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Enums\MatchType;
+use App\Exceptions\Matches\InvalidMatchOutcomeException;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
 
-function sideWithCompetitor(EventMatch $match, int $position): MatchSide
+function sideWithCompetitor(EventMatch $match, int $position, ?int $entryOrder = null): MatchSide
 {
     $side = MatchSide::factory()->create([
         'match_id' => $match->id,
         'position' => $position,
     ]);
 
-    MatchCompetitor::factory()->create([
+    $competitor = MatchCompetitor::factory()->create([
         'match_id' => $match->id,
         'match_side_id' => $side->id,
     ]);
+    $competitor->forceFill(['entry_order' => $entryOrder])->save();
 
     return $side;
 }
 
-it('records a finish and winning side directly on the match', function () {
+/**
+ * @return array{EventMatch, list<MatchCompetitor>}
+ */
+function eliminationMatch(MatchType $matchType, int $competitorCount = 3): array
+{
+    $match = EventMatch::factory()->create(['match_type' => $matchType]);
+    $competitors = [];
+
+    foreach (range(1, $competitorCount) as $position) {
+        $side = sideWithCompetitor(
+            $match,
+            $position,
+            $matchType === MatchType::RoyalRumble ? $position : null,
+        );
+        $competitors[] = $side->competitors()->firstOrFail();
+    }
+
+    return [$match, $competitors];
+}
+
+/**
+ * @param  array<int, MatchEliminationData>  $eliminations
+ */
+function matchResult(
+    MatchFinish $finish,
+    ?MatchSide $winningSide,
+    array $eliminations = [],
+): MatchResultData {
+    return new MatchResultData($finish, $winningSide, collect($eliminations));
+}
+
+it('records an ordinary finish and winning side', function () {
     $match = EventMatch::factory()->create();
     $winningSide = sideWithCompetitor($match, 1);
 
     $resultedMatch = resolve(RecordResultAction::class)->handle(
         $match,
-        MatchFinish::Pinfall,
-        $winningSide,
+        matchResult(MatchFinish::Pinfall, $winningSide),
     );
 
     expect($resultedMatch->match_finish)->toBe(MatchFinish::Pinfall)
@@ -43,27 +77,137 @@ it('records a draw without a winning side', function () {
 
     $resultedMatch = resolve(RecordResultAction::class)->handle(
         $match,
-        MatchFinish::TimeLimitDraw,
-        null,
+        matchResult(MatchFinish::TimeLimitDraw, null),
     );
 
     expect($resultedMatch->match_finish)->toBe(MatchFinish::TimeLimitDraw)
         ->and($resultedMatch->winningSide)->toBeNull();
 });
 
+it('records a complete battle royal elimination history', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+    $winner = $competitors[2];
+    $firstEliminated = $competitors[0];
+    $secondEliminated = $competitors[1];
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($firstEliminated, 1, $winner),
+            new MatchEliminationData($secondEliminated, 2, $winner),
+        ]),
+    );
+
+    expect($firstEliminated->refresh()->elimination_order)->toBe(1)
+        ->and($firstEliminated->eliminated_by_match_competitor_id)->toBe($winner->id)
+        ->and($secondEliminated->refresh()->elimination_order)->toBe(2)
+        ->and($secondEliminated->eliminated_by_match_competitor_id)->toBe($winner->id)
+        ->and($winner->refresh()->elimination_order)->toBeNull();
+});
+
+it('records a royal rumble outcome with entry and elimination order', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::RoyalRumble);
+    $winner = $competitors[2];
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($competitors[0], 1, $winner),
+            new MatchEliminationData($competitors[1], 2, $winner),
+        ]),
+    );
+
+    expect($match->competitors()->orderBy('entry_order')->pluck('entry_order')->all())->toBe([1, 2, 3])
+        ->and($match->competitors()->orderBy('elimination_order')->pluck('elimination_order')->filter()->values()->all())
+        ->toBe([1, 2]);
+});
+
+it('records a partial elimination history for a no-outcome elimination match', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+
+    $resultedMatch = resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::NoDecision, null, [
+            new MatchEliminationData($competitors[0], 1, $competitors[2]),
+        ]),
+    );
+
+    expect($resultedMatch->match_finish)->toBe(MatchFinish::NoDecision)
+        ->and($resultedMatch->winning_side_id)->toBeNull()
+        ->and($competitors[0]->refresh()->elimination_order)->toBe(1)
+        ->and($competitors[1]->refresh()->elimination_order)->toBeNull();
+});
+
+it('replaces a previously recorded outcome atomically', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+    $firstWinner = $competitors[2];
+    $correctedWinner = $competitors[1];
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $firstWinner->side, [
+            new MatchEliminationData($competitors[0], 1, $firstWinner),
+            new MatchEliminationData($correctedWinner, 2, $firstWinner),
+        ]),
+    );
+
+    $correctedMatch = resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Forfeit, $correctedWinner->side, [
+            new MatchEliminationData($firstWinner, 1),
+            new MatchEliminationData($competitors[0], 2, $correctedWinner),
+        ]),
+    );
+
+    expect($correctedMatch->match_finish)->toBe(MatchFinish::Forfeit)
+        ->and($correctedMatch->winning_side_id)->toBe($correctedWinner->match_side_id)
+        ->and($firstWinner->refresh()->elimination_order)->toBe(1)
+        ->and($firstWinner->eliminated_by_match_competitor_id)->toBeNull()
+        ->and($correctedWinner->refresh()->elimination_order)->toBeNull();
+});
+
+it('rolls back an invalid correction without changing the recorded outcome', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+    $winner = $competitors[2];
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($competitors[0], 1, $winner),
+            new MatchEliminationData($competitors[1], 2, $winner),
+        ]),
+    );
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::NoDecision, null, [
+            new MatchEliminationData($competitors[0], 2),
+        ]),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+
+    expect($match->refresh()->match_finish)->toBe(MatchFinish::Stipulation)
+        ->and($match->winning_side_id)->toBe($winner->match_side_id)
+        ->and($competitors[0]->refresh()->elimination_order)->toBe(1)
+        ->and($competitors[1]->refresh()->elimination_order)->toBe(2);
+});
+
 it('requires a winning side for a decisive finish', function () {
     $match = EventMatch::factory()->create();
 
-    expect(fn () => resolve(RecordResultAction::class)->handle($match, MatchFinish::Submission, null))
-        ->toThrow(InvalidMatchConfigurationException::class);
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Submission, null),
+    ))->toThrow(InvalidMatchOutcomeException::class);
 });
 
 it('rejects a winning side for a no-outcome finish', function () {
     $match = EventMatch::factory()->create();
     $side = sideWithCompetitor($match, 1);
 
-    expect(fn () => resolve(RecordResultAction::class)->handle($match, MatchFinish::NoDecision, $side))
-        ->toThrow(InvalidMatchConfigurationException::class);
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::NoDecision, $side),
+    ))->toThrow(InvalidMatchOutcomeException::class);
 });
 
 it('rejects a side belonging to another match', function () {
@@ -71,14 +215,111 @@ it('rejects a side belonging to another match', function () {
     $otherMatch = EventMatch::factory()->create();
     $otherSide = sideWithCompetitor($otherMatch, 1);
 
-    expect(fn () => resolve(RecordResultAction::class)->handle($match, MatchFinish::Pinfall, $otherSide))
-        ->toThrow(InvalidMatchConfigurationException::class);
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $otherSide),
+    ))->toThrow(InvalidMatchOutcomeException::class);
 });
 
 it('rejects an empty winning side', function () {
     $match = EventMatch::factory()->create();
     $emptySide = MatchSide::factory()->for($match, 'match')->create(['position' => 1]);
 
-    expect(fn () => resolve(RecordResultAction::class)->handle($match, MatchFinish::Pinfall, $emptySide))
-        ->toThrow(InvalidMatchConfigurationException::class);
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $emptySide),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+});
+
+it('rejects elimination metadata for an ordinary match', function () {
+    $match = EventMatch::factory()->create();
+    $winningSide = sideWithCompetitor($match, 1);
+    $competitor = $match->competitors()->firstOrFail();
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $winningSide, [
+            new MatchEliminationData($competitor, 1),
+        ]),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+});
+
+it('requires every losing competitor in a decisive elimination match', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+    $winner = $competitors[2];
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($competitors[0], 1, $winner),
+        ]),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+});
+
+it('rejects eliminating the winning competitor', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+    $winner = $competitors[2];
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($competitors[0], 1, $winner),
+            new MatchEliminationData($winner, 2, $competitors[1]),
+        ]),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+});
+
+it('rejects an eliminated competitor from another match', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+    $otherMatch = EventMatch::factory()->create();
+    $otherCompetitor = sideWithCompetitor($otherMatch, 1)->competitors()->firstOrFail();
+    $winner = $competitors[2];
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($otherCompetitor, 1, $winner),
+            new MatchEliminationData($competitors[1], 2, $winner),
+        ]),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+});
+
+it('rejects a self elimination', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+    $winner = $competitors[2];
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($competitors[0], 1, $competitors[0]),
+            new MatchEliminationData($competitors[1], 2, $winner),
+        ]),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+});
+
+it('rejects a royal rumble with invalid entry order', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::RoyalRumble);
+    $competitors[1]->forceFill(['entry_order' => null])->save();
+    $winner = $competitors[2];
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($competitors[0], 1, $winner),
+            new MatchEliminationData($competitors[1], 2, $winner),
+        ]),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+});
+
+it('rejects an elimination credited after the eliminator exited', function () {
+    [$match, $competitors] = eliminationMatch(MatchType::BattleRoyal);
+    $winner = $competitors[2];
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winner->side, [
+            new MatchEliminationData($competitors[0], 1, $competitors[1]),
+            new MatchEliminationData($competitors[1], 2, $competitors[0]),
+        ]),
+    ))->toThrow(InvalidMatchOutcomeException::class);
 });


### PR DESCRIPTION
## Summary
- introduce typed match result and elimination payloads
- record match finishes, winning sides, and elimination histories atomically
- validate Battle Royal and Royal Rumble entry, elimination, winner, and chronology invariants
- allow corrected results to replace prior outcome metadata transactionally
- separate outcome failures from match configuration failures

## Verification
- focused match suites: 97 tests, 191 assertions
- Unit, Integration, and Feature suites: 3,307 tests, 10,853 assertions
- application and Pest PHPStan: passed
- Rector, type coverage, and Pint with Blade: passed

## Local browser note
The browser test reaches the built application, then its DatabaseMigrations teardown encounters a pre-existing legacy migration down() that alters events_matches_results after the forward-only redesign migration removed that table. The clean GitHub runner remains the authoritative browser/application check; the same development history passed on PR #891.