### PR TITLE
test: harden factory relationship states

### DIFF
--- a/database/factories/TagTeams/TagTeamFactory.php
+++ b/database/factories/TagTeams/TagTeamFactory.php
@@ -40,12 +40,12 @@ class TagTeamFactory extends Factory
         $now = now();
         $employmentStartDate = $now->copy()->subDays(3);
 
-        $wrestlers = Wrestler::factory()->count(2)
-            ->has(Employment::factory()->started($employmentStartDate), 'employments')
-            ->create();
-
         return $this->has(Employment::factory()->started($employmentStartDate), 'employments')
-            ->withCurrentWrestlers($wrestlers, $employmentStartDate);
+            ->withCurrentWrestlers(
+                Wrestler::factory()->count(2)
+                    ->has(Employment::factory()->started($employmentStartDate), 'employments'),
+                $employmentStartDate,
+            );
     }
 
     public function bookable(): static
@@ -62,12 +62,13 @@ class TagTeamFactory extends Factory
     public function withFutureEmployment(): static
     {
         $employmentStartDate = Carbon::tomorrow();
-        $wrestlers = Wrestler::factory()->count(2)
-            ->has(Employment::factory()->started($employmentStartDate), 'employments')
-            ->create();
 
         return $this->has(Employment::factory()->started($employmentStartDate), 'employments')
-            ->withCurrentWrestlers($wrestlers, Carbon::now());
+            ->withCurrentWrestlers(
+                Wrestler::factory()->count(2)
+                    ->has(Employment::factory()->started($employmentStartDate), 'employments'),
+                $employmentStartDate,
+            );
     }
 
     public function futureEmployment(): static
@@ -80,14 +81,15 @@ class TagTeamFactory extends Factory
         $now = now();
         $employmentStartDate = $now->copy()->subDays(3);
         $suspensionStartDate = $now->copy()->subDays(2);
-        $wrestlers = Wrestler::factory()->count(2)
-            ->has(Employment::factory()->started($employmentStartDate), 'employments')
-            ->has(Suspension::factory()->started($suspensionStartDate), 'suspensions')
-            ->create();
 
         return $this->has(Employment::factory()->started($employmentStartDate), 'employments')
             ->has(Suspension::factory()->started($suspensionStartDate), 'suspensions')
-            ->withCurrentWrestlers($wrestlers, $employmentStartDate);
+            ->withCurrentWrestlers(
+                Wrestler::factory()->count(2)
+                    ->has(Employment::factory()->started($employmentStartDate), 'employments')
+                    ->has(Suspension::factory()->started($suspensionStartDate), 'suspensions'),
+                $employmentStartDate,
+            );
     }
 
     public function retired(): static
@@ -95,21 +97,20 @@ class TagTeamFactory extends Factory
         $now = now();
         $employmentStartDate = $now->copy()->subDays(3);
         $retirementStartDate = $now->copy()->subDays(2);
-        $wrestlers = Wrestler::factory()->count(2)
-            ->has(Employment::factory()->started($employmentStartDate)->ended($retirementStartDate), 'employments')
-            ->has(Retirement::factory()->started($retirementStartDate), 'retirements')
-            ->create();
 
         return $this->has(Employment::factory()->started($employmentStartDate)->ended($retirementStartDate), 'employments')
             ->has(Retirement::factory()->started($retirementStartDate), 'retirements')
-            ->withCurrentWrestlers($wrestlers, $employmentStartDate);
+            ->withCurrentWrestlers(
+                Wrestler::factory()->count(2)
+                    ->has(Employment::factory()->started($employmentStartDate)->ended($retirementStartDate), 'employments')
+                    ->has(Retirement::factory()->started($retirementStartDate), 'retirements'),
+                $employmentStartDate,
+            );
     }
 
     public function unemployed(): static
     {
-        $wrestlers = Wrestler::factory()->count(2)->create();
-
-        return $this->withCurrentWrestlers($wrestlers);
+        return $this->withCurrentWrestlers(Wrestler::factory()->count(2));
     }
 
     public function released(): static
