### PR TITLE
refactor: execute table actions directly

### DIFF
--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -27,7 +27,6 @@ use App\Exceptions\Roster\Individuals\CannotBeUnretiredException;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
-use App\Livewire\Managers\Components\Actions;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
@@ -269,22 +268,20 @@ class Main extends BaseTable
 
     public function handleManagerAction(string $action, int $managerId): void
     {
-        $manager = Manager::findOrFail($managerId);
-
-        // Delegate to the Actions component
-        $actionsComponent = new Actions();
-        $actionsComponent->manager = $manager;
+        $manager = $action === 'restore'
+            ? Manager::onlyTrashed()->findOrFail($managerId)
+            : Manager::findOrFail($managerId);
 
         match ($action) {
-            'employ' => $actionsComponent->employ(),
-            'release' => $actionsComponent->release(),
-            'retire' => $actionsComponent->retire(),
-            'unretire' => $actionsComponent->unretire(),
-            'suspend' => $actionsComponent->suspend(),
-            'reinstate' => $actionsComponent->reinstate(),
-            'injure' => $actionsComponent->injure(),
-            'heal' => $actionsComponent->healFromInjury(),
-            'restore' => $actionsComponent->restore(),
+            'employ' => $this->employ($manager),
+            'release' => $this->release($manager),
+            'retire' => $this->retire($manager),
+            'unretire' => $this->unretire($manager),
+            'suspend' => $this->suspend($manager),
+            'reinstate' => $this->reinstate($manager),
+            'injure' => $this->injure($manager),
+            'heal' => $this->clearFromInjury($manager),
+            'restore' => $this->restore($managerId),
             default => null,
         };
     }

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -27,7 +27,6 @@ use App\Exceptions\Roster\Individuals\CannotBeUnretiredException;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
-use App\Livewire\Referees\Components\Actions;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
@@ -270,22 +269,20 @@ class Main extends BaseTable
 
     public function handleRefereeAction(string $action, int $refereeId): void
     {
-        $referee = Referee::findOrFail($refereeId);
-
-        // Delegate to the Actions component
-        $actionsComponent = new Actions();
-        $actionsComponent->referee = $referee;
+        $referee = $action === 'restore'
+            ? Referee::onlyTrashed()->findOrFail($refereeId)
+            : Referee::findOrFail($refereeId);
 
         match ($action) {
-            'employ' => $actionsComponent->employ(),
-            'release' => $actionsComponent->release(),
-            'retire' => $actionsComponent->retire(),
-            'unretire' => $actionsComponent->unretire(),
-            'suspend' => $actionsComponent->suspend(),
-            'reinstate' => $actionsComponent->reinstate(),
-            'injure' => $actionsComponent->injure(),
-            'heal' => $actionsComponent->healFromInjury(),
-            'restore' => $actionsComponent->restore(),
+            'employ' => $this->employ($referee),
+            'release' => $this->release($referee),
+            'retire' => $this->retire($referee),
+            'unretire' => $this->unretire($referee),
+            'suspend' => $this->suspend($referee),
+            'reinstate' => $this->reinstate($referee),
+            'injure' => $this->injure($referee),
+            'heal' => $this->clearFromInjury($referee),
+            'restore' => $this->restore($refereeId),
             default => null,
         };
     }

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -7,12 +7,14 @@ namespace App\Livewire\Titles\Tables;
 use App\Actions\Titles\DebutAction;
 use App\Actions\Titles\DeleteAction;
 use App\Actions\Titles\PullAction;
+use App\Actions\Titles\ReinstateAction;
 use App\Actions\Titles\RestoreAction;
 use App\Actions\Titles\RetireAction;
 use App\Actions\Titles\UnretireAction;
 use App\Builders\Titles\TitleBuilder;
 use App\Exceptions\Titles\CannotBeDebutedException;
 use App\Exceptions\Titles\CannotBePulledException;
+use App\Exceptions\Titles\CannotBeReinstatedException;
 use App\Exceptions\Titles\CannotBeRetiredException;
 use App\Exceptions\Titles\CannotBeUnretiredException;
 use App\Livewire\Base\Tables\BaseTable;
@@ -21,7 +23,6 @@ use App\Livewire\Components\Tables\Filters\FirstActivityPeriodFilter;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
-use App\Livewire\Titles\Components\Actions;
 use App\Models\Titles\Title;
 use App\Queries\Titles\TitleChampionshipQuery;
 use Illuminate\Database\Eloquent\Builder;
@@ -300,21 +301,32 @@ class Main extends BaseTable
         return back();
     }
 
+    public function reinstate(Title $title): RedirectResponse
+    {
+        Gate::authorize('reinstate', $title);
+
+        try {
+            resolve(ReinstateAction::class)->handle($title);
+        } catch (CannotBeReinstatedException $exception) {
+            return redirect()->back()->with('error', $exception->getMessage());
+        }
+
+        return back();
+    }
+
     public function handleTitleAction(string $action, int $titleId): void
     {
-        $title = Title::findOrFail($titleId);
-
-        // Delegate to the Actions component
-        $actionsComponent = new Actions();
-        $actionsComponent->title = $title;
+        $title = $action === 'restore'
+            ? Title::onlyTrashed()->findOrFail($titleId)
+            : Title::findOrFail($titleId);
 
         match ($action) {
-            'debut' => $actionsComponent->debut(),
-            'pull' => $actionsComponent->deactivate(),
-            'reinstate' => $actionsComponent->reinstate(),
-            'retire' => $actionsComponent->retire(),
-            'unretire' => $actionsComponent->unretire(),
-            'restore' => $actionsComponent->restore(),
+            'debut' => $this->debut($title),
+            'pull' => $this->putOnHold($title),
+            'reinstate' => $this->reinstate($title),
+            'retire' => $this->retire($title),
+            'unretire' => $this->unretire($title),
+            'restore' => $this->restore($titleId),
             default => null,
         };
     }

--- a/app/Livewire/Wrestlers/Tables/Main.php
+++ b/app/Livewire/Wrestlers/Tables/Main.php
@@ -5,22 +5,33 @@ declare(strict_types=1);
 namespace App\Livewire\Wrestlers\Tables;
 
 use App\Actions\Wrestlers\DeleteAction;
+use App\Actions\Wrestlers\EmployAction;
+use App\Actions\Wrestlers\HealAction;
+use App\Actions\Wrestlers\InjureAction;
+use App\Actions\Wrestlers\ReinstateAction;
+use App\Actions\Wrestlers\ReleaseAction;
 use App\Actions\Wrestlers\RestoreAction;
+use App\Actions\Wrestlers\RetireAction;
+use App\Actions\Wrestlers\SuspendAction;
+use App\Actions\Wrestlers\UnretireAction;
 use App\Builders\Roster\WrestlerBuilder;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
+use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
-use App\Livewire\Wrestlers\Components\Actions;
 use App\Models\Roster\Wrestlers\Wrestler;
+use Closure;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
 /** @extends BaseTable<Wrestler> */
 class Main extends BaseTable
 {
+    use ExecutesRosterActions;
+
     protected bool $showActionColumn = true;
 
     protected string $databaseTableName = 'wrestlers';
@@ -131,23 +142,29 @@ class Main extends BaseTable
 
     public function handleWrestlerAction(string $action, int $wrestlerId): void
     {
-        $wrestler = Wrestler::findOrFail($wrestlerId);
-
-        // Delegate to the Actions component
-        $actionsComponent = new Actions();
-        $actionsComponent->wrestler = $wrestler;
+        $wrestler = $action === 'restore'
+            ? Wrestler::onlyTrashed()->findOrFail($wrestlerId)
+            : Wrestler::findOrFail($wrestlerId);
 
         match ($action) {
-            'employ' => $actionsComponent->employ(),
-            'release' => $actionsComponent->release(),
-            'retire' => $actionsComponent->retire(),
-            'unretire' => $actionsComponent->unretire(),
-            'suspend' => $actionsComponent->suspend(),
-            'reinstate' => $actionsComponent->reinstate(),
-            'injure' => $actionsComponent->injure(),
-            'heal' => $actionsComponent->healFromInjury(),
-            'restore' => $actionsComponent->restore(),
+            'employ' => $this->executeWrestlerAction('employ', 'employed', $wrestler, fn () => resolve(EmployAction::class)->handle($wrestler)),
+            'release' => $this->executeWrestlerAction('release', 'released', $wrestler, fn () => resolve(ReleaseAction::class)->handle($wrestler)),
+            'retire' => $this->executeWrestlerAction('retire', 'retired', $wrestler, fn () => resolve(RetireAction::class)->handle($wrestler)),
+            'unretire' => $this->executeWrestlerAction('unretire', 'unretired', $wrestler, fn () => resolve(UnretireAction::class)->handle($wrestler)),
+            'suspend' => $this->executeWrestlerAction('suspend', 'suspended', $wrestler, fn () => resolve(SuspendAction::class)->handle($wrestler)),
+            'reinstate' => $this->executeWrestlerAction('reinstate', 'reinstated', $wrestler, fn () => resolve(ReinstateAction::class)->handle($wrestler)),
+            'injure' => $this->executeWrestlerAction('injure', 'injured', $wrestler, fn () => resolve(InjureAction::class)->handle($wrestler)),
+            'heal' => $this->executeWrestlerAction('clearFromInjury', 'healed', $wrestler, fn () => resolve(HealAction::class)->handle($wrestler)),
+            'restore' => $this->restore($wrestlerId),
             default => null,
         };
+    }
+
+    /** @param Closure(): void $action */
+    private function executeWrestlerAction(string $ability, string $successAction, Wrestler $wrestler, Closure $action): void
+    {
+        Gate::authorize($ability, $wrestler);
+
+        $this->executeRosterAction($successAction, 'wrestler', $action);
     }
 }

--- a/tests/Feature/Architecture/RuntimeBoundaryTest.php
+++ b/tests/Feature/Architecture/RuntimeBoundaryTest.php
@@ -17,3 +17,17 @@ test('application runtime code does not create records through model factories',
 
     expect($factoryUsages)->toBeEmpty();
 });
+
+test('Livewire components do not instantiate other Livewire components', function () {
+    $componentConstructions = [];
+
+    foreach (Finder::create()->files()->in(app_path('Livewire'))->name('*.php') as $file) {
+        if (! preg_match('/new\s+Actions\s*\(/', $file->getContents())) {
+            continue;
+        }
+
+        $componentConstructions[] = $file->getRelativePathname();
+    }
+
+    expect($componentConstructions)->toBeEmpty();
+});


### PR DESCRIPTION
## Summary
- stop table components from manually instantiating sibling Livewire action components
- execute authorized domain Actions at the active table boundary
- preserve lifecycle redirects and restore soft-deleted records through the existing table methods
- add an architecture regression guard

## Verification
- 38 focused tests passed, 217 assertions
- composer lint
- composer test:types
- git diff --check