### PR TITLE
refactor: centralize championship reign writes

### DIFF
--- a/.ai/rules/actions-lifecycle.md
+++ b/.ai/rules/actions-lifecycle.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Actions,Lifecycle}/**'
+---
+
+# Actions Lifecycle
+
+## Centralize championship reign writes
+Use ChampionshipReignManager as the single persistence boundary for opening, closing, and reconciling title championship reigns. Match and title Actions retain eligibility, locking, and workflow orchestration; TitleChampionshipQuery remains read-only reporting.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -6,6 +6,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | --- | --- |
 | app/{Actions,Collections,Lifecycle,Models,Rules}/** | .ai/rules/actions-collections-lifecycle-models-rules.md |
 | app/{Actions,Lifecycle,Models}/** | .ai/rules/actions-lifecycle-models.md |
+| app/{Actions,Lifecycle}/** | .ai/rules/actions-lifecycle.md |
 | app/Actions/Matches/** | .ai/rules/actions-matches.md |
 | app/Actions/** | .ai/rules/actions.md |
 | app/** | .ai/rules/app.md |

--- a/app/Actions/Matches/ApplyMatchTitleOutcomesAction.php
+++ b/app/Actions/Matches/ApplyMatchTitleOutcomesAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\Matches;
 use App\Data\Matches\MatchResultData;
 use App\Enums\Titles\TitleType;
 use App\Exceptions\Matches\InvalidMatchOutcomeException;
+use App\Lifecycle\ChampionshipReignManager;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\TagTeams\TagTeam;
@@ -14,11 +15,12 @@ use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 
 class ApplyMatchTitleOutcomesAction
 {
+    public function __construct(private readonly ChampionshipReignManager $championshipReigns) {}
+
     public function handle(EventMatch $match, MatchResultData $result): void
     {
         DB::transaction(function () use ($match, $result): void {
@@ -53,11 +55,11 @@ class ApplyMatchTitleOutcomesAction
                     ? $this->championForTitle($title, $winningCompetitors)
                     : null;
 
-                $this->ensureLineageCanBeReconciled($lockedMatch, $title, $reigns);
+                $this->championshipReigns->ensureMatchCanBeReconciled($lockedMatch, $title, $reigns);
             }
 
             foreach ($titles as $title) {
-                $this->reconcileTitle(
+                $this->championshipReigns->reconcileMatchOutcome(
                     $lockedMatch,
                     $title,
                     $desiredChampions[$title->id],
@@ -99,92 +101,5 @@ class ApplyMatchTitleOutcomesAction
         }
 
         return $eligibleCompetitors->sole();
-    }
-
-    /** @param Collection<int, TitleChampionship> $reigns */
-    private function ensureLineageCanBeReconciled(
-        EventMatch $match,
-        Title $title,
-        Collection $reigns,
-    ): void {
-        $reignWonAtMatch = $this->activeReignsForTitle($title, $reigns)
-            ->firstWhere('won_match_id', $match->id);
-
-        if ($reignWonAtMatch?->lost_match_id !== null) {
-            throw InvalidMatchOutcomeException::titleLineageHasAdvanced();
-        }
-    }
-
-    /** @param Collection<int, TitleChampionship> $reigns */
-    private function reconcileTitle(
-        EventMatch $match,
-        Title $title,
-        Wrestler|TagTeam|null $desiredChampion,
-        Collection $reigns,
-    ): void {
-        $activeReigns = $this->activeReignsForTitle($title, $reigns);
-        $reignWonAtMatch = $activeReigns->firstWhere('won_match_id', $match->id);
-        $currentReign = $activeReigns
-            ->whereNull('lost_at')
-            ->sortByDesc('won_at')
-            ->first();
-
-        if ($reignWonAtMatch !== null && $this->reignBelongsTo($reignWonAtMatch, $desiredChampion)) {
-            return;
-        }
-
-        if ($reignWonAtMatch !== null) {
-            $reignWonAtMatch->delete();
-
-            $currentReign = $activeReigns->firstWhere('lost_match_id', $match->id);
-            $currentReign?->update([
-                'lost_match_id' => null,
-                'lost_at' => null,
-            ]);
-        }
-
-        if ($desiredChampion === null || $this->reignBelongsTo($currentReign, $desiredChampion)) {
-            return;
-        }
-
-        $eventDate = $match->event->date;
-
-        if (! $eventDate instanceof Carbon) {
-            throw InvalidMatchOutcomeException::undatedTitleMatch();
-        }
-
-        $currentReign?->update([
-            'lost_match_id' => $match->id,
-            'lost_at' => $eventDate,
-        ]);
-
-        TitleChampionship::query()->create([
-            'title_id' => $title->id,
-            'champion_type' => $desiredChampion->getMorphClass(),
-            'champion_id' => $desiredChampion->id,
-            'won_match_id' => $match->id,
-            'won_at' => $eventDate,
-        ]);
-    }
-
-    /**
-     * @param  Collection<int, TitleChampionship>  $reigns
-     * @return Collection<int, TitleChampionship>
-     */
-    private function activeReignsForTitle(Title $title, Collection $reigns): Collection
-    {
-        return $reigns
-            ->where('title_id', $title->id)
-            ->filter(fn (TitleChampionship $reign): bool => $reign->deleted_at === null);
-    }
-
-    private function reignBelongsTo(
-        ?TitleChampionship $reign,
-        Wrestler|TagTeam|null $champion,
-    ): bool {
-        return $reign !== null
-            && $champion !== null
-            && $reign->champion_type === $champion->getMorphClass()
-            && $reign->champion_id === $champion->id;
     }
 }