@@ -117,12 +118,13 @@ class TagTeamFactory extends Factory
         $now = now();
         $employmentStartDate = $now->copy()->subDays(2);
         $employmentEndDate = $now->copy()->subDays();
-        $wrestlers = Wrestler::factory()->count(2)
-            ->has(Employment::factory()->started($employmentStartDate)->ended($employmentEndDate), 'employments')
-            ->create();
 
         return $this->has(Employment::factory()->started($employmentStartDate)->ended($employmentEndDate), 'employments')
-            ->withCurrentWrestlers($wrestlers, $employmentStartDate);
+            ->withCurrentWrestlers(
+                Wrestler::factory()->count(2)
+                    ->has(Employment::factory()->started($employmentStartDate)->ended($employmentEndDate), 'employments'),
+                $employmentStartDate,
+            );
     }
 
     public function withCurrentWrestlers($wrestlers, $joinDate = null): static

--- a/database/factories/Titles/TitleChampionshipFactory.php
+++ b/database/factories/Titles/TitleChampionshipFactory.php
@@ -46,14 +46,11 @@ class TitleChampionshipFactory extends Factory
      */
     public function forWrestler(?Wrestler $wrestler = null): static
     {
-        $wrestler = $wrestler ?? Wrestler::factory()->create();
+        if ($wrestler === null) {
+            return $this->for(Wrestler::factory(), 'champion');
+        }
 
-        return $this->state(function () use ($wrestler) {
-            return [
-                'champion_type' => $wrestler->getMorphClass(),
-                'champion_id' => $wrestler->id,
-            ];
-        });
+        return $this->for($wrestler, 'champion');
     }
 
     /**
@@ -61,14 +58,11 @@ class TitleChampionshipFactory extends Factory
      */
     public function forTagTeam(?TagTeam $tagTeam = null): static
     {
-        $tagTeam = $tagTeam ?? TagTeam::factory()->create();
+        if ($tagTeam === null) {
+            return $this->for(TagTeam::factory(), 'champion');
+        }
 
-        return $this->state(function () use ($tagTeam) {
-            return [
-                'champion_type' => $tagTeam->getMorphClass(),
-                'champion_id' => $tagTeam->id,
-            ];
-        });
+        return $this->for($tagTeam, 'champion');
     }
 
     /**
@@ -135,6 +129,7 @@ class TitleChampionshipFactory extends Factory
     public function current(): static
     {
         return $this->state([
+            'lost_match_id' => null,
             'lost_at' => null,
         ]);
     }

--- a/database/factories/Wrestlers/WrestlerFactory.php
+++ b/database/factories/Wrestlers/WrestlerFactory.php
@@ -121,8 +121,9 @@ class WrestlerFactory extends Factory
      */
     public function onCurrentTagTeam(?TagTeam $tagTeam = null): static
     {
-        $tagTeam ??= TagTeam::factory()->create();
-
-        return $this->hasAttached($tagTeam, ['joined_at' => now()->toDateTimeString()]);
+        return $this->hasAttached(
+            $tagTeam ?? TagTeam::factory(),
+            ['joined_at' => now()->toDateTimeString()],
+        );
     }
 }

--- a/tests/Unit/database/Factories/TagTeams/TagTeamFactoryTest.php
+++ b/tests/Unit/database/Factories/TagTeams/TagTeamFactoryTest.php
@@ -5,8 +5,13 @@ declare(strict_types=1);
 namespace Tests\Unit\Database\Factories\TagTeams;
 
 use App\Enums\Shared\EmploymentStatus;
+use App\Models\Lifecycle\Employment;
+use App\Models\Lifecycle\Retirement;
+use App\Models\Lifecycle\Suspension;
 use App\Models\TagTeams\TagTeam;
+use App\Models\Wrestlers\Wrestler;
 use Database\Factories\TagTeams\TagTeamFactory;
