### PR TITLE
fix: restore browser-backed match result workflow

### DIFF
--- a/.ai/rules/browser.md
+++ b/.ai/rules/browser.md
@@ -5,5 +5,5 @@ paths:
 
 # Browser
 
-## Reset browser databases with migrations
-Use DatabaseMigrations for browser tests; keep database reset configuration centralized in tests/Pest.php.
+## Refresh browser databases without rollbacks
+Use RefreshDatabase for browser tests and keep reset configuration centralized in tests/Pest.php. Browser tests must not use DatabaseMigrations because this project uses forward-only migrations without rollback support.

--- a/app/Http/Controllers/Events/EventsController.php
+++ b/app/Http/Controllers/Events/EventsController.php
@@ -19,7 +19,6 @@ class EventsController
         return view('events.show', [
             'event' => $event->load([
                 'venue',
-                'matches.matchType',
                 'matches.referees',
                 'matches.titles',
                 'matches.competitors.competitor',

--- a/app/Livewire/Table/DataTableComponent.php
+++ b/app/Livewire/Table/DataTableComponent.php
@@ -8,6 +8,7 @@ use Illuminate\Contracts\Pagination\LengthAwarePaginator;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\WithPagination;
 
@@ -104,6 +105,9 @@ abstract class DataTableComponent extends Component
             $this->sortDirection = 'asc';
         }
     }
+
+    #[On('refreshDatatable')]
+    public function refreshDatatable(): void {}
 
     public function render(): View
     {

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -49,6 +49,7 @@
     </div>
     <!-- End of Main -->
     <!-- End of Page -->
+    @livewire('wire-elements-modal')
     @livewireScriptConfig
 </body>
 </html>

--- a/resources/views/components/matches/table-result-action.blade.php
+++ b/resources/views/components/matches/table-result-action.blade.php
@@ -1,0 +1,7 @@
+<x-buttons.light
+    size="sm"
+    data-test="match-result-action"
+    wire:click="$dispatch('openModal', { component: 'matches.modals.result-modal', arguments: { matchId: {{ $row->id }} } })"
+>
+    {{ $row->match_finish === null ? 'Record Result' : 'Correct Result' }}
+</x-buttons.light>

--- a/resources/views/livewire/matches/modals/result-modal.blade.php
+++ b/resources/views/livewire/matches/modals/result-modal.blade.php
@@ -1,0 +1,92 @@
+<x-modal size="lg">
+    <div class="space-y-6">
+        @error('outcome')
+            <div class="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700" role="alert">
+                {{ $message }}
+            </div>
+        @enderror
+
+        <div class="grid gap-4 md:grid-cols-2">
+            <x-form.inputs.select
+                label="Finish"
+                wire:model.live="finish"
+                :options="$this->finishOptions"
+                placeholder="Select a finish"
+            />
+
+            <x-form.inputs.select
+                label="Winning Side"
+                wire:model="winningSideId"
+                :options="$this->sideOptions"
+                placeholder="No winning side"
+            />
+        </div>
+
+        @if ($this->match->match_type->recordsIndividualEliminations())
+            <section class="space-y-3">
+                <div>
+                    <h4 class="text-sm font-semibold text-gray-900">Eliminations</h4>
+                    <p class="text-xs text-gray-600">
+                        Record each eliminated competitor in order. Leave the winner without an elimination order.
+                    </p>
+                </div>
+
+                <div class="overflow-x-auto rounded-lg border border-gray-200">
+                    <table class="w-full text-left text-sm">
+                        <thead class="bg-gray-100 text-xs font-medium text-gray-600">
+                            <tr>
+                                <th class="px-4 py-2.5">Competitor</th>
+                                <th class="px-4 py-2.5">Order</th>
+                                <th class="px-4 py-2.5">Eliminated By</th>
+                            </tr>
+                        </thead>
+                        <tbody class="divide-y divide-gray-200">
+                            @foreach ($this->match->competitors as $competitor)
+                                <tr wire:key="result-competitor-{{ $competitor->id }}">
+                                    <td class="px-4 py-3 font-medium text-gray-800">
+                                        {{ $competitor->competitor->name }}
+                                    </td>
+                                    <td class="w-28 px-4 py-3">
+                                        <input
+                                            type="number"
+                                            min="1"
+                                            wire:model="eliminations.{{ $competitor->id }}.order"
+                                            class="block h-8.5 w-full rounded-md border border-gray-300 bg-white px-3 text-sm focus:border-gray-500 focus:ring-gray-500"
+                                            aria-label="Elimination order for {{ $competitor->competitor->name }}"
+                                        />
+                                        @error("eliminations.{$competitor->id}.order")
+                                            <p class="mt-1 text-xs text-red-600">{{ $message }}</p>
+                                        @enderror
+                                    </td>
+                                    <td class="px-4 py-3">
+                                        <x-form.inputs.select
+                                            wire:model="eliminations.{{ $competitor->id }}.eliminatedById"
+                                            :options="collect($this->competitorOptions)->except($competitor->id)->all()"
+                                            placeholder="Not recorded"
+                                            size="sm"
+                                            aria-label="Eliminator for {{ $competitor->competitor->name }}"
+                                        />
+                                    </td>
+                                </tr>
+                            @endforeach
+                        </tbody>
+                    </table>
+                </div>
+            </section>
+        @endif
+    </div>
+
+    <x-slot:footer>
+        <div class="flex flex-1 justify-end gap-2">
+            <x-buttons.light wire:click="$dispatch('closeModal')">Cancel</x-buttons.light>
+            <x-buttons.primary
+                data-test="save-result"
+                wire:click="save"
+                wire:loading.attr="disabled"
+                wire:target="save"
+            >
+                Save Result
+            </x-buttons.primary>
+        </div>
+    </x-slot:footer>
+</x-modal>

--- a/tests/Browser/MatchResultTest.php
+++ b/tests/Browser/MatchResultTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MatchFinish;
+use App\Models\Events\Event;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
+use App\Models\Wrestlers\Wrestler;
+
+beforeEach(function () {
+    $this->event = Event::factory()->create();
+    $this->match = EventMatch::factory()->for($this->event)->create();
+    $firstWrestler = Wrestler::factory()->create(['name' => 'First Competitor']);
+    $secondWrestler = Wrestler::factory()->create(['name' => 'Second Competitor']);
+
+    foreach ([$firstWrestler, $secondWrestler] as $index => $wrestler) {
+        $side = MatchSide::factory()->for($this->match, 'match')->create([
+            'position' => $index + 1,
+        ]);
+
+        MatchCompetitor::factory()->create([
+            'match_id' => $this->match->id,
+            'match_side_id' => $side->id,
+            'competitor_type' => $wrestler->getMorphClass(),
+            'competitor_id' => $wrestler->id,
+        ]);
+    }
+
+    $this->winningSide = $this->match->sides()->firstOrFail();
+    $this->actingAs(administrator());
+});
+
+test('administrator can record a match result', function () {
+    $page = visit(route('events.show', $this->event));
+
+    $page->press('@match-result-action')
+        ->waitForText('Record Match Result')
+        ->select('#finish', MatchFinish::Pinfall->value)
+        ->select('#winningSideId', $this->winningSide->id)
+        ->press('@save-result')
+        ->waitForText('Correct Result')
+        ->assertSee('First Competitor by Pinfall')
+        ->assertNoJavascriptErrors();
+
+    expect($this->match->refresh()->match_finish)->toBe(MatchFinish::Pinfall)
+        ->and($this->match->winning_side_id)->toBe($this->winningSide->id);
+});
+
+test('administrator can correct a match result', function () {
+    $this->match->update([
+        'match_finish' => MatchFinish::Pinfall,
+        'winning_side_id' => $this->winningSide->id,
+    ]);
+
+    $page = visit(route('events.show', $this->event));
+
+    $page->press('@match-result-action')
+        ->waitForText('Correct Match Result')
+        ->select('#finish', MatchFinish::TimeLimitDraw->value)
+        ->press('@save-result')
+        ->waitForText('Time Limit Draw')
+        ->assertNoJavascriptErrors();
+
+    expect($this->match->refresh()->match_finish)->toBe(MatchFinish::TimeLimitDraw)
+        ->and($this->match->winning_side_id)->toBeNull();
+});

--- a/tests/Feature/Http/Controllers/Events/EventsControllerShowTest.php
+++ b/tests/Feature/Http/Controllers/Events/EventsControllerShowTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Http\Controllers\Events\EventsController;
 use App\Livewire\Matches\Tables\MatchesTable;
 use App\Models\Events\Event;
+use App\Models\Matches\EventMatch;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Laravel\get;
@@ -28,6 +29,18 @@ describe('Events Controller', function () {
             ->assertViewIs('events.show')
             ->assertViewHas('event', $this->event)
             ->assertSeeLivewire(MatchesTable::class);
+    });
+
+    /**
+     * @see EventsController::show()
+     */
+    test('show loads an event with matches', function () {
+        EventMatch::factory()->for($this->event)->create();
+
+        actingAs(administrator())
+            ->get(action([EventsController::class, 'show'], $this->event))
+            ->assertOk()
+            ->assertViewHas('event', fn (Event $event): bool => $event->relationLoaded('matches'));
     });
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Foundation\Testing\DatabaseMigrations;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\Support\Carbon;
@@ -26,7 +25,7 @@ require_once __DIR__.'/Helpers/LivewireHelpers.php';
 |
 */
 
-pest()->extend(TestCase::class)->use(DatabaseMigrations::class)->in('Browser');
+pest()->extend(TestCase::class)->use(RefreshDatabase::class)->in('Browser');
 
 pest()->extend(TestCase::class)->use(RefreshDatabase::class)->in('Integration', 'Unit');
 


### PR DESCRIPTION
## Summary
- replace rollback-based browser migrations with RefreshDatabase to support forward-only migrations
- mount the Wire Elements modal root and reconnect datatable refresh events
- remove the stale matchType relationship eager load from the event page
- cover recording and correcting match results in Pest browser tests
- update the durable browser-testing rule

## Verification
- browser suite: 19 tests, 65 assertions
- focused controller and Livewire tests: 40 tests, 85 assertions
- composer test:push: 3,336 tests, 10,952 assertions
- Rector, type coverage, Pint with Blade, application PHPStan, and Pest PHPStan passed