### PR TITLE
fix: secure Livewire dummy data generation

### DIFF
--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -63,6 +63,8 @@ trait GeneratesDummyData
      */
     public function fillDummyFields(): void
     {
+        abort_unless(app()->environment(['local', 'testing']), 404);
+
         $fields = $this->getDummyDataFields();
 
         foreach ($fields as $field => $generator) {

--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -39,13 +39,10 @@ class FormModal extends BaseFormModal
 
     protected function getDummyDataFields(): array
     {
-        /** @var Venue|null $venue */
-        $venue = Venue::query()->inRandomOrder()->first();
-
         return [
             'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
             'date' => fn () => fake()->dateTimeBetween('now', '+3 month')->format('Y-m-d H:i:s'),
-            'venue_id' => fn () => $venue?->id ?? Venue::factory()->create()->id, // @phpstan-ignore-line
+            'venue_id' => fn () => Venue::query()->inRandomOrder()->value('id'),
             'preview' => fn () => Str::of(fake()->text())->value(),
         ];
     }

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -176,10 +176,13 @@ class FormModal extends BaseFormModal
      */
     protected function generateRefereeAssignments(): array
     {
-        // Most matches have 1 referee, some special matches might have 2
         $refereeCount = fake()->randomFloat(null, 0, 1) < 0.9 ? 1 : 2;
 
-        return Referee::factory()->count($refereeCount)->create()->pluck('id')->toArray();
+        return Referee::query()
+            ->inRandomOrder()
+            ->limit($refereeCount)
+            ->pluck('id')
+            ->all();
     }
 
     /**
@@ -192,13 +195,15 @@ class FormModal extends BaseFormModal
      */
     protected function generateTitleAssignments(): array
     {
-        // 30% chance of being a championship match
         if (fake()->randomFloat(null, 0, 1) < 0.3) {
-            /** @phpstan-ignore-next-line */
-            return [Title::inRandomOrder()->first()?->id ?? Title::factory()->create()->id];
+            return Title::query()
+                ->inRandomOrder()
+                ->limit(1)
+                ->pluck('id')
+                ->all();
         }
 
-        return []; // Non-title match
+        return [];
     }
 
     /**
@@ -211,10 +216,13 @@ class FormModal extends BaseFormModal
      */
     protected function generateWrestlerAssignments(): array
     {
-        // For now, generate 2-4 wrestlers (singles to tag team)
         $wrestlerCount = fake()->numberBetween(2, 4);
 
-        return Wrestler::factory()->count($wrestlerCount)->create()->pluck('id')->toArray();
+        return Wrestler::query()
+            ->inRandomOrder()
+            ->limit($wrestlerCount)
+            ->pluck('id')
+            ->all();
     }
 
     /**

--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -54,16 +54,17 @@ class FormModal extends BaseFormModal
 
     protected function getDummyDataFields(): array
     {
-        /** @var Wrestler $wrestlerA */
-        /** @var Wrestler $wrestlerB */
-        [$wrestlerA, $wrestlerB] = Wrestler::factory()->count(2)->create();
+        $wrestlerIds = Wrestler::query()
+            ->inRandomOrder()
+            ->limit(2)
+            ->pluck('id');
 
         return [
             'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
             'signature_move' => fn () => Str::of(fake()->optional(0.8)->sentence(3))->title()->value(),
             'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
-            'wrestlerA' => fn () => $wrestlerA->id,
-            'wrestlerB' => fn () => $wrestlerB->id,
+            'wrestlerA' => fn () => $wrestlerIds->first(),
+            'wrestlerB' => fn () => $wrestlerIds->get(1),
         ];
     }
 

--- a/tests/Feature/Architecture/RuntimeBoundaryTest.php
+++ b/tests/Feature/Architecture/RuntimeBoundaryTest.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Symfony\Component\Finder\Finder;
+
+test('application runtime code does not create records through model factories', function () {
+    $factoryUsages = [];
+
+    foreach (Finder::create()->files()->in(app_path())->name('*.php') as $file) {
+        if (! str_contains($file->getContents(), '::factory(')) {
+            continue;
+        }
+
+        $factoryUsages[] = $file->getRelativePathname();
+    }
+
+    expect($factoryUsages)->toBeEmpty();
+});

--- a/tests/Feature/Workflows/EventManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/EventManagementWorkflowTest.php
@@ -162,6 +162,7 @@ describe('Event Creation and Scheduling Workflow', function () {
     test('event creation with dummy data workflow', function () {
         // Given: An authenticated administrator
         $admin = administrator();
+        Venue::factory()->create();
 
         // When: Opening create modal and using dummy data
         actingAs($admin);

--- a/tests/Integration/Livewire/TagTeams/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/TagTeams/Modals/FormModalTest.php
@@ -602,6 +602,16 @@ describe('TagTeams FormModal Tests', function () {
 
             expect($wrestlerA)->not->toBe($wrestlerB);
         });
+
+        test('dummy data does not persist additional wrestlers', function () {
+            Wrestler::factory()->count(5)->create();
+
+            testLivewire(FormModal::class)
+                ->call('openModal')
+                ->call('fillDummyFields');
+
+            expect(Wrestler::query()->count())->toBe(5);
+        });
     });
 
     describe('integration with employment system', function () {

--- a/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
+++ b/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Livewire\Concerns\GeneratesDummyData;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Tests\Integration\Livewire\Concerns\GeneratesDummyDataTest;
 
 /**
@@ -237,6 +238,28 @@ describe('GeneratesDummyData Unit Tests', function () {
     });
 
     describe('field population', function () {
+        test('rejects dummy data requests outside local and testing environments', function () {
+            $form = new class
+            {
+                use GeneratesDummyData;
+
+                public string $name = '';
+
+                protected function getDummyDataFields(): array
+                {
+                    return ['name' => 'Test Name'];
+                }
+            };
+
+            app()->detectEnvironment(fn () => 'production');
+
+            try {
+                expect(fn () => $form->fillDummyFields())->toThrow(NotFoundHttpException::class);
+            } finally {
+                app()->detectEnvironment(fn () => 'testing');
+            }
+        });
+
         test('populates fields directly on a form', function () {
             $form = new class
             {


### PR DESCRIPTION
## Summary
- reject Livewire dummy-data actions outside local and testing environments
- stop application runtime code from creating records through model factories
- sample existing wrestlers, referees, titles, and venues for development auto-fill
- enforce the runtime factory boundary with an architecture test

## Verification
- composer lint
- focused Livewire and workflow tests: 73 tests, 273 assertions
- composer test:types
- composer test:push passed type coverage, Rector, formatting, and both PHPStan configurations; final parallel Pest stage was stopped after a bounded silent wait