### PR TITLE
feat: record match results from events

### DIFF
--- a/app/Livewire/Matches/Modals/ResultModal.php
+++ b/app/Livewire/Matches/Modals/ResultModal.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Matches\Modals;
+
+use App\Actions\Matches\RecordResultAction;
+use App\Data\Matches\MatchEliminationData;
+use App\Data\Matches\MatchResultData;
+use App\Enums\MatchFinish;
+use App\Exceptions\BaseBusinessException;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Validation\Rule;
+use Illuminate\View\View;
+use Livewire\Attributes\Computed;
+use LivewireUI\Modal\ModalComponent;
+
+class ResultModal extends ModalComponent
+{
+    public int $matchId;
+
+    public ?string $finish = null;
+
+    public ?int $winningSideId = null;
+
+    /** @var array<int, array{order: int|string|null, eliminatedById: int|string|null}> */
+    public array $eliminations = [];
+
+    public function mount(int $matchId): void
+    {
+        $this->matchId = $matchId;
+
+        $match = $this->match();
+        $this->finish = $match->match_finish?->value;
+        $this->winningSideId = $match->winning_side_id;
+        $this->eliminations = $match->competitors
+            ->mapWithKeys(fn (MatchCompetitor $competitor): array => [
+                $competitor->id => [
+                    'order' => $competitor->elimination_order,
+                    'eliminatedById' => $competitor->eliminated_by_match_competitor_id,
+                ],
+            ])
+            ->all();
+    }
+
+    public function save(): void
+    {
+        $match = $this->match();
+        Gate::authorize('update', EventMatch::class);
+
+        $competitorIds = $match->competitors->modelKeys();
+        $sideIds = $match->sides->modelKeys();
+
+        $validated = $this->validate([
+            'finish' => ['required', Rule::enum(MatchFinish::class)],
+            'winningSideId' => ['nullable', 'integer', Rule::in($sideIds)],
+            'eliminations' => ['array'],
+            'eliminations.*.order' => ['nullable', 'integer', 'min:1', 'distinct'],
+            'eliminations.*.eliminatedById' => ['nullable', 'integer', Rule::in($competitorIds)],
+        ]);
+
+        $finish = MatchFinish::from($validated['finish']);
+        $winningSide = $this->winningSide($match);
+
+        try {
+            resolve(RecordResultAction::class)->handle(
+                $match,
+                new MatchResultData(
+                    finish: $finish,
+                    winningSide: $winningSide,
+                    eliminations: $this->eliminationData($match),
+                ),
+            );
+        } catch (BaseBusinessException $exception) {
+            $this->addError('outcome', $exception->getMessage());
+
+            return;
+        }
+
+        $this->dispatch('refreshDatatable');
+        $this->dispatch('closeModal');
+    }
+
+    public function updatedFinish(?string $finish): void
+    {
+        if ($finish === null || $finish === '') {
+            return;
+        }
+
+        $matchFinish = MatchFinish::tryFrom($finish);
+
+        if ($matchFinish !== null && ! $matchFinish->requiresWinningSide()) {
+            $this->winningSideId = null;
+        }
+    }
+
+    #[Computed]
+    public function match(): EventMatch
+    {
+        return EventMatch::query()
+            ->with(['sides.competitors.competitor', 'competitors.competitor'])
+            ->findOrFail($this->matchId);
+    }
+
+    /** @return array<string, string> */
+    #[Computed]
+    public function finishOptions(): array
+    {
+        return MatchFinish::options();
+    }
+
+    /** @return array<int, string> */
+    #[Computed]
+    public function sideOptions(): array
+    {
+        return $this->match()->sides
+            ->mapWithKeys(fn (MatchSide $side): array => [
+                $side->id => $side->competitors
+                    ->map(fn (MatchCompetitor $competitor): string => $competitor->competitor->name)
+                    ->join(' & '),
+            ])
+            ->all();
+    }
+
+    /** @return array<int, string> */
+    #[Computed]
+    public function competitorOptions(): array
+    {
+        return $this->match()->competitors
+            ->mapWithKeys(fn (MatchCompetitor $competitor): array => [
+                $competitor->id => $competitor->competitor->name,
+            ])
+            ->all();
+    }
+
+    public function getModalTitle(): string
+    {
+        return $this->match()->match_finish === null ? 'Record Match Result' : 'Correct Match Result';
+    }
+
+    public function render(): View
+    {
+        return view('livewire.matches.modals.result-modal');
+    }
+
+    private function winningSide(EventMatch $match): ?MatchSide
+    {
+        if ($this->winningSideId === null) {
+            return null;
+        }
+
+        return $match->sides->sole('id', $this->winningSideId);
+    }
+
+    /** @return Collection<int, MatchEliminationData> */
+    private function eliminationData(EventMatch $match): Collection
+    {
+        return collect($this->eliminations)
+            ->filter(fn (array $elimination): bool => is_numeric($elimination['order']))
+            ->map(function (array $elimination, int $competitorId) use ($match): MatchEliminationData {
+                $eliminatedById = $elimination['eliminatedById'];
+
+                return new MatchEliminationData(
+                    competitor: $match->competitors->sole('id', $competitorId),
+                    order: (int) $elimination['order'],
+                    eliminatedBy: is_numeric($eliminatedById)
+                        ? $match->competitors->sole('id', (int) $eliminatedById)
+                        : null,
+                );
+            })
+            ->values();
+    }
+}

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -114,6 +114,9 @@ class MatchesTable extends DataTableComponent
                         return $row->match_finish->label();
                     }
                 )->html(),
