### PR TITLE
fix: type wrestler table actions

### DIFF
--- a/app/Livewire/Wrestlers/Tables/Main.php
+++ b/app/Livewire/Wrestlers/Tables/Main.php
@@ -15,6 +15,7 @@ use App\Actions\Wrestlers\RetireAction;
 use App\Actions\Wrestlers\SuspendAction;
 use App\Actions\Wrestlers\UnretireAction;
 use App\Builders\Roster\WrestlerBuilder;
+use App\Enums\Roster\RosterEntityType;
 use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Components\Tables\Columns\FirstEmploymentDateColumn;
 use App\Livewire\Components\Tables\Filters\FirstEmploymentFilter;
@@ -165,6 +166,6 @@ class Main extends BaseTable
     {
         Gate::authorize($ability, $wrestler);
 
-        $this->executeRosterAction($successAction, 'wrestler', $action);
+        $this->executeRosterAction($successAction, RosterEntityType::Wrestler, $action);
     }
 }


### PR DESCRIPTION
## Summary
- pass the typed roster entity enum from the Wrestler table action boundary
- restore compatibility between the two independently verified Livewire refactors

## Verification
- 11 focused tests passed, 37 assertions
- composer lint
- composer test:types
- pre-push quality gates through Rector and type coverage
- git diff --check