--- a/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
+++ b/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\TagTeams;
 
+use App\Lifecycle\ChampionshipReignManager;
 use App\Models\TagTeams\TagTeam;
 use App\Models\TagTeams\TagTeamManager;
 use App\Models\TagTeams\TagTeamWrestler;
@@ -11,6 +12,8 @@ use Illuminate\Support\Carbon;
 
 class EndCurrentRelationshipsAction
 {
+    public function __construct(private readonly ChampionshipReignManager $championshipReigns) {}
+
     public function handle(TagTeam $tagTeam, Carbon $effectiveDate): void
     {
         TagTeamWrestler::query()
@@ -22,5 +25,7 @@ class EndCurrentRelationshipsAction
             ->where('tag_team_id', $tagTeam->id)
             ->current()
             ->update(['fired_at' => $effectiveDate]);
+
+        $this->championshipReigns->endCurrentReignsForChampion($tagTeam, $effectiveDate);
     }
 }

--- a/app/Actions/Titles/DeleteAction.php
+++ b/app/Actions/Titles/DeleteAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Titles;
 
+use App\Lifecycle\ChampionshipReignManager;
 use App\Lifecycle\DeletionStateManager;
 use App\Models\Titles\Title;
 use Illuminate\Support\Carbon;
@@ -11,7 +12,10 @@ use Illuminate\Support\Facades\DB;
 
 class DeleteAction
 {
-    public function __construct(private readonly DeletionStateManager $deletionState) {}
+    public function __construct(
+        private readonly ChampionshipReignManager $championshipReigns,
+        private readonly DeletionStateManager $deletionState,
+    ) {}
 
     /**
      * Delete a title.
@@ -41,18 +45,24 @@ class DeleteAction
         $deletionDate = $deletionDate ?? now();
 
         DB::transaction(function () use ($title, $deletionDate): void {
+            $lockedTitle = Title::query()
+                ->lockForUpdate()
+                ->findOrFail($title->getKey());
+
             // Handle title status cleanup based on current state
-            if ($title->isCurrentlyActive()) {
+            if ($lockedTitle->isCurrentlyActive()) {
                 // End active status (pull the title from active competition)
-                $title->activityPeriods()->where('ended_at', null)->update(['ended_at' => $deletionDate]);
-            } elseif ($title->isRetired()) {
+                $lockedTitle->activityPeriods()->where('ended_at', null)->update(['ended_at' => $deletionDate]);
+            } elseif ($lockedTitle->isRetired()) {
                 // End retirement period (retired titles are not active)
-                $title->retirements()->where('ended_at', null)->update(['ended_at' => $deletionDate]);
+                $lockedTitle->retirements()->where('ended_at', null)->update(['ended_at' => $deletionDate]);
             }
             // Note: Inactive (pulled) titles that have debuted require no status cleanup
 
+            $this->championshipReigns->endCurrentReign($lockedTitle, $deletionDate);
+
             // Soft delete the title record
-            $this->deletionState->delete($title, $deletionDate);
+            $this->deletionState->delete($lockedTitle, $deletionDate);
         });
     }
 }

--- a/app/Actions/Titles/RetireAction.php
+++ b/app/Actions/Titles/RetireAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\Titles;
 use App\Actions\Lifecycle\EndActivityPeriodAction;
 use App\Enums\Lifecycle\LifecycleTransitionType;
 use App\Exceptions\Titles\CannotBeRetiredException;
+use App\Lifecycle\ChampionshipReignManager;
 use App\Lifecycle\RetirementPeriodManager;
 use App\Lifecycle\TitleLifecycleEligibility;
 use App\Models\Titles\Title;
@@ -17,6 +18,7 @@ class RetireAction
 {
     public function __construct(
         private readonly EndActivityPeriodAction $endActivityPeriod,
+        private readonly ChampionshipReignManager $championshipReigns,
         private readonly RetirementPeriodManager $retirementPeriods,
         private readonly TitleLifecycleEligibility $eligibility,
     ) {}
@@ -52,11 +54,7 @@ class RetireAction
                 $this->endActivityPeriod->handle($lockedTitle, $operationalDate);
             }
 
-            // End current championship if title has an active champion
-            $currentChampionship = $lockedTitle->currentChampionship;
-            if ($currentChampionship) {
-                $currentChampionship->update(['lost_at' => $retirementDate]);
-            }
+            $this->championshipReigns->endCurrentReign($lockedTitle, $retirementDate);
 
             $this->retirementPeriods->start($lockedTitle, $retirementDate, LifecycleTransitionType::Retired);
         });

--- a/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
+++ b/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Actions\Wrestlers;
 
+use App\Lifecycle\ChampionshipReignManager;
 use App\Models\Stables\StableWrestler;
 use App\Models\TagTeams\TagTeamWrestler;
 use App\Models\Wrestlers\Wrestler;
@@ -12,6 +13,8 @@ use Illuminate\Support\Carbon;
 
 class EndCurrentRelationshipsAction
 {
+    public function __construct(private readonly ChampionshipReignManager $championshipReigns) {}
+
     public function handle(Wrestler $wrestler, Carbon $effectiveDate): void
     {
         TagTeamWrestler::query()
@@ -29,8 +32,6 @@ class EndCurrentRelationshipsAction
             ->current()
             ->update(['fired_at' => $effectiveDate]);
 
-        $wrestler->currentChampionships()->update([
-            'lost_at' => $effectiveDate,
-        ]);
+        $this->championshipReigns->endCurrentReignsForChampion($wrestler, $effectiveDate);
     }
 }

--- a/app/Lifecycle/ChampionshipReignManager.php
+++ b/app/Lifecycle/ChampionshipReignManager.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Exceptions\Matches\InvalidMatchOutcomeException;
+use App\Models\Contracts\CanBeChampion;
+use App\Models\Matches\EventMatch;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+final class ChampionshipReignManager
+{
+    /** @param Collection<int, TitleChampionship> $reigns */
+    public function ensureMatchCanBeReconciled(
+        EventMatch $match,
+        Title $title,
+        Collection $reigns,
+    ): void {
+        $reignWonAtMatch = $this->activeReignsForTitle($title, $reigns)
+            ->firstWhere('won_match_id', $match->id);
+
+        if ($reignWonAtMatch?->lost_match_id !== null) {
+            throw InvalidMatchOutcomeException::titleLineageHasAdvanced();
+        }
+    }
+
+    /** @param Collection<int, TitleChampionship> $reigns */
+    public function reconcileMatchOutcome(
+        EventMatch $match,
+        Title $title,
+        Wrestler|TagTeam|null $desiredChampion,
+        Collection $reigns,
+    ): void {
+        $activeReigns = $this->activeReignsForTitle($title, $reigns);
+        $reignWonAtMatch = $activeReigns->firstWhere('won_match_id', $match->id);
+        $currentReign = $activeReigns
+            ->whereNull('lost_at')
+            ->sortByDesc('won_at')
+            ->first();
+
+        if ($reignWonAtMatch !== null && $this->reignBelongsTo($reignWonAtMatch, $desiredChampion)) {
+            return;
+        }
+
+        if ($reignWonAtMatch !== null) {
+            $reignWonAtMatch->delete();
+
+            $currentReign = $activeReigns->firstWhere('lost_match_id', $match->id);
+            $currentReign?->update([
+                'lost_match_id' => null,
+                'lost_at' => null,
+            ]);
+        }
+
+        if ($desiredChampion === null || $this->reignBelongsTo($currentReign, $desiredChampion)) {
+            return;
+        }
+
+        $eventDate = $match->event->date;
+
+        if (! $eventDate instanceof Carbon) {
+            throw InvalidMatchOutcomeException::undatedTitleMatch();
+        }
+
+        $currentReign?->update([
+            'lost_match_id' => $match->id,
+            'lost_at' => $eventDate,
+        ]);
+
+        TitleChampionship::query()->create([
+            'title_id' => $title->id,
+            'champion_type' => $desiredChampion->getMorphClass(),
+            'champion_id' => $desiredChampion->id,
+            'won_match_id' => $match->id,
+            'won_at' => $eventDate,
+        ]);
+    }
+
+    public function endCurrentReign(Title $title, Carbon $endedAt): void
+    {
+        TitleChampionship::query()
+            ->forTitleId($title->id)
+            ->current()
+            ->lockForUpdate()
+            ->first()
+            ?->update(['lost_at' => $endedAt]);
+    }
+
+    /** @param Model&CanBeChampion<*> $champion */
+    public function endCurrentReignsForChampion(Model&CanBeChampion $champion, Carbon $endedAt): void
+    {
+        $champion->currentChampionships()
+            ->lockForUpdate()
+            ->get()
+            ->each->update(['lost_at' => $endedAt]);
+    }
+
+    /**
+     * @param  Collection<int, TitleChampionship>  $reigns
+     * @return Collection<int, TitleChampionship>
+     */
+    private function activeReignsForTitle(Title $title, Collection $reigns): Collection
+    {
+        return $reigns
+            ->where('title_id', $title->id)
+            ->filter(fn (TitleChampionship $reign): bool => $reign->deleted_at === null);
+    }
+
+    private function reignBelongsTo(
+        ?TitleChampionship $reign,
+        Wrestler|TagTeam|null $champion,
+    ): bool {
+        return $reign !== null
+            && $champion !== null
+            && $reign->champion_type === $champion->getMorphClass()
+            && $reign->champion_id === $champion->id;
+    }
+}