+            Column::make(__('core.actions'))
+                ->view('components.matches.table-result-action')
+                ->html(),
         ];
     }
 }

--- a/resources/views/components/matches/table-result-action.blade.php
+++ b/resources/views/components/matches/table-result-action.blade.php
@@ -1,0 +1,6 @@
+<x-buttons.light
+    size="sm"
+    wire:click="$dispatch('openModal', { component: 'matches.modals.result-modal', arguments: { matchId: {{ $row->id }} } })"
+>
+    {{ $row->match_finish === null ? 'Record Result' : 'Correct Result' }}
+</x-buttons.light>

--- a/resources/views/livewire/matches/modals/result-modal.blade.php
+++ b/resources/views/livewire/matches/modals/result-modal.blade.php
@@ -1,0 +1,87 @@
+<x-modal size="lg">
+    <div class="space-y-6">
+        @error('outcome')
+            <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+                {{ $message }}
+            </div>
+        @enderror
+
+        <div class="grid gap-4 md:grid-cols-2">
+            <x-form.inputs.select
+                label="Finish"
+                wire:model.live="finish"
+                :options="$this->finishOptions"
+                placeholder="Select a finish"
+            />
+
+            <x-form.inputs.select
+                label="Winning Side"
+                wire:model="winningSideId"
+                :options="$this->sideOptions"
+                placeholder="No winning side"
+            />
+        </div>
+
+        @if ($this->match->match_type->recordsIndividualEliminations())
+            <section class="space-y-3">
+                <div>
+                    <h4 class="text-sm font-semibold text-gray-900">Eliminations</h4>
+                    <p class="text-xs text-gray-600">
+                        Record each eliminated competitor in order. Leave the winner without an elimination order.
+                    </p>
+                </div>
+
+                <div class="overflow-x-auto rounded-lg border border-gray-200">
+                    <table class="w-full text-left text-sm">
+                        <thead class="bg-gray-100 text-xs font-medium text-gray-600">
+                            <tr>
+                                <th class="px-4 py-2.5">Competitor</th>
+                                <th class="px-4 py-2.5">Order</th>
+                                <th class="px-4 py-2.5">Eliminated By</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200">
+                            @foreach ($this->match->competitors as $competitor)
+                                <tr wire:key="result-competitor-{{ $competitor->id }}">
+                                    <td class="px-4 py-3 font-medium text-gray-800">
+                                        {{ $competitor->competitor->name }}
+                                    </td>
+                                    <td class="w-28 px-4 py-3">
+                                        <input
+                                            type="number"
+                                            min="1"
+                                            wire:model="eliminations.{{ $competitor->id }}.order"
+                                            class="block h-8.5 w-full rounded-md border border-gray-300 bg-white px-3 text-sm focus:border-gray-500 focus:ring-gray-500"
+                                            aria-label="Elimination order for {{ $competitor->competitor->name }}"
+                                        />
+                                        @error("eliminations.{$competitor->id}.order")
+                                            <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+                                        @enderror
+                                    </td>
+                                    <td class="px-4 py-3">
+                                        <x-form.inputs.select
+                                            wire:model="eliminations.{{ $competitor->id }}.eliminatedById"
+                                            :options="collect($this->competitorOptions)->except($competitor->id)->all()"
+                                            placeholder="Not recorded"
+                                            size="sm"
+                                            aria-label="Eliminator for {{ $competitor->competitor->name }}"
+                                        />
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        @endif
+    </div>
+
+    <x-slot:footer>
+        <div class="flex flex-1 justify-end gap-2">
+            <x-buttons.light wire:click="$dispatch('closeModal')">Cancel</x-buttons.light>
+            <x-buttons.primary wire:click="save" wire:loading.attr="disabled" wire:target="save">
+                Save Result
+            </x-buttons.primary>
+        </div>
+    </x-slot:footer>
+</x-modal>

