### PR TITLE
refactor: separate match form responsibilities

### DIFF
--- a/app/Livewire/Matches/Enums/CompetitorSelectionLayout.php
+++ b/app/Livewire/Matches/Enums/CompetitorSelectionLayout.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Matches\Enums;
+
+use App\Enums\MatchType;
+
+enum CompetitorSelectionLayout: string
+{
+    case Singles = 'singles';
+    case TagTeam = 'tag-team';
+    case TripleThreat = 'triple-threat';
+    case FatalFourWay = 'fatal-four-way';
+    case BattleRoyal = 'battle-royal';
+    case Generic = 'generic';
+
+    public static function forMatchType(MatchType $matchType): self
+    {
+        return match ($matchType) {
+            MatchType::Singles => self::Singles,
+            MatchType::TagTeam,
+            MatchType::SixManTagTeam,
+            MatchType::EightManTagTeam,
+            MatchType::TenManTagTeam,
+            MatchType::TornadoTagTeam => self::TagTeam,
+            MatchType::TripleThreat,
+            MatchType::Triangle => self::TripleThreat,
+            MatchType::Fatal4Way => self::FatalFourWay,
+            MatchType::BattleRoyal,
+            MatchType::RoyalRumble => self::BattleRoyal,
+            default => self::Generic,
+        };
+    }
+}

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -9,7 +9,6 @@ use App\Actions\Matches\UpdateMatchAction;
 use App\Data\Matches\EventMatchData;
 use App\Enums\MatchType;
 use App\Livewire\Base\BaseForm;
-use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\Concerns\HasStandardValidationAttributes;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
@@ -49,17 +48,9 @@ use Illuminate\Validation\Rules\Enum;
  * @since 1.0.0
  * @see BaseForm For base form functionality and patterns
  * @see EventMatch For the underlying event match model
- *
- * @property string $preview Match promotional preview content
- * @property MatchType $matchType Match type enum
- * @property array<int, array{wrestlers?: array<int>, tag_teams?: array<int>}> $competitors Competitors grouped by side
- * @property array<int> $referees Array of referee IDs for match officials
- * @property array<int> $titles Array of title IDs at stake in the match
  */
 class CreateEditForm extends BaseForm
 {
-    use GeneratesDummyData;
-
     /**
      * The model instance being edited, or null for new event match creation.
      *
@@ -131,6 +122,18 @@ class CreateEditForm extends BaseForm
      * @var array<int> Title database IDs
      */
     public array $titles = [];
+
+    public function resetCompetitorsFor(MatchType $matchType): void
+    {
+        $sideCount = $matchType->usesIndividualCompetitorSides()
+            ? 1
+            : ($matchType->numberOfSides() ?? 1);
+
+        $this->competitors = array_fill(0, $sideCount, [
+            'wrestlers' => [],
+            'tag_teams' => [],
+        ]);
+    }
 
     /**
      * Store a new event match.
@@ -459,26 +462,6 @@ class CreateEditForm extends BaseForm
             'competitors' => 'competitors',
             'referees' => 'referees',
             'titles' => 'championship titles',
-        ];
-    }
-
-    /**
-     * Get dummy data field definitions for event match forms.
-     *
-     * Provides realistic fake data generators for development and testing
-     * purposes, allowing quick population of match forms with wrestling-
-     * appropriate dummy data.
-     *
-     * @return array<string, callable|mixed> Array mapping field names to generators
-     */
-    protected function getDummyDataFields(): array
-    {
-        return [
-            'preview' => fn () => fake()->paragraph(2).' This epic showdown promises to deliver non-stop action!',
-            'matchType' => fn () => fake()->randomElement(MatchType::cases()),
-            'competitors' => fn () => fake()->randomElements(range(1, 50), fake()->numberBetween(2, 6)), // 2-6 wrestlers
-            'referees' => fn () => [fake()->numberBetween(1, 20)], // Single referee
-            'titles' => fn () => fake()->boolean(0.3) ? fake()->randomElements(range(1, 15), fake()->numberBetween(1, 2)) : [], // 30% chance of title match
         ];
     }
 }

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -11,37 +11,17 @@ use App\Livewire\Concerns\Data\PresentsRefereesList;
 use App\Livewire\Concerns\Data\PresentsTagTeamsList;
 use App\Livewire\Concerns\Data\PresentsTitlesList;
 use App\Livewire\Concerns\Data\PresentsWrestlersList;
+use App\Livewire\Matches\Enums\CompetitorSelectionLayout;
 use App\Livewire\Matches\Forms\CreateEditForm;
+use App\Livewire\Matches\Support\MatchFormDummyData;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchStipulation;
-use App\Models\Referees\Referee;
-use App\Models\Titles\Title;
-use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
-use Log;
+use Livewire\Attributes\Locked;
 
-/**
- * Livewire modal component for wrestling match management within events.
- *
- * Manages the creation and editing of individual wrestling matches that occur
- * during events. Handles complex relationships between wrestlers, referees,
- * titles, match types, and promotional content. Supports dynamic view rendering
- * based on match type requirements.
- *
- * Key Features:
- * - Modal-based event match form interface
- * - Match type and competitor assignment
- * - Referee and title assignment
- * - Dynamic view rendering based on match type
- * - Wrestling match data generation for testing
- *
- * @extends BaseFormModal<CreateEditForm, EventMatch>
- *
- * @see BaseFormModal For modal functionality and patterns
- * @see EventMatch For the underlying match model structure
- */
+/** @extends BaseFormModal<CreateEditForm, EventMatch> */
 class FormModal extends BaseFormModal
 {
     use PresentsMatchTypesList;
@@ -50,61 +30,34 @@ class FormModal extends BaseFormModal
     use PresentsTitlesList;
     use PresentsWrestlersList;
 
-    /**
-     * Event identifier for match association.
-     *
-     * Required context for all matches since they cannot exist without an event.
-     * Comes from route model binding in the parent component.
-     *
-     * @var int Event database ID
-     */
-    public int $eventId;
+    #[Locked]
+    public int $eventId = 0;
 
-    /**
-     * String name to render view for each match type.
-     *
-     * Determines which Blade template to use for rendering match-specific
-     * form fields based on the selected match type (singles, tag team, etc.).
-     *
-     * @var string View template identifier for dynamic rendering
-     */
-    public string $subViewToUse;
-
-    /**
-     * Get the form class that handles event match data validation and processing.
-     *
-     * @return class-string<CreateEditForm> The fully qualified class name of CreateEditForm
-     */
     public CreateEditForm $form;
+
+    private MatchFormDummyData $dummyData;
+
+    public function boot(MatchFormDummyData $dummyData): void
+    {
+        $this->dummyData = $dummyData;
+    }
 
     protected function getFormClass(): string
     {
         return CreateEditForm::class;
     }
 
-    /**
-     * Get the model class that represents event match entities.
-     *
-     * @return class-string<EventMatch> The fully qualified class name of EventMatch model
-     */
     protected function getModelClass(): string
     {
         return EventMatch::class;
     }
 
-    /**
-     * Get the Blade view path for rendering the event match form modal.
-     *
-     * @return string The view path relative to resources/views
-     */
     protected function getModalPath(): string
     {
         return 'livewire.matches.modals.form-modal';
     }
 
-    /**
-     * @return array<int, string>
-     */
+    /** @return array<int, string> */
     #[Computed(cache: true, key: 'active-match-stipulations-list', seconds: 180)]
     public function getMatchStipulations(): array
     {
@@ -115,189 +68,27 @@ class FormModal extends BaseFormModal
             ->all();
     }
 
-    /**
-     * Generate dummy data fields for event match testing and development.
-     *
-     * Returns field generators for event match data including match types,
-     * competitor assignments, referee assignments, title stakes, and promotional content.
-     *
-     * @return array<string, callable(): mixed> Array mapping field names to generators
-     */
+    /** @return array<string, mixed> */
     protected function getDummyDataFields(): array
     {
-        return [
-            'matchType' => fn () => $this->getRandomMatchType(),
-            'referees' => fn () => $this->generateRefereeAssignments(),
-            'titles' => fn () => $this->generateTitleAssignments(),
-            'wrestlers' => fn () => $this->generateWrestlerAssignments(),
-            'preview' => fn () => $this->generateMatchPreview(),
-        ];
+        return $this->dummyData->generate();
     }
 
-    /**
-     * Generate random event match data for testing and development.
-     *
-     * Populates the form with realistic wrestling match data including
-     * match types, competitor assignments, referee assignments, title
-     * stakes, and promotional content.
-     */
-    public function generateRandomData(): void
-    {
-        $this->form->fill([
-            'matchType' => $this->getRandomMatchType(),
-            'referees' => $this->generateRefereeAssignments(),
-            'titles' => $this->generateTitleAssignments(),
-            'wrestlers' => $this->generateWrestlerAssignments(),
-            'preview' => $this->generateMatchPreview(),
-        ]);
-    }
-
-    /**
-     * Get a random match type for testing.
-     *
-     * Returns a random MatchType enum case for various wrestling match styles
-     * including singles, tag team, ladder matches, cage matches, etc.
-     *
-     * @return MatchType A random match type enum
-     */
-    protected function getRandomMatchType(): MatchType
-    {
-        return fake()->randomElement(MatchType::cases());
-    }
-
-    /**
-     * Generate referee assignments for the match.
-     *
-     * Creates referee assignments appropriate for different match types.
-     * Most matches have one referee, but special matches may require
-     * additional officials.
-     *
-     * @return array<int> Array of referee IDs
-     */
-    protected function generateRefereeAssignments(): array
-    {
-        $refereeCount = fake()->randomFloat(null, 0, 1) < 0.9 ? 1 : 2;
-
-        return Referee::query()
-            ->inRandomOrder()
-            ->limit($refereeCount)
-            ->pluck('id')
-            ->all();
-    }
-
-    /**
-     * Generate title assignments for championship matches.
-     *
-     * Creates title stakes for matches, with some matches being for
-     * championships and others being non-title matches.
-     *
-     * @return array<int> Array of title IDs (empty for non-title matches)
-     */
-    protected function generateTitleAssignments(): array
-    {
-        if (fake()->randomFloat(null, 0, 1) < 0.3) {
-            return Title::query()
-                ->inRandomOrder()
-                ->limit(1)
-                ->pluck('id')
-                ->all();
-        }
-
-        return [];
-    }
-
-    /**
-     * Generate wrestler assignments for the match.
-     *
-     * Creates wrestler assignments appropriate for different match types.
-     * Singles matches get 2 wrestlers, tag team matches get 4, etc.
-     *
-     * @return array<int> Array of wrestler IDs
-     */
-    protected function generateWrestlerAssignments(): array
-    {
-        $wrestlerCount = fake()->numberBetween(2, 4);
-
-        return Wrestler::query()
-            ->inRandomOrder()
-            ->limit($wrestlerCount)
-            ->pluck('id')
-            ->all();
-    }
-
-    /**
-     * Generate promotional preview content for wrestling matches.
-     *
-     * Creates realistic promotional text that would be used to advertise
-     * wrestling matches, including storyline elements, competitor highlights,
-     * and match stipulations.
-     *
-     * @return string Generated match preview text
-     */
-    protected function generateMatchPreview(): string
-    {
-        $matchIntros = [
-            'In what promises to be an explosive encounter',
-            'Two wrestling titans collide when',
-            'The stage is set for an epic showdown as',
-            'Tensions reach a boiling point in this highly anticipated match featuring',
-            'Get ready for non-stop action when',
-            'The rivalry intensifies as',
-        ];
-
-        $matchElements = [
-            'championship gold hangs in the balance',
-            'personal vendettas will be settled',
-            'only one competitor can emerge victorious',
-            'careers and reputations are on the line',
-            'months of buildup culminate in this decisive battle',
-            'the wrestling world will witness something special',
-        ];
-
-        $callsToAction = [
-            "Don't miss this incredible matchup!",
-            "You won't want to blink during this one!",
-            'This match could steal the entire show!',
-            'Witness wrestling at its absolute finest!',
-            'The action starts when the bell rings!',
-            'This is what wrestling is all about!',
-        ];
-
-        return fake()->randomElement($matchIntros).' '.
-               fake()->randomElement($matchElements).'. '.
-               fake()->randomElement($callsToAction);
-    }
-
-    /**
-     * Component mount lifecycle - properly initialize eventId before form creation.
-     *
-     * @param  mixed  $modelId  Optional model ID for editing (Livewire standard)
-     */
     public function mount(mixed $modelId = null): void
     {
         parent::mount($modelId);
 
-        // Set eventId on form - this should always happen since eventId is required context
-        if ($this->eventId > 0 && $this->form) {
+        if ($this->eventId > 0) {
             $this->form->eventId = $this->eventId;
-        } elseif ($this->form) {
-            // Log warning if eventId is not properly set (development aid)
-            Log::warning('Matches FormModal: eventId not properly initialized', [
-                'eventId' => $this->eventId,
-                'component' => static::class,
-            ]);
         }
     }
 
     public function openModal(mixed $modelId = null): void
     {
-        // Check authorization before opening modal
-        if ($modelId !== null) {
-            // Editing existing match - check update permission
-            Gate::authorize('update', EventMatch::class);
-        } else {
-            // Creating new match - check create permission
+        if ($modelId === null) {
             Gate::authorize('create', EventMatch::class);
+        } else {
+            Gate::authorize('update', EventMatch::query()->findOrFail($modelId));
         }
 
         parent::openModal($modelId);
@@ -305,131 +96,44 @@ class FormModal extends BaseFormModal
 
     public function getModalTitle(): string
     {
-        if (isset($this->model)) {
-            return 'Edit Match';
-        }
-
-        return 'Create Match';
+        return isset($this->model) ? 'Edit Match' : 'Create Match';
     }
 
     public function submitForm(): bool
     {
-        // Store whether we're creating or updating before the form submission
         $isCreating = $this->form->isCreating();
+        $wasStored = parent::submitForm();
 
-        $result = parent::submitForm();
-
-        if ($result) {
-            // Dispatch the appropriate event based on whether we created or updated
-            if ($isCreating) {
-                $this->dispatch('matchCreated');
-            } else {
-                $this->dispatch('matchUpdated');
-            }
-
-            // Reset the form after successful submission
-            $this->form->reset();
+        if (! $wasStored) {
+            return false;
         }
 
-        return $result;
+        $this->dispatch($isCreating ? 'matchCreated' : 'matchUpdated');
+        $this->form->reset();
+
+        return true;
     }
 
-    /**
-     * Handle match type selection changes for dynamic UI updates.
-     *
-     * When the match type changes, we need to:
-     * 1. Clear incompatible competitor data
-     * 2. Initialize the correct competitor structure
-     * 3. Reset validation state
-     */
     public function updatedFormMatchType(mixed $value): void
     {
-        if (! $value) {
-            return;
-        }
+        $matchType = $value instanceof MatchType ? $value : MatchType::tryFrom((string) $value);
 
-        // Clear existing competitor data when match type changes
-        $this->form->competitors = [];
-
-        // Initialize competitor structure based on match type
-        $matchType = $value instanceof MatchType ? $value : MatchType::tryFrom($value);
-        if ($matchType) {
-            $this->initializeCompetitorStructure($matchType);
+        if ($matchType !== null) {
+            $this->form->resetCompetitorsFor($matchType);
         }
     }
 
-    /**
-     * Get the currently selected match type enum.
-     */
-    public function getSelectedMatchType(): ?MatchType
-    {
-        return $this->form->matchType;
-    }
-
-    /**
-     * Check if the current match type allows wrestlers.
-     */
-    public function getMatchTypeAllowsWrestlersProperty(): bool
-    {
-        $matchType = $this->getSelectedMatchType();
-
-        return $matchType ? $matchType->allowsWrestlers() : true;
-    }
-
-    /**
-     * Check if the current match type allows tag teams.
-     */
     public function getMatchTypeAllowsTagTeamsProperty(): bool
     {
-        $matchType = $this->getSelectedMatchType();
-
-        return $matchType ? $matchType->allowsTagTeams() : false;
+        return $this->form->matchType?->allowsTagTeams() ?? false;
     }
 
-    /**
-     * Get the number of sides required for the current match type.
-     */
-    public function getNumberOfSidesProperty(): int
+    #[Computed]
+    public function competitorSelectionLayout(): ?CompetitorSelectionLayout
     {
-        $matchType = $this->getSelectedMatchType();
-
-        return $matchType?->numberOfSides() ?? 1;
-    }
-
-    /**
-     * Get the match type name for template logic.
-     */
-    public function getMatchTypeNameProperty(): string
-    {
-        $matchType = $this->getSelectedMatchType();
-
-        return $matchType ? mb_strtolower($matchType->name) : '';
-    }
-
-    /**
-     * Initialize the competitor structure based on match type.
-     */
-    private function initializeCompetitorStructure(MatchType $matchType): void
-    {
-        $numberOfSides = $matchType->numberOfSides() ?? 1;
-        $competitors = [];
-
-        if ($matchType->usesIndividualCompetitorSides()) {
-            $competitors[0] = [
-                'wrestlers' => [],
-                'tag_teams' => [],
-            ];
-        } else {
-            // Other matches: Initialize empty competitor structure for each side
-            for ($i = 0; $i < $numberOfSides; $i++) {
-                $competitors[$i] = [
-                    'wrestlers' => [],
-                    'tag_teams' => [],
-                ];
-            }
-        }
-
-        $this->form->competitors = $competitors;
+        return $this->form->matchType === null
+            ? null
+            : CompetitorSelectionLayout::forMatchType($this->form->matchType);
     }
 
     public function render(): View

--- a/app/Livewire/Matches/Support/MatchFormDummyData.php
+++ b/app/Livewire/Matches/Support/MatchFormDummyData.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Matches\Support;
+
+use App\Enums\MatchType;
+use App\Lifecycle\RosterBookingEligibility;
+use App\Models\Referees\Referee;
+use App\Models\Titles\Title;
+use App\Models\Wrestlers\Wrestler;
+
+final class MatchFormDummyData
+{
+    /**
+     * @return array{
+     *     matchType: MatchType,
+     *     competitors: array<int, array{wrestlers: array<int>, tag_teams: array<int>}>,
+     *     referees: array<int>,
+     *     titles: array<int>,
+     *     preview: string
+     * }
+     */
+    public function generate(): array
+    {
+        $wrestlerIds = Wrestler::query()
+            ->employed()
+            ->get()
+            ->filter(fn (Wrestler $wrestler): bool => RosterBookingEligibility::allows($wrestler))
+            ->shuffle()
+            ->take(2)
+            ->modelKeys();
+
+        $refereeIds = Referee::query()
+            ->employed()
+            ->get()
+            ->filter(fn (Referee $referee): bool => RosterBookingEligibility::allows($referee))
+            ->shuffle()
+            ->take(1)
+            ->modelKeys();
+
+        return [
+            'matchType' => MatchType::Singles,
+            'competitors' => [
+                ['wrestlers' => array_slice($wrestlerIds, 0, 1), 'tag_teams' => []],
+                ['wrestlers' => array_slice($wrestlerIds, 1, 1), 'tag_teams' => []],
+            ],
+            'referees' => $refereeIds,
+            'titles' => fake()->boolean(30)
+                ? Title::query()->active()->inRandomOrder()->limit(1)->pluck('id')->all()
+                : [],
+            'preview' => fake()->paragraph(2),
+        ];
+    }
+}

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -91,18 +91,6 @@ parameters:
 			path: app/Livewire/Managers/Components/Actions.php
 
 		-
-			message: '#^Negated boolean expression is always false\.$#'
-			identifier: booleanNot.alwaysFalse
-			count: 1
-			path: app/Livewire/Matches/Forms/CreateEditForm.php
-
-		-
-			message: '#^Right side of && is always true\.$#'
-			identifier: booleanAnd.rightAlwaysTrue
-			count: 1
-			path: app/Livewire/Matches/Modals/FormModal.php
-
-		-
 			message: '#^Instanceof between Illuminate\\View\\View and Illuminate\\Contracts\\View\\View will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1

--- a/resources/views/livewire/matches/modals/form-modal.blade.php
+++ b/resources/views/livewire/matches/modals/form-modal.blade.php
@@ -15,141 +15,143 @@
     {{-- Dynamic Competitor Selection Based on Match Type --}}
     @if ($form->matchType)
         <div class="space-y-4">
-            @if (str_contains($this->matchTypeName, 'singles'))
-                {{-- Singles Match: 2 sides, 1 wrestler each --}}
-                <x-form-modal.modal-input>
-                    <div class="grid grid-cols-2 gap-4">
-                        <x-form.inputs.select
-                            label="Competitor 1"
-                            wire:model="form.competitors.0.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                        <x-form.inputs.select
-                            label="Competitor 2"
-                            wire:model="form.competitors.1.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                    </div>
-                </x-form-modal.modal-input>
-
-            @elseif (str_contains($this->matchTypeName, 'tag') || str_contains($this->matchTypeName, 'team'))
-                {{-- Tag Team Match: 2 sides, wrestlers or tag teams --}}
-                <x-form-modal.modal-input>
-                    <div class="grid grid-cols-2 gap-4">
-                        <div class="space-y-2">
-                            <label class="text-sm font-medium">Team A</label>
+            @switch ($this->competitorSelectionLayout)
+                @case (\App\Livewire\Matches\Enums\CompetitorSelectionLayout::Singles)
+                    {{-- Singles Match: 2 sides, 1 wrestler each --}}
+                    <x-form-modal.modal-input>
+                        <div class="grid grid-cols-2 gap-4">
                             <x-form.inputs.select
-                                label="Wrestlers"
-                                wire:model="form.competitors.0.wrestlers"
+                                label="Competitor 1"
+                                wire:model="form.competitors.0.wrestlers.0"
                                 :options="$this->getWrestlers"
-                                multiple
                             />
+                            <x-form.inputs.select
+                                label="Competitor 2"
+                                wire:model="form.competitors.1.wrestlers.0"
+                                :options="$this->getWrestlers"
+                            />
+                        </div>
+                    </x-form-modal.modal-input>
+                    @break
+                @case (\App\Livewire\Matches\Enums\CompetitorSelectionLayout::TagTeam)
+                    {{-- Tag Team Match: 2 sides, wrestlers or tag teams --}}
+                    <x-form-modal.modal-input>
+                        <div class="grid grid-cols-2 gap-4">
+                            <div class="space-y-2">
+                                <label class="text-sm font-medium">Team A</label>
+                                <x-form.inputs.select
+                                    label="Wrestlers"
+                                    wire:model="form.competitors.0.wrestlers"
+                                    :options="$this->getWrestlers"
+                                    multiple
+                                />
+                                <x-form.inputs.select
+                                    label="Tag Teams"
+                                    wire:model="form.competitors.0.tag_teams"
+                                    :options="$this->getTagTeams"
+                                />
+                            </div>
+                            <div class="space-y-2">
+                                <label class="text-sm font-medium">Team B</label>
+                                <x-form.inputs.select
+                                    label="Wrestlers"
+                                    wire:model="form.competitors.1.wrestlers"
+                                    :options="$this->getWrestlers"
+                                    multiple
+                                />
+                                <x-form.inputs.select
+                                    label="Tag Teams"
+                                    wire:model="form.competitors.1.tag_teams"
+                                    :options="$this->getTagTeams"
+                                />
+                            </div>
+                        </div>
+                    </x-form-modal.modal-input>
+                    @break
+                @case (\App\Livewire\Matches\Enums\CompetitorSelectionLayout::TripleThreat)
+                    {{-- Triple Threat: 3 sides, 1 wrestler each --}}
+                    <x-form-modal.modal-input>
+                        <div class="grid grid-cols-3 gap-4">
+                            <x-form.inputs.select
+                                label="Competitor 1"
+                                wire:model="form.competitors.0.wrestlers.0"
+                                :options="$this->getWrestlers"
+                            />
+                            <x-form.inputs.select
+                                label="Competitor 2"
+                                wire:model="form.competitors.1.wrestlers.0"
+                                :options="$this->getWrestlers"
+                            />
+                            <x-form.inputs.select
+                                label="Competitor 3"
+                                wire:model="form.competitors.2.wrestlers.0"
+                                :options="$this->getWrestlers"
+                            />
+                        </div>
+                    </x-form-modal.modal-input>
+                    @break
+                @case (\App\Livewire\Matches\Enums\CompetitorSelectionLayout::FatalFourWay)
+                    {{-- Fatal Four Way: 4 sides, 1 wrestler each --}}
+                    <x-form-modal.modal-input>
+                        <div class="grid grid-cols-2 gap-4">
+                            <x-form.inputs.select
+                                label="Competitor 1"
+                                wire:model="form.competitors.0.wrestlers.0"
+                                :options="$this->getWrestlers"
+                            />
+                            <x-form.inputs.select
+                                label="Competitor 2"
+                                wire:model="form.competitors.1.wrestlers.0"
+                                :options="$this->getWrestlers"
+                            />
+                            <x-form.inputs.select
+                                label="Competitor 3"
+                                wire:model="form.competitors.2.wrestlers.0"
+                                :options="$this->getWrestlers"
+                            />
+                            <x-form.inputs.select
+                                label="Competitor 4"
+                                wire:model="form.competitors.3.wrestlers.0"
+                                :options="$this->getWrestlers"
+                            />
+                        </div>
+                    </x-form-modal.modal-input>
+                    @break
+                @case (\App\Livewire\Matches\Enums\CompetitorSelectionLayout::BattleRoyal)
+                    {{-- Battle Royal: Multiple individual wrestlers --}}
+                    <x-form-modal.modal-input>
+                        <x-form.inputs.select
+                            label="Competitors (Select Multiple)"
+                            wire:model="form.competitors.0.wrestlers"
+                            :options="$this->getWrestlers"
+                            multiple
+                        />
+                        <p class="mt-1 text-sm text-gray-600">Select all wrestlers participating in this match</p>
+                    </x-form-modal.modal-input>
+                    @break
+                @default
+                    {{-- Default/Unknown Match Type: Generic competitor selection --}}
+                    <x-form-modal.modal-input>
+                        <x-form.inputs.select
+                            label="Wrestlers"
+                            wire:model="form.competitors.0.wrestlers"
+                            :options="$this->getWrestlers"
+                            multiple
+                        />
+                    </x-form-modal.modal-input>
+
+                    @if ($this->matchTypeAllowsTagTeams)
+                        <x-form-modal.modal-input>
                             <x-form.inputs.select
                                 label="Tag Teams"
                                 wire:model="form.competitors.0.tag_teams"
                                 :options="$this->getTagTeams"
-                            />
-                        </div>
-                        <div class="space-y-2">
-                            <label class="text-sm font-medium">Team B</label>
-                            <x-form.inputs.select
-                                label="Wrestlers"
-                                wire:model="form.competitors.1.wrestlers"
-                                :options="$this->getWrestlers"
                                 multiple
                             />
-                            <x-form.inputs.select
-                                label="Tag Teams"
-                                wire:model="form.competitors.1.tag_teams"
-                                :options="$this->getTagTeams"
-                            />
-                        </div>
-                    </div>
-                </x-form-modal.modal-input>
+                        </x-form-modal.modal-input>
+                    @endif
 
-            @elseif (str_contains($this->matchTypeName, 'triple') || str_contains($this->matchTypeName, 'three'))
-                {{-- Triple Threat: 3 sides, 1 wrestler each --}}
-                <x-form-modal.modal-input>
-                    <div class="grid grid-cols-3 gap-4">
-                        <x-form.inputs.select
-                            label="Competitor 1"
-                            wire:model="form.competitors.0.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                        <x-form.inputs.select
-                            label="Competitor 2"
-                            wire:model="form.competitors.1.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                        <x-form.inputs.select
-                            label="Competitor 3"
-                            wire:model="form.competitors.2.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                    </div>
-                </x-form-modal.modal-input>
-
-            @elseif (str_contains($this->matchTypeName, 'fatal') || str_contains($this->matchTypeName, 'four'))
-                {{-- Fatal Four Way: 4 sides, 1 wrestler each --}}
-                <x-form-modal.modal-input>
-                    <div class="grid grid-cols-2 gap-4">
-                        <x-form.inputs.select
-                            label="Competitor 1"
-                            wire:model="form.competitors.0.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                        <x-form.inputs.select
-                            label="Competitor 2"
-                            wire:model="form.competitors.1.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                        <x-form.inputs.select
-                            label="Competitor 3"
-                            wire:model="form.competitors.2.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                        <x-form.inputs.select
-                            label="Competitor 4"
-                            wire:model="form.competitors.3.wrestlers.0"
-                            :options="$this->getWrestlers"
-                        />
-                    </div>
-                </x-form-modal.modal-input>
-
-            @elseif (str_contains($this->matchTypeName, 'battle') || str_contains($this->matchTypeName, 'rumble') || str_contains($this->matchTypeName, 'royal'))
-                {{-- Battle Royal: Multiple individual wrestlers --}}
-                <x-form-modal.modal-input>
-                    <x-form.inputs.select
-                        label="Competitors (Select Multiple)"
-                        wire:model="form.competitors.0.wrestlers"
-                        :options="$this->getWrestlers"
-                        multiple
-                    />
-                    <p class="mt-1 text-sm text-gray-600">Select all wrestlers participating in this match</p>
-                </x-form-modal.modal-input>
-
-            @else
-                {{-- Default/Unknown Match Type: Generic competitor selection --}}
-                <x-form-modal.modal-input>
-                    <x-form.inputs.select
-                        label="Wrestlers"
-                        wire:model="form.competitors.0.wrestlers"
-                        :options="$this->getWrestlers"
-                        multiple
-                    />
-                </x-form-modal.modal-input>
-
-                @if ($this->matchTypeAllowsTagTeams)
-                    <x-form-modal.modal-input>
-                        <x-form.inputs.select
-                            label="Tag Teams"
-                            wire:model="form.competitors.0.tag_teams"
-                            :options="$this->getTagTeams"
-                            multiple
-                        />
-                    </x-form-modal.modal-input>
-                @endif
-            @endif
+            @endswitch
         </div>
     @else
         {{-- No match type selected - show helper text --}}

--- a/tests/Feature/Livewire/Matches/Modals/DynamicUITest.php
+++ b/tests/Feature/Livewire/Matches/Modals/DynamicUITest.php
@@ -6,6 +6,7 @@ use App\Enums\MatchType;
 use App\Livewire\Matches\Modals\FormModal;
 use App\Models\Events\Event;
 use App\Models\Users\User;
+use Livewire\Attributes\Locked;
 
 use function Pest\Livewire\livewire;
 
@@ -16,6 +17,12 @@ beforeEach(function () {
 });
 
 describe('Dynamic Match Type UI', function () {
+    it('locks the event context against client-side changes', function () {
+        $eventId = new ReflectionProperty(FormModal::class, 'eventId');
+
+        expect($eventId->getAttributes(Locked::class))->toHaveCount(1);
+    });
+
     it('shows helper text when no match type is selected', function () {
         $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal');

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -103,6 +103,40 @@ describe('FormModal Rendering', function () {
         // Match types are now enums, so they should all be listed
         $component->assertSee('Singles');
     });
+
+    it('fills the form with valid match data', function () {
+        $wrestlers = Wrestler::factory()->count(2)->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
+        $unavailableWrestler = Wrestler::factory()->create();
+        $unavailableReferee = Referee::factory()->create();
+
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->call('fillDummyFields')
+            ->assertSet('form.matchType', MatchType::Singles)
+            ->assertSet('form.competitors', function (array $competitors) use ($wrestlers): bool {
+                $competitorIds = collect($competitors)
+                    ->pluck('wrestlers')
+                    ->flatten()
+                    ->sort()
+                    ->values()
+                    ->all();
+
+                return $competitorIds === $wrestlers->modelKeys();
+            })
+            ->assertSet('form.referees', [$referee->id])
+            ->assertSet('form.competitors', function (array $competitors) use ($unavailableWrestler): bool {
+                return ! collect($competitors)
+                    ->pluck('wrestlers')
+                    ->flatten()
+                    ->contains($unavailableWrestler->id);
+            })
+            ->assertSet('form.referees', fn (array $refereeIds): bool => ! in_array(
+                $unavailableReferee->id,
+                $refereeIds,
+                true,
+            ));
+    });
 });
 
 describe('FormModal Match Stipulation Integration', function () {

--- a/tests/Unit/Livewire/Matches/Enums/CompetitorSelectionLayoutTest.php
+++ b/tests/Unit/Livewire/Matches/Enums/CompetitorSelectionLayoutTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MatchType;
+use App\Livewire\Matches\Enums\CompetitorSelectionLayout;
+
+it('maps match types to their competitor selection layout', function (
+    MatchType $matchType,
+    CompetitorSelectionLayout $layout,
+) {
+    expect(CompetitorSelectionLayout::forMatchType($matchType))->toBe($layout);
+})->with([
+    [MatchType::Singles, CompetitorSelectionLayout::Singles],
+    [MatchType::TagTeam, CompetitorSelectionLayout::TagTeam],
+    [MatchType::SixManTagTeam, CompetitorSelectionLayout::TagTeam],
+    [MatchType::EightManTagTeam, CompetitorSelectionLayout::TagTeam],
+    [MatchType::TenManTagTeam, CompetitorSelectionLayout::TagTeam],
+    [MatchType::TornadoTagTeam, CompetitorSelectionLayout::TagTeam],
+    [MatchType::TripleThreat, CompetitorSelectionLayout::TripleThreat],
+    [MatchType::Triangle, CompetitorSelectionLayout::TripleThreat],
+    [MatchType::Fatal4Way, CompetitorSelectionLayout::FatalFourWay],
+    [MatchType::BattleRoyal, CompetitorSelectionLayout::BattleRoyal],
+    [MatchType::RoyalRumble, CompetitorSelectionLayout::BattleRoyal],
+    [MatchType::TwoOnOneHandicap, CompetitorSelectionLayout::Generic],
+    [MatchType::ThreeOnTwoHandicap, CompetitorSelectionLayout::Generic],
+    [MatchType::Gauntlet, CompetitorSelectionLayout::Generic],
+]);


### PR DESCRIPTION
## Summary
- move match dummy-data generation into a focused support class using real bookable roster records
- replace Blade string inspection with an explicit competitor-selection layout enum
- keep competitor resetting on the form and lock the event context in the modal
- authorize updates against the actual match model and remove obsolete PHPStan baseline entries

## Verification
- composer lint
- focused Pest suite: 61 tests, 121 assertions
- application PHPStan
- Pest PHPStan
- composer test:push