### PR TITLE
refactor: type venue states

### DIFF
--- a/app/Casts/AddressCast.php
+++ b/app/Casts/AddressCast.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Casts;
 
+use App\Enums\Shared\UnitedStatesState;
 use App\ValueObjects\Address;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
@@ -17,7 +18,7 @@ class AddressCast implements CastsAttributes
         return new Address(
             streetAddress: (string) $attributes['street_address'],
             city: (string) $attributes['city'],
-            state: (string) $attributes['state'],
+            state: UnitedStatesState::from((string) $attributes['state']),
             zipcode: (string) $attributes['zipcode'],
         );
     }

--- a/app/Data/Events/VenueData.php
+++ b/app/Data/Events/VenueData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Data\Events;
 
+use App\Enums\Shared\UnitedStatesState;
 use App\ValueObjects\Address;
 
 readonly class VenueData
@@ -20,6 +21,6 @@ readonly class VenueData
         public string $state,
         public string $zipcode,
     ) {
-        $this->address = new Address($street_address, $city, $state, $zipcode);
+        $this->address = new Address($street_address, $city, UnitedStatesState::from($state), $zipcode);
     }
 }

--- a/app/Livewire/Venues/Forms/CreateEditForm.php
+++ b/app/Livewire/Venues/Forms/CreateEditForm.php
@@ -130,7 +130,7 @@ class CreateEditForm extends BaseForm
             'address' => new Address(
                 streetAddress: $this->street_address,
                 city: $this->city,
-                state: $this->state,
+                state: UnitedStatesState::from($this->state),
                 zipcode: (string) $this->zipcode,
             ),
         ];

--- a/app/ValueObjects/Address.php
+++ b/app/ValueObjects/Address.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\ValueObjects;
 
+use App\Enums\Shared\UnitedStatesState;
 use InvalidArgumentException;
 
 readonly class Address
@@ -11,10 +12,10 @@ readonly class Address
     public function __construct(
         public string $streetAddress,
         public string $city,
-        public string $state,
+        public UnitedStatesState $state,
         public string $zipcode,
     ) {
-        if (mb_trim($this->streetAddress) === '' || mb_trim($this->city) === '' || mb_trim($this->state) === '') {
+        if (mb_trim($this->streetAddress) === '' || mb_trim($this->city) === '') {
             throw new InvalidArgumentException('Address fields cannot be empty.');
         }
 
@@ -25,7 +26,7 @@ readonly class Address
 
     public function formatted(): string
     {
-        return "{$this->streetAddress}, {$this->city}, {$this->state} {$this->zipcode}";
+        return "{$this->streetAddress}, {$this->city}, {$this->state->value} {$this->zipcode}";
     }
 
     /** @return array{street_address: string, city: string, state: string, zipcode: string} */
@@ -34,7 +35,7 @@ readonly class Address
         return [
             'street_address' => $this->streetAddress,
             'city' => $this->city,
-            'state' => $this->state,
+            'state' => $this->state->value,
             'zipcode' => $this->zipcode,
         ];
     }

--- a/database/factories/Events/VenueFactory.php
+++ b/database/factories/Events/VenueFactory.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Database\Factories\Events;
 
+use App\Enums\Shared\UnitedStatesState;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Str;
 
@@ -25,7 +26,7 @@ class VenueFactory extends Factory
             'name' => Str::of($name)->append(' Arena')->value(),
             'street_address' => fake()->buildingNumber().' '.fake()->streetName(),
             'city' => fake()->city(),
-            'state' => fake()->stateAbbr(),
+            'state' => fake()->randomElement(UnitedStatesState::cases())->value,
             'zipcode' => str(fake()->postcode())->substr(0, 5)->value(),
         ];
     }

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -37,7 +37,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'Integration Test Arena',
                 street_address: '123 Test Street',
                 city: 'Test City',
-                state: 'TS',
+                state: 'Texas',
                 zipcode: '12345'
             );
 
@@ -47,7 +47,7 @@ describe('Venue Action Integration Tests', function () {
             expect($venue->name)->toBe('Integration Test Arena');
             expect($venue->street_address)->toBe('123 Test Street');
             expect($venue->city)->toBe('Test City');
-            expect($venue->state)->toBe('TS');
+            expect($venue->state)->toBe('Texas');
             expect($venue->zipcode)->toBe('12345');
             expect($venue->exists)->toBeTrue();
         });
@@ -57,7 +57,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'Database Test Arena',
                 street_address: '456 Database Lane',
                 city: 'Database City',
-                state: 'DB',
+                state: 'Delaware',
                 zipcode: '54321'
             );
 
@@ -67,7 +67,7 @@ describe('Venue Action Integration Tests', function () {
             expect($retrievedVenue->name)->toBe('Database Test Arena');
             expect($retrievedVenue->street_address)->toBe('456 Database Lane');
             expect($retrievedVenue->city)->toBe('Database City');
-            expect($retrievedVenue->state)->toBe('DB');
+            expect($retrievedVenue->state)->toBe('Delaware');
             expect($retrievedVenue->zipcode)->toBe('54321');
         });
 
