### PR TITLE
fix: create event factory venues deterministically

### DIFF
--- a/database/factories/Events/EventFactory.php
+++ b/database/factories/Events/EventFactory.php
@@ -100,6 +100,6 @@ class EventFactory extends Factory
      */
     public function withVenue(): static
     {
-        return $this->state(['venue_id' => Venue::inRandomOrder()->first()]);
+        return $this->for(Venue::factory(), 'venue');
     }
 }

--- a/tests/Unit/database/Factories/Events/EventFactoryTest.php
+++ b/tests/Unit/database/Factories/Events/EventFactoryTest.php
@@ -60,6 +60,16 @@ describe('EventFactory Unit Tests', function () {
     });
 
     describe('factory state methods', function () {
+        test('with venue creates and associates a venue', function () {
+            // Act
+            $event = Event::factory()->withVenue()->create();
+            $venue = $event->venue()->firstOrFail();
+
+            // Assert
+            expect($venue)->toBeInstanceOf(Venue::class)
+                ->and($event->venue_id)->toBe($venue->id);
+        });
+
         test('scheduled state works correctly', function () {
             // Arrange
             $venue = Venue::factory()->create();


### PR DESCRIPTION
## Summary
- create a related venue when using the event factory's withVenue state
- store the related venue key through the Eloquent factory relationship instead of assigning a model to venue_id
- cover the persisted venue association

## Verification
- php artisan test --compact tests/Unit/database/Factories/Events/EventFactoryTest.php
- composer lint
- focused Pest PHPStan
- composer test:push (type coverage, Rector, Pint, and both PHPStan configurations passed; final parallel Pest stage stalled locally and was stopped after producing no output)
