### PR TITLE
refactor: enforce Eloquent morph aliases

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -22,6 +22,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/{Actions/Matches,Services}/** | .ai/rules/matches-services.md |
 | app/{Actions,Models}/Matches/** | .ai/rules/matches.md |
 | database/migrations/** | .ai/rules/migrations.md |
+| app/{Models,Providers,Actions,Lifecycle}/** | .ai/rules/models-providers-actions-lifecycle.md |
 | app/{Models,ValueObjects,Casts}/** | .ai/rules/models-value-objects-casts.md |
 | app/Models/** | .ai/rules/models.md |
 | app/{Livewire,Http/Requests,Actions,Services}/** | .ai/rules/requests-actions-services.md |

--- a/.ai/rules/models-providers-actions-lifecycle.md
+++ b/.ai/rules/models-providers-actions-lifecycle.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Models,Providers,Actions,Lifecycle}/**'
+---
+
+# Models Providers Actions Lifecycle
+
+## Enforce stable Eloquent morph aliases
+All polymorphic persistence must use the enforced morph map and obtain aliases through getMorphClass(). Supported aliases are event, manager, match, referee, stable, tag_team, title, venue, and wrestler; never store PHP class names or ad hoc morph strings.

--- a/app/Enums/Lifecycle/LifecycleOwnerType.php
+++ b/app/Enums/Lifecycle/LifecycleOwnerType.php
@@ -46,16 +46,6 @@ enum LifecycleOwnerType: string
 
     public function morphAlias(): string
     {
-        return match ($this) {
-            self::Event => (new Event())->getMorphClass(),
-            self::Manager => (new Manager())->getMorphClass(),
-            self::Match => (new EventMatch())->getMorphClass(),
-            self::Referee => (new Referee())->getMorphClass(),
-            self::Stable => (new Stable())->getMorphClass(),
-            self::TagTeam => (new TagTeam())->getMorphClass(),
-            self::Title => (new Title())->getMorphClass(),
-            self::Venue => (new Venue())->getMorphClass(),
-            self::Wrestler => (new Wrestler())->getMorphClass(),
-        };
+        return $this->value;
     }
 }

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -71,9 +71,11 @@ class MatchesTable extends DataTableComponent
                 ->label(fn (EventMatch $row): string => $row->competitors
                     ->competitorsBySidePosition()
                     ->map(fn (Collection $side): string => $side->map(function (Wrestler|TagTeam $competitor): string {
-                        $type = str($competitor->getMorphClass())->kebab()->plural();
+                        $routeName = $competitor instanceof Wrestler
+                            ? 'wrestlers.show'
+                            : 'tag-teams.show';
 
-                        return '<a href="'.route($type.'.show', $competitor->id).'">'.$competitor->name.'</a>';
+                        return '<a href="'.route($routeName, $competitor).'">'.$competitor->name.'</a>';
                     })->join(' & '))
                     ->join(' vs '))
                 ->html(),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -61,12 +61,12 @@ class AppServiceProvider extends ServiceProvider
             return str_replace(':values', $values, $message);
         });
 
-        Relation::morphMap([
+        Relation::enforceMorphMap([
             'wrestler' => Wrestler::class,
             'manager' => Manager::class,
             'match' => EventMatch::class,
             'title' => Title::class,
-            'tagTeam' => TagTeam::class,
+            'tag_team' => TagTeam::class,
             'referee' => Referee::class,
             'stable' => Stable::class,
             'event' => Event::class,

--- a/database/factories/Titles/TitleChampionshipFactory.php
+++ b/database/factories/Titles/TitleChampionshipFactory.php
@@ -26,11 +26,11 @@ class TitleChampionshipFactory extends Factory
      */
     public function definition(): array
     {
-        $type = fake()->randomElement(['wrestler', 'tagTeam']);
+        $type = fake()->randomElement(['wrestler', 'tag_team']);
 
         $champion = match ($type) {
             'wrestler' => Wrestler::factory()->create(),
-            'tagTeam' => TagTeam::factory()->create(),
+            'tag_team' => TagTeam::factory()->create(),
             default => throw new InvalidArgumentException("Unknown champion type: {$type}"),
         };
 
@@ -69,7 +69,7 @@ class TitleChampionshipFactory extends Factory
 
         return $this->state(function () use ($tagTeam) {
             return [
-                'champion_type' => 'tagTeam',
+                'champion_type' => 'tag_team',
                 'champion_id' => $tagTeam->id,
             ];
         });

--- a/database/migrations/2026_08_15_232954_normalize_tag_team_morph_alias.php
+++ b/database/migrations/2026_08_15_232954_normalize_tag_team_morph_alias.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        collect([
+            ['table' => 'employments', 'column' => 'employable_type'],
+            ['table' => 'suspensions', 'column' => 'suspendable_type'],
+            ['table' => 'retirements', 'column' => 'retirable_type'],
+            ['table' => 'lifecycle_transitions', 'column' => 'subject_type'],
+            ['table' => 'titles_championships', 'column' => 'champion_type'],
+            ['table' => 'events_matches_competitors', 'column' => 'competitor_type'],
+        ])->each(function (array $morphColumn): void {
+            DB::table($morphColumn['table'])
+                ->where($morphColumn['column'], 'tagTeam')
+                ->update([$morphColumn['column'] => 'tag_team']);
+        });
+    }
+};

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -31,6 +31,8 @@ single-consumer relationship traits or speculative override helpers.
 
 ## Related Model Resolution
 