@@ -76,7 +76,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'O\'Malley\'s Arena & Entertainment Center',
                 street_address: '789 O\'Connor St.',
                 city: 'St. Louis',
-                state: 'MO',
+                state: 'Missouri',
                 zipcode: '63101'
             );
 
@@ -85,7 +85,7 @@ describe('Venue Action Integration Tests', function () {
             expect($venue->name)->toBe('O\'Malley\'s Arena & Entertainment Center');
             expect($venue->street_address)->toBe('789 O\'Connor St.');
             expect($venue->city)->toBe('St. Louis');
-            expect($venue->state)->toBe('MO');
+            expect($venue->state)->toBe('Missouri');
             expect($venue->zipcode)->toBe('63101');
         });
 
@@ -94,7 +94,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'Minimal Arena',
                 street_address: '100 Basic St',
                 city: 'Basic City',
-                state: 'BC',
+                state: 'California',
                 zipcode: '10000'
             );
 
@@ -103,7 +103,7 @@ describe('Venue Action Integration Tests', function () {
             expect($venue->name)->toBe('Minimal Arena');
             expect($venue->street_address)->toBe('100 Basic St');
             expect($venue->city)->toBe('Basic City');
-            expect($venue->state)->toBe('BC');
+            expect($venue->state)->toBe('California');
             expect($venue->zipcode)->toBe('10000');
         });
     });
@@ -140,7 +140,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'Database Updated',
                 street_address: $venue->street_address,
                 city: $venue->city,
-                state: 'DU',
+                state: 'Utah',
                 zipcode: $venue->zipcode
             );
 
@@ -148,7 +148,7 @@ describe('Venue Action Integration Tests', function () {
 
             $retrievedVenue = Venue::findOrFail($venue->id);
             expect($retrievedVenue->name)->toBe('Database Updated');
-            expect($retrievedVenue->state)->toBe('DU');
+            expect($retrievedVenue->state)->toBe('Utah');
         });
 
         test('update action handles address changes', function () {
@@ -163,7 +163,7 @@ describe('Venue Action Integration Tests', function () {
                 name: $venue->name,
                 street_address: '456 New Avenue',
                 city: 'New City',
-                state: 'NS',
+                state: 'Nevada',
                 zipcode: '54321'
             );
 
@@ -171,7 +171,7 @@ describe('Venue Action Integration Tests', function () {
 
             expect($updatedVenue->street_address)->toBe('456 New Avenue');
             expect($updatedVenue->city)->toBe('New City');
-            expect($updatedVenue->state)->toBe('NS');
+            expect($updatedVenue->state)->toBe('Nevada');
             expect($updatedVenue->zipcode)->toBe('54321');
         });
 
@@ -297,7 +297,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'Event Association Arena',
                 street_address: '123 Event St',
                 city: 'Event City',
-                state: 'EC',
+                state: 'Colorado',
                 zipcode: '12345'
             );
 
@@ -344,7 +344,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'Validation Test Arena',
                 street_address: '123 Validation St',
                 city: 'Validation City',
-                state: 'VC',
+                state: 'Virginia',
                 zipcode: '12345'
             );
 
@@ -364,7 +364,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'Updated Validation Arena',
                 street_address: '456 Updated St',
                 city: 'Updated City',
-                state: 'UC',
+                state: 'Connecticut',
                 zipcode: '54321'
             );
 
@@ -373,7 +373,7 @@ describe('Venue Action Integration Tests', function () {
             expect($updatedVenue->name)->toBe('Updated Validation Arena');
             expect($updatedVenue->street_address)->toBe('456 Updated St');
             expect($updatedVenue->city)->toBe('Updated City');
-            expect($updatedVenue->state)->toBe('UC');
+            expect($updatedVenue->state)->toBe('Connecticut');
             expect($updatedVenue->zipcode)->toBe('54321');
         });
     });
@@ -384,7 +384,7 @@ describe('Venue Action Integration Tests', function () {
                 name: 'Timestamp Test Arena',
                 street_address: '123 Time St',
                 city: 'Time City',
-                state: 'TC',
+                state: 'Tennessee',
                 zipcode: '12345'
             );
 

--- a/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
+++ b/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Shared\UnitedStatesState;
 use App\Livewire\Base\BaseForm;
 use App\Models\Events\Venue;
 use App\ValueObjects\Address;
@@ -115,7 +116,7 @@ describe('VenueForm Integration Tests', function () {
             expect($data)->toHaveKeys(['name', 'address']);
             expect($data['name'])->toBe('Madison Square Garden')
                 ->and($data['address'])->toEqual(
-                    new Address('4 Pennsylvania Plaza', 'New York', 'New York', '10001'),
+                    new Address('4 Pennsylvania Plaza', 'New York', UnitedStatesState::NewYork, '10001'),
                 );
         });
     });

--- a/tests/Unit/Casts/AddressCastTest.php
+++ b/tests/Unit/Casts/AddressCastTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Enums\Shared\UnitedStatesState;
 use App\Models\Events\Venue;
 use App\ValueObjects\Address;
 