--- a/tests/Integration/Livewire/Matches/Modals/ResultModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/ResultModalTest.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MatchFinish;
+use App\Enums\MatchType;
+use App\Livewire\Matches\Modals\ResultModal;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
+use App\Models\Users\User;
+use App\Models\Wrestlers\Wrestler;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->administrator()->create());
+});
+
+/**
+ * @return array{EventMatch, list<MatchCompetitor>}
+ */
+function matchWithResultCompetitors(MatchType $type = MatchType::Singles, int $count = 2): array
+{
+    $match = EventMatch::factory()->create(['match_type' => $type]);
+    $competitors = [];
+
+    foreach (range(1, $count) as $position) {
+        $side = MatchSide::factory()->for($match, 'match')->create(['position' => $position]);
+        $wrestler = Wrestler::factory()->create(['name' => "Competitor {$position}"]);
+        $competitors[] = MatchCompetitor::factory()->create([
+            'match_id' => $match->id,
+            'match_side_id' => $side->id,
+            'competitor_type' => $wrestler->getMorphClass(),
+            'competitor_id' => $wrestler->id,
+            'entry_order' => $type === MatchType::RoyalRumble ? $position : null,
+        ]);
+    }
+
+    return [$match, $competitors];
+}
+
+it('records an ordinary match result', function () {
+    [$match, $competitors] = matchWithResultCompetitors();
+    $winningSide = $competitors[0]->side;
+
+    livewire(ResultModal::class, ['matchId' => $match->id])
+        ->set('finish', MatchFinish::Pinfall->value)
+        ->set('winningSideId', $winningSide->id)
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertDispatched('refreshDatatable')
+        ->assertDispatched('closeModal');
+
+    expect($match->refresh()->match_finish)->toBe(MatchFinish::Pinfall)
+        ->and($match->winning_side_id)->toBe($winningSide->id);
+});
+
+it('records a draw without a winning side', function () {
+    [$match, $competitors] = matchWithResultCompetitors();
+
+    livewire(ResultModal::class, ['matchId' => $match->id])
+        ->set('winningSideId', $competitors[0]->match_side_id)
+        ->set('finish', MatchFinish::TimeLimitDraw->value)
+        ->assertSet('winningSideId', null)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect($match->refresh()->match_finish)->toBe(MatchFinish::TimeLimitDraw)
+        ->and($match->winning_side_id)->toBeNull();
+});
+
+it('records a complete elimination match result', function () {
+    [$match, $competitors] = matchWithResultCompetitors(MatchType::BattleRoyal, 3);
+    $winner = $competitors[2];
+
+    livewire(ResultModal::class, ['matchId' => $match->id])
+        ->set('finish', MatchFinish::Stipulation->value)
+        ->set('winningSideId', $winner->match_side_id)
+        ->set("eliminations.{$competitors[0]->id}.order", '1')
+        ->set("eliminations.{$competitors[0]->id}.eliminatedById", (string) $winner->id)
+        ->set("eliminations.{$competitors[1]->id}.order", '2')
+        ->set("eliminations.{$competitors[1]->id}.eliminatedById", (string) $winner->id)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect($competitors[0]->refresh()->elimination_order)->toBe(1)
+        ->and($competitors[0]->eliminated_by_match_competitor_id)->toBe($winner->id)
+        ->and($competitors[1]->refresh()->elimination_order)->toBe(2)
+        ->and($winner->refresh()->elimination_order)->toBeNull();
+});
+
+it('loads an existing result for correction', function () {
+    [$match, $competitors] = matchWithResultCompetitors(MatchType::BattleRoyal, 3);
+    $match->update([
+        'match_finish' => MatchFinish::Stipulation,
+        'winning_side_id' => $competitors[2]->match_side_id,
+    ]);
+    $competitors[0]->forceFill([
+        'elimination_order' => 1,
+        'eliminated_by_match_competitor_id' => $competitors[2]->id,
+    ])->save();
+
+    livewire(ResultModal::class, ['matchId' => $match->id])
+        ->assertSet('finish', MatchFinish::Stipulation->value)
+        ->assertSet('winningSideId', $competitors[2]->match_side_id)
+        ->assertSet("eliminations.{$competitors[0]->id}.order", 1)
+        ->assertSee('Correct Match Result');
+});
+
+it('shows domain validation failures without closing the modal', function () {
+    [$match] = matchWithResultCompetitors();
+
+    livewire(ResultModal::class, ['matchId' => $match->id])
+        ->set('finish', MatchFinish::Pinfall->value)
+        ->call('save')
+        ->assertHasErrors(['outcome'])
+        ->assertNotDispatched('closeModal');
+
+    expect($match->refresh()->match_finish)->toBeNull();
+});
+
+it('hides elimination inputs for ordinary matches', function () {
+    [$match] = matchWithResultCompetitors();
+
+    livewire(ResultModal::class, ['matchId' => $match->id])
+        ->assertDontSee('Eliminations');
+});
+
+it('renders elimination inputs for supported match types', function () {
+    [$match] = matchWithResultCompetitors(MatchType::RoyalRumble, 10);
+
+    livewire(ResultModal::class, ['matchId' => $match->id])
+        ->assertSee('Eliminations')
+        ->assertSee('Competitor 1')
+        ->assertSee('Competitor 10');
+});
+
+it('requires an administrator to record a result', function () {
+    [$match] = matchWithResultCompetitors();
+    $this->actingAs(User::factory()->create());
+
+    livewire(ResultModal::class, ['matchId' => $match->id])
+        ->set('finish', MatchFinish::TimeLimitDraw->value)
+        ->call('save')
+        ->assertForbidden();
+});

