### PR TITLE
refactor: persist event and venue forms through actions

### DIFF
--- a/app/Livewire/Events/Forms/CreateEditForm.php
+++ b/app/Livewire/Events/Forms/CreateEditForm.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\Livewire\Events\Forms;
 
+use App\Data\Events\EventData;
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Concerns\Data\PresentsVenuesList;
 use App\Models\Events\Event;
+use App\Models\Events\Venue;
 use App\Rules\Events\DateCanBeChanged;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -140,6 +142,21 @@ class CreateEditForm extends BaseForm
             'venue_id' => $this->venue_id,
             'preview' => $this->preview,
         ];
+    }
+
+    public function toData(): EventData
+    {
+        return new EventData(
+            name: $this->name,
+            date: $this->date ? Carbon::parse($this->date) : null,
+            venue: $this->venue_id ? Venue::query()->findOrFail($this->venue_id) : null,
+            preview: $this->preview ?: null,
+        );
+    }
+
+    public function event(): Event
+    {
+        return Event::query()->findOrFail($this->modelId);
     }
 
     /**

--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Livewire\Events\Modals;
 
+use App\Actions\Events\CreateAction;
+use App\Actions\Events\UpdateAction;
 use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Concerns\Data\PresentsVenuesList;
 use App\Livewire\Events\Forms\CreateEditForm;
@@ -21,6 +23,16 @@ class FormModal extends BaseFormModal
     use PresentsVenuesList;
 
     public CreateEditForm $form;
+
+    private CreateAction $createAction;
+
+    private UpdateAction $updateAction;
+
+    public function boot(CreateAction $createAction, UpdateAction $updateAction): void
+    {
+        $this->createAction = $createAction;
+        $this->updateAction = $updateAction;
+    }
 
     protected function getFormClass(): string
     {
@@ -68,6 +80,21 @@ class FormModal extends BaseFormModal
         }
 
         parent::openModal($modelId);
+    }
+
+    protected function storeForm(): bool
+    {
+        $this->form->validate();
+
+        if ($this->form->isEditing()) {
+            $this->updateAction->handle($this->form->event(), $this->form->toData());
+
+            return true;
+        }
+
+        $this->createAction->handle($this->form->toData());
+
+        return true;
     }
 
     public function render(): View

--- a/app/Livewire/Venues/Forms/CreateEditForm.php
+++ b/app/Livewire/Venues/Forms/CreateEditForm.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Venues\Forms;
 
+use App\Data\Events\VenueData;
 use App\Enums\Shared\UnitedStatesState;
 use App\Livewire\Base\BaseForm;
 use App\Models\Events\Venue;
@@ -134,6 +135,22 @@ class CreateEditForm extends BaseForm
                 zipcode: (string) $this->zipcode,
             ),
         ];
+    }
+
+    public function toData(): VenueData
+    {
+        return new VenueData(
+            name: $this->name,
+            street_address: $this->street_address,
+            city: $this->city,
+            state: $this->state,
+            zipcode: (string) $this->zipcode,
+        );
+    }
+
+    public function venue(): Venue
+    {
+        return Venue::query()->findOrFail($this->modelId);
     }
 
     /**

--- a/app/Livewire/Venues/Modals/FormModal.php
+++ b/app/Livewire/Venues/Modals/FormModal.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Livewire\Venues\Modals;
 
+use App\Actions\Venues\CreateAction;
+use App\Actions\Venues\UpdateAction;
 use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Venues\Forms\CreateEditForm;
 use App\Models\Events\Venue;
@@ -16,6 +18,16 @@ use Illuminate\View\View;
 class FormModal extends BaseFormModal
 {
     public CreateEditForm $form;
+
+    private CreateAction $createAction;
+
+    private UpdateAction $updateAction;
+
+    public function boot(CreateAction $createAction, UpdateAction $updateAction): void
+    {
+        $this->createAction = $createAction;
+        $this->updateAction = $updateAction;
+    }
 
     protected function getFormClass(): string
     {
@@ -62,6 +74,21 @@ class FormModal extends BaseFormModal
     public function render(): View
     {
         return view($this->modalFormPath ?? 'livewire.venues.modals.form-modal');
+    }
+
+    protected function storeForm(): bool
+    {
+        $this->form->validate();
+
+        if ($this->form->isEditing()) {
+            $this->updateAction->handle($this->form->venue(), $this->form->toData());
+
+            return true;
+        }
+
+        $this->createAction->handle($this->form->toData());
+
+        return true;
     }
 
     public function submitForm(): bool


### PR DESCRIPTION
## Summary
- map Event and Venue Livewire forms into typed data objects
- persist Event and Venue changes through their domain actions
- keep Livewire components responsible for validation and UI orchestration only

## Verification
- composer test:push
- 76 focused tests, 239 assertions