--- a/docs/architecture/championship-system.md
+++ b/docs/architecture/championship-system.md
@@ -26,7 +26,7 @@ Models expose their explicit persisted naming fields: `name` for wrestlers and t
 
 ## Match Outcomes
 
-`ApplyMatchTitleOutcomesAction` is the championship-lineage boundary composed by `RecordResultAction`. It locks every attached title and its reigns before applying a result, so winner metadata and championship changes commit or roll back together.
+`ApplyMatchTitleOutcomesAction` is the match-side championship orchestrator composed by `RecordResultAction`. It locks every attached title and its reigns before applying a result, so winner metadata and championship changes commit or roll back together. `ChampionshipReignManager` is the single reign write boundary: it opens, closes, and reconciles persisted reigns for match outcomes, title retirement, title deletion, and champion relationship cleanup. Reporting remains in `TitleChampionshipQuery`.
 
 A champion defense leaves the current reign open. A compatible challenger winning by a title-changing finish closes the current reign with the match and event date, then creates the challenger's reign with the same match and date. A vacant title creates only the new reign. Winner-take-all matches apply that transition independently to every attached title inside the same transaction.
 

--- a/tests/Integration/Actions/TagTeams/EndCurrentRelationshipsActionTest.php
+++ b/tests/Integration/Actions/TagTeams/EndCurrentRelationshipsActionTest.php
@@ -5,12 +5,15 @@ declare(strict_types=1);
 use App\Actions\TagTeams\EndCurrentRelationshipsAction;
 use App\Models\Managers\Manager;
 use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
 use App\Models\Wrestlers\Wrestler;
 
 test('it ends only the tag teams current relationships', function () {
     $tagTeam = TagTeam::factory()->employed()->create();
     $wrestler = Wrestler::factory()->employed()->create();
     $manager = Manager::factory()->employed()->create();
+    $title = Title::factory()->tagTeam()->create();
     $effectiveDate = now();
     $formerMembershipEndedAt = now()->subWeek();
     $currentMembershipStartedAt = now()->subDay();
@@ -21,6 +24,11 @@ test('it ends only the tag teams current relationships', function () {
     ]);
     $tagTeam->wrestlers()->attach($wrestler, ['joined_at' => $currentMembershipStartedAt]);
     $tagTeam->managers()->attach($manager, ['hired_at' => $currentMembershipStartedAt]);
+    $championship = TitleChampionship::factory()
+        ->for($title)
+        ->forTagTeam($tagTeam)
+        ->current()
+        ->create();
 
     resolve(EndCurrentRelationshipsAction::class)
         ->handle($tagTeam, $effectiveDate);
@@ -28,7 +36,8 @@ test('it ends only the tag teams current relationships', function () {
     $tagTeam->refresh();
 
     expect($tagTeam->currentWrestlers)->toBeEmpty()
-        ->and($tagTeam->currentManagers)->toBeEmpty();
+        ->and($tagTeam->currentManagers)->toBeEmpty()
+        ->and($championship->refresh()->lost_at?->toDateTimeString())->toBe($effectiveDate->toDateTimeString());
 
     $this->assertDatabaseHas('tag_teams_wrestlers', [
         'tag_team_id' => $tagTeam->id,

--- a/tests/Integration/Actions/Titles/DeletionLifecycleTest.php
+++ b/tests/Integration/Actions/Titles/DeletionLifecycleTest.php
@@ -7,11 +7,26 @@ use App\Actions\Titles\RestoreAction;
 use App\Enums\Lifecycle\LifecycleDimension;
 use App\Enums\Lifecycle\LifecycleTransitionType;
 use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
 
 use function Spatie\PestPluginTestTime\testTime;
 
 beforeEach(function () {
     testTime()->freeze();
+});
+
+test('deleting a title ends its current championship reign', function () {
+    $title = Title::factory()->create();
+    $championship = TitleChampionship::factory()
+        ->for($title)
+        ->current()
+        ->create();
+    $deletedAt = now()->subDay()->startOfSecond();
+
+    resolve(DeleteAction::class)->handle($title, $deletedAt);
+
+    expect($championship->refresh()->lost_at)->toEqual($deletedAt)
+        ->and($title->refresh()->trashed())->toBeTrue();
 });
 
 test('it audits title deletion and restoration', function () {

--- a/tests/Integration/Actions/Titles/RetireActionTest.php
+++ b/tests/Integration/Actions/Titles/RetireActionTest.php
@@ -8,6 +8,7 @@ use App\Actions\Titles\UnretireAction;
 use App\Exceptions\Titles\CannotBeReinstatedException;
 use App\Exceptions\Titles\CannotBeUnretiredException;
 use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
 
 use function Spatie\PestPluginTestTime\testTime;
 
@@ -22,6 +23,19 @@ test('it closes current title activity when scheduling retirement', function () 
     expect($title->currentActivityPeriod()->doesntExist())->toBeTrue()
         ->and($title->activityPeriods()->latest('id')->firstOrFail()->ended_at)->toEqual(now()->startOfSecond())
         ->and($title->currentRetirement()->firstOrFail()->started_at)->toEqual($retirementDate);
+});
+
+test('retirement ends the current championship reign', function () {
+    $title = Title::factory()->active()->create();
+    $championship = TitleChampionship::factory()
+        ->for($title)
+        ->current()
+        ->create();
+    $retirementDate = now()->subDay()->startOfSecond();
+
+    resolve(RetireAction::class)->handle($title, $retirementDate);
+
+    expect($championship->refresh()->lost_at)->toEqual($retirementDate);
 });
 
 test('retirement closes activity opened from a stale inactive snapshot', function () {

--- a/tests/Integration/Lifecycle/ChampionshipReignManagerTest.php
+++ b/tests/Integration/Lifecycle/ChampionshipReignManagerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Lifecycle\ChampionshipReignManager;
+use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
+use Illuminate\Support\Facades\DB;
+
+test('it ends only the current championship reign', function () {
+    $title = Title::factory()->create();
+    $previousReign = TitleChampionship::factory()
+        ->for($title)
+        ->ended()
+        ->create();
+    $currentReign = TitleChampionship::factory()
+        ->for($title)
+        ->current()
+        ->create();
+    $endedAt = now()->startOfSecond();
+
+    DB::transaction(function () use ($title, $endedAt): void {
+        resolve(ChampionshipReignManager::class)->endCurrentReign($title, $endedAt);
+    });
+
+    expect($currentReign->refresh()->lost_at)->toEqual($endedAt)
+        ->and($previousReign->refresh()->lost_at)->not->toEqual($endedAt);
+});
+
+test('ending a vacant championship is a no-op', function () {
+    $title = Title::factory()->create();
+
+    DB::transaction(function () use ($title): void {
+        resolve(ChampionshipReignManager::class)->endCurrentReign($title, now());
+    });
+
+    expect($title->championships()->doesntExist())->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- introduce ChampionshipReignManager as the single championship-reign persistence boundary
- delegate match corrections, title retirement, title deletion, and champion relationship cleanup to it
- close tag-team championship reigns during relationship cleanup, matching wrestler behavior
- document and record the shared architecture rule

## Verification
- 39 focused Pest tests, 95 assertions
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- targeted Pint with Blade passed

## Local lint note
The full local push gate reaches Pint but the Blade formatter subprocess fails because the injected environment contains both NO_COLOR and FORCE_COLOR. GitHub Actions will run the canonical formatter check in a clean environment.