--- a/tests/Integration/Livewire/Matches/Tables/MatchesTableTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MatchesTableTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\MatchFinish;
 use App\Enums\MatchType;
 use App\Livewire\Matches\Tables\MatchesTable;
 use App\Models\Events\Event;
@@ -55,6 +56,20 @@ describe('MatchesTable Rendering', function () {
 
         livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Singles');
+    });
+
+    it('offers result recording and correction from the table', function () {
+        $event = Event::factory()->create();
+        $unresultedMatch = EventMatch::factory()->for($event)->create();
+        $resultedMatch = EventMatch::factory()->for($event)->create([
+            'match_finish' => MatchFinish::TimeLimitDraw,
+        ]);
+
+        livewire(MatchesTable::class, ['eventId' => $event->id])
+            ->assertSee('Record Result')
+            ->assertSee('Correct Result')
+            ->assertSeeHtml("matchId: {$unresultedMatch->id}")
+            ->assertSeeHtml("matchId: {$resultedMatch->id}");
     });
 
     it('displays match competitors', function () {


### PR DESCRIPTION
## Summary
- add a dedicated Livewire modal for recording and correcting match outcomes
- capture winning sides plus Battle Royal and Royal Rumble elimination details
- expose result actions from event match tables and translate domain failures at the UI boundary

## Verification
- focused Livewire integration suite: 35 tests, 76 assertions
- application PHPStan: passed
- Pest PHPStan: passed
- Rector: passed
- type coverage: passed
- Pint with Blade formatting: passed
- full non-browser suite: 3,316 tests passed, 10,939 assertions

## Known unrelated local issue
The browser phase reaches the existing legacy migration that alters the removed events_matches_results table and fails before browser tests execute. This branch does not change migrations; GitHub Actions remains the authoritative clean-environment check.