### PR TITLE
refactor: simplify model test generator

### DIFF
--- a/app/Console/Commands/EnhancedTestMakeCommand.php
+++ b/app/Console/Commands/EnhancedTestMakeCommand.php
@@ -49,7 +49,6 @@ class EnhancedTestMakeCommand extends TestMakeCommand
                     $this->info('* Generating standardized model test with Ringside...');
 
                     $result = $this->call('ringside:make:test', [
-                        '--unit' => $this->option('unit'),
                         '--model' => $modelName,
                     ]);
 

--- a/app/Console/Commands/MakeModelTest.php
+++ b/app/Console/Commands/MakeModelTest.php
@@ -23,7 +23,6 @@ class MakeModelTest extends Command
 
         // Delegate to the full Ringside command
         $args = [
-            '--unit' => true,
             '--model' => $modelName,
         ];
 

--- a/app/Console/Commands/RingsideMakeTest.php
+++ b/app/Console/Commands/RingsideMakeTest.php
@@ -17,8 +17,8 @@ use ReflectionMethod;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\text;
 
-#[Signature('ringside:make:test {name? : The name of the test (optional)} {--unit : Create a unit test} {--feature : Create a feature test} {--model= : Generate a model test for the specified model} {--directory= : Specify model directory (e.g., Users for Users/User)} {--action= : Generate an action test for the specified action} {--repository= : Generate a repository test for the specified repository}')]
-#[Description('Generate standardized Ringside tests (models, actions, repositories)')]
+#[Signature('ringside:make:test {--model= : Generate a model test for the specified model} {--directory= : Specify model directory (e.g., Users for Users/User)}')]
+#[Description('Generate a standardized Ringside model test')]
 class RingsideMakeTest extends Command
 {
     /**
@@ -28,66 +28,16 @@ class RingsideMakeTest extends Command
     {
         $filesystem = new Filesystem();
 
-        // Determine test type and entity with interactive prompts
         if ($this->option('model')) {
             $directory = $this->option('directory');
 
             return $this->generateModelTest($this->option('model'), $filesystem, $directory);
         }
 
-        if ($this->option('action')) {
-            $this->error('Action test generation not yet implemented.');
-
-            return 1;
-        }
-
-        if ($this->option('repository')) {
-            $this->error('Repository test generation not yet implemented.');
-
-            return 1;
-        }
-
-        // No specific test type provided - show interactive prompts
-        return $this->handleInteractiveMode($filesystem);
-    }
-
-    /**
-     * Handle interactive mode when no specific options are provided.
-     */
-    protected function handleInteractiveMode(Filesystem $filesystem): int
-    {
         $this->info('🚀 Ringside Test Generator');
         $this->line('');
 
-        // Ask for test type
-        $testType = select(
-            label: 'What type of test would you like to generate?',
-            options: [
-                'model' => 'Model test (data layer validation)',
-                'action' => 'Action test (coming soon)',
-                'repository' => 'Repository test (coming soon)',
-            ],
-            default: 'model'
-        );
-
-        if ($testType === 'action') {
-            $this->error('Action test generation not yet implemented.');
-
-            return 1;
-        }
-
-        if ($testType === 'repository') {
-            $this->error('Repository test generation not yet implemented.');
-
-            return 1;
-        }
-
-        // Handle model test type
-        if ($testType === 'model') {
-            return $this->handleInteractiveModelTest($filesystem);
-        }
-
-        return 1;
+        return $this->handleInteractiveModelTest($filesystem);
     }
 
     /**
@@ -174,13 +124,6 @@ class RingsideMakeTest extends Command
      */
     protected function generateModelTest(string $modelName, Filesystem $filesystem, ?string $directory = null): int
     {
-        // Validate unit flag is present
-        if (! $this->option('unit')) {
-            $this->error('Model tests currently only support --unit flag');
-
-            return 1;
-        }
-
         // Resolve model class and namespace
         $modelClass = $this->resolveModelClass($modelName, $directory);
 
@@ -192,7 +135,8 @@ class RingsideMakeTest extends Command
 
         // Generate test file path
         $testClassName = Str::studly($modelName).'Test';
-        $testFilePath = base_path("tests/Unit/Models/{$testClassName}.php");
+        $relativeTestPath = $this->modelTestPath($modelClass, $testClassName);
+        $testFilePath = base_path($relativeTestPath);
 
         // Check if test already exists
         if ($filesystem->exists($testFilePath)) {
@@ -228,9 +172,22 @@ class RingsideMakeTest extends Command
         $this->line('1. Review generated fillable properties array');
         $this->line('2. Verify casts configuration');
         $this->line('3. Update traits list if needed');
-        $this->line("4. Run: php artisan test tests/Unit/Models/{$testClassName}.php");
+        $this->line("4. Run: php artisan test {$relativeTestPath}");
 
         return 0;
+    }
+
+    protected function modelTestPath(string $modelClass, string $testClassName): string
+    {
+        $relativeModelClass = Str::after($modelClass, 'App\\Models\\');
+        $relativeModelDirectory = str_contains($relativeModelClass, '\\')
+            ? Str::beforeLast($relativeModelClass, '\\')
+            : '';
+        $relativeTestDirectory = $relativeModelDirectory === ''
+            ? 'tests/Unit/Models'
+            : 'tests/Unit/Models/'.str_replace('\\', '/', $relativeModelDirectory);
+
+        return "{$relativeTestDirectory}/{$testClassName}.php";
     }
 
     /**

--- a/docs/development/commands.md
+++ b/docs/development/commands.md
@@ -37,27 +37,27 @@ This document provides a comprehensive reference for all development and testing
 ## Test Generation
 
 ### Ringside Test Generator
-- `php artisan ringside:make:test --unit --model="ModelName"` - Generate standardized model unit tests
+- `php artisan ringside:make:test --model="ModelName"` - Generate standardized model unit tests
 
 ### Command Examples
 
 ```bash
 # Generate test for Wrestler model (auto-detected in Wrestlers/ directory)
-php artisan ringside:make:test --unit --model="Wrestler"
-# Creates: tests/Unit/Models/WrestlerTest.php
+php artisan ringside:make:test --model="Wrestler"
+# Creates: tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php
 
 # Generate test for User model with directory specification
 php artisan make:model-test User --directory=Users
-# Creates: tests/Unit/Models/UserTest.php
+# Creates: tests/Unit/Models/Users/UserTest.php
 # Resolves: App\Models\Users\User
 
 # Generate test for nested model
-php artisan ringside:make:test --unit --model="TitleChampionship"  
-# Creates: tests/Unit/Models/TitleChampionshipTest.php
+php artisan ringside:make:test --model="TitleChampionship"
+# Creates: tests/Unit/Models/Titles/TitleChampionshipTest.php
 
 # Generate test with full namespace
-php artisan ringside:make:test --unit --model="App\Models\Events\Venue"
-# Creates: tests/Unit/Models/VenueTest.php
+php artisan ringside:make:test --model="App\Models\Events\Venue"
+# Creates: tests/Unit/Models/Events/VenueTest.php
 ```
 
 ### Enhanced Command Integration
@@ -72,14 +72,14 @@ php artisan make:model-test Product
 php artisan make:model-test User --directory=Users
 
 # Option 3: Full Ringside command
-php artisan ringside:make:test --unit --model="Product"
+php artisan ringside:make:test --model="Product"
 
 # Option 4: Full command with directory
-php artisan ringside:make:test --unit --model="User" --directory="Users"
+php artisan ringside:make:test --model="User" --directory="Users"
 
 # Option 5: Interactive mode
 php artisan ringside:make:test
-# Prompts for test type, model selection, and optional directory
+# Prompts for the model and optional directory
 
 # Option 6: Enhanced Laravel integration
 php artisan make:test ProductTest --unit

--- a/tests/Feature/Console/Commands/RingsideMakeTestTest.php
+++ b/tests/Feature/Console/Commands/RingsideMakeTestTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Console\Commands\RingsideMakeTest;
+use App\Models\Events\Event;
+use App\Models\Roster\Wrestlers\Wrestler;
+
+final class TestableRingsideMakeTest extends RingsideMakeTest
+{
+    public function pathFor(string $modelClass): string
+    {
+        return $this->modelTestPath($modelClass, class_basename($modelClass).'Test');
+    }
+}
+
+test('it mirrors model namespaces in generated unit test paths', function (string $modelClass, string $expectedPath) {
+    $command = new TestableRingsideMakeTest();
+
+    expect($command->pathFor($modelClass))->toBe($expectedPath);
+})->with([
+    'roster model' => [
+        Wrestler::class,
+        'tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php',
+    ],
+    'event model' => [
+        Event::class,
+        'tests/Unit/Models/Events/EventTest.php',
+    ],
+    'root model' => [
+        'App\\Models\\User',
+        'tests/Unit/Models/UserTest.php',
+    ],
+]);


### PR DESCRIPTION
## Summary
- scope the custom generator to the model unit tests it actually supports
- remove unimplemented action, repository, feature, and redundant unit modes
- mirror App\Models namespaces in generated Unit test paths
- update generator documentation and add path regression coverage

## Verification
- 3 focused tests passed
- composer lint
- composer test:types
- git diff --check