### PR TITLE
fix: show previous title champions

### DIFF
--- a/app/Builders/Titles/TitleChampionshipBuilder.php
+++ b/app/Builders/Titles/TitleChampionshipBuilder.php
@@ -55,4 +55,19 @@ class TitleChampionshipBuilder extends Builder
 
         return $this;
     }
+
+    public function withPreviousChampionshipId(): static
+    {
+        $this->addSelect([
+            'previous_championship_id' => TitleChampionship::query()
+                ->from('titles_championships as previous_championships')
+                ->select('previous_championships.id')
+                ->whereColumn('previous_championships.title_id', 'titles_championships.title_id')
+                ->whereColumn('previous_championships.won_at', '<', 'titles_championships.won_at')
+                ->orderByDesc('previous_championships.won_at')
+                ->limit(1),
+        ]);
+
+        return $this;
+    }
 }

--- a/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
@@ -9,9 +9,10 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\DateColumn;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Livewire\Table\DataTableComponent;
+use App\Models\TagTeams\TagTeam;
 use App\Models\Titles\TitleChampionship;
+use App\Models\Wrestlers\Wrestler;
 use App\Queries\Titles\TitleChampionshipQuery;
-use Illuminate\Database\Eloquent\Model;
 
 /**
  * @extends DataTableComponent<TitleChampionship>
@@ -45,11 +46,8 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
                 ->title(fn (TitleChampionship $row) => $row->title->name)
                 ->location(fn (TitleChampionship $row) => route('titles.show', $row->title)),
             LinkColumn::make(__('championships.previous_champion'))
-                ->title(fn (TitleChampionship $row) => 'N/A') // TODO: Implement previous champion lookup
-                ->location(function (Model $row) {
-                    // TODO: Implement previous champion navigation
-                    return null;
-                }),
+                ->title(fn (TitleChampionship $row) => $row->previousChampionship?->champion->name ?? 'N/A')
+                ->location(fn (TitleChampionship $row) => $this->championLocation($row)),
             DateColumn::make(__('championships.dates_held'), 'won_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('championships.dates_held'), 'lost_at')
@@ -57,5 +55,20 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
             Column::make(__('championships.days_held'))
                 ->label(fn (TitleChampionship $row): int => TitleChampionshipQuery::reignLengthInDays($row)),
         ];
+    }
+
+    private function championLocation(TitleChampionship $championship): ?string
+    {
+        return match (true) {
+            $championship->previousChampionship?->champion instanceof Wrestler => route(
+                'wrestlers.show',
+                $championship->previousChampionship->champion,
+            ),
+            $championship->previousChampionship?->champion instanceof TagTeam => route(
+                'tag-teams.show',
+                $championship->previousChampionship->champion,
+            ),
+            default => null,
+        };
     }
 }

--- a/app/Livewire/Table/DataTableComponent.php
+++ b/app/Livewire/Table/DataTableComponent.php
@@ -143,7 +143,11 @@ abstract class DataTableComponent extends Component
         $query = $this->builder();
 
         if ($this->additionalSelects) {
-            $query->select('*')->addSelect($this->additionalSelects);
+            if ($query->getQuery()->columns === null) {
+                $query->select('*');
+            }
+
+            $query->addSelect($this->additionalSelects);
         }
 
         $this->applySearch($query);

--- a/app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
@@ -31,6 +31,7 @@ class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
         return TitleChampionship::query()
             ->forChampion($tagTeam)
             ->previous()
-            ->with('title');
+            ->withPreviousChampionshipId()
+            ->with(['title', 'previousChampionship.champion']);
     }
 }

--- a/app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php
@@ -35,6 +35,7 @@ class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
         return TitleChampionship::query()
             ->forChampion($wrestler)
             ->previous()
-            ->with('title');
+            ->withPreviousChampionshipId()
+            ->with(['title', 'previousChampionship.champion']);
     }
 }

--- a/app/Models/Titles/TitleChampionship.php
+++ b/app/Models/Titles/TitleChampionship.php
@@ -27,6 +27,7 @@ use Illuminate\Support\Carbon;
  * @property string $champion_type
  * @property int|null $won_match_id
  * @property int|null $lost_match_id
+ * @property int|null $previous_championship_id
  * @property Carbon $won_at
  * @property Carbon|null $lost_at
  * @property Carbon|null $deleted_at
@@ -34,6 +35,7 @@ use Illuminate\Support\Carbon;
  * @property-read EventMatch|null $wonEventMatch
  * @property-read EventMatch|null $lostEventMatch
  * @property-read Title|null $title
+ * @property-read TitleChampionship|null $previousChampionship
  * @property-read Wrestler|TagTeam $champion
  *
  * @property Carbon|null $created_at
@@ -117,5 +119,11 @@ class TitleChampionship extends Model
     public function lostEventMatch(): BelongsTo
     {
         return $this->belongsTo(EventMatch::class, 'lost_match_id');
+    }
+
+    /** @return BelongsTo<TitleChampionship, $this> */
+    public function previousChampionship(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'previous_championship_id');
     }
 }

--- a/tests/Feature/Livewire/Wrestlers/Tables/PreviousTitleChampionshipsTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/PreviousTitleChampionshipsTest.php
@@ -3,6 +3,9 @@
 declare(strict_types=1);
 
 use App\Livewire\Wrestlers\Tables\PreviousTitleChampionships;
+use App\Models\TagTeams\TagTeam;
+use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
 use App\Models\Users\User;
 use App\Models\Wrestlers\Wrestler;
 use Illuminate\Support\Collection;
@@ -63,6 +66,27 @@ describe('PreviousTitleChampionshipsTable Query Building', function () {
 });
 
 describe('PreviousTitleChampionshipsTable Rendering', function () {
+    it('links to the champion who held the title before the wrestler', function () {
+        $title = Title::factory()->create();
+        $previousChampion = TagTeam::factory()->create(['name' => 'Previous Champions']);
+        TitleChampionship::factory()
+            ->for($title)
+            ->forTagTeam($previousChampion)
+            ->wonOn('2020-01-01')
+            ->lostOn('2020-06-01')
+            ->create();
+        TitleChampionship::factory()
+            ->for($title)
+            ->forWrestler($this->wrestler)
+            ->wonOn('2020-06-01')
+            ->lostOn('2021-01-01')
+            ->create();
+
+        testLivewire(PreviousTitleChampionships::class, ['wrestlerId' => $this->wrestler->id])
+            ->assertSee('Previous Champions')
+            ->assertSeeHtml(route('tag-teams.show', $previousChampion));
+    });
+
     it('can render with wrestler id set', function () {
         $component = testLivewire(PreviousTitleChampionships::class, ['wrestlerId' => $this->wrestler->id]);
 


### PR DESCRIPTION
## Summary
- select the immediately preceding title reign with a correlated builder subquery
- eager-load the preceding championship and polymorphic champion without per-row queries
- replace the previous-champion placeholder with the real champion name and route
- preserve builder-selected computed columns in the shared data table pipeline

## Verification
- composer lint
- focused Pest suite: 36 tests, 72 assertions
- application PHPStan
- composer test:push