### PR TITLE
refactor: tighten Eloquent casts

### DIFF
--- a/app/Casts/WeightCast.php
+++ b/app/Casts/WeightCast.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Casts;
+
+use App\ValueObjects\Weight;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+use Illuminate\Database\Eloquent\Model;
+
+/** @implements CastsAttributes<Weight, Weight|int> */
+class WeightCast implements CastsAttributes
+{
+    public function get(Model $model, string $key, mixed $value, array $attributes): Weight
+    {
+        return new Weight((int) $value);
+    }
+
+    public function set(Model $model, string $key, mixed $value, array $attributes): int
+    {
+        return $value instanceof Weight
+            ? $value->toPounds()
+            : (new Weight((int) $value))->toPounds();
+    }
+}

--- a/app/Data/TagTeams/TagTeamMembershipData.php
+++ b/app/Data/TagTeams/TagTeamMembershipData.php
@@ -75,7 +75,7 @@ readonly class TagTeamMembershipData
     public function combinedWeightInPounds(): int
     {
         return (int) $this->getWrestlers()->sum(
-            fn (Wrestler $wrestler): int => $wrestler->weight
+            fn (Wrestler $wrestler): int => $wrestler->weight->toPounds()
         );
     }
 }

--- a/app/Models/Titles/TitleChampionship.php
+++ b/app/Models/Titles/TitleChampionship.php
@@ -77,7 +77,6 @@ class TitleChampionship extends Model
         return [
             'won_at' => 'datetime',
             'lost_at' => 'datetime',
-            'last_held_reign' => 'datetime',
         ];
     }
 

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Eloquent\Attributes\Fillable;
 use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
-use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -30,7 +29,7 @@ use Illuminate\Support\Carbon;
  * @property string $last_name
  * @property string $full_name
  * @property string $email
- * @property string|null $email_verified_at
+ * @property Carbon|null $email_verified_at
  * @property string $password
  * @property UserStatus $status
  * @property string|null $avatar_path
@@ -79,18 +78,8 @@ class User extends Authenticatable
             'role' => Role::class,
             'status' => UserStatus::class,
             'phone_number' => PhoneNumberCast::class,
+            'email_verified_at' => 'datetime',
+            'password' => 'hashed',
         ];
-    }
-
-    /**
-     * Get the user's password.
-     *
-     * @return Attribute<mixed, mixed>
-     */
-    public function password(): Attribute
-    {
-        return new Attribute(
-            set: fn (string $value) => bcrypt($value),
-        );
     }
 }

--- a/app/Models/Wrestlers/Wrestler.php
+++ b/app/Models/Wrestlers/Wrestler.php
@@ -6,6 +6,7 @@ namespace App\Models\Wrestlers;
 
 use App\Builders\Roster\WrestlerBuilder;
 use App\Casts\HeightCast;
+use App\Casts\WeightCast;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\HasChampionshipReigns;
 use App\Models\Concerns\HasComputedEmploymentStatus;
@@ -34,6 +35,7 @@ use App\Models\TagTeams\TagTeam;
 use App\Models\TagTeams\TagTeamWrestler;
 use App\Models\Titles\TitleChampionship;
 use App\ValueObjects\Height;
+use App\ValueObjects\Weight;
 use Database\Factories\Wrestlers\WrestlerFactory;
 use Illuminate\Database\Eloquent\Attributes\Appends;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
@@ -61,7 +63,7 @@ use Illuminate\Support\Carbon;
  * @property int $id
  * @property string $name
  * @property Height $height
- * @property int $weight
+ * @property Weight $weight
  * @property string $hometown
  * @property string|null $signature_move
  * @property EmploymentStatus $status
@@ -245,6 +247,7 @@ class Wrestler extends Model implements CanBeAStableMember, CanBeChampion, Emplo
     {
         return [
             'height' => HeightCast::class,
+            'weight' => WeightCast::class,
         ];
     }
 }

--- a/tests/Feature/Workflows/WrestlerManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/WrestlerManagementWorkflowTest.php
@@ -58,7 +58,7 @@ describe('Wrestler Creation Journey', function () {
         $wrestler = Wrestler::where('name', 'John Cena')->firstOrFail();
         expect($wrestler->hometown)->toBe('West Newbury, MA');
         expect($wrestler->height->toInches())->toBe(73); // 6'1" = 73 inches
-        expect($wrestler->weight)->toBe(251);
+        expect($wrestler->weight->toPounds())->toBe(251);
         expect($wrestler->signature_move)->toBe('Attitude Adjustment');
 
         // And: Should appear in the wrestlers table

--- a/tests/Integration/Actions/Wrestlers/CreateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/CreateActionTest.php
@@ -32,7 +32,7 @@ test('it creates a wrestler with basic information', function () {
     expect($result->height->feet)->toBe(6);
     expect($result->height->inches)->toBe(1);
     expect($result->hometown)->toBe('West Newbury, Massachusetts');
-    expect($result->weight)->toBe(251);
+    expect($result->weight->toPounds())->toBe(251);
     expect($result->signature_move)->toBe('Attitude Adjustment');
 
     $this->assertDatabaseHas('wrestlers', [
@@ -99,7 +99,7 @@ test('it creates wrestler with all optional fields', function () {
     expect($result->height->feet)->toBe(6);
     expect($result->height->inches)->toBe(2);
     expect($result->hometown)->toBe('Austin, Texas');
-    expect($result->weight)->toBe(252);
+    expect($result->weight->toPounds())->toBe(252);
     expect($result->signature_move)->toBe('Stone Cold Stunner');
 
     // Verify database state

--- a/tests/Integration/Actions/Wrestlers/RestoreActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/RestoreActionTest.php
@@ -234,7 +234,7 @@ test('it preserves wrestler identity and metadata', function () {
     expect($wrestler->id)->toBe($originalId);
     expect($wrestler->name)->toBe($originalName);
     expect($wrestler->hometown)->toBe($originalHometown);
-    expect($wrestler->weight)->toBe($originalWeight);
+    expect($wrestler->weight->toPounds())->toBe($originalWeight);
 });
 
 test('it handles wrestler with no relationships', function () {

--- a/tests/Integration/Actions/Wrestlers/UpdateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/UpdateActionTest.php
@@ -37,7 +37,7 @@ test('it updates wrestler basic information', function () {
     expect($result)->toBeInstanceOf(Wrestler::class);
     expect($result->name)->toBe('Updated Name');
     expect($result->height->toInches())->toBe(75);
-    expect($result->weight)->toBe(250);
+    expect($result->weight->toPounds())->toBe(250);
     expect($result->hometown)->toBe('Updated Town');
     expect($result->signature_move)->toBe('Updated Move');
 
@@ -258,7 +258,7 @@ test('it returns updated wrestler instance', function () {
     expect($result->id)->toBe($wrestler->id);
     expect($result->name)->toBe('Return Test');
     expect($result->height->toInches())->toBe(76);
-    expect($result->weight)->toBe(240);
+    expect($result->weight->toPounds())->toBe(240);
 });
 
 test('it handles height conversion correctly', function () {

--- a/tests/Integration/Database/Seeders/WrestlersTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/WrestlersTableSeederTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Wrestlers\Wrestler;
+use App\ValueObjects\Weight;
 use Database\Seeders\WrestlersTableSeeder;
 use Illuminate\Support\Facades\Artisan;
 
@@ -55,7 +56,7 @@ describe('WrestlersTableSeeder Integration Tests', function () {
                 expect($wrestler->hometown)->not->toBeEmpty();
                 expect($wrestler->height->feet)->toBeInt();
                 expect($wrestler->height->inches)->toBeInt();
-                expect($wrestler->weight)->toBeInt();
+                expect($wrestler->weight)->toBeInstanceOf(Weight::class);
             }
         });
 
@@ -67,7 +68,7 @@ describe('WrestlersTableSeeder Integration Tests', function () {
             foreach ($wrestlers as $wrestler) {
                 expect($wrestler->height->feet)->toBeBetween(4, 8);
                 expect($wrestler->height->inches)->toBeBetween(0, 11);
-                expect($wrestler->weight)->toBeBetween(100, 500);
+                expect($wrestler->weight->toPounds())->toBeBetween(100, 500);
             }
         });
 

--- a/tests/Unit/Casts/WeightCastTest.php
+++ b/tests/Unit/Casts/WeightCastTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Wrestlers\Wrestler;
+use App\ValueObjects\Weight;
+
+test('it casts stored pounds to weight', function () {
+    $wrestler = Wrestler::factory()->create(['weight' => 225]);
+
+    expect($wrestler->weight)->toEqual(new Weight(225));
+});
+
+test('it stores weight values as pounds', function () {
+    $wrestler = Wrestler::factory()->create(['weight' => new Weight(225)]);
+
+    expect($wrestler->getRawOriginal('weight'))->toBe(225)
+        ->and($wrestler->weight)->toEqual(new Weight(225));
+});
+
+test('it rejects invalid weight values', function (int $weight) {
+    expect(fn () => Wrestler::factory()->create(['weight' => $weight]))
+        ->toThrow(InvalidArgumentException::class);
+})->with([0, -1]);

--- a/tests/Unit/Models/Titles/TitleChampionshipTest.php
+++ b/tests/Unit/Models/Titles/TitleChampionshipTest.php
@@ -43,7 +43,7 @@ describe('TitleChampionship Model Unit Tests', function () {
 
             expect($casts['won_at'])->toBe('datetime');
             expect($casts['lost_at'])->toBe('datetime');
-            expect($casts['last_held_reign'])->toBe('datetime');
+            expect($casts)->not->toHaveKey('last_held_reign');
         });
 
         test('title championship has correct default values', function () {

--- a/tests/Unit/Models/Users/UserTest.php
+++ b/tests/Unit/Models/Users/UserTest.php
@@ -8,6 +8,8 @@ use App\Enums\Users\UserStatus;
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Hash;
 
 /**
  * Unit tests for User model structure and configuration.
@@ -49,6 +51,8 @@ describe('User Model Unit Tests', function () {
 
             expect($casts['role'])->toBe(Role::class);
             expect($casts['status'])->toBe(UserStatus::class);
+            expect($casts['email_verified_at'])->toBe('datetime');
+            expect($casts['password'])->toBe('hashed');
         });
 
         test('has custom eloquent builder', function () {
@@ -92,6 +96,16 @@ describe('User Model Unit Tests', function () {
 
             expect($modelConstants)->toBeEmpty();
         });
+    });
+
+    test('casts verification timestamps and hashes passwords', function () {
+        $user = User::factory()->create([
+            'email_verified_at' => '2026-08-15 12:00:00',
+            'password' => 'plain-text-password',
+        ]);
+
+        expect($user->email_verified_at)->toBeInstanceOf(Carbon::class)
+            ->and(Hash::check('plain-text-password', $user->password))->toBeTrue();
     });
 
 });

--- a/tests/Unit/database/Factories/Wrestlers/WrestlerFactoryTest.php
+++ b/tests/Unit/database/Factories/Wrestlers/WrestlerFactoryTest.php
@@ -31,7 +31,7 @@ describe('wrestler factory states', function () {
 
         expect((string) $wrestler->name)->toBeString();
         expect($wrestler->height)->toBeInstanceOf(Height::class);
-        expect($wrestler->weight)->toBeGreaterThan(0);
+        expect($wrestler->weight->toPounds())->toBeGreaterThan(0);
         expect($wrestler->hometown)->toBeString();
         expect($wrestler->status)->toBeInstanceOf(EmploymentStatus::class);
     });


### PR DESCRIPTION
## Summary
- cast wrestler weight through the existing Weight value object
- use Laravel's native hashed password and verification datetime casts
- remove the stale title championship cast

## Verification
- composer test:push
- focused Pest suite: 46 tests, 178 assertions
- composer lint
- application and Pest PHPStan
- Rector