@@ -14,13 +15,13 @@ test('it casts venue address columns to an address', function () {
     ]);
 
     expect($venue->address)->toEqual(
-        new Address('4 Pennsylvania Plaza', 'New York', 'New York', '10001'),
+        new Address('4 Pennsylvania Plaza', 'New York', UnitedStatesState::NewYork, '10001'),
     );
 });
 
 test('it stores an address across the existing venue columns', function () {
     $venue = Venue::factory()->create([
-        'address' => new Address('4 Pennsylvania Plaza', 'New York', 'New York', '10001'),
+        'address' => new Address('4 Pennsylvania Plaza', 'New York', UnitedStatesState::NewYork, '10001'),
     ]);
 
     expect($venue->getRawOriginal('street_address'))->toBe('4 Pennsylvania Plaza')

--- a/tests/Unit/ValueObjects/AddressTest.php
+++ b/tests/Unit/ValueObjects/AddressTest.php
@@ -2,10 +2,11 @@
 
 declare(strict_types=1);
 
+use App\Enums\Shared\UnitedStatesState;
 use App\ValueObjects\Address;
 
 test('it represents and formats a venue address', function () {
-    $address = new Address('4 Pennsylvania Plaza', 'New York', 'New York', '10001');
+    $address = new Address('4 Pennsylvania Plaza', 'New York', UnitedStatesState::NewYork, '10001');
 
     expect($address->formatted())->toBe('4 Pennsylvania Plaza, New York, New York 10001')
         ->and($address->toAttributes())->toBe([
@@ -16,16 +17,15 @@ test('it represents and formats a venue address', function () {
         ]);
 });
 
-test('it rejects incomplete address fields', function (string $street, string $city, string $state) {
-    expect(fn () => new Address($street, $city, $state, '10001'))
+test('it rejects incomplete address fields', function (string $street, string $city) {
+    expect(fn () => new Address($street, $city, UnitedStatesState::NewYork, '10001'))
         ->toThrow(InvalidArgumentException::class);
 })->with([
-    'missing street' => ['', 'New York', 'New York'],
-    'missing city' => ['4 Pennsylvania Plaza', '', 'New York'],
-    'missing state' => ['4 Pennsylvania Plaza', 'New York', ''],
+    'missing street' => ['', 'New York'],
+    'missing city' => ['4 Pennsylvania Plaza', ''],
 ]);
 
 test('it rejects invalid ZIP codes', function (string $zipcode) {
-    expect(fn () => new Address('4 Pennsylvania Plaza', 'New York', 'New York', $zipcode))
+    expect(fn () => new Address('4 Pennsylvania Plaza', 'New York', UnitedStatesState::NewYork, $zipcode))
         ->toThrow(InvalidArgumentException::class);
 })->with(['1234', '123456', 'abcde']);

--- a/tests/Unit/database/Factories/Shared/VenueFactoryTest.php
+++ b/tests/Unit/database/Factories/Shared/VenueFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Database\Factories;
 
+use App\Enums\Shared\UnitedStatesState;
 use App\Models\Events\Venue;
 use Database\Factories\Events\VenueFactory;
 
@@ -58,7 +59,7 @@ describe('VenueFactory Unit Tests', function () {
             expect($venue->city)->toBeString();
             expect(mb_strlen($venue->city))->toBeGreaterThan(2);
             expect($venue->state)->toBeString();
-            expect(mb_strlen($venue->state))->toBe(2);
+            expect(UnitedStatesState::tryFrom($venue->state))->not->toBeNull();
             expect($venue->zipcode)->toBeString();
             expect(mb_strlen($venue->zipcode))->toBe(5);
         });
@@ -70,13 +71,13 @@ describe('VenueFactory Unit Tests', function () {
             $venue = Venue::factory()->make([
                 'name' => 'Custom Arena',
                 'city' => 'Custom City',
-                'state' => 'CC',
+                'state' => UnitedStatesState::Colorado->value,
             ]);
 
             // Assert
             expect($venue->name)->toBe('Custom Arena');
             expect($venue->city)->toBe('Custom City');
-            expect($venue->state)->toBe('CC');
+            expect($venue->state)->toBe(UnitedStatesState::Colorado->value);
         });
 
         test('maintains required attributes when overriding', function () {
@@ -112,7 +113,7 @@ describe('VenueFactory Unit Tests', function () {
             foreach ($venues as $venue) {
                 expect($venue->name)->toBeString();
                 expect($venue->zipcode)->toMatch('/^\d{5}$/');
-                expect($venue->state)->toMatch('/^[A-Z]{2}$/');
+                expect(UnitedStatesState::tryFrom($venue->state))->not->toBeNull();
             }
         });
     });


### PR DESCRIPTION
## Summary
- represent address state with the existing UnitedStatesState enum
- convert persisted venue state values through the address cast and input boundaries
- align venue factories and lifecycle fixtures with valid application states

## Verification
- composer test:push
- focused Pest suite: 53 tests, 168 assertions
- composer lint
- application and Pest PHPStan
- Rector