+- Eloquent polymorphic relationships use an enforced morph map. Persist the stable lowercase aliases `event`, `manager`, `match`, `referee`, `stable`, `tag_team`, `title`, `venue`, and `wrestler`; never persist PHP class names or ad hoc aliases.
+- Obtain a model's persisted alias through `getMorphClass()`. `LifecycleOwnerType` uses the same backed values for lifecycle transition subjects.
 - Employment history uses the shared `App\Models\Lifecycle\Employment` model and an `employable` polymorphic owner.
 - Wrestlers, managers, referees, and tag teams expose the same typed employment relationships through `IsEmployable`.
 - Employment state uses one predicate per distinct meaning: `isEmployed()`, `hasFutureEmployment()`, `hasNoCurrentOrFutureEmployment()`, `isReleased()`, and `hasEmploymentHistory()`. Do not add aliases for those states.

--- a/tests/Feature/Architecture/EloquentMorphMapTest.php
+++ b/tests/Feature/Architecture/EloquentMorphMapTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Events\Event;
+use App\Models\Events\Venue;
+use App\Models\Managers\Manager;
+use App\Models\Matches\EventMatch;
+use App\Models\Referees\Referee;
+use App\Models\Stables\Stable;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Users\User;
+use App\Models\Wrestlers\Wrestler;
+use Illuminate\Database\ClassMorphViolationException;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
+test('it enforces stable aliases for every polymorphic model', function () {
+    expect(Relation::requiresMorphMap())->toBeTrue()
+        ->and(Relation::morphMap())->toBe([
+            'wrestler' => Wrestler::class,
+            'manager' => Manager::class,
+            'match' => EventMatch::class,
+            'title' => Title::class,
+            'tag_team' => TagTeam::class,
+            'referee' => Referee::class,
+            'stable' => Stable::class,
+            'event' => Event::class,
+            'venue' => Venue::class,
+        ]);
+});
+
+test('it rejects models without an approved polymorphic alias', function () {
+    expect(fn () => (new User())->getMorphClass())
+        ->toThrow(ClassMorphViolationException::class);
+});

