### PR TITLE
fix: build coherent championship factory timelines

### DIFF
--- a/database/factories/Titles/TitleChampionshipFactory.php
+++ b/database/factories/Titles/TitleChampionshipFactory.php
@@ -12,7 +12,7 @@ use App\Models\Titles\TitleChampionship;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
-use InvalidArgumentException;
+use LogicException;
 
 /**
  * @extends Factory<TitleChampionship>
@@ -26,17 +26,13 @@ class TitleChampionshipFactory extends Factory
      */
     public function definition(): array
     {
-        $type = fake()->randomElement(['wrestler', 'tag_team']);
-
-        $champion = match ($type) {
-            'wrestler' => Wrestler::factory()->create(),
-            'tag_team' => TagTeam::factory()->create(),
-            default => throw new InvalidArgumentException("Unknown champion type: {$type}"),
-        };
+        $champion = fake()->boolean()
+            ? Wrestler::factory()->create()
+            : TagTeam::factory()->create();
 
         return [
             'title_id' => Title::factory(),
-            'champion_type' => $type, // Use morph map key instead of full class name
+            'champion_type' => $champion->getMorphClass(),
             'champion_id' => $champion->id,
             'won_match_id' => null,
             'lost_match_id' => null,
@@ -46,7 +42,7 @@ class TitleChampionshipFactory extends Factory
     }
 
     /**
-     * Configure the factory for a tag team champion.
+     * Configure the factory for a wrestler champion.
      */
     public function forWrestler(?Wrestler $wrestler = null): static
     {
@@ -54,7 +50,7 @@ class TitleChampionshipFactory extends Factory
 
         return $this->state(function () use ($wrestler) {
             return [
-                'champion_type' => 'wrestler',
+                'champion_type' => $wrestler->getMorphClass(),
                 'champion_id' => $wrestler->id,
             ];
         });
@@ -69,7 +65,7 @@ class TitleChampionshipFactory extends Factory
 
         return $this->state(function () use ($tagTeam) {
             return [
-                'champion_type' => 'tag_team',
+                'champion_type' => $tagTeam->getMorphClass(),
                 'champion_id' => $tagTeam->id,
             ];
         });
@@ -97,21 +93,40 @@ class TitleChampionshipFactory extends Factory
 
     public function wonAtEventMatch(?EventMatch $eventMatch = null): static
     {
+        $eventMatch ??= EventMatch::factory()
+            ->for(Event::factory()->past())
+            ->create();
+
         return $this->state([
             'won_match_id' => $eventMatch->id,
-            'won_at' => $eventMatch->event->date,
+            'won_at' => $this->eventDate($eventMatch),
         ]);
     }
 
     public function lostAtEventMatch(?EventMatch $lostEventMatch = null, ?EventMatch $wonEventMatch = null): static
     {
-        $lostEventMatch ?? EventMatch::factory()->for(Event::factory())->create();
-        $wonEventMatch ?? EventMatch::factory()->for(Event::factory()->state(['date' => $lostEventMatch->event->date->subMonth(1)]))->create();
+        $lostEventMatch ??= EventMatch::factory()
+            ->for(Event::factory()->past())
+            ->create();
+
+        $lostAt = $this->eventDate($lostEventMatch);
+
+        $wonEventMatch ??= EventMatch::factory()
+            ->for(Event::factory()->state(['date' => $lostAt->copy()->subMonth()]))
+            ->create();
 
         return $this->state([
+            'won_match_id' => $wonEventMatch->id,
+            'won_at' => $this->eventDate($wonEventMatch),
             'lost_match_id' => $lostEventMatch->id,
-            'lost_at' => $lostEventMatch->event->date,
+            'lost_at' => $lostAt,
         ]);
+    }
+
+    private function eventDate(EventMatch $eventMatch): Carbon
+    {
+        return $eventMatch->event->date
+            ?? throw new LogicException('A championship event match must belong to a scheduled event.');
     }
 
     /**

--- a/tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
+++ b/tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Unit\Database\Factories;
 
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
@@ -61,10 +62,8 @@ describe('TitleChampionshipFactory Unit Tests', function () {
             $title = Title::factory()->create();
 
             // Act
-            $championship = TitleChampionship::factory()->make([
+            $championship = TitleChampionship::factory()->forWrestler($wrestler)->make([
                 'title_id' => $title->id,
-                'champion_type' => 'wrestler',
-                'champion_id' => $wrestler->id,
             ]);
 
             // Assert
@@ -107,6 +106,48 @@ describe('TitleChampionshipFactory Unit Tests', function () {
             expect(requiredDate($championship->lost_at)->format('Y-m-d H:i:s'))->toBe($lostDate->format('Y-m-d H:i:s'));
             expect($championship->lost_match_id)->toBe($lostMatch->id);
             expect(requiredDate($championship->lost_at)->isAfter($championship->won_at))->toBeTrue();
+        });
+
+        test('won at event match creates a scheduled match when one is not supplied', function () {
+            // Act
+            $championship = TitleChampionship::factory()->wonAtEventMatch()->create();
+
+            // Assert
+            expect($championship->wonEventMatch)->toBeInstanceOf(EventMatch::class)
+                ->and($championship->won_at)->toEqual($championship->wonEventMatch?->event->date);
+        });
+
+        test('lost at event match creates a complete championship timeline', function () {
+            // Act
+            $championship = TitleChampionship::factory()->lostAtEventMatch()->create();
+
+            // Assert
+            expect($championship->wonEventMatch)->toBeInstanceOf(EventMatch::class)
+                ->and($championship->lostEventMatch)->toBeInstanceOf(EventMatch::class)
+                ->and($championship->won_at)->toEqual($championship->wonEventMatch?->event->date)
+                ->and($championship->lost_at)->toEqual($championship->lostEventMatch?->event->date)
+                ->and(requiredDate($championship->lost_at)->isAfter($championship->won_at))->toBeTrue();
+        });
+
+        test('lost at event match retains supplied winning and losing matches', function () {
+            // Arrange
+            $wonEventMatch = EventMatch::factory()
+                ->for(Event::factory()->state(['date' => now()->subMonth()]))
+                ->create();
+            $lostEventMatch = EventMatch::factory()
+                ->for(Event::factory()->past())
+                ->create();
+
+            // Act
+            $championship = TitleChampionship::factory()
+                ->lostAtEventMatch($lostEventMatch, $wonEventMatch)
+                ->create();
+
+            // Assert
+            expect($championship->won_match_id)->toBe($wonEventMatch->id)
+                ->and($championship->lost_match_id)->toBe($lostEventMatch->id)
+                ->and($championship->won_at)->toEqual($wonEventMatch->event->date)
+                ->and($championship->lost_at)->toEqual($lostEventMatch->event->date);
         });
     });
 


### PR DESCRIPTION
## Summary
- derive championship morph aliases from their champion models
- create scheduled event matches when championship timeline states omit them
- persist both winning and losing match relationships for ended reigns
- reject championship matches whose events do not have dates
- add focused factory timeline and relationship coverage

## Verification
- php artisan test --compact tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
- focused application and Pest PHPStan
- composer lint
- composer test:push (type coverage, Rector, Pint, and both PHPStan configurations passed; final local parallel Pest stage stalled without output and was stopped)