+use Illuminate\Support\Carbon;
 
 /**
  * Unit tests for TagTeamFactory data generation and state management.
@@ -46,6 +51,22 @@ describe('TagTeamFactory Unit Tests', function () {
     });
 
     describe('factory state methods', function () {
+        test('configuring relationship states does not persist related models', function (string $state) {
+            TagTeam::factory()->{$state}();
+
+            expect(Wrestler::query()->count())->toBe(0)
+                ->and(Employment::query()->count())->toBe(0)
+                ->and(Suspension::query()->count())->toBe(0)
+                ->and(Retirement::query()->count())->toBe(0);
+        })->with([
+            'employed',
+            'withFutureEmployment',
+            'suspended',
+            'retired',
+            'unemployed',
+            'released',
+        ]);
+
         test('employed state works correctly', function () {
             // Arrange & Act
             $tagTeam = TagTeam::factory()->employed()->create();
@@ -68,6 +89,14 @@ describe('TagTeamFactory Unit Tests', function () {
 
             // Assert
             expect($tagTeam->isRetired())->toBeTrue();
+        });
+
+        test('future employment aligns wrestler membership with the employment date', function () {
+            $tagTeam = TagTeam::factory()->withFutureEmployment()->create();
+
+            expect($tagTeam->currentWrestlers)->toHaveCount(2)
+                ->and($tagTeam->currentWrestlers->pluck('pivot.joined_at')->unique()->values()->all())
+                ->toEqual([Carbon::tomorrow()->toDateTimeString()]);
         });
     });
 

--- a/tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
+++ b/tests/Unit/database/Factories/Titles/TitleChampionshipFactoryTest.php
@@ -88,6 +88,15 @@ describe('TitleChampionshipFactory Unit Tests', function () {
             expect($championship->title_id)->toBe($title->id);
         });
 
+        test('configuring a champion relationship does not persist the champion', function (string $state, string $modelClass) {
+            TitleChampionship::factory()->{$state}();
+
+            expect($modelClass::query()->count())->toBe(0);
+        })->with([
+            ['forWrestler', Wrestler::class],
+            ['forTagTeam', TagTeam::class],
+        ]);
+
         test('past championship state works correctly', function () {
             // Arrange
             $wonDate = now()->subMonths(6);
@@ -148,6 +157,16 @@ describe('TitleChampionshipFactory Unit Tests', function () {
                 ->and($championship->lost_match_id)->toBe($lostEventMatch->id)
                 ->and($championship->won_at)->toEqual($wonEventMatch->event->date)
                 ->and($championship->lost_at)->toEqual($lostEventMatch->event->date);
+        });
+
+        test('current state clears an existing loss date and match', function () {
+            $championship = TitleChampionship::factory()
+                ->lostAtEventMatch()
+                ->current()
+                ->make();
+
+            expect($championship->lost_match_id)->toBeNull()
+                ->and($championship->lost_at)->toBeNull();
         });
     });
 

--- a/tests/Unit/database/Factories/Wrestlers/WrestlerFactoryTest.php
+++ b/tests/Unit/database/Factories/Wrestlers/WrestlerFactoryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Unit\Database\Factories;
 
 use App\Enums\Shared\EmploymentStatus;
+use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
 use App\ValueObjects\Height;
 use Database\Factories\Wrestlers\WrestlerFactory;
@@ -101,5 +102,11 @@ describe('wrestler factory states', function () {
         $wrestler = Wrestler::factory()->onCurrentTagTeam()->create();
 
         expect($wrestler->currentTagTeam)->not->toBeNull();
+    });
+
+    test('configuring a current tag team does not persist the team', function () {
+        Wrestler::factory()->onCurrentTagTeam();
+
+        expect(TagTeam::query()->count())->toBe(0);
     });
 });


### PR DESCRIPTION
## Summary
- defer related roster model creation until tag-team and wrestler factories are persisted
- align future tag-team membership dates with the scheduled employment start
- defer optional championship champion relationships and clear stale loss matches for current reigns
- add focused factory regression coverage

## Verification
- composer lint
- focused factory tests: 39 tests, 102 assertions
- composer test:push passed formatting, Rector, type coverage, application PHPStan, and Pest PHPStan; its final parallel Pest stage was stopped after several minutes without output