### PR TITLE
test: enforce lifecycle factory chronology

### DIFF
--- a/database/factories/Concerns/HasLifecyclePeriodStates.php
+++ b/database/factories/Concerns/HasLifecyclePeriodStates.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories\Concerns;
+
+use DateTimeInterface;
+use Illuminate\Support\Carbon;
+use InvalidArgumentException;
+
+trait HasLifecyclePeriodStates
+{
+    public function current(): static
+    {
+        return $this->state(fn (): array => ['ended_at' => null]);
+    }
+
+    public function started(Carbon $startedAt): static
+    {
+        return $this->state(fn (): array => ['started_at' => $startedAt]);
+    }
+
+    public function ended(Carbon $endedAt): static
+    {
+        return $this->state(function (array $attributes) use ($endedAt): array {
+            $startedAt = $this->parseLifecycleDate($attributes['started_at'] ?? null);
+
+            if ($endedAt->isBefore($startedAt)) {
+                throw new InvalidArgumentException('A lifecycle period cannot end before it starts.');
+            }
+
+            return ['ended_at' => $endedAt];
+        });
+    }
+
+    private function parseLifecycleDate(mixed $value): Carbon
+    {
+        if ($value instanceof DateTimeInterface || is_string($value) || is_int($value) || is_float($value)) {
+            return Carbon::parse($value);
+        }
+
+        throw new InvalidArgumentException('A lifecycle period requires a valid start date.');
+    }
+}

--- a/database/factories/Lifecycle/ActivityPeriodFactory.php
+++ b/database/factories/Lifecycle/ActivityPeriodFactory.php
@@ -7,12 +7,15 @@ namespace Database\Factories\Lifecycle;
 use App\Models\Lifecycle\ActivityPeriod;
 use App\Models\Stables\Stable;
 use App\Models\Titles\Title;
+use Database\Factories\Concerns\HasLifecyclePeriodStates;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
 /** @extends Factory<ActivityPeriod> */
 class ActivityPeriodFactory extends Factory
 {
+    use HasLifecyclePeriodStates;
+
     /** @return array<string, mixed> */
     public function definition(): array
     {
@@ -28,15 +31,5 @@ class ActivityPeriodFactory extends Factory
             Stable::factory(),
             Title::factory(),
         ]), 'activeable');
-    }
-
-    public function started(Carbon $startedAt): static
-    {
-        return $this->state(fn (): array => ['started_at' => $startedAt]);
-    }
-
-    public function ended(Carbon $endedAt): static
-    {
-        return $this->state(fn (): array => ['ended_at' => $endedAt]);
     }
 }

--- a/database/factories/Lifecycle/EmploymentFactory.php
+++ b/database/factories/Lifecycle/EmploymentFactory.php
@@ -9,6 +9,7 @@ use App\Models\Managers\Manager;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
+use Database\Factories\Concerns\HasLifecyclePeriodStates;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
@@ -17,6 +18,8 @@ use Illuminate\Support\Carbon;
  */
 class EmploymentFactory extends Factory
 {
+    use HasLifecyclePeriodStates;
+
     /**
      * Define the model's default state.
      *
@@ -40,23 +43,5 @@ class EmploymentFactory extends Factory
         ]);
 
         return $this->for($employableFactory, 'employable');
-    }
-
-    public function current(): static
-    {
-        return $this->state(fn (): array => [
-            'started_at' => Carbon::yesterday(),
-            'ended_at' => null,
-        ]);
-    }
-
-    public function started(Carbon $startedAt): static
-    {
-        return $this->state(fn (): array => ['started_at' => $startedAt]);
-    }
-
-    public function ended(Carbon $endedAt): static
-    {
-        return $this->state(fn (): array => ['ended_at' => $endedAt]);
     }
 }

--- a/database/factories/Lifecycle/InjuryFactory.php
+++ b/database/factories/Lifecycle/InjuryFactory.php
@@ -8,12 +8,15 @@ use App\Models\Lifecycle\Injury;
 use App\Models\Managers\Manager;
 use App\Models\Referees\Referee;
 use App\Models\Wrestlers\Wrestler;
+use Database\Factories\Concerns\HasLifecyclePeriodStates;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
 /** @extends Factory<Injury> */
 class InjuryFactory extends Factory
 {
+    use HasLifecyclePeriodStates;
+
     /** @return array<string, mixed> */
     public function definition(): array
     {
@@ -32,23 +35,5 @@ class InjuryFactory extends Factory
         ]);
 
         return $this->for($injurableFactory, 'injurable');
-    }
-
-    public function current(): static
-    {
-        return $this->state(fn (): array => [
-            'started_at' => Carbon::yesterday(),
-            'ended_at' => null,
-        ]);
-    }
-
-    public function started(Carbon $startedAt): static
-    {
-        return $this->state(fn (): array => ['started_at' => $startedAt]);
-    }
-
-    public function ended(Carbon $endedAt): static
-    {
-        return $this->state(fn (): array => ['ended_at' => $endedAt]);
     }
 }

