### PR TITLE
refactor: type roster error presentation

### DIFF
--- a/app/Enums/Roster/RosterEntityType.php
+++ b/app/Enums/Roster/RosterEntityType.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Roster;
+
+enum RosterEntityType: string
+{
+    case Wrestler = 'wrestler';
+    case Manager = 'manager';
+    case Referee = 'referee';
+    case TagTeam = 'tag-team';
+
+    public function translationNamespace(): string
+    {
+        return match ($this) {
+            self::Wrestler => 'wrestlers',
+            self::Manager => 'managers',
+            self::Referee => 'referees',
+            self::TagTeam => 'tag-teams',
+        };
+    }
+}

--- a/app/Livewire/Concerns/ExecutesRosterActions.php
+++ b/app/Livewire/Concerns/ExecutesRosterActions.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Concerns;
 
+use App\Enums\Roster\RosterEntityType;
 use App\Exceptions\BaseBusinessException;
 use App\Services\ErrorMessageMappingService;
 use Closure;
@@ -13,27 +14,16 @@ trait ExecutesRosterActions
     /** @param Closure(): void $action */
     protected function executeRosterAction(
         string $actionName,
-        string $entityType,
+        RosterEntityType $entityType,
         Closure $action,
     ): void {
         try {
             $action();
 
-            $this->dispatch("{$entityType}-updated");
-            session()->flash('success', __("{$entityType}s.actions.{$actionName}"));
+            $this->dispatch("{$entityType->value}-updated");
+            session()->flash('success', __("{$entityType->translationNamespace()}.actions.{$actionName}"));
         } catch (BaseBusinessException $exception) {
-            session()->flash('error', __($this->mapException($exception, $entityType)));
+            session()->flash('error', __(ErrorMessageMappingService::map($exception, $entityType)));
         }
-    }
-
-    private function mapException(BaseBusinessException $exception, string $entityType): string
-    {
-        return match ($entityType) {
-            'wrestler' => ErrorMessageMappingService::mapWrestlerException($exception),
-            'manager' => ErrorMessageMappingService::mapManagerException($exception),
-            'referee' => ErrorMessageMappingService::mapRefereeException($exception),
-            'tag-team' => ErrorMessageMappingService::mapTagTeamException($exception),
-            default => "{$entityType}s.errors.general_error",
-        };
     }
 }

--- a/app/Livewire/Managers/Components/Actions.php
+++ b/app/Livewire/Managers/Components/Actions.php
@@ -13,6 +13,7 @@ use App\Actions\Managers\RestoreAction;
 use App\Actions\Managers\RetireAction;
 use App\Actions\Managers\SuspendAction;
 use App\Actions\Managers\UnretireAction;
+use App\Enums\Roster\RosterEntityType;
 use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Models\Roster\Managers\Manager;
 use Illuminate\Contracts\View\View;
@@ -33,55 +34,55 @@ class Actions extends Component
     public function employ(): void
     {
         Gate::authorize('employ', $this->manager);
-        $this->executeRosterAction('employed', 'manager', fn () => resolve(EmployAction::class)->handle($this->manager));
+        $this->executeRosterAction('employed', RosterEntityType::Manager, fn () => resolve(EmployAction::class)->handle($this->manager));
     }
 
     public function release(): void
     {
         Gate::authorize('release', $this->manager);
-        $this->executeRosterAction('released', 'manager', fn () => resolve(ReleaseAction::class)->handle($this->manager));
+        $this->executeRosterAction('released', RosterEntityType::Manager, fn () => resolve(ReleaseAction::class)->handle($this->manager));
     }
 
     public function retire(): void
     {
         Gate::authorize('retire', $this->manager);
-        $this->executeRosterAction('retired', 'manager', fn () => resolve(RetireAction::class)->handle($this->manager));
+        $this->executeRosterAction('retired', RosterEntityType::Manager, fn () => resolve(RetireAction::class)->handle($this->manager));
     }
 
     public function unretire(): void
     {
         Gate::authorize('unretire', $this->manager);
-        $this->executeRosterAction('unretired', 'manager', fn () => resolve(UnretireAction::class)->handle($this->manager));
+        $this->executeRosterAction('unretired', RosterEntityType::Manager, fn () => resolve(UnretireAction::class)->handle($this->manager));
     }
 
     public function suspend(): void
     {
         Gate::authorize('suspend', $this->manager);
-        $this->executeRosterAction('suspended', 'manager', fn () => resolve(SuspendAction::class)->handle($this->manager));
+        $this->executeRosterAction('suspended', RosterEntityType::Manager, fn () => resolve(SuspendAction::class)->handle($this->manager));
     }
 
     public function reinstate(): void
     {
         Gate::authorize('reinstate', $this->manager);
-        $this->executeRosterAction('reinstated', 'manager', fn () => resolve(ReinstateAction::class)->handle($this->manager));
+        $this->executeRosterAction('reinstated', RosterEntityType::Manager, fn () => resolve(ReinstateAction::class)->handle($this->manager));
     }
 
     public function injure(): void
     {
         Gate::authorize('injure', $this->manager);
-        $this->executeRosterAction('injured', 'manager', fn () => resolve(InjureAction::class)->handle($this->manager));
+        $this->executeRosterAction('injured', RosterEntityType::Manager, fn () => resolve(InjureAction::class)->handle($this->manager));
     }
 
     public function healFromInjury(): void
     {
         Gate::authorize('clearFromInjury', $this->manager);
-        $this->executeRosterAction('healed', 'manager', fn () => resolve(HealAction::class)->handle($this->manager));
+        $this->executeRosterAction('healed', RosterEntityType::Manager, fn () => resolve(HealAction::class)->handle($this->manager));
     }
 
     public function restore(): void
     {
         Gate::authorize('restore', $this->manager);
-        $this->executeRosterAction('restored', 'manager', fn () => resolve(RestoreAction::class)->handle($this->manager));
+        $this->executeRosterAction('restored', RosterEntityType::Manager, fn () => resolve(RestoreAction::class)->handle($this->manager));
     }
 
     public function render(): View

--- a/app/Livewire/Referees/Components/Actions.php
+++ b/app/Livewire/Referees/Components/Actions.php
@@ -13,6 +13,7 @@ use App\Actions\Referees\RestoreAction;
 use App\Actions\Referees\RetireAction;
 use App\Actions\Referees\SuspendAction;
 use App\Actions\Referees\UnretireAction;
+use App\Enums\Roster\RosterEntityType;
 use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Models\Roster\Referees\Referee;
 use Illuminate\Contracts\View\View;
@@ -33,55 +34,55 @@ class Actions extends Component
     public function employ(): void
     {
         Gate::authorize('employ', $this->referee);
-        $this->executeRosterAction('employed', 'referee', fn () => resolve(EmployAction::class)->handle($this->referee));
+        $this->executeRosterAction('employed', RosterEntityType::Referee, fn () => resolve(EmployAction::class)->handle($this->referee));
     }
 
     public function release(): void
     {
         Gate::authorize('release', $this->referee);
-        $this->executeRosterAction('released', 'referee', fn () => resolve(ReleaseAction::class)->handle($this->referee));
+        $this->executeRosterAction('released', RosterEntityType::Referee, fn () => resolve(ReleaseAction::class)->handle($this->referee));
     }
 
     public function retire(): void
     {
         Gate::authorize('retire', $this->referee);
-        $this->executeRosterAction('retired', 'referee', fn () => resolve(RetireAction::class)->handle($this->referee));
+        $this->executeRosterAction('retired', RosterEntityType::Referee, fn () => resolve(RetireAction::class)->handle($this->referee));
     }
 
     public function unretire(): void
     {
         Gate::authorize('unretire', $this->referee);
-        $this->executeRosterAction('unretired', 'referee', fn () => resolve(UnretireAction::class)->handle($this->referee));
+        $this->executeRosterAction('unretired', RosterEntityType::Referee, fn () => resolve(UnretireAction::class)->handle($this->referee));
     }
 
     public function suspend(): void
     {
         Gate::authorize('suspend', $this->referee);
-        $this->executeRosterAction('suspended', 'referee', fn () => resolve(SuspendAction::class)->handle($this->referee));
+        $this->executeRosterAction('suspended', RosterEntityType::Referee, fn () => resolve(SuspendAction::class)->handle($this->referee));
     }
 
     public function reinstate(): void
     {
         Gate::authorize('reinstate', $this->referee);
-        $this->executeRosterAction('reinstated', 'referee', fn () => resolve(ReinstateAction::class)->handle($this->referee));
+        $this->executeRosterAction('reinstated', RosterEntityType::Referee, fn () => resolve(ReinstateAction::class)->handle($this->referee));
     }
 
     public function injure(): void
     {
         Gate::authorize('injure', $this->referee);
-        $this->executeRosterAction('injured', 'referee', fn () => resolve(InjureAction::class)->handle($this->referee));
+        $this->executeRosterAction('injured', RosterEntityType::Referee, fn () => resolve(InjureAction::class)->handle($this->referee));
     }
 
     public function healFromInjury(): void
     {
         Gate::authorize('clearFromInjury', $this->referee);
-        $this->executeRosterAction('healed', 'referee', fn () => resolve(HealAction::class)->handle($this->referee));
+        $this->executeRosterAction('healed', RosterEntityType::Referee, fn () => resolve(HealAction::class)->handle($this->referee));
     }
 
     public function restore(): void
     {
         Gate::authorize('restore', $this->referee);
-        $this->executeRosterAction('restored', 'referee', fn () => resolve(RestoreAction::class)->handle($this->referee));
+        $this->executeRosterAction('restored', RosterEntityType::Referee, fn () => resolve(RestoreAction::class)->handle($this->referee));
     }
 
     public function render(): View

--- a/app/Livewire/TagTeams/Components/Actions.php
+++ b/app/Livewire/TagTeams/Components/Actions.php
@@ -12,6 +12,7 @@ use App\Actions\TagTeams\RestoreAction;
 use App\Actions\TagTeams\RetireAction;
 use App\Actions\TagTeams\SuspendAction;
 use App\Actions\TagTeams\UnretireAction;
+use App\Enums\Roster\RosterEntityType;
 use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Models\Roster\TagTeams\TagTeam;
 use Illuminate\Contracts\View\View;
@@ -32,49 +33,49 @@ class Actions extends Component
     public function employ(): void
     {
         Gate::authorize('employ', $this->tagTeam);
-        $this->executeRosterAction('employed', 'tag-team', fn () => resolve(EmployAction::class)->handle($this->tagTeam));
+        $this->executeRosterAction('employed', RosterEntityType::TagTeam, fn () => resolve(EmployAction::class)->handle($this->tagTeam));
     }
 
     public function release(): void
     {
         Gate::authorize('release', $this->tagTeam);
-        $this->executeRosterAction('released', 'tag-team', fn () => resolve(ReleaseAction::class)->handle($this->tagTeam));
+        $this->executeRosterAction('released', RosterEntityType::TagTeam, fn () => resolve(ReleaseAction::class)->handle($this->tagTeam));
     }
 
     public function retire(): void
     {
         Gate::authorize('retire', $this->tagTeam);
-        $this->executeRosterAction('retired', 'tag-team', fn () => resolve(RetireAction::class)->handle($this->tagTeam));
+        $this->executeRosterAction('retired', RosterEntityType::TagTeam, fn () => resolve(RetireAction::class)->handle($this->tagTeam));
     }
 
     public function unretire(): void
     {
         Gate::authorize('unretire', $this->tagTeam);
-        $this->executeRosterAction('unretired', 'tag-team', fn () => resolve(UnretireAction::class)->handle($this->tagTeam));
+        $this->executeRosterAction('unretired', RosterEntityType::TagTeam, fn () => resolve(UnretireAction::class)->handle($this->tagTeam));
     }
 
     public function suspend(): void
     {
         Gate::authorize('suspend', $this->tagTeam);
-        $this->executeRosterAction('suspended', 'tag-team', fn () => resolve(SuspendAction::class)->handle($this->tagTeam));
+        $this->executeRosterAction('suspended', RosterEntityType::TagTeam, fn () => resolve(SuspendAction::class)->handle($this->tagTeam));
     }
 
     public function reinstate(): void
     {
         Gate::authorize('reinstate', $this->tagTeam);
-        $this->executeRosterAction('reinstated', 'tag-team', fn () => resolve(ReinstateAction::class)->handle($this->tagTeam));
+        $this->executeRosterAction('reinstated', RosterEntityType::TagTeam, fn () => resolve(ReinstateAction::class)->handle($this->tagTeam));
     }
 
     public function delete(): void
     {
         Gate::authorize('delete', $this->tagTeam);
-        $this->executeRosterAction('deleted', 'tag-team', fn () => resolve(DeleteAction::class)->handle($this->tagTeam));
+        $this->executeRosterAction('deleted', RosterEntityType::TagTeam, fn () => resolve(DeleteAction::class)->handle($this->tagTeam));
     }
 
     public function restore(): void
     {
         Gate::authorize('restore', $this->tagTeam);
-        $this->executeRosterAction('restored', 'tag-team', fn () => resolve(RestoreAction::class)->handle($this->tagTeam));
+        $this->executeRosterAction('restored', RosterEntityType::TagTeam, fn () => resolve(RestoreAction::class)->handle($this->tagTeam));
     }
 
     public function render(): View

--- a/app/Livewire/Wrestlers/Components/Actions.php
+++ b/app/Livewire/Wrestlers/Components/Actions.php
@@ -13,6 +13,7 @@ use App\Actions\Wrestlers\RestoreAction;
 use App\Actions\Wrestlers\RetireAction;
 use App\Actions\Wrestlers\SuspendAction;
 use App\Actions\Wrestlers\UnretireAction;
+use App\Enums\Roster\RosterEntityType;
 use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Models\Roster\Wrestlers\Wrestler;
 use Illuminate\Contracts\View\View;
@@ -33,55 +34,55 @@ class Actions extends Component
     public function employ(): void
     {
         Gate::authorize('employ', $this->wrestler);
-        $this->executeRosterAction('employed', 'wrestler', fn () => resolve(EmployAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('employed', RosterEntityType::Wrestler, fn () => resolve(EmployAction::class)->handle($this->wrestler));
     }
 
     public function release(): void
     {
         Gate::authorize('release', $this->wrestler);
-        $this->executeRosterAction('released', 'wrestler', fn () => resolve(ReleaseAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('released', RosterEntityType::Wrestler, fn () => resolve(ReleaseAction::class)->handle($this->wrestler));
     }
 
     public function retire(): void
     {
         Gate::authorize('retire', $this->wrestler);
-        $this->executeRosterAction('retired', 'wrestler', fn () => resolve(RetireAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('retired', RosterEntityType::Wrestler, fn () => resolve(RetireAction::class)->handle($this->wrestler));
     }
 
     public function unretire(): void
     {
         Gate::authorize('unretire', $this->wrestler);
-        $this->executeRosterAction('unretired', 'wrestler', fn () => resolve(UnretireAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('unretired', RosterEntityType::Wrestler, fn () => resolve(UnretireAction::class)->handle($this->wrestler));
     }
 
     public function suspend(): void
     {
         Gate::authorize('suspend', $this->wrestler);
-        $this->executeRosterAction('suspended', 'wrestler', fn () => resolve(SuspendAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('suspended', RosterEntityType::Wrestler, fn () => resolve(SuspendAction::class)->handle($this->wrestler));
     }
 
     public function reinstate(): void
     {
         Gate::authorize('reinstate', $this->wrestler);
-        $this->executeRosterAction('reinstated', 'wrestler', fn () => resolve(ReinstateAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('reinstated', RosterEntityType::Wrestler, fn () => resolve(ReinstateAction::class)->handle($this->wrestler));
     }
 
     public function injure(): void
     {
         Gate::authorize('injure', $this->wrestler);
-        $this->executeRosterAction('injured', 'wrestler', fn () => resolve(InjureAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('injured', RosterEntityType::Wrestler, fn () => resolve(InjureAction::class)->handle($this->wrestler));
     }
 
     public function healFromInjury(): void
     {
         Gate::authorize('clearFromInjury', $this->wrestler);
-        $this->executeRosterAction('healed', 'wrestler', fn () => resolve(HealAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('healed', RosterEntityType::Wrestler, fn () => resolve(HealAction::class)->handle($this->wrestler));
     }
 
     public function restore(): void
     {
         Gate::authorize('restore', $this->wrestler);
-        $this->executeRosterAction('restored', 'wrestler', fn () => resolve(RestoreAction::class)->handle($this->wrestler));
+        $this->executeRosterAction('restored', RosterEntityType::Wrestler, fn () => resolve(RestoreAction::class)->handle($this->wrestler));
     }
 
     public function render(): View

--- a/app/Services/ErrorMessageMappingService.php
+++ b/app/Services/ErrorMessageMappingService.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services;
 
 use App\Enums\BusinessRuleReason;
+use App\Enums\Roster\RosterEntityType;
 use App\Exceptions\BaseBusinessException;
 use App\Exceptions\Roster\Individuals\CannotBeClearedFromInjuryException;
 use App\Exceptions\Roster\Individuals\CannotBeEmployedException;
@@ -22,87 +23,64 @@ use App\Exceptions\Roster\TagTeams\CannotBeRestoredException as TagTeamCannotBeR
 use App\Exceptions\Roster\TagTeams\CannotBeRetiredException as TagTeamCannotBeRetiredException;
 use App\Exceptions\Roster\TagTeams\CannotBeSuspendedException as TagTeamCannotBeSuspendedException;
 use App\Exceptions\Roster\TagTeams\CannotBeUnretiredException as TagTeamCannotBeUnretiredException;
-use Throwable;
 
 final class ErrorMessageMappingService
 {
-    public static function mapWrestlerException(Throwable $exception): string
+    public static function map(BaseBusinessException $exception, RosterEntityType $entityType): string
     {
-        return self::map($exception, 'wrestlers');
-    }
-
-    public static function mapRefereeException(Throwable $exception): string
-    {
-        return self::map($exception, 'referees');
-    }
-
-    public static function mapManagerException(Throwable $exception): string
-    {
-        return self::map($exception, 'managers');
-    }
-
-    public static function mapTagTeamException(Throwable $exception): string
-    {
-        return self::map($exception, 'tag-teams');
-    }
-
-    private static function map(Throwable $exception, string $entity): string
-    {
-        $reason = $exception instanceof BaseBusinessException
-            ? $exception->reason()
-            : BusinessRuleReason::General;
+        $reason = $exception->reason();
 
         $key = match ($exception::class) {
             CannotBeEmployedException::class,
-            TagTeamCannotBeEmployedException::class => self::employmentKey($reason, $entity),
+            TagTeamCannotBeEmployedException::class => self::employmentKey($reason, $entityType),
             CannotBeReleasedException::class,
-            TagTeamCannotBeReleasedException::class => self::releaseKey($reason, $entity),
+            TagTeamCannotBeReleasedException::class => self::releaseKey($reason, $entityType),
             CannotBeRetiredException::class,
-            TagTeamCannotBeRetiredException::class => self::retirementKey($reason, $entity),
+            TagTeamCannotBeRetiredException::class => self::retirementKey($reason, $entityType),
             CannotBeUnretiredException::class,
             TagTeamCannotBeUnretiredException::class => self::unretirementKey($reason),
             CannotBeSuspendedException::class,
-            TagTeamCannotBeSuspendedException::class => self::suspensionKey($reason, $entity),
+            TagTeamCannotBeSuspendedException::class => self::suspensionKey($reason, $entityType),
             CannotBeReinstatedException::class,
             TagTeamCannotBeReinstatedException::class => self::reinstatementKey($reason),
-            CannotBeInjuredException::class => self::injuryKey($reason, $entity),
+            CannotBeInjuredException::class => self::injuryKey($reason, $entityType),
             CannotBeClearedFromInjuryException::class => self::healingKey($reason),
             CannotBeRestoredException::class,
             TagTeamCannotBeRestoredException::class => self::restorationKey($reason),
             default => 'general_error',
         };
 
-        return "{$entity}.errors.{$key}";
+        return "{$entityType->translationNamespace()}.errors.{$key}";
     }
 
-    private static function employmentKey(BusinessRuleReason $reason, string $entity): string
+    private static function employmentKey(BusinessRuleReason $reason, RosterEntityType $entityType): string
     {
         return match ($reason) {
             BusinessRuleReason::AlreadyEmployed => 'already_employed',
             BusinessRuleReason::Suspended => 'cannot_employ_suspended',
             BusinessRuleReason::Retired => 'cannot_employ_retired',
-            BusinessRuleReason::Injured => $entity === 'managers' ? 'cannot_employ_injured' : 'cannot_employ',
+            BusinessRuleReason::Injured => $entityType === RosterEntityType::Manager ? 'cannot_employ_injured' : 'cannot_employ',
             default => 'cannot_employ',
         };
     }
 
-    private static function releaseKey(BusinessRuleReason $reason, string $entity): string
+    private static function releaseKey(BusinessRuleReason $reason, RosterEntityType $entityType): string
     {
         return match ($reason) {
             BusinessRuleReason::Unemployed => 'not_employed',
-            BusinessRuleReason::Suspended => in_array($entity, ['managers', 'tag-teams'], true)
+            BusinessRuleReason::Suspended => in_array($entityType, [RosterEntityType::Manager, RosterEntityType::TagTeam], true)
                 ? 'cannot_release_suspended'
                 : 'cannot_release',
             default => 'cannot_release',
         };
     }
 
-    private static function retirementKey(BusinessRuleReason $reason, string $entity): string
+    private static function retirementKey(BusinessRuleReason $reason, RosterEntityType $entityType): string
     {
         return match ($reason) {
             BusinessRuleReason::Unemployed => 'cannot_retire_unemployed',
             BusinessRuleReason::AlreadyRetired => 'already_retired',
-            BusinessRuleReason::Suspended => in_array($entity, ['managers', 'tag-teams'], true)
+            BusinessRuleReason::Suspended => in_array($entityType, [RosterEntityType::Manager, RosterEntityType::TagTeam], true)
                 ? 'cannot_retire_suspended'
                 : 'cannot_retire',
             default => 'cannot_retire',
@@ -116,16 +94,16 @@ final class ErrorMessageMappingService
             : 'cannot_unretire';
     }
 
-    private static function suspensionKey(BusinessRuleReason $reason, string $entity): string
+    private static function suspensionKey(BusinessRuleReason $reason, RosterEntityType $entityType): string
     {
         return match ($reason) {
             BusinessRuleReason::AlreadySuspended => 'already_suspended',
-            BusinessRuleReason::Unemployed => match ($entity) {
-                'managers', 'tag-teams' => 'not_employed_suspend',
-                'referees' => 'cannot_suspend_unemployed',
+            BusinessRuleReason::Unemployed => match ($entityType) {
+                RosterEntityType::Manager, RosterEntityType::TagTeam => 'not_employed_suspend',
+                RosterEntityType::Referee => 'cannot_suspend_unemployed',
                 default => 'cannot_suspend',
             },
-            BusinessRuleReason::Injured => $entity === 'managers' ? 'cannot_suspend_injured' : 'cannot_suspend',
+            BusinessRuleReason::Injured => $entityType === RosterEntityType::Manager ? 'cannot_suspend_injured' : 'cannot_suspend',
             default => 'cannot_suspend',
         };
     }
@@ -139,16 +117,16 @@ final class ErrorMessageMappingService
         };
     }
 
-    private static function injuryKey(BusinessRuleReason $reason, string $entity): string
+    private static function injuryKey(BusinessRuleReason $reason, RosterEntityType $entityType): string
     {
         return match ($reason) {
             BusinessRuleReason::AlreadyInjured => 'already_injured',
-            BusinessRuleReason::Unemployed => match ($entity) {
-                'managers' => 'not_employed_injure',
-                'referees' => 'cannot_injure_unemployed',
+            BusinessRuleReason::Unemployed => match ($entityType) {
+                RosterEntityType::Manager => 'not_employed_injure',
+                RosterEntityType::Referee => 'cannot_injure_unemployed',
                 default => 'cannot_injure',
             },
-            BusinessRuleReason::Suspended => $entity === 'managers' ? 'cannot_injure_suspended' : 'cannot_injure',
+            BusinessRuleReason::Suspended => $entityType === RosterEntityType::Manager ? 'cannot_injure_suspended' : 'cannot_injure',
             default => 'cannot_injure',
         };
     }

--- a/tests/Unit/Services/ErrorMessageMappingServiceTest.php
+++ b/tests/Unit/Services/ErrorMessageMappingServiceTest.php
@@ -3,7 +3,9 @@
 declare(strict_types=1);
 
 use App\Enums\BusinessRuleReason;
+use App\Enums\Roster\RosterEntityType;
 use App\Exceptions\Roster\Individuals\CannotBeClearedFromInjuryException;
+use App\Exceptions\Roster\Individuals\CannotBeDeletedException;
 use App\Exceptions\Roster\Individuals\CannotBeEmployedException;
 use App\Exceptions\Roster\Individuals\CannotBeInjuredException;
 use App\Exceptions\Roster\Individuals\CannotBeReinstatedException;
@@ -25,24 +27,24 @@ test('it maps roster failures from stable reasons instead of message text', func
     $exception = CannotBeReinstatedException::injured($wrestler, 'wording may change');
 
     expect($exception->reason())->toBe(BusinessRuleReason::Injured)
-        ->and(ErrorMessageMappingService::mapWrestlerException($exception))
+        ->and(ErrorMessageMappingService::map($exception, RosterEntityType::Wrestler))
         ->toBe('wrestlers.errors.cannot_reinstate_injured')
-        ->and(ErrorMessageMappingService::mapManagerException($exception))
+        ->and(ErrorMessageMappingService::map($exception, RosterEntityType::Manager))
         ->toBe('managers.errors.cannot_reinstate_injured')
-        ->and(ErrorMessageMappingService::mapRefereeException($exception))
+        ->and(ErrorMessageMappingService::map($exception, RosterEntityType::Referee))
         ->toBe('referees.errors.cannot_reinstate_injured');
 });
 
 test('it maps common lifecycle reasons for each roster presentation', function () {
     $wrestler = new Wrestler(['name' => 'Test Wrestler']);
 
-    expect(ErrorMessageMappingService::mapWrestlerException(CannotBeEmployedException::employed($wrestler)))
+    expect(ErrorMessageMappingService::map(CannotBeEmployedException::employed($wrestler), RosterEntityType::Wrestler))
         ->toBe('wrestlers.errors.already_employed')
-        ->and(ErrorMessageMappingService::mapManagerException(CannotBeSuspendedException::unemployed($wrestler)))
+        ->and(ErrorMessageMappingService::map(CannotBeSuspendedException::unemployed($wrestler), RosterEntityType::Manager))
         ->toBe('managers.errors.not_employed_suspend')
-        ->and(ErrorMessageMappingService::mapRefereeException(CannotBeInjuredException::unemployed($wrestler)))
+        ->and(ErrorMessageMappingService::map(CannotBeInjuredException::unemployed($wrestler), RosterEntityType::Referee))
         ->toBe('referees.errors.cannot_injure_unemployed')
-        ->and(ErrorMessageMappingService::mapWrestlerException(CannotBeClearedFromInjuryException::notInjured($wrestler)))
+        ->and(ErrorMessageMappingService::map(CannotBeClearedFromInjuryException::notInjured($wrestler), RosterEntityType::Wrestler))
         ->toBe('wrestlers.errors.not_injured');
 });
 
@@ -51,7 +53,7 @@ test('it maps restoration failures from the not-deleted reason', function () {
     $exception = CannotBeRestoredException::notDeleted($wrestler);
 
     expect($exception->reason())->toBe(BusinessRuleReason::NotDeleted)
-        ->and(ErrorMessageMappingService::mapWrestlerException($exception))
+        ->and(ErrorMessageMappingService::map($exception, RosterEntityType::Wrestler))
         ->toBe('wrestlers.errors.not_deleted');
 });
 
@@ -60,11 +62,11 @@ test('it maps available roster reinstatement failures to suspension guidance', f
     $exception = CannotBeReinstatedException::available($wrestler);
 
     expect($exception->reason())->toBe(BusinessRuleReason::NotSuspended)
-        ->and(ErrorMessageMappingService::mapWrestlerException($exception))
+        ->and(ErrorMessageMappingService::map($exception, RosterEntityType::Wrestler))
         ->toBe('wrestlers.errors.not_suspended')
-        ->and(ErrorMessageMappingService::mapManagerException($exception))
+        ->and(ErrorMessageMappingService::map($exception, RosterEntityType::Manager))
         ->toBe('managers.errors.not_suspended')
-        ->and(ErrorMessageMappingService::mapRefereeException($exception))
+        ->and(ErrorMessageMappingService::map($exception, RosterEntityType::Referee))
         ->toBe('referees.errors.not_suspended');
 });
 
@@ -73,36 +75,37 @@ test('it maps tag team reinstatement failures from a stable reason', function ()
     $exception = TagTeamCannotBeReinstatedException::notSuspended($tagTeam);
 
     expect($exception->reason())->toBe(BusinessRuleReason::NotSuspended)
-        ->and(ErrorMessageMappingService::mapTagTeamException($exception))
+        ->and(ErrorMessageMappingService::map($exception, RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.not_suspended');
 });
 
 test('it maps tag team lifecycle failures from stable reasons', function () {
     $tagTeam = new TagTeam(['name' => 'Test Team']);
 
-    expect(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeEmployedException::alreadyEmployed($tagTeam)))
+    expect(ErrorMessageMappingService::map(TagTeamCannotBeEmployedException::alreadyEmployed($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.already_employed')
-        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeEmployedException::retired($tagTeam)))
+        ->and(ErrorMessageMappingService::map(TagTeamCannotBeEmployedException::retired($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.cannot_employ_retired')
-        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeReleasedException::notEmployed($tagTeam)))
+        ->and(ErrorMessageMappingService::map(TagTeamCannotBeReleasedException::notEmployed($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.not_employed')
-        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeRetiredException::notEmployed($tagTeam)))
+        ->and(ErrorMessageMappingService::map(TagTeamCannotBeRetiredException::notEmployed($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.cannot_retire_unemployed')
-        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeRetiredException::alreadyRetired($tagTeam)))
+        ->and(ErrorMessageMappingService::map(TagTeamCannotBeRetiredException::alreadyRetired($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.already_retired')
-        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeUnretiredException::notRetired($tagTeam)))
+        ->and(ErrorMessageMappingService::map(TagTeamCannotBeUnretiredException::notRetired($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.not_retired')
-        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeSuspendedException::notEmployed($tagTeam)))
+        ->and(ErrorMessageMappingService::map(TagTeamCannotBeSuspendedException::notEmployed($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.not_employed_suspend')
-        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeSuspendedException::alreadySuspended($tagTeam)))
+        ->and(ErrorMessageMappingService::map(TagTeamCannotBeSuspendedException::alreadySuspended($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.already_suspended')
-        ->and(ErrorMessageMappingService::mapTagTeamException(TagTeamCannotBeRestoredException::notDeleted($tagTeam)))
+        ->and(ErrorMessageMappingService::map(TagTeamCannotBeRestoredException::notDeleted($tagTeam), RosterEntityType::TagTeam))
         ->toBe('tag-teams.errors.not_deleted');
 });
 
-test('it uses a general message for unknown exceptions', function () {
-    $exception = new RuntimeException('Unknown failure.');
+test('it uses a general message for an unmapped business exception', function () {
+    $wrestler = new Wrestler(['name' => 'Test Wrestler']);
+    $exception = CannotBeDeletedException::alreadyDeleted($wrestler);
 
-    expect(ErrorMessageMappingService::mapWrestlerException($exception))
+    expect(ErrorMessageMappingService::map($exception, RosterEntityType::Wrestler))
         ->toBe('wrestlers.errors.general_error');
 });


### PR DESCRIPTION
## Summary
- replace roster entity string literals with a backed RosterEntityType enum
- reduce the error mapper to one typed BaseBusinessException entry point
- use the enum for Livewire event and translation namespaces

## Verification
- 102 focused tests passed, 310 assertions
- composer lint
- composer test:types
- git diff --check