### PR TITLE
refactor: simplify Livewire form foundation

### DIFF
--- a/app/Livewire/Base/BaseForm.php
+++ b/app/Livewire/Base/BaseForm.php
@@ -6,296 +6,47 @@ namespace App\Livewire\Base;
 
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\ValidationException;
+use Livewire\Attributes\Locked;
 use Livewire\Form;
 
 /**
- * Abstract base class for Livewire form components.
- *
- * This base form provides common functionality for all Livewire forms in the application,
- * including model binding, form filling, and standardized validation patterns. It serves
- * as a foundation for creating consistent form experiences across different entities.
- *
- * The class establishes a standardized pattern for form management that includes:
- * - Consistent model binding and data population mechanisms
- * - Standardized validation rule and attribute definition patterns
- * - Common utility methods for form display and model interaction
- * - Extensible hooks for custom data loading and transformation
- * - Generic type support for maintaining type safety across implementations
- *
- * Key Design Principles:
- * - Template Method Pattern: Defines the skeleton of form operations while allowing
- *   subclasses to override specific steps (rules, validation attributes, data transformation)
- * - Single Responsibility: Each method has a focused purpose in the form lifecycle
- * - Extensibility: Provides hooks (loadExtraData) for custom implementations
- * - Type Safety: Uses generics to maintain type safety while allowing flexibility
- *
- * The class uses generics to maintain type safety while allowing flexibility for
- * different form implementations and their associated models. Child classes should
- * extend this base to inherit common form behaviors while implementing their
- * specific validation rules and data handling logic.
- *
- * @template TForm of BaseForm The concrete form class extending this base
- * @template TFormModel of Model|null The Eloquent model type this form manages
- *
- * @author Your Name
- *
- * @since 1.0.0
- * @see WrestlerForm For a comprehensive implementation example
- * @see EventForm For a simple implementation example
- * @see CreateEditForm For a complex relationship example
- *
- * @example
- * ```php
- * // Creating a concrete form implementation
- * class WrestlerForm extends BaseForm
- * {
- *     protected ?Model $formModel = null;
- *
- *     public string $name = '';
- *     public string $hometown = '';
- *     // ... other properties
- *
- *     protected function rules(): array
- *     {
- *         return [
- *             'name' => 'required|string|max:255',
- *             'hometown' => 'required|string|max:255',
- *         ];
- *     }
- *
- *     protected function getModelData(): array
- *     {
- *         return [
- *             'name' => $this->name,
- *             'hometown' => $this->hometown,
- *         ];
- *     }
- * }
- *
- * // Using in a Livewire component
- * class ManageWrestler extends Component
- * {
- *     public WrestlerForm $form;
- *
- *     public function mount(?Wrestler $wrestler = null): void
- *     {
- *         $this->form->setModel($wrestler);
- *     }
- *
- *     public function save(): void
- *     {
- *         $this->form->store();
- *         // Handle success response
- *     }
- * }
- * ```
+ * @template TForm of BaseForm
+ * @template TFormModel of Model|null
  */
 abstract class BaseForm extends Form
 {
-    /**
-     * The Eloquent model instance being managed by this form.
-     *
-     * This property holds the model that the form is either creating (null)
-     * or editing (populated model). The generic type TFormModel allows
-     * child classes to specify their exact model type while maintaining
-     * type safety throughout the application.
-     *
-     * State Management:
-     * - null: Form is in creation mode for new records
-     * - Model instance: Form is in edit mode for existing records
-     *
-     * The model serves as the source of truth for form data population
-     * and the target for data persistence operations.
-     *
-     * @var TFormModel The model instance or null for new records
-     */
+    /** @var TFormModel */
     protected ?Model $formModel = null;
 
-    /**
-     * The ID of the model being edited, or null for new records.
-     *
-     * This property persists across Livewire hydration cycles, ensuring
-     * that edit mode is maintained even when the formModel object reference
-     * is lost during Livewire's serialization/deserialization process.
-     *
-     * Made public so Livewire can properly hydrate this property.
-     *
-     * @var int|string|null The model's primary key value
-     */
+    #[Locked]
     public int|string|null $modelId = null;
 
-    /**
-     * A fallback field name for display purposes.
-     *
-     * Used by utility methods when a specific field name cannot be determined
-     * or when generating default display names for form elements. This provides
-     * a graceful fallback for error scenarios or incomplete data situations.
-     *
-     * @var string Default field name for fallback scenarios
-     */
-    protected string $fieldName = 'Unknown';
-
-    /**
-     * Set the model for this form and populate form fields.
-     *
-     * This method implements the Template Method pattern by defining the standard
-     * flow for model binding while allowing subclasses to customize specific steps
-     * through the loadExtraData() hook method.
-     *
-     * The method performs several critical operations:
-     * 1. Binds the model instance to the form state
-     * 2. Populates form fields using Livewire's automatic fill mechanism
-     * 3. Triggers custom data loading for specialized form requirements
-     *
-     * When null is passed, the form is prepared for creating a new record with
-     * default values. When a model is passed, the form is prepared for editing
-     * that record with its current data values populated into form fields.
-     *
-     * @param  TFormModel  $formModel  The model to bind to this form, or null for new records
-     *
-     * @see fill() Livewire's automatic form field population
-     * @see loadExtraData() Hook for custom data loading implementations
-     *
-     * @example
-     * ```php
-     * // Setting up form for editing an existing wrestler
-     * $wrestler = Wrestler::find(1);
-     * $form->setModel($wrestler);
-     * // Form fields are now populated with wrestler data
-     * // Custom loadExtraData() is called for additional setup
-     *
-     * // Setting up form for creating a new wrestler
-     * $form->setModel(null);
-     * // Form is ready for new record creation with default values
-     * ```
-     */
+    /** @param TFormModel $formModel */
     public function setModel(?Model $formModel): void
     {
         $this->formModel = $formModel;
         $this->modelId = $formModel?->getKey();
 
-        // Fill form fields from model attributes if model exists
-        if ($formModel) {
+        if ($formModel !== null) {
             $this->fill($formModel->getAttributes());
         }
 
         $this->loadExtraData();
     }
 
-    /**
-     * Determine if the form is in creation mode.
-     *
-     * Utility method to check the current form state for conditional logic
-     * in form components. Useful for displaying different UI elements,
-     * applying different validation rules, or handling different workflows
-     * based on whether the form is creating or editing.
-     *
-     * @return bool True if creating a new record, false if editing existing
-     *
-     * @example
-     * ```php
-     * // In a form component
-     * public function getSubmitButtonText(): string
-     * {
-     *     return $this->isCreating() ? 'Create Wrestler' : 'Update Wrestler';
-     * }
-     *
-     * // In validation logic
-     * public function store(): bool
-     * {
-     *     $wasCreating = $this->isCreating();
-     *     $result = $this->storeModel();
-     *
-     *     if ($wasCreating && $result) {
-     *         // Handle post-creation logic
-     *         $this->handleNewRecordTasks();
-     *     }
-     *
-     *     return $result;
-     * }
-     * ```
-     */
     public function isCreating(): bool
     {
         return $this->modelId === null;
     }
 
-    /**
-     * Determine if the form is in editing mode.
-     *
-     * Utility method to check if the form is currently editing an existing
-     * model instance. Complementary to isCreating() for complete state
-     * checking capabilities in form logic.
-     *
-     * @return bool True if editing an existing record, false if creating new
-     *
-     * @example
-     * ```php
-     * // In form validation
-     * if ($this->isEditing()) {
-     *     // Apply edit-specific validation rules
-     *     $this->validateEditConstraints();
-     * }
-     *
-     * // In UI rendering - use HTML comment style for Blade examples
-     * <!-- In Blade template: -->
-     * <!-- @if($form->isEditing()) -->
-     * <!--     <p>Last updated: {{ $form->formModel->updated_at }}</p> -->
-     * <!-- @endif -->
-     * ```
-     */
     public function isEditing(): bool
     {
-        return $this->formModel !== null;
+        return $this->modelId !== null;
     }
 
-    /**
-     * Generate a display name for editing based on a model field.
-     *
-     * This utility method safely extracts a field value from the bound model
-     * to create user-friendly display names, typically used in form headers,
-     * breadcrumbs, page titles, or any UI element that needs to display
-     * model-specific information.
-     *
-     * The method provides several layers of safety:
-     * 1. Checks if the model exists (handles creation mode gracefully)
-     * 2. Accesses the requested field directly so field access failures propagate
-     * 3. Handles null field values with appropriate fallbacks
-     * 4. Converts values to strings for display purposes
-     *
-     * @param  string  $fieldName  The name of the model field to extract
-     * @return string The field value as a string, or 'Unknown' when the model or value is null
-     *
-     * @example
-     * ```php
-     * // In a form component for page titles
-     * public function getPageTitle(): string
-     * {
-     *     if ($this->isEditing()) {
-     *         return "Edit " . $this->generateModelEditName('name');
-     *         // Returns: "Edit Stone Cold Steve Austin"
-     *     }
-     *     return "Create New Wrestler";
-     * }
-     *
-     * // Usage in Blade templates for breadcrumbs
-     * // <nav aria-label="breadcrumb">
-     * //     <ol class="breadcrumb">
-     * //         <li><a href="/wrestlers">Wrestlers</a></li>
-     * //         <li>{{ $form->generateModelEditName('name') }}</li>
-     * //     </ol>
-     * // </nav>
-     *
-     * // For form headers with context
-     * // <h1>
-     * //     {{ $form->isEditing() ? 'Edit ' . $form->generateModelEditName('name') : 'New Wrestler' }}
-     * // </h1>
-     * ```
-     */
     public function generateModelEditName(string $fieldName): string
     {
-        // Handle creation mode - no model available
-        if (! $this->formModel) {
+        if ($this->formModel === null) {
             return 'Unknown';
         }
 
@@ -304,151 +55,9 @@ abstract class BaseForm extends Form
         return (string) ($value ?? 'Unknown');
     }
 
-    /**
-     * Load additional data specific to the form implementation.
-     *
-     * This hook method implements part of the Template Method pattern by providing
-     * a customization point for subclasses to perform specialized data loading,
-     * transformation, or setup operations. It is called automatically after a
-     * model is set via setModel(), ensuring that all standard form population
-     * has completed before custom logic executes.
-     *
-     * The method is designed to be overridden by concrete form implementations
-     * that need to perform operations beyond simple field population, such as:
-     * - Converting stored data formats to form-friendly representations
-     * - Loading related model data that isn't automatically filled
-     * - Computing derived values for display purposes
-     * - Setting up default values for new records
-     * - Initializing complex form state based on model relationships
-     *
-     * Common Implementation Patterns:
-     *
-     * **Data Transformation**: Converting database storage formats to user-friendly
-     * form inputs (e.g., converting stored inches to feet/inches display format)
-     *
-     * **Relationship Loading**: Populating form fields with data from model
-     * relationships (e.g., loading employment start dates, match participants)
-     *
-     * **Computed Properties**: Calculating display values based on model data
-     * (e.g., age from birthdate, career statistics)
-     *
-     * **Conditional Setup**: Applying different initialization logic based on
-     * model state or user permissions
-     *
-     *
-     * @example
-     * ```php
-     * // In WrestlerForm - Data transformation example
-     * public function loadExtraData(): void
-     * {
-     *     if ($this->formModel) {
-     *         // Convert stored height (inches) to feet/inches for display
-     *         $height = $this->formModel->height;
-     *         $this->height_feet = (int) floor($height / 12);
-     *         $this->height_inches = $height % 12;
-     *
-     *         // Load employment start date from relationship
-     *         $this->start_date = $this->formModel->firstEmployment?->started_at;
-     *     } else {
-     *         // Set defaults for new records
-     *         $this->height_feet = 6;
-     *         $this->height_inches = 0;
-     *     }
-     * }
-     *
-     * // In CreateEditForm - Relationship loading example
-     * public function loadExtraData(): void
-     * {
-     *     if ($this->formModel) {
-     *         // Load many-to-many relationships as arrays
-     *         $this->wrestler_ids = $this->formModel->wrestlers->pluck('id')->toArray();
-     *         $this->referee_ids = $this->formModel->referees->pluck('id')->toArray();
-     *
-     *         // Load complex relationship data
-     *         $this->match_outcome_data = $this->formModel->outcome?->toFormData();
-     *     }
-     * }
-     *
-     * // In EventForm - Simple default setup example
-     * public function loadExtraData(): void
-     * {
-     *     if (!$this->formModel) {
-     *         // Set reasonable defaults for new events
-     *         $this->date = now()->addWeeks(2)->toDateString();
-     *         $this->start_time = '19:00';
-     *         $this->status = 'scheduled';
-     *     }
-     * }
-     * ```
-     *
-     * @see WrestlerForm::loadExtraData() For height conversion and employment loading
-     * @see CreateEditForm::loadExtraData() For relationship array population
-     * @see setModel() For the complete model binding workflow
-     */
-    protected function loadExtraData(): void
-    {
-        // Default implementation does nothing
-        // Child classes should override this method to implement custom loading logic
-    }
+    protected function loadExtraData(): void {}
 
-    /**
-     * Store model data with validation and persistence handling.
-     *
-     * This method provides the standard workflow for persisting form data to
-     * the database. It handles both creation and update operations seamlessly,
-     * applying validation and transforming form data into model-compatible
-     * format before persistence.
-     *
-     * The method implements a standardized flow:
-     * 1. Validate all form data using defined rules
-     * 2. Transform form data using getModelData() method
-     * 3. Create or update the model based on current form state
-     * 4. Return success status for UI feedback
-     *
-     * Child classes can override this method to add custom logic such as:
-     * - Additional validation steps
-     * - Related model creation/updates
-     * - Event broadcasting
-     * - Cache invalidation
-     * - Audit logging
-     *
-     *
-     * @throws ValidationException If validation fails
-     * @return bool True on successful storage, false on failure
-     *
-     * @see getModelData() For data transformation implementation
-     * @see rules() For validation rule definition
-     * @see WrestlerForm::store() For example with employment relationship handling
-     *
-     * @example
-     * ```php
-     * // Basic usage in a Livewire component
-     * public function save(): void
-     * {
-     *     if ($this->form->store()) {
-     *         session()->flash('message', 'Record saved successfully!');
-     *         $this->redirect('/wrestlers');
-     *     }
-     * }
-     *
-     * // Override in child class for custom logic
-     * public function store(): bool
-     * {
-     *     $this->validate();
-     *
-     *     $wasCreating = $this->isCreating();
-     *     $result = $this->storeModel();
-     *
-     *     if ($result && $wasCreating) {
-     *         // Handle post-creation tasks
-     *         $this->createInitialEmployment();
-     *         $this->sendWelcomeNotification();
-     *     }
-     *
-     *     return $result;
-     * }
-     * ```
-     */
+    /** @throws ValidationException */
     public function store(): bool
     {
         $this->validate();
@@ -456,297 +65,38 @@ abstract class BaseForm extends Form
         return $this->storeModel();
     }
 
-    /**
-     * Submit the form (alias for store method).
-     *
-     * Provides a convenient alias for the store method to match common
-     * form submission patterns and testing expectations.
-     *
-     * @return bool True on successful submission, false otherwise
-     */
-    public function submit(): bool
-    {
-        return $this->store();
-    }
-
-    /**
-     * Perform the actual model persistence operation.
-     *
-     * This method handles the low-level database operations for both creating
-     * new models and updating existing ones. It uses the getModelData() method
-     * to transform form data into model-compatible format and applies the
-     * appropriate persistence strategy based on the current form state.
-     *
-     * The method abstracts away the differences between creation and update
-     * operations, providing a consistent interface for child classes while
-     * handling the underlying Eloquent operations appropriately.
-     *
-     * For creation operations:
-     * - Creates a new model instance with the provided data
-     * - Saves the new instance to the database
-     * - Updates formModel property with the new instance
-     *
-     * For update operations:
-     * - Updates the existing model with new data
-     * - Saves changes to the database
-     * - Maintains the existing model reference
-     *
-     *
-     * @return bool True if the model was successfully saved, false otherwise
-     *
-     * @see getModelData() For data transformation requirements
-     * @see isCreating() For operation mode detection
-     *
-     * @example
-     * ```php
-     * // Called automatically by store() method
-     * public function store(): bool
-     * {
-     *     $this->validate();
-     *
-     *     // This will call storeModel() internally
-     *     $result = $this->storeModel();
-     *
-     *     if ($result) {
-     *         // Handle successful save
-     *         $this->handlePostSaveOperations();
-     *     }
-     *
-     *     return $result;
-     * }
-     * ```
-     */
     protected function storeModel(): bool
     {
-        $data = $this->getModelData();
-
         if ($this->isCreating()) {
-            // Create new model instance
             $modelClass = $this->getModelClass();
-            $this->formModel = $modelClass::create($data);
+            $this->formModel = $modelClass::query()->create($this->getModelData());
             $this->modelId = $this->formModel->getKey();
-        } else {
-            // Update existing model
-            // Ensure we have the model instance - reload if necessary
-            if (! $this->formModel && $this->modelId) {
-                $modelClass = $this->getModelClass();
-                $this->formModel = $modelClass::findOrFail($this->modelId);
-            }
 
-            $this->formModel->update($data);
+            return true;
         }
+
+        if ($this->formModel === null) {
+            $modelClass = $this->getModelClass();
+            $this->formModel = $modelClass::query()->findOrFail($this->modelId);
+        }
+
+        $this->formModel->update($this->getModelData());
 
         return true;
     }
 
-    /**
-     * Transform form data into model-compatible format.
-     *
-     * This abstract method must be implemented by child classes to define how
-     * form fields are transformed into data suitable for model persistence.
-     * The method serves as a data transformation layer between the form's
-     * user-friendly representation and the model's storage requirements.
-     *
-     * The method should return an associative array where keys correspond to
-     * model attributes and values are the transformed form data. This allows
-     * for complex data transformations, calculations, and format conversions
-     * before database storage.
-     *
-     * Common transformation patterns include:
-     * - Converting display formats to storage formats
-     * - Combining multiple form fields into single model attributes
-     * - Applying business logic calculations
-     * - Filtering out fields that shouldn't be mass-assigned
-     * - Converting user input to appropriate data types
-     *
-     * @return array<string, mixed> Model data ready for persistence
-     *
-     * @example
-     * ```php
-     * // In WrestlerForm - Complex transformation example
-     * protected function getModelData(): array
-     * {
-     *     // Convert feet/inches to total inches for storage
-     *     $height = new Height($this->height_feet, $this->height_inches);
-     *
-     *     return [
-     *         'name' => $this->name,
-     *         'hometown' => $this->hometown,
-     *         'height' => $height->toInches(), // Transform to storage format
-     *         'weight' => $this->weight,
-     *         'signature_move' => $this->signature_move,
-     *         // Note: employment data excluded - handled separately
-     *     ];
-     * }
-     *
-     * // In EventForm - Simple mapping example
-     * protected function getModelData(): array
-     * {
-     *     return [
-     *         'name' => $this->name,
-     *         'date' => $this->date,
-     *         'venue' => $this->venue,
-     *         'capacity' => $this->capacity,
-     *         'ticket_price' => $this->ticket_price * 100, // Convert to cents
-     *     ];
-     * }
-     *
-     * // In CreateEditForm - Relationship exclusion example
-     * protected function getModelData(): array
-     * {
-     *     return [
-     *         'event_id' => $this->event_id,
-     *         'match_type' => $this->match_type,
-     *         'scheduled_duration' => $this->scheduled_duration,
-     *         'notes' => $this->notes,
-     *         // wrestler_ids handled separately in relationships
-     *     ];
-     * }
-     * ```
-     *
-     * @see storeModel() For usage in persistence workflow
-     * @see WrestlerForm::getModelData() For complex transformation example
-     */
+    /** @return array<string, mixed> */
     abstract protected function getModelData(): array;
 
-    /**
-     * Define validation rules for form fields.
-     *
-     * This abstract method must be implemented by child classes to specify
-     * the validation rules for their form fields. The method should return
-     * an array of Laravel validation rules that will be applied during the
-     * form submission process.
-     *
-     * The validation rules array follows Laravel's standard format where
-     * keys are field names and values are arrays of validation rules.
-     * Rules can include built-in Laravel validators, custom rule objects,
-     * conditional rules, and database uniqueness constraints.
-     *
-     * Child classes should implement comprehensive validation including:
-     * - Required field validation
-     * - Data type and format validation
-     * - Uniqueness constraints with proper model exclusion for updates
-     * - Custom business logic validation
-     * - Conditional validation based on form state
-     *
-     * @return array<string, array<int, mixed>> Laravel validation rules array
-     *
-     * @example
-     * ```php
-     * // In WrestlerForm - Comprehensive validation example
-     * protected function rules(): array
-     * {
-     *     return [
-     *         'name' => [
-     *             'required',
-     *             'string',
-     *             'max:255',
-     *             Rule::unique('wrestlers', 'name')->ignore($this->formModel)
-     *         ],
-     *         'hometown' => ['required', 'string', 'max:255'],
-     *         'height_feet' => ['required', 'integer', 'min:5', 'max:7'],
-     *         'height_inches' => ['required', 'integer', 'min:0', 'max:11'],
-     *         'weight' => ['required', 'integer', 'digits:3'],
-     *         'signature_move' => [
-     *             'nullable',
-     *             'string',
-     *             'max:255',
-     *             Rule::unique('wrestlers', 'signature_move')->ignore($this->formModel)
-     *         ],
-     *         'start_date' => [
-     *             'nullable',
-     *             'date',
-     *             new CanChangeEmploymentDate($this->formModel)
-     *         ],
-     *     ];
-     * }
-     *
-     * // In EventForm - Simpler validation example
-     * protected function rules(): array
-     * {
-     *     return [
-     *         'name' => ['required', 'string', 'max:255'],
-     *         'date' => ['required', 'date', 'after:today'],
-     *         'venue' => ['required', 'string', 'max:255'],
-     *         'capacity' => ['required', 'integer', 'min:50'],
-     *     ];
-     * }
-     * ```
-     *
-     * @see store() For validation usage in storage workflow
-     * @see validationAttributes() For custom field name definitions
-     */
+    /** @return array<string, array<int, mixed>> */
     abstract protected function rules(): array;
 
-    /**
-     * Define user-friendly attribute names for validation messages.
-     *
-     * This method allows child classes to provide custom field names that
-     * will be used in validation error messages instead of the actual form
-     * property names. This improves user experience by showing intuitive,
-     * readable field names in error messages.
-     *
-     * The method should return an array where keys are form property names
-     * and values are the user-friendly names that should appear in validation
-     * error messages. Only fields that need custom names need to be included;
-     * fields not specified will use their property names as-is.
-     *
-     * This is particularly useful for:
-     * - Converting technical field names to user-friendly terms
-     * - Providing proper capitalization and spacing
-     * - Using domain-specific terminology that users understand
-     * - Improving accessibility and user experience
-     *
-     * @return array<string, string> Field name mappings for validation messages
-     *
-     * @example
-     * ```php
-     * // In WrestlerForm - Technical to friendly mapping
-     * protected function validationAttributes(): array
-     * {
-     *     return [
-     *         'height_feet' => 'feet',
-     *         'height_inches' => 'inches',
-     *         'signature_move' => 'signature move',
-     *         'start_date' => 'start date',
-     *     ];
-     * }
-     * // Error message: "The feet field is required" instead of "The height_feet field is required"
-     *
-     * // In CreateEditForm - Domain terminology example
-     * protected function validationAttributes(): array
-     * {
-     *     return [
-     *         'wrestler_ids' => 'participating wrestlers',
-     *         'referee_id' => 'assigned referee',
-     *         'match_type' => 'match type',
-     *         'scheduled_duration' => 'scheduled duration',
-     *     ];
-     * }
-     * ```
-     *
-     * @see rules() For validation rule definitions
-     */
+    /** @return array<string, string> */
     protected function validationAttributes(): array
     {
         return [];
     }
 
-    /**
-     * Get the model class name for this form.
-     *
-     * This method should return the fully qualified class name of the model
-     * that this form manages. Used for creating new model instances.
-     *
-     * @return string The fully qualified model class name
-     *
-     * @example
-     * ```php
-     * protected function getModelClass(): string
-     * {
-     *     return Event::class;
-     * }
-     * ```
-     */
+    /** @return class-string<Model> */
     abstract protected function getModelClass(): string;
 }

--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -8,363 +8,76 @@ use App\Livewire\Concerns\GeneratesDummyData;
 use Illuminate\Database\Eloquent\Model;
 
 /**
- * Base class for all form modals with essential functionality.
- *
- * This base class provides a standardized foundation for creating modal dialogs
- * that contain forms for creating or editing Eloquent models. It combines the
- * modal functionality from BaseModal with form-specific features like dummy
- * data generation for development and testing purposes.
- *
- * The class follows a simple template method pattern where child classes provide
- * configuration details (form class, model class, modal path) while this base
- * class handles the common modal lifecycle and integration with the dummy data
- * generation system.
- *
- * Key Features:
- * - Seamless integration with BaseModal for consistent modal behavior
- * - Automatic dummy data generation via GeneratesDummyData trait
- * - Type-safe form and model class specification
- * - Simplified configuration through abstract methods
- * - Proper Livewire component lifecycle management
- *
- * Design Philosophy:
- * - Composition over complexity: Uses traits for specialized functionality
- * - Configuration over convention: Child classes specify their requirements
- * - Fail fast: Let individual components handle their own validation
- * - Single responsibility: Focus on modal-specific concerns
- *
- * @template TForm of BaseForm The form class this modal manages
- * @template TModel of Model The Eloquent model type this modal creates/edits
+ * @template TForm of BaseForm
+ * @template TModel of Model
  *
  * @extends BaseModal<TForm, TModel>
- *
- * @author Your Name
- *
- * @since 1.0.0
- * @see BaseModal For core modal functionality and lifecycle management
- * @see GeneratesDummyData For dummy data generation capabilities
- * @see BaseForm For form implementation requirements
- *
- * @example
- * ```php
- * // Creating a wrestler form modal
- * class FormModal extends BaseFormModal
- * {
- *     protected function getFormClass(): string
- *     {
- *         return WrestlerForm::class;
- *     }
- *
- *     protected function getModelClass(): string
- *     {
- *         return Wrestler::class;
- *     }
- *
- *     protected function getModalPath(): string
- *     {
- *         return 'modals.wrestler-form';
- *     }
- *
- *     protected function getDummyDataFields(): array
- *     {
- *         return [
- *             'name' => fn() => $this->generateWrestlingName(),
- *             'hometown' => fn() => fake()->city(),
- *             'weight' => fn() => fake()->numberBetween(150, 300),
- *             'signature_move' => fn() => $this->generateSignatureMove(),
- *         ];
- *     }
- * }
- *
- * // Usage in a Livewire component
- * class ManageWrestlers extends Component
- * {
- *     public FormModal $modal;
- *
- *     public function createWrestler(): void
- *     {
- *         $this->modal->openModal();
- *     }
- *
- *     public function editWrestler(int $wrestlerId): void
- *     {
- *         $this->modal->openModal($wrestlerId);
- *     }
- * }
- *
- * // In Blade template
- * <button wire:click="createWrestler">Add Wrestler</button>
- * <button wire:click="modal.fillDummyFields">Fill Test Data</button>
- * ```
  */
 abstract class BaseFormModal extends BaseModal
 {
     use GeneratesDummyData;
 
-    /**
-     * Get the form class that this modal will instantiate and manage.
-     *
-     * Returns the fully qualified class name of the Livewire form that will
-     * handle the creation or editing of models within this modal. The form
-     * must extend BaseForm to ensure compatibility with the modal's
-     * lifecycle and data binding patterns.
-     *
-     * This method is called during modal initialization to set up the proper
-     * form instance for handling user input and model persistence.
-     *
-     * @return class-string<TForm> Fully qualified form class name
-     *
-     * @example
-     * ```php
-     * protected function getFormClass(): string
-     * {
-     *     return WrestlerForm::class;
-     * }
-     *
-     * // For more complex scenarios:
-     * protected function getFormClass(): string
-     * {
-     *     // Could return different forms based on context
-     *     return $this->isAdvancedMode()
-     *         ? AdvancedWrestlerForm::class
-     *         : WrestlerForm::class;
-     * }
-     * ```
-     *
-     * @see BaseForm For form implementation requirements
-     * @see mount() For when this method is called during initialization
-     */
     abstract protected function getFormClass(): string;
 
-    /**
-     * Get the Eloquent model class that this modal creates or edits.
-     *
-     * Returns the fully qualified class name of the Eloquent model that this
-     * modal's form will create (when opened without parameters) or edit (when
-     * opened with a model ID). This class is used for type safety and proper
-     * model resolution during the modal lifecycle.
-     *
-     * The model class must extend Illuminate\Database\Eloquent\Model and should
-     * be compatible with the form class returned by getFormClass().
-     *
-     * @return class-string<TModel> Fully qualified model class name
-     *
-     * @example
-     * ```php
-     * protected function getModelClass(): string
-     * {
-     *     return Wrestler::class;
-     * }
-     *
-     * // For polymorphic scenarios:
-     * protected function getModelClass(): string
-     * {
-     *     return match($this->entityType) {
-     *         'wrestler' => Wrestler::class,
-     *         'manager' => Manager::class,
-     *         default => throw new \InvalidArgumentException('Unknown entity type')
-     *     };
-     * }
-     * ```
-     *
-     * @see Model For base model requirements
-     * @see BaseModal For how model classes are used in modal lifecycle
-     */
     abstract protected function getModelClass(): string;
 
-    /**
-     * Get the Blade view path for rendering this modal.
-     *
-     * Returns the view path (relative to resources/views) that contains the
-     * Blade template for this modal's UI. The view should include the modal
-     * structure, form fields, and any modal-specific styling or JavaScript.
-     *
-     * The path follows Laravel's dot notation convention for nested directories
-     * and should not include the .blade.php extension.
-     *
-     * @return string Blade view path using dot notation
-     *
-     * @example
-     * ```php
-     * protected function getModalPath(): string
-     * {
-     *     return 'modals.wrestler-form';
-     *     // Corresponds to: resources/views/modals/wrestler-form.blade.php
-     * }
-     *
-     * // For organized view structures:
-     * protected function getModalPath(): string
-     * {
-     *     return 'livewire.modals.forms.wrestler';
-     *     // Corresponds to: resources/views/livewire/modals/forms/wrestler.blade.php
-     * }
-     *
-     * // For dynamic view selection:
-     * protected function getModalPath(): string
-     * {
-     *     $baseView = 'modals.wrestler';
-     *     return $this->isCompactMode() ? $baseView . '-compact' : $baseView . '-full';
-     * }
-     * ```
-     *
-     * @see mount() For when this path is set during modal initialization
-     */
     abstract protected function getModalPath(): string;
 
-    /*
-     * The concrete form property is declared by each subclass so that PHP
-     * (which enforces invariant property types between parent and child)
-     * and Livewire 4 (which uses the declared type to rehydrate the form
-     * instance between requests) can work with a concrete BaseForm
-     * subclass — e.g. `public WrestlerForm $form;`.
-     */
-
-    /**
-     * Indicates if the modal is currently open.
-     */
     public bool $isModalOpen = false;
 
-    /**
-     * Open the modal.
-     */
     public function openModal(mixed $modelId = null): void
     {
-        // Ensure proper initialization if mount wasn't called
-        if (! isset($this->modalFormPath)) {
-            $this->mount($modelId);
-        } else {
-            // Always re-mount to ensure proper form state
-            $this->mount($modelId);
-        }
-
+        $this->mount($modelId);
         $this->isModalOpen = true;
     }
 
-    /**
-     * Close the modal.
-     */
     public function closeModal(): void
     {
         $this->isModalOpen = false;
     }
 
-    /**
-     * Save method for backward compatibility with tests.
-     *
-     * This method delegates to submitForm() to maintain compatibility
-     * with existing test patterns while using the new BaseFormModal API.
-     */
     public function save(): void
     {
         $this->submitForm();
     }
 
-    /**
-     * Submit the form through the modal.
-     *
-     * This method provides a bridge for testing that allows calling
-     * form submission directly on the modal component.
-     */
     public function submitForm(): bool
     {
-        // Ensure form has the correct model before submission
-        // This handles cases where Livewire form property hydration
-        // loses the model state between mount and submission
-        if (isset($this->model) && $this->form !== null) {
+        if ($this->model !== null) {
             $this->form->setModel($this->model);
         }
 
-        $result = $this->storeForm();
-
-        if ($result) {
-            $this->dispatch('refreshDatatable');
-            $this->closeModal();
-            $this->dispatch('closeModal');
-            $this->dispatch('form-submitted');
+        if (! $this->storeForm()) {
+            return false;
         }
 
-        return $result;
+        $this->dispatch('refreshDatatable');
+        $this->closeModal();
+        $this->dispatch('closeModal');
+        $this->dispatch('form-submitted');
+
+        return true;
     }
 
-    /**
-     * Persist the form through its default storage workflow.
-     *
-     * Specialized modals may override this hook to delegate persistence to
-     * application actions while retaining the shared modal submission flow.
-     */
     protected function storeForm(): bool
     {
         return $this->form->store();
     }
 
-    /**
-     * Initialize the modal with proper configuration and lifecycle setup.
-     *
-     * This method extends the parent BaseModal::mount() to add form-specific
-     * initialization including setting the modal view path and ensuring proper
-     * integration with the form and dummy data systems.
-     *
-     * The method is called automatically by Livewire when the component is
-     * instantiated, whether for creating new records (modelId = null) or
-     * editing existing ones (modelId provided).
-     *
-     * Initialization Flow:
-     * 1. Set modal view path from getModalPath()
-     * 2. Call parent mount() for core modal setup
-     * 3. Form and model binding handled by parent class
-     * 4. Dummy data capabilities available via trait
-     *
-     * @param  mixed  $modelId  The ID of the model to edit, or null for creation mode
-     *
-     * @example
-     * ```php
-     * // Called automatically by Livewire:
-     * // - When opening modal for new record: mount(null)
-     * // - When opening modal for editing: mount(123)
-     *
-     * // In parent component:
-     * public function openCreateModal(): void
-     * {
-     *     $this->modal->mount(); // Triggers mount(null)
-     * }
-     *
-     * public function openEditModal(int $id): void
-     * {
-     *     $this->modal->mount($id); // Triggers mount($id)
-     * }
-     * ```
-     *
-     * @see BaseModal::mount() For core modal initialization logic
-     * @see getModalPath() For view path configuration
-     */
     public function mount(mixed $modelId = null): void
     {
         $this->modalFormPath = $this->getModalPath();
 
-        // Initialize the model type
         $modelClass = $this->getModelClass();
         $this->modelType = new $modelClass();
 
-        // Initialize the form if it doesn't exist (Livewire auto-initialization)
-        if ($this->form === null) {
+        if (! isset($this->form)) {
             $formClass = $this->getFormClass();
             $this->form = new $formClass($this, 'form');
         }
 
-        // Set the form as the modelForm for BaseModal compatibility
-        // IMPORTANT: Ensure both properties reference the same instance
         $this->modelForm = $this->form;
 
-        // Set default title fields
-        $this->modelTitleField = 'name';
-        $this->titleField = 'name';
-
         parent::mount($modelId);
-
-        // Ensure the form property also has the model if one was loaded
-        // This is critical because Livewire manages $this->form separately
-        if (isset($modelId) && isset($this->model)) {
-            $this->form->setModel($this->model);
-        }
     }
 }

--- a/app/Livewire/Base/BaseModal.php
+++ b/app/Livewire/Base/BaseModal.php
@@ -5,154 +5,58 @@ declare(strict_types=1);
 namespace App\Livewire\Base;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\View\View;
 use LivewireUI\Modal\ModalComponent;
 
 /**
- * Base class for all modal components.
- *
- * This abstract class provides the foundation for all modal dialog components
- * in the application. It handles the common modal lifecycle, form integration,
- * and provides a consistent interface for modal operations across different
- * entity types.
- *
- * The class is designed to work seamlessly with BaseForm implementations,
- * providing a standardized way to display forms within modal dialogs while
- * maintaining proper state management and user experience patterns.
- *
- * Key Features:
- * - Seamless integration with BaseForm classes
- * - Automatic modal title generation based on operation type
- * - Proper model binding and form state management
- * - Event dispatching for component communication
- * - Consistent modal lifecycle management
- * - Type safety through generics
- *
  * @template TModelForm of BaseForm
  * @template TModelType of Model
- *
- * @see BaseForm For form integration requirements
- * @see BaseFormModal For form-specific modal implementation
  */
 abstract class BaseModal extends ModalComponent
 {
-    /**
-     * @var TModelType|null
-     */
-    protected ?Model $model;
+    /** @var TModelType|null */
+    protected ?Model $model = null;
 
-    /**
-     * @var TModelForm|null
-     */
+    /** @var TModelForm */
     protected BaseForm $modelForm;
 
-    /**
-     * @var TModelType
-     */
+    /** @var TModelType */
     protected Model $modelType;
 
     protected string $modalFormPath;
 
-    protected string $modelTitleField;
+    protected string $modelTitleField = 'name';
 
-    protected string $titleField;
-
-    /**
-     * Initialize the modal with proper configuration and lifecycle setup.
-     *
-     * This method is called automatically by Livewire when the modal component
-     * is instantiated. It handles the initial setup including model loading,
-     * form binding, and state preparation for both create and edit operations.
-     *
-     * @param  int|string|null  $modelId  The ID of the model to edit, or null for creation mode
-     */
     public function mount(int|string|null $modelId = null): void
     {
-        if ($modelId !== null) {
-            $id = is_numeric($modelId) ? (int) $modelId : $modelId;
-            $this->model = $this->modelType::findOrFail($id);
-            $this->modelForm->setModel($this->model);
-        } else {
-            // Reset to create mode
+        if ($modelId === null) {
             $this->model = null;
             $this->modelForm->reset();
+
+            return;
         }
+
+        $id = is_numeric($modelId) ? (int) $modelId : $modelId;
+        $this->model = $this->modelType::query()->findOrFail($id);
+        $this->modelForm->setModel($this->model);
     }
 
-    /**
-     * Generate the modal title based on the current operation.
-     *
-     * Creates user-friendly modal titles that indicate whether the user is
-     * creating a new record or editing an existing one. For edit operations,
-     * it attempts to include the model's display name for better context.
-     *
-     * @return string The generated modal title
-     */
     public function getModalTitle(): string
     {
-        if (isset($this->model)) {
+        if ($this->model !== null) {
             return 'Edit '.$this->modelForm->generateModelEditName($this->modelTitleField);
         }
 
         return 'Add '.(isset($this->modelType) ? class_basename($this->modelType) : 'Record');
     }
 
-    /**
-     * Clear the form and reset it to the appropriate state.
-     *
-     * Resets the form to its initial state, either with the bound model data
-     * (for edit operations) or to empty state (for create operations).
-     */
     public function clear(): void
     {
-        if ($this->modelForm === null) {
-            return; // Cannot clear if form is not initialized
-        }
-
         if ($this->model !== null) {
             $this->modelForm->setModel($this->model);
-        } else {
-            $this->modelForm->reset();
-        }
-    }
 
-    /**
-     * Save the form data and handle the modal lifecycle.
-     *
-     * Processes the form submission, and if successful, dispatches events
-     * to refresh related components and closes the modal. This provides
-     * a consistent save workflow across all modal implementations.
-     */
-    public function save(): void
-    {
-        if ($this->modelForm->store()) {
-            $this->dispatch('refreshDatatable');
-
-            $this->closeModal();
-        }
-    }
-
-    /**
-     * Render the modal view.
-     *
-     * Returns the appropriate view for the modal, with fallback handling
-     * for missing views to prevent errors during development.
-     *
-     * @return View The rendered modal view
-     */
-    public function render(): View
-    {
-        // Ensure modalFormPath is set
-        if (! isset($this->modalFormPath)) {
-            $this->modalFormPath = 'blank';
+            return;
         }
 
-        $view = 'livewire.'.$this->modalFormPath;
-
-        if (! view()->exists($view)) {
-            $view = 'blank';
-        }
-
-        return view($view);
+        $this->modelForm->reset();
     }
 }

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -23,7 +23,6 @@ class FormModal extends BaseFormModal
 
         // Override title field to use full_name for managers
         $this->modelTitleField = 'full_name';
-        $this->titleField = 'full_name';
     }
 
     public CreateEditForm $form;

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -56,7 +56,6 @@ class FormModal extends BaseFormModal
 
         // Set the title field to use full_name instead of name
         $this->modelTitleField = 'full_name';
-        $this->titleField = 'full_name';
     }
 
     public function openModal(mixed $modelId = null): void

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27,20 +27,8 @@ parameters:
 		-
 			message: '#^Access to an undefined property App\\Livewire\\Base\\BaseFormModal\<TForm of App\\Livewire\\Base\\BaseForm, TModel of Illuminate\\Database\\Eloquent\\Model\>\:\:\$form\.$#'
 			identifier: property.notFound
-			count: 4
+			count: 3
 			path: app/Livewire/Base/BaseFormModal.php
-
-		-
-			message: '#^PHPDoc tag @var for property App\\Livewire\\Base\\BaseModal\:\:\$modelForm with type \(TModelForm of App\\Livewire\\Base\\BaseForm\)\|null is not subtype of native type App\\Livewire\\Base\\BaseForm\.$#'
-			identifier: property.phpDocType
-			count: 1
-			path: app/Livewire/Base/BaseModal.php
-
-		-
-			message: '#^Strict comparison using \=\=\= between TModelForm of App\\Livewire\\Base\\BaseForm and null will always evaluate to false\.$#'
-			identifier: identical.alwaysFalse
-			count: 1
-			path: app/Livewire/Base/BaseModal.php
 
 		-
 			message: '#^Access to an undefined property Illuminate\\Database\\Eloquent\\Model\:\:\$first_name\.$#'

--- a/tests/Unit/Livewire/Base/BaseFormModalTest.php
+++ b/tests/Unit/Livewire/Base/BaseFormModalTest.php
@@ -120,8 +120,6 @@ describe('BaseFormModal Unit Tests', function () {
             expect($docComment)->toContain('TForm of BaseForm');
             expect($docComment)->toContain('TModel of Model');
             expect($docComment)->toContain('@extends BaseModal');
-            expect($docComment)->toContain('@see BaseModal');
-            expect($docComment)->toContain('@see GeneratesDummyData');
         });
     });
 

--- a/tests/Unit/Livewire/Base/LivewireBaseFormTest.php
+++ b/tests/Unit/Livewire/Base/LivewireBaseFormTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Livewire\Base\BaseForm;
+use Livewire\Attributes\Locked;
 use Livewire\Form;
 use Tests\Integration\Livewire\Base\BaseFormTest;
 
@@ -69,7 +70,7 @@ describe('BaseForm Unit Tests', function () {
             $concreteMethodNames = array_map(fn ($method) => $method->getName(), $concreteMethods);
 
             expect($concreteMethodNames)->toContain('fill');
-            expect($concreteMethodNames)->toContain('submit');
+            expect($concreteMethodNames)->toContain('store');
             expect($concreteMethodNames)->toContain('validationAttributes');
         });
     });
@@ -85,6 +86,12 @@ describe('BaseForm Unit Tests', function () {
             expect($formModelProperty->hasType())->toBeTrue();
             expect(reflectionTypeName($formModelProperty))->toBe('Illuminate\\Database\\Eloquent\\Model');
             expect(requiredReflectionType($formModelProperty->getType())->allowsNull())->toBeTrue();
+        });
+
+        test('locks the model identifier against client-side changes', function () {
+            $property = new ReflectionProperty(BaseForm::class, 'modelId');
+
+            expect($property->getAttributes(Locked::class))->toHaveCount(1);
         });
     });
 
@@ -102,7 +109,7 @@ describe('BaseForm Unit Tests', function () {
             // Should have concrete methods for common workflow
             $concreteMethods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED);
             $concreteMethodNames = array_map(fn ($method) => $method->getName(), $concreteMethods);
-            expect($concreteMethodNames)->toContain('submit');
+            expect($concreteMethodNames)->toContain('store');
             expect($concreteMethodNames)->toContain('fill');
         });
     });
@@ -144,10 +151,6 @@ describe('BaseForm Unit Tests', function () {
             expect($docComment)->toContain('@template');
             expect($docComment)->toContain('TForm of BaseForm');
             expect($docComment)->toContain('TFormModel of Model');
-            expect($docComment)->toContain('@author');
-            expect($docComment)->toContain('@since');
-            expect($docComment)->toContain('@see');
-            expect($docComment)->toContain('@example');
         });
     });
 

--- a/tests/Unit/Livewire/Concerns/BaseModalTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseModalTest.php
@@ -77,7 +77,6 @@ describe('BaseModal Unit Tests', function () {
 
             expect($reflection->hasProperty('modalFormPath'))->toBeTrue();
             expect($reflection->hasProperty('modelTitleField'))->toBeTrue();
-            expect($reflection->hasProperty('titleField'))->toBeTrue();
 
             $modalFormPath = $reflection->getProperty('modalFormPath');
             expect($modalFormPath->isProtected())->toBeTrue();
@@ -87,9 +86,6 @@ describe('BaseModal Unit Tests', function () {
             expect($modelTitleField->isProtected())->toBeTrue();
             expect(reflectionTypeName($modelTitleField))->toBe('string');
 
-            $titleField = $reflection->getProperty('titleField');
-            expect($titleField->isProtected())->toBeTrue();
-            expect(reflectionTypeName($titleField))->toBe('string');
         });
     });
 
@@ -142,27 +138,12 @@ describe('BaseModal Unit Tests', function () {
             expect($method->getNumberOfParameters())->toBe(0);
         });
 
-        test('has save method', function () {
+        test('leaves the submission workflow to form modals', function () {
             $reflection = new ReflectionClass(BaseModal::class);
 
-            expect($reflection->hasMethod('save'))->toBeTrue();
-
-            $method = $reflection->getMethod('save');
-            expect($method->isPublic())->toBeTrue();
-            expect(reflectionReturnTypeName($method))->toBe('void');
-            expect($method->getNumberOfParameters())->toBe(0);
+            expect($reflection->hasMethod('save'))->toBeFalse();
         });
 
-        test('has render method', function () {
-            $reflection = new ReflectionClass(BaseModal::class);
-
-            expect($reflection->hasMethod('render'))->toBeTrue();
-
-            $method = $reflection->getMethod('render');
-            expect($method->isPublic())->toBeTrue();
-            expect(reflectionReturnTypeName($method))->toBe('Illuminate\\View\\View');
-            expect($method->getNumberOfParameters())->toBe(0);
-        });
     });
 
     describe('namespace and naming', function () {
@@ -184,7 +165,6 @@ describe('BaseModal Unit Tests', function () {
 
             // Check for actual imports in BaseModal
             expect($source)->toContain('use Illuminate\\Database\\Eloquent\\Model;');
-            expect($source)->toContain('use Illuminate\\View\\View;');
             expect($source)->toContain('use LivewireUI\\Modal\\ModalComponent;');
         });
     });
@@ -198,8 +178,6 @@ describe('BaseModal Unit Tests', function () {
 
             // Should have template methods
             expect($reflection->hasMethod('mount'))->toBeTrue();
-            expect($reflection->hasMethod('save'))->toBeTrue();
-            expect($reflection->hasMethod('render'))->toBeTrue();
         });
     });
 


### PR DESCRIPTION
## Summary
- reduce the shared Livewire form and modal foundation from 1,338 lines to 255 focused lines
- lock form model identifiers against client-side mutation
- remove dead modal state, duplicate submission behavior, and stale implementation-detail documentation
- update structural tests to enforce the remaining contract and the locked identifier
- remove resolved PHPStan baseline entries

## Verification
- composer lint
- vendor/bin/phpstan analyse --memory-limit=4G --no-progress --error-format=table
- php artisan test --compact tests/Unit/Livewire/Base tests/Unit/Livewire/Concerns/BaseModalTest.php tests/Integration/Livewire/Venues/Modals/FormModalTest.php tests/Integration/Livewire/Managers/Modals/FormModalTest.php tests/Integration/Livewire/Referees/Modals/FormModalTest.php
- 125 tests passed with 349 assertions
- composer test:push deterministic gates passed; final parallel Pest process was stopped after becoming silent