--- a/tests/Integration/Livewire/Matches/Tables/MatchesTableTest.php
+++ b/tests/Integration/Livewire/Matches/Tables/MatchesTableTest.php
@@ -178,7 +178,9 @@ describe('MatchesTable Complex Relationships', function () {
         livewire(MatchesTable::class, ['eventId' => $event->id])
             ->assertSee('Wrestler One')
             ->assertSee('Wrestler Two')
-            ->assertSee('Tag Team');
+            ->assertSee('Tag Team')
+            ->assertSeeHtml(route('wrestlers.show', $wrestler1))
+            ->assertSeeHtml(route('tag-teams.show', $tagTeam));
     });
 
     it('displays championship matches correctly', function () {

--- a/tests/Integration/Models/Titles/TitleChampionshipTest.php
+++ b/tests/Integration/Models/Titles/TitleChampionshipTest.php
@@ -98,7 +98,7 @@ describe('TitleChampionship Model', function () {
             expect($wrestlerChampionship->champion)->toBeInstanceOf(Wrestler::class);
             expect($tagTeamChampionship->champion)->toBeInstanceOf(TagTeam::class);
             expect($wrestlerChampionship->champion_type)->toBe('wrestler');
-            expect($tagTeamChampionship->champion_type)->toBe('tagTeam');
+            expect($tagTeamChampionship->champion_type)->toBe('tag_team');
             expect($wrestlerChampionship->champion()->firstOrFail()->getKey())->toBe($this->wrestler->id);
             expect($tagTeamChampionship->champion()->firstOrFail()->getKey())->toBe($this->tagTeam->id);
         });
@@ -271,7 +271,7 @@ describe('TitleChampionship Model', function () {
             // Filter current championships
             $currentChampionships = TitleChampionship::whereNull('lost_at')->get();
             expect($currentChampionships)->toHaveCount(1);
-            expect($currentChampionships->firstOrFail()->champion_type)->toBe('tagTeam');
+            expect($currentChampionships->firstOrFail()->champion_type)->toBe('tag_team');
 
             // Filter by champion type
             $wrestlerChampionships = TitleChampionship::where('champion_type', 'wrestler')->get();

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Models\Users\User;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\TestCase;
 use Illuminate\Support\Carbon;
@@ -28,6 +29,15 @@ require_once __DIR__.'/Helpers/LivewireHelpers.php';
 pest()->extend(TestCase::class)->use(RefreshDatabase::class)->in('Browser');
 
 pest()->extend(TestCase::class)->use(RefreshDatabase::class)->in('Integration', 'Unit');
+
+pest()
+    ->beforeEach(function () {
+        Relation::requireMorphMap(false);
+    })
+    ->afterEach(function () {
+        Relation::requireMorphMap();
+    })
+    ->in('Unit/Models/Concerns');
 
 pest()
     ->extend(TestCase::class)

--- a/tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
+++ b/tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
@@ -36,7 +36,7 @@ describe('TitleChampionshipFactory Unit Tests', function () {
 
             // Assert
             expect($championship->title_id)->toBeInt();
-            expect($championship->champion_type)->toBeIn(['wrestler', 'tagTeam']);
+            expect($championship->champion_type)->toBeIn(['wrestler', 'tag_team']);
             expect($championship->champion_id)->toBeInt();
             expect($championship->won_match_id)->toBeNull(); // Default has no match
             expect($championship->lost_match_id)->toBeNull(); // Current championship
@@ -84,7 +84,7 @@ describe('TitleChampionshipFactory Unit Tests', function () {
             ]);
 
             // Assert
-            expect($championship->champion_type)->toBe('tagTeam');
+            expect($championship->champion_type)->toBe('tag_team');
             expect($championship->champion_id)->toBe($tagTeam->id);
             expect($championship->title_id)->toBe($title->id);
         });


### PR DESCRIPTION
## Summary
- enforce the application morph map so unmapped model classes cannot leak into persistence
- normalize the legacy tagTeam alias to tag_team with a forward-only data migration
- align lifecycle owner aliases, factories, architecture documentation, shared AI rules, and regression coverage

## Verification
- composer test:push
- focused Pest suite: 48 tests, 129 assertions
- composer lint
- application and Pest PHPStan
- Rector