--- a/database/factories/Lifecycle/RetirementFactory.php
+++ b/database/factories/Lifecycle/RetirementFactory.php
@@ -11,12 +11,15 @@ use App\Models\Stables\Stable;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\Title;
 use App\Models\Wrestlers\Wrestler;
+use Database\Factories\Concerns\HasLifecyclePeriodStates;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
 /** @extends Factory<Retirement> */
 class RetirementFactory extends Factory
 {
+    use HasLifecyclePeriodStates;
+
     /** @return array<string, mixed> */
     public function definition(): array
     {
@@ -38,23 +41,5 @@ class RetirementFactory extends Factory
         ]);
 
         return $this->for($retirableFactory, 'retirable');
-    }
-
-    public function current(): static
-    {
-        return $this->state(fn (): array => [
-            'started_at' => Carbon::yesterday(),
-            'ended_at' => null,
-        ]);
-    }
-
-    public function started(Carbon $startedAt): static
-    {
-        return $this->state(fn (): array => ['started_at' => $startedAt]);
-    }
-
-    public function ended(Carbon $endedAt): static
-    {
-        return $this->state(fn (): array => ['ended_at' => $endedAt]);
     }
 }

--- a/database/factories/Lifecycle/SuspensionFactory.php
+++ b/database/factories/Lifecycle/SuspensionFactory.php
@@ -9,12 +9,15 @@ use App\Models\Managers\Manager;
 use App\Models\Referees\Referee;
 use App\Models\TagTeams\TagTeam;
 use App\Models\Wrestlers\Wrestler;
+use Database\Factories\Concerns\HasLifecyclePeriodStates;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Support\Carbon;
 
 /** @extends Factory<Suspension> */
 class SuspensionFactory extends Factory
 {
+    use HasLifecyclePeriodStates;
+
     /** @return array<string, mixed> */
     public function definition(): array
     {
@@ -34,23 +37,5 @@ class SuspensionFactory extends Factory
         ]);
 
         return $this->for($suspendableFactory, 'suspendable');
-    }
-
-    public function current(): static
-    {
-        return $this->state(fn (): array => [
-            'started_at' => Carbon::yesterday(),
-            'ended_at' => null,
-        ]);
-    }
-
-    public function started(Carbon $startedAt): static
-    {
-        return $this->state(fn (): array => ['started_at' => $startedAt]);
-    }
-
-    public function ended(Carbon $endedAt): static
-    {
-        return $this->state(fn (): array => ['ended_at' => $endedAt]);
     }
 }

--- a/tests/Unit/database/Factories/Lifecycle/LifecyclePeriodFactoryStatesTest.php
+++ b/tests/Unit/database/Factories/Lifecycle/LifecyclePeriodFactoryStatesTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Lifecycle\ActivityPeriod;
+use App\Models\Lifecycle\Employment;
+use App\Models\Lifecycle\Injury;
+use App\Models\Lifecycle\Retirement;
+use App\Models\Lifecycle\Suspension;
+use App\Models\Managers\Manager;
+use App\Models\Referees\Referee;
+use App\Models\Wrestlers\Wrestler;
+use Database\Factories\Lifecycle\ActivityPeriodFactory;
+use Database\Factories\Lifecycle\EmploymentFactory;
+use Database\Factories\Lifecycle\InjuryFactory;
+use Database\Factories\Lifecycle\RetirementFactory;
+use Database\Factories\Lifecycle\SuspensionFactory;
+use Database\Factories\Managers\ManagerFactory;
+use Database\Factories\Referees\RefereeFactory;
+use Database\Factories\Wrestlers\WrestlerFactory;
+
+test('lifecycle period factories create valid date ranges', function (
+    ActivityPeriodFactory|EmploymentFactory|InjuryFactory|RetirementFactory|SuspensionFactory $factory,
+) {
+    $startedAt = now()->subMonth();
+    $endedAt = now()->subWeek();
+
+    $period = $factory
+        ->started($startedAt)
+        ->ended($endedAt)
+        ->makeOne();
+
+    expect($period->started_at->toDateTimeString())->toBe($startedAt->toDateTimeString())
+        ->and($period->ended_at?->toDateTimeString())->toBe($endedAt->toDateTimeString());
+})->with('lifecycle period factories');
+
+test('lifecycle period factories reject an end before the start', function (
+    ActivityPeriodFactory|EmploymentFactory|InjuryFactory|RetirementFactory|SuspensionFactory $factory,
+) {
+    $startedAt = now()->subWeek();
+    $endedAt = now()->subMonth();
+
+    expect(fn () => $factory->started($startedAt)->ended($endedAt)->makeOne())
+        ->toThrow(InvalidArgumentException::class, 'A lifecycle period cannot end before it starts.');
+})->with('lifecycle period factories');
+
+test('current lifecycle period state preserves its configured start', function (
+    ActivityPeriodFactory|EmploymentFactory|InjuryFactory|RetirementFactory|SuspensionFactory $factory,
+) {
+    $startedAt = now()->subMonth();
+
+    $period = $factory
+        ->started($startedAt)
+        ->ended(now()->subWeek())
+        ->current()
+        ->makeOne();
+
+    expect($period->started_at->toDateTimeString())->toBe($startedAt->toDateTimeString())
+        ->and($period->ended_at)->toBeNull();
+})->with('lifecycle period factories');
+
+test('individual lifecycle factory states do not combine injury and suspension', function (
+    ManagerFactory|RefereeFactory|WrestlerFactory $factory,
+    string $expectedCurrentPeriod,
+) {
+    $individual = $factory->createOne();
+
+    expect($individual->currentInjury()->exists())->toBe($expectedCurrentPeriod === 'injury')
+        ->and($individual->currentSuspension()->exists())->toBe($expectedCurrentPeriod === 'suspension');
+})->with([
+    'injured manager' => [fn (): ManagerFactory => Manager::factory()->injured(), 'injury'],
+    'suspended manager' => [fn (): ManagerFactory => Manager::factory()->suspended(), 'suspension'],
+    'injured referee' => [fn (): RefereeFactory => Referee::factory()->injured(), 'injury'],
+    'suspended referee' => [fn (): RefereeFactory => Referee::factory()->suspended(), 'suspension'],
+    'injured wrestler' => [fn (): WrestlerFactory => Wrestler::factory()->injured(), 'injury'],
+    'suspended wrestler' => [fn (): WrestlerFactory => Wrestler::factory()->suspended(), 'suspension'],
+]);
+
+dataset('lifecycle period factories', [
+    'activity period' => fn (): ActivityPeriodFactory => ActivityPeriod::factory(),
+    'employment' => fn (): EmploymentFactory => Employment::factory(),
+    'injury' => fn (): InjuryFactory => Injury::factory(),
+    'retirement' => fn (): RetirementFactory => Retirement::factory(),
+    'suspension' => fn (): SuspensionFactory => Suspension::factory(),
+]);


### PR DESCRIPTION
## Summary
- centralize lifecycle period factory states in one reusable concern
- reject lifecycle periods that end before they start
- preserve configured start dates when switching a period back to current
- verify named individual injury and suspension states remain mutually exclusive

## Verification
- composer lint
- focused lifecycle factory tests: 29 tests, 59 assertions
- composer test:types
- composer test:push passed type coverage, Rector, formatting, and both PHPStan configurations; final parallel Pest stage was stopped after a bounded silent wait