### PR TITLE
feat: apply title outcomes from match results

### DIFF
--- a/.ai/rules/actions-matches.md
+++ b/.ai/rules/actions-matches.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/Actions/Matches/**'
+---
+
+# Actions Matches
+
+## Apply championship lineage from match outcomes
+RecordResultAction must apply match result metadata and all attached title outcomes in one transaction. Finishes that allow title changes transfer or establish each reign using the event date; DQ, countout, draws, and no-decisions retain the existing champion. Corrections may void reigns created by that match and restore the prior reign, but must reject rewriting lineage once a later reign depends on it.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -6,6 +6,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | --- | --- |
 | app/{Actions,Collections,Lifecycle,Models,Rules}/** | .ai/rules/actions-collections-lifecycle-models-rules.md |
 | app/{Actions,Lifecycle,Models}/** | .ai/rules/actions-lifecycle-models.md |
+| app/Actions/Matches/** | .ai/rules/actions-matches.md |
 | app/Actions/** | .ai/rules/actions.md |
 | app/** | .ai/rules/app.md |
 | tests/Browser/** | .ai/rules/browser.md |

--- a/app/Actions/Matches/ApplyMatchTitleOutcomesAction.php
+++ b/app/Actions/Matches/ApplyMatchTitleOutcomesAction.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Actions\Matches;
+
+use App\Data\Matches\MatchResultData;
+use App\Enums\Titles\TitleType;
+use App\Exceptions\Matches\InvalidMatchOutcomeException;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+class ApplyMatchTitleOutcomesAction
+{
+    public function handle(EventMatch $match, MatchResultData $result): void
+    {
+        DB::transaction(function () use ($match, $result): void {
+            $lockedMatch = EventMatch::query()
+                ->with('event')
+                ->lockForUpdate()
+                ->findOrFail($match->id);
+            $titleIds = $lockedMatch->titles()->pluck((new Title())->qualifyColumn('id'));
+
+            if ($titleIds->isEmpty()) {
+                return;
+            }
+
+            $titles = Title::query()
+                ->whereKey($titleIds)
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
+            $reigns = TitleChampionship::query()
+                ->withTrashed()
+                ->whereIn('title_id', $titleIds)
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
+            $winningCompetitors = $this->winningCompetitors($lockedMatch, $result);
+
+            /** @var array<int, Wrestler|TagTeam|null> $desiredChampions */
+            $desiredChampions = [];
+
+            foreach ($titles as $title) {
+                $desiredChampions[$title->id] = $result->finish->allowsTitleChange()
+                    ? $this->championForTitle($title, $winningCompetitors)
+                    : null;
+
+                $this->ensureLineageCanBeReconciled($lockedMatch, $title, $reigns);
+            }
+
+            foreach ($titles as $title) {
+                $this->reconcileTitle(
+                    $lockedMatch,
+                    $title,
+                    $desiredChampions[$title->id],
+                    $reigns,
+                );
+            }
+        });
+    }
+
+    /** @return Collection<int, MatchCompetitor> */
+    private function winningCompetitors(EventMatch $match, MatchResultData $result): Collection
+    {
+        if (! $result->finish->allowsTitleChange() || $result->winningSide === null) {
+            return new Collection();
+        }
+
+        return MatchCompetitor::query()
+            ->whereBelongsTo($match, 'eventMatch')
+            ->where('match_side_id', $result->winningSide->id)
+            ->with('competitor')
+            ->get();
+    }
+
+    /**
+     * @param  Collection<int, MatchCompetitor>  $winningCompetitors
+     */
+    private function championForTitle(Title $title, Collection $winningCompetitors): Wrestler|TagTeam
+    {
+        $eligibleCompetitors = $winningCompetitors
+            ->map(fn (MatchCompetitor $competitor): Wrestler|TagTeam => $competitor->competitor)
+            ->filter(fn (Wrestler|TagTeam $competitor): bool => match ($title->type) {
+                TitleType::Singles => $competitor instanceof Wrestler,
+                TitleType::TagTeam => $competitor instanceof TagTeam,
+            })
+            ->values();
+
+        if ($eligibleCompetitors->count() !== 1) {
+            throw InvalidMatchOutcomeException::invalidTitleWinner($title->type);
+        }
+
+        return $eligibleCompetitors->sole();
+    }
+
+    /** @param Collection<int, TitleChampionship> $reigns */
+    private function ensureLineageCanBeReconciled(
+        EventMatch $match,
+        Title $title,
+        Collection $reigns,
+    ): void {
+        $reignWonAtMatch = $this->activeReignsForTitle($title, $reigns)
+            ->firstWhere('won_match_id', $match->id);
+
+        if ($reignWonAtMatch?->lost_match_id !== null) {
+            throw InvalidMatchOutcomeException::titleLineageHasAdvanced();
+        }
+    }
+
+    /** @param Collection<int, TitleChampionship> $reigns */
+    private function reconcileTitle(
+        EventMatch $match,
+        Title $title,
+        Wrestler|TagTeam|null $desiredChampion,
+        Collection $reigns,
+    ): void {
+        $activeReigns = $this->activeReignsForTitle($title, $reigns);
+        $reignWonAtMatch = $activeReigns->firstWhere('won_match_id', $match->id);
+        $currentReign = $activeReigns
+            ->whereNull('lost_at')
+            ->sortByDesc('won_at')
+            ->first();
+
+        if ($reignWonAtMatch !== null && $this->reignBelongsTo($reignWonAtMatch, $desiredChampion)) {
+            return;
+        }
+
+        if ($reignWonAtMatch !== null) {
+            $reignWonAtMatch->delete();
+
+            $currentReign = $activeReigns->firstWhere('lost_match_id', $match->id);
+            $currentReign?->update([
+                'lost_match_id' => null,
+                'lost_at' => null,
+            ]);
+        }
+
+        if ($desiredChampion === null || $this->reignBelongsTo($currentReign, $desiredChampion)) {
+            return;
+        }
+
+        $eventDate = $match->event->date;
+
+        if (! $eventDate instanceof Carbon) {
+            throw InvalidMatchOutcomeException::undatedTitleMatch();
+        }
+
+        $currentReign?->update([
+            'lost_match_id' => $match->id,
+            'lost_at' => $eventDate,
+        ]);
+
+        TitleChampionship::query()->create([
+            'title_id' => $title->id,
+            'champion_type' => $desiredChampion->getMorphClass(),
+            'champion_id' => $desiredChampion->id,
+            'won_match_id' => $match->id,
+            'won_at' => $eventDate,
+        ]);
+    }
+
+    /**
+     * @param  Collection<int, TitleChampionship>  $reigns
+     * @return Collection<int, TitleChampionship>
+     */
+    private function activeReignsForTitle(Title $title, Collection $reigns): Collection
+    {
+        return $reigns
+            ->where('title_id', $title->id)
+            ->filter(fn (TitleChampionship $reign): bool => $reign->deleted_at === null);
+    }
+
+    private function reignBelongsTo(
+        ?TitleChampionship $reign,
+        Wrestler|TagTeam|null $champion,
+    ): bool {
+        return $reign !== null
+            && $champion !== null
+            && $reign->champion_type === $champion->getMorphClass()
+            && $reign->champion_id === $champion->id;
+    }
+}

--- a/app/Actions/Matches/RecordResultAction.php
+++ b/app/Actions/Matches/RecordResultAction.php
@@ -14,7 +14,10 @@ use Illuminate\Support\Facades\DB;
 
 class RecordResultAction
 {
-    public function __construct(private MatchOutcomeRequirements $requirements) {}
+    public function __construct(
+        private MatchOutcomeRequirements $requirements,
+        private ApplyMatchTitleOutcomesAction $applyTitleOutcomes,
+    ) {}
 
     public function handle(EventMatch $match, MatchResultData $result): EventMatch
     {
@@ -34,6 +37,7 @@ class RecordResultAction
             );
 
             $this->requirements->ensureSatisfied($lockedMatch, $lockedResult, $lockedCompetitors);
+            $this->applyTitleOutcomes->handle($lockedMatch, $lockedResult);
 
             $lockedMatch->update([
                 'match_finish' => $result->finish,

--- a/app/Enums/MatchFinish.php
+++ b/app/Enums/MatchFinish.php
@@ -39,6 +39,21 @@ enum MatchFinish: string
         };
     }
 
+    public function allowsTitleChange(): bool
+    {
+        return match ($this) {
+            self::Pinfall,
+            self::Submission,
+            self::Knockout,
+            self::Stipulation,
+            self::Forfeit => true,
+            self::Disqualification,
+            self::Countout,
+            self::TimeLimitDraw,
+            self::NoDecision => false,
+        };
+    }
+
     /** @return array<string, string> */
     public static function options(): array
     {

--- a/app/Exceptions/Matches/InvalidMatchOutcomeException.php
+++ b/app/Exceptions/Matches/InvalidMatchOutcomeException.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Exceptions\Matches;
 
+use App\Enums\Titles\TitleType;
 use App\Exceptions\BaseBusinessException;
 
 final class InvalidMatchOutcomeException extends BaseBusinessException
@@ -76,5 +77,20 @@ final class InvalidMatchOutcomeException extends BaseBusinessException
     public static function invalidEntryOrder(): self
     {
         return new self('Royal Rumble entry order must be unique, positive, and consecutive.');
+    }
+
+    public static function invalidTitleWinner(TitleType $titleType): self
+    {
+        return new self("The winning side must contain exactly one {$titleType->value} championship competitor.");
+    }
+
+    public static function undatedTitleMatch(): self
+    {
+        return new self('A title change cannot be recorded for an event without a date.');
+    }
+
+    public static function titleLineageHasAdvanced(): self
+    {
+        return new self('This result cannot be corrected because a later title reign depends on it.');
     }
 }

--- a/app/Models/Titles/TitleChampionship.php
+++ b/app/Models/Titles/TitleChampionship.php
@@ -17,6 +17,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
 
 /**
@@ -29,6 +30,7 @@ use Illuminate\Support\Carbon;
  * @property int|null $lost_match_id
  * @property Carbon $won_at
  * @property Carbon|null $lost_at
+ * @property Carbon|null $deleted_at
  *
  * @property-read EventMatch|null $wonEventMatch
  * @property-read EventMatch|null $lostEventMatch
@@ -48,6 +50,9 @@ use Illuminate\Support\Carbon;
  * @method static TitleChampionshipBuilder<static>|TitleChampionship newQuery()
  * @method static TitleChampionshipBuilder<static>|TitleChampionship previous()
  * @method static TitleChampionshipBuilder<static>|TitleChampionship query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|TitleChampionship onlyTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|TitleChampionship withTrashed()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|TitleChampionship withoutTrashed()
  *
  * @mixin \Eloquent
  */
@@ -59,6 +64,8 @@ class TitleChampionship extends Model
 {
     /** @use HasFactory<TitleChampionshipFactory> */
     use HasFactory;
+
+    use SoftDeletes;
 
     /**
      * Get the attributes that should be cast.

--- a/database/migrations/2026_08_15_215840_add_deleted_at_to_titles_championships_table.php
+++ b/database/migrations/2026_08_15_215840_add_deleted_at_to_titles_championships_table.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('titles_championships', function (Blueprint $table) {
+            $table->softDeletes();
+        });
+    }
+};

--- a/docs/architecture/championship-system.md
+++ b/docs/architecture/championship-system.md
@@ -24,6 +24,14 @@ Models expose their explicit persisted naming fields: `name` for wrestlers and t
 
 `Title::status` is computed from activity-period relationships and is not a stored or cast database attribute. Only the persisted title `type` value is enum-cast.
 
+## Match Outcomes
+
+`ApplyMatchTitleOutcomesAction` is the championship-lineage boundary composed by `RecordResultAction`. It locks every attached title and its reigns before applying a result, so winner metadata and championship changes commit or roll back together.
+
+A champion defense leaves the current reign open. A compatible challenger winning by a title-changing finish closes the current reign with the match and event date, then creates the challenger's reign with the same match and date. A vacant title creates only the new reign. Winner-take-all matches apply that transition independently to every attached title inside the same transaction.
+
+Correcting a result soft deletes a reign incorrectly created by that match and reopens the preceding reign before applying the corrected outcome. Corrections are rejected after a later reign has been recorded because rewriting that earlier result would invalidate dependent lineage.
+
 ## Related Documentation
 - [Business Rules](business-rules.md)
 - [Match System](match-system.md)

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -76,7 +76,9 @@ Assignment Actions treat each requested collection as an atomic command. They re
 
 Royal Rumble competitors record a unique `entry_order` within the match. Battle Royal competitors may leave entry order unset because they begin simultaneously. Eliminated competitors record a unique `elimination_order`; the winner remains without one. `eliminated_by_match_competitor_id` optionally identifies the competitor responsible for the elimination and remains nullable for joint, external, or indeterminate eliminations.
 
-`RecordResultAction` records the finish, winning side, and elimination history as one atomic outcome. A decisive Battle Royal or Royal Rumble result accounts for every losing competitor exactly once, never eliminates a winner, and preserves chronological elimination order. No-outcome finishes may retain a valid partial elimination history. Recording a corrected result replaces the previous outcome metadata in the same transaction.
+`RecordResultAction` records the finish, winning side, elimination history, and attached championship outcomes as one atomic outcome. A decisive Battle Royal or Royal Rumble result accounts for every losing competitor exactly once, never eliminates a winner, and preserves chronological elimination order. No-outcome finishes may retain a valid partial elimination history.
+
+Pinfall, submission, knockout, stipulation, and forfeit finishes allow titles to change hands. Disqualification, countout, time-limit draw, and no-decision finishes retain the existing champion. A title-changing winner must contain exactly one competitor compatible with each attached title type, and a new reign uses the event date. Recording a corrected result reconciles title lineage in the same transaction; it may void a reign created by that match and restore its predecessor, but it cannot rewrite a reign that later championship history already depends on.
 
 ## Related Documentation
 - [Business Rules](business-rules.md)

--- a/tests/Integration/Actions/Matches/RecordResultActionTest.php
+++ b/tests/Integration/Actions/Matches/RecordResultActionTest.php
@@ -7,23 +7,42 @@ use App\Data\Matches\MatchEliminationData;
 use App\Data\Matches\MatchResultData;
 use App\Enums\MatchFinish;
 use App\Enums\MatchType;
+use App\Enums\Titles\TitleType;
 use App\Exceptions\Matches\InvalidMatchOutcomeException;
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
+use App\Models\Wrestlers\Wrestler;
 
-function sideWithCompetitor(EventMatch $match, int $position, ?int $entryOrder = null): MatchSide
-{
+function sideWithCompetitor(
+    EventMatch $match,
+    int $position,
+    ?int $entryOrder = null,
+    Wrestler|TagTeam|null $competitor = null,
+): MatchSide {
     $side = MatchSide::factory()->create([
         'match_id' => $match->id,
         'position' => $position,
     ]);
 
-    $competitor = MatchCompetitor::factory()->create([
+    $matchCompetitorAttributes = [
         'match_id' => $match->id,
         'match_side_id' => $side->id,
-    ]);
-    $competitor->forceFill(['entry_order' => $entryOrder])->save();
+    ];
+
+    if ($competitor !== null) {
+        $matchCompetitorAttributes += [
+            'competitor_type' => $competitor->getMorphClass(),
+            'competitor_id' => $competitor->id,
+        ];
+    }
+
+    $matchCompetitor = MatchCompetitor::factory()->create($matchCompetitorAttributes);
+    $matchCompetitor->forceFill(['entry_order' => $entryOrder])->save();
 
     return $side;
 }
@@ -322,4 +341,236 @@ it('rejects an elimination credited after the eliminator exited', function () {
             new MatchEliminationData($competitors[1], 2, $competitors[0]),
         ]),
     ))->toThrow(InvalidMatchOutcomeException::class);
+});
+
+it('transfers a singles title to the winning challenger', function () {
+    $eventDate = now()->subDay()->startOfSecond();
+    $event = Event::factory()->create(['date' => $eventDate]);
+    $match = EventMatch::factory()->for($event)->create();
+    $champion = Wrestler::factory()->create();
+    $challenger = Wrestler::factory()->create();
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $reign = TitleChampionship::factory()
+        ->for($title)
+        ->forWrestler($champion)
+        ->wonOn($eventDate->copy()->subMonth()->toDateTimeString())
+        ->create();
+    sideWithCompetitor($match, 1, competitor: $champion);
+    $winningSide = sideWithCompetitor($match, 2, competitor: $challenger);
+    $match->titles()->attach($title);
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $winningSide),
+    );
+
+    $newReign = $title->championships()->current()->sole();
+
+    expect($reign->refresh()->lost_match_id)->toBe($match->id)
+        ->and($reign->lost_at?->equalTo($eventDate))->toBeTrue()
+        ->and($newReign->champion->is($challenger))->toBeTrue()
+        ->and($newReign->won_match_id)->toBe($match->id)
+        ->and($newReign->won_at->equalTo($eventDate))->toBeTrue();
+});
+
+it('retains a title when its champion wins', function () {
+    $event = Event::factory()->past()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $champion = Wrestler::factory()->create();
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $reign = TitleChampionship::factory()->for($title)->forWrestler($champion)->create();
+    $winningSide = sideWithCompetitor($match, 1, competitor: $champion);
+    sideWithCompetitor($match, 2, competitor: Wrestler::factory()->create());
+    $match->titles()->attach($title);
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Submission, $winningSide),
+    );
+
+    expect($reign->refresh()->lost_at)->toBeNull()
+        ->and($title->championships()->count())->toBe(1);
+});
+
+it('does not transfer a title on a disqualification', function () {
+    $event = Event::factory()->past()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $champion = Wrestler::factory()->create();
+    $challenger = Wrestler::factory()->create();
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $reign = TitleChampionship::factory()->for($title)->forWrestler($champion)->create();
+    sideWithCompetitor($match, 1, competitor: $champion);
+    $winningSide = sideWithCompetitor($match, 2, competitor: $challenger);
+    $match->titles()->attach($title);
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Disqualification, $winningSide),
+    );
+
+    expect($reign->refresh()->lost_at)->toBeNull()
+        ->and($title->championships()->count())->toBe(1);
+});
+
+it('crowns the winner of a vacant title match', function () {
+    $event = Event::factory()->past()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $winner = Wrestler::factory()->create();
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $winningSide = sideWithCompetitor($match, 1, competitor: $winner);
+    sideWithCompetitor($match, 2, competitor: Wrestler::factory()->create());
+    $match->titles()->attach($title);
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Knockout, $winningSide),
+    );
+
+    $reign = $title->championships()->current()->sole();
+
+    expect($reign->champion->is($winner))->toBeTrue()
+        ->and($reign->won_match_id)->toBe($match->id);
+});
+
+it('transfers every title in a winner-take-all match', function () {
+    $event = Event::factory()->past()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $winner = Wrestler::factory()->create();
+    $firstTitle = Title::factory()->create(['type' => TitleType::Singles]);
+    $secondTitle = Title::factory()->create(['type' => TitleType::Singles]);
+    $firstReign = TitleChampionship::factory()
+        ->for($firstTitle)
+        ->forWrestler(Wrestler::factory()->create())
+        ->create();
+    $secondReign = TitleChampionship::factory()
+        ->for($secondTitle)
+        ->forWrestler(Wrestler::factory()->create())
+        ->create();
+    $winningSide = sideWithCompetitor($match, 1, competitor: $winner);
+    sideWithCompetitor($match, 2, competitor: $firstReign->champion);
+    sideWithCompetitor($match, 3, competitor: $secondReign->champion);
+    $match->titles()->attach([$firstTitle->id, $secondTitle->id]);
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Stipulation, $winningSide),
+    );
+
+    expect($firstTitle->championships()->current()->sole()->champion->is($winner))->toBeTrue()
+        ->and($secondTitle->championships()->current()->sole()->champion->is($winner))->toBeTrue();
+});
+
+it('transfers a tag team title to a winning tag team', function () {
+    $event = Event::factory()->past()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $champion = TagTeam::factory()->create();
+    $challenger = TagTeam::factory()->create();
+    $title = Title::factory()->create(['type' => TitleType::TagTeam]);
+    TitleChampionship::factory()->for($title)->forTagTeam($champion)->create();
+    sideWithCompetitor($match, 1, competitor: $champion);
+    $winningSide = sideWithCompetitor($match, 2, competitor: $challenger);
+    $match->titles()->attach($title);
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $winningSide),
+    );
+
+    expect($title->championships()->current()->sole()->champion->is($challenger))->toBeTrue();
+});
+
+it('rejects a winner incompatible with the title type', function () {
+    $event = Event::factory()->past()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $title = Title::factory()->create(['type' => TitleType::TagTeam]);
+    $winningSide = sideWithCompetitor($match, 1, competitor: Wrestler::factory()->create());
+    $match->titles()->attach($title);
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $winningSide),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+
+    expect($match->refresh()->match_finish)->toBeNull()
+        ->and($title->championships()->count())->toBe(0);
+});
+
+it('rejects a title change at an undated event', function () {
+    $event = Event::factory()->unscheduled()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $winningSide = sideWithCompetitor($match, 1, competitor: Wrestler::factory()->create());
+    $match->titles()->attach($title);
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $winningSide),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+
+    expect($match->refresh()->match_finish)->toBeNull()
+        ->and($title->championships()->count())->toBe(0);
+});
+
+it('restores title lineage when a result is corrected to a draw', function () {
+    $event = Event::factory()->past()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $champion = Wrestler::factory()->create();
+    $challenger = Wrestler::factory()->create();
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $originalReign = TitleChampionship::factory()->for($title)->forWrestler($champion)->create();
+    sideWithCompetitor($match, 1, competitor: $champion);
+    $winningSide = sideWithCompetitor($match, 2, competitor: $challenger);
+    $match->titles()->attach($title);
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $winningSide),
+    );
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::TimeLimitDraw, null),
+    );
+
+    expect($originalReign->refresh()->lost_at)->toBeNull()
+        ->and($originalReign->lost_match_id)->toBeNull()
+        ->and($title->championships()->current()->sole()->is($originalReign))->toBeTrue()
+        ->and(TitleChampionship::onlyTrashed()->where('won_match_id', $match->id)->exists())->toBeTrue();
+});
+
+it('rejects correcting a title result after later lineage exists', function () {
+    $event = Event::factory()->past()->create();
+    $match = EventMatch::factory()->for($event)->create();
+    $champion = Wrestler::factory()->create();
+    $challenger = Wrestler::factory()->create();
+    $laterChampion = Wrestler::factory()->create();
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    TitleChampionship::factory()->for($title)->forWrestler($champion)->create();
+    sideWithCompetitor($match, 1, competitor: $champion);
+    $winningSide = sideWithCompetitor($match, 2, competitor: $challenger);
+    $match->titles()->attach($title);
+
+    resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::Pinfall, $winningSide),
+    );
+
+    $laterMatch = EventMatch::factory()->for(Event::factory()->past())->create();
+    $challengerReign = $title->championships()->current()->sole();
+    $challengerReign->update([
+        'lost_match_id' => $laterMatch->id,
+        'lost_at' => $laterMatch->event->date,
+    ]);
+    TitleChampionship::factory()
+        ->for($title)
+        ->forWrestler($laterChampion)
+        ->wonAtEventMatch($laterMatch)
+        ->create();
+
+    expect(fn () => resolve(RecordResultAction::class)->handle(
+        $match,
+        matchResult(MatchFinish::TimeLimitDraw, null),
+    ))->toThrow(InvalidMatchOutcomeException::class);
+
+    expect($match->refresh()->match_finish)->toBe(MatchFinish::Pinfall)
+        ->and($title->championships()->current()->sole()->champion->is($laterChampion))->toBeTrue();
 });

--- a/tests/Unit/Enums/MatchFinishTest.php
+++ b/tests/Unit/Enums/MatchFinishTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MatchFinish;
+
+it('identifies whether a finish allows a title change', function (MatchFinish $finish, bool $allowsTitleChange) {
+    expect($finish->allowsTitleChange())->toBe($allowsTitleChange);
+})->with([
+    'pinfall' => [MatchFinish::Pinfall, true],
+    'submission' => [MatchFinish::Submission, true],
+    'knockout' => [MatchFinish::Knockout, true],
+    'stipulation' => [MatchFinish::Stipulation, true],
+    'forfeit' => [MatchFinish::Forfeit, true],
+    'disqualification' => [MatchFinish::Disqualification, false],
+    'countout' => [MatchFinish::Countout, false],
+    'time-limit draw' => [MatchFinish::TimeLimitDraw, false],
+    'no decision' => [MatchFinish::NoDecision, false],
+]);


### PR DESCRIPTION
## Summary
- apply championship outcomes atomically when match results are recorded
- preserve and reconcile title reign history when results are corrected
- validate singles and tag-team winners and retain titles for non-title-changing finishes
- document the match-to-championship boundary and add its shared AI rule

## Verification
- focused Pest: 73 tests, 165 assertions
- full Pest: 3,355 tests, 10,988 assertions
- PHPStan application and Pest configurations
- Rector and type coverage
- targeted Pint with Blade

## Local lint note
The full local pre-push hook reaches Pint but the Blade formatter subprocess fails because the injected local environment contains both NO_COLOR and FORCE_COLOR. The code-focused formatter checks pass; GitHub Actions will run the canonical lint check in a clean environment.