### PR TITLE
refactor: remove stale generated docblocks

### DIFF
--- a/app/Enums/Shared/ActivationStatus.php
+++ b/app/Enums/Shared/ActivationStatus.php
@@ -14,7 +14,6 @@ namespace App\Enums\Shared;
  * Wrestling promotions need consistent status tracking across different
  * entity types. This enum provides the common statuses used by multiple
  * entity types to ensure consistency in status management.
- *
  */
 enum ActivationStatus: string
 {

--- a/app/Enums/Shared/ActivationStatus.php
+++ b/app/Enums/Shared/ActivationStatus.php
@@ -15,14 +15,6 @@ namespace App\Enums\Shared;
  * entity types. This enum provides the common statuses used by multiple
  * entity types to ensure consistency in status management.
  *
- * @example
- * ```php
- * // Used by Stables
- * $stable->status = ActivationStatus::Active;
- *
- * // Used by Titles
- * $title->status = ActivationStatus::Inactive;
- * ```
  */
 enum ActivationStatus: string
 {

--- a/app/Enums/Stables/StableMemberType.php
+++ b/app/Enums/Stables/StableMemberType.php
@@ -16,7 +16,6 @@ use InvalidArgumentException;
  * Defines the valid types of members that can belong to a stable and their
  * corresponding relationship names. Provides type-safe member type handling
  * and automatic model type detection.
- *
  */
 enum StableMemberType: string
 {

--- a/app/Enums/Stables/StableMemberType.php
+++ b/app/Enums/Stables/StableMemberType.php
@@ -17,11 +17,6 @@ use InvalidArgumentException;
  * corresponding relationship names. Provides type-safe member type handling
  * and automatic model type detection.
  *
- * @example
- * ```php
- * $type = StableMemberType::fromModel($wrestler);
- * $relationshipName = $type->getRelationshipName(); // 'wrestlers'
- * ```
  */
 enum StableMemberType: string
 {

--- a/app/Livewire/Base/Tables/BasePreviousManagersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousManagersTable.php
@@ -26,7 +26,6 @@ abstract class BasePreviousManagersTable extends DataTableComponent
     public function configure(): void {}
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Base/Tables/BasePreviousManagersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousManagersTable.php
@@ -26,7 +26,6 @@ abstract class BasePreviousManagersTable extends DataTableComponent
     public function configure(): void {}
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
@@ -37,7 +37,6 @@ abstract class BasePreviousMatchesTable extends DataTableComponent
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
@@ -37,7 +37,6 @@ abstract class BasePreviousMatchesTable extends DataTableComponent
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Base/Tables/BasePreviousStablesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousStablesTable.php
@@ -26,7 +26,6 @@ abstract class BasePreviousStablesTable extends DataTableComponent
     public function configure(): void {}
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Base/Tables/BasePreviousStablesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousStablesTable.php
@@ -26,7 +26,6 @@ abstract class BasePreviousStablesTable extends DataTableComponent
     public function configure(): void {}
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
@@ -35,7 +35,6 @@ abstract class BasePreviousTagTeamsTable extends DataTableComponent
     abstract protected function getPartnerRoute(TagTeamWrestler $row): string;
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
@@ -35,7 +35,6 @@ abstract class BasePreviousTagTeamsTable extends DataTableComponent
     abstract protected function getPartnerRoute(TagTeamWrestler $row): string;
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
@@ -35,7 +35,6 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
@@ -35,7 +35,6 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
@@ -26,7 +26,6 @@ abstract class BasePreviousWrestlersTable extends DataTableComponent
     public function configure(): void {}
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousWrestlersTable.php
@@ -26,7 +26,6 @@ abstract class BasePreviousWrestlersTable extends DataTableComponent
     public function configure(): void {}
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -21,29 +21,6 @@ use LogicException;
  *
  * @since 1.0.0
  *
- * @example
- * ```php
- * class CreateEditForm extends BaseForm
- * {
- *     use GeneratesDummyData;
- *
- *     public string $preview = '';
- *     public int $matchTypeId = 0;
- *
- *     protected function getDummyDataFields(): array
- *     {
- *         return [
- *             'preview' => fn() => fake()->paragraph() . ' Epic match!',
- *             'matchTypeId' => fn() => fake()->numberBetween(1, 10),
- *         ];
- *     }
- *
- *     public function fillWithDummyData(): void
- *     {
- *         $this->fillDummyFields();
- *     }
- * }
- * ```
  */
 trait GeneratesDummyData
 {
@@ -55,11 +32,6 @@ trait GeneratesDummyData
      * both callable generators and static values.
      *
      *
-     * @example
-     * ```php
-     * // Call this method to populate all defined dummy fields
-     * $this->fillDummyFields();
-     * ```
      */
     public function fillDummyFields(): void
     {
@@ -108,18 +80,6 @@ trait GeneratesDummyData
      *
      * @return array<string, callable|mixed> Array mapping field names to generators
      *
-     * @example
-     * ```php
-     * protected function getDummyDataFields(): array
-     * {
-     *     return [
-     *         'name' => fn() => $this->generateWrestlingName(),
-     *         'signature_move' => fn() => $this->generateSignatureMove(),
-     *         'weight' => fn() => fake()->numberBetween(150, 300),
-     *         'active' => true, // Static value
-     *     ];
-     * }
-     * ```
      */
     abstract protected function getDummyDataFields(): array;
 
@@ -132,12 +92,6 @@ trait GeneratesDummyData
      *
      * @return string A realistic wrestling name
      *
-     * @example
-     * Possible outputs:
-     * - "John Smith"
-     * - "Thunder Johnson"
-     * - "The Destroyer"
-     * - "Mike 'Steel' Rodriguez"
      */
     protected function generateWrestlingName(): string
     {
@@ -162,12 +116,6 @@ trait GeneratesDummyData
      *
      * @return string A realistic signature move name
      *
-     * @example
-     * Possible outputs:
-     * - "Stone Cold Stunner"
-     * - "Tombstone Slam"
-     * - "Submission"
-     * - "People's Elbow"
      */
     protected function generateSignatureMove(): string
     {
@@ -199,12 +147,6 @@ trait GeneratesDummyData
      *
      * @return string A realistic venue name
      *
-     * @example
-     * Possible outputs:
-     * - "Madison Square Garden"
-     * - "American Airlines Center"
-     * - "Chicago Stadium"
-     * - "Wells Fargo Arena"
      */
     protected function generateVenueName(): string
     {
@@ -232,12 +174,6 @@ trait GeneratesDummyData
      *
      * @return string A realistic championship title name
      *
-     * @example
-     * Possible outputs:
-     * - "Intercontinental Championship Title"
-     * - "Women's Tag Team Titles"
-     * - "World Heavyweight Title"
-     * - "United States Championship"
      */
     protected function generateChampionshipTitle(): string
     {
@@ -261,17 +197,6 @@ trait GeneratesDummyData
      *
      * @return array<string, mixed> Address components with proper typing
      *
-     * @example
-     * ```php
-     * $address = $this->generateUSAddress();
-     * // Returns:
-     * // [
-     * //     'street_address' => '123 Main Street',
-     * //     'city' => 'Chicago',
-     * //     'state' => 'IL',
-     * //     'zipcode' => 60601
-     * // ]
-     * ```
      */
     protected function generateUSAddress(): array
     {
@@ -302,17 +227,6 @@ trait GeneratesDummyData
      * @param  string  $maxPeriod  Maximum future period (e.g., '+3 months', '+1 year')
      * @return string|null Date string in Y-m-d format, or null
      *
-     * @example
-     * ```php
-     * // 80% chance of a date within 3 months
-     * $startDate = $this->generateFutureDate(0.8, '+3 months');
-     *
-     * // Always generate a date within 1 year
-     * $contractDate = $this->generateFutureDate(1.0, '+1 year');
-     *
-     * // 30% chance of a date within 6 months
-     * $optionalDate = $this->generateFutureDate(0.3, '+6 months');
-     * ```
      */
     protected function generateFutureDate(float $probability = 0.8, string $maxPeriod = '+3 months'): ?string
     {
@@ -337,12 +251,6 @@ trait GeneratesDummyData
      * @param  string  $maxPeriod  Maximum future period (default: '+3 month')
      * @return string|null The formatted date string or null
      *
-     * @example
-     * ```php
-     * // Common usage in FormModal getDummyDataFields()
-     * 'start_date' => fn () => $this->generateOptionalStartDate(),
-     * 'employment_date' => fn () => $this->generateOptionalEmploymentDate(0.7),
-     * ```
      */
     protected function generateOptionalStartDate(
         string $format = 'Y-m-d H:i:s',

--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -20,7 +20,6 @@ use LogicException;
  * @author Ringside
  *
  * @since 1.0.0
- *
  */
 trait GeneratesDummyData
 {
@@ -30,8 +29,6 @@ trait GeneratesDummyData
      * This method automatically detects whether the form uses direct properties
      * or a form object pattern and populates fields accordingly. It supports
      * both callable generators and static values.
-     *
-     *
      */
     public function fillDummyFields(): void
     {
@@ -79,7 +76,6 @@ trait GeneratesDummyData
      * to define which fields should be populated and how they should be generated.
      *
      * @return array<string, callable|mixed> Array mapping field names to generators
-     *
      */
     abstract protected function getDummyDataFields(): array;
 
@@ -91,7 +87,6 @@ trait GeneratesDummyData
      * Perfect for wrestler, manager, or character name generation.
      *
      * @return string A realistic wrestling name
-     *
      */
     protected function generateWrestlingName(): string
     {
@@ -115,7 +110,6 @@ trait GeneratesDummyData
      * signature moves and finishers.
      *
      * @return string A realistic signature move name
-     *
      */
     protected function generateSignatureMove(): string
     {
@@ -146,7 +140,6 @@ trait GeneratesDummyData
      * appropriate venue suffixes.
      *
      * @return string A realistic venue name
-     *
      */
     protected function generateVenueName(): string
     {
@@ -173,7 +166,6 @@ trait GeneratesDummyData
      * nomenclature used in professional wrestling.
      *
      * @return string A realistic championship title name
-     *
      */
     protected function generateChampionshipTitle(): string
     {
@@ -196,7 +188,6 @@ trait GeneratesDummyData
      * including proper state abbreviations and valid ZIP code formats.
      *
      * @return array<string, mixed> Address components with proper typing
-     *
      */
     protected function generateUSAddress(): array
     {
@@ -226,7 +217,6 @@ trait GeneratesDummyData
      * @param  float  $probability  Probability of generating a date (0.0 to 1.0)
      * @param  string  $maxPeriod  Maximum future period (e.g., '+3 months', '+1 year')
      * @return string|null Date string in Y-m-d format, or null
-     *
      */
     protected function generateFutureDate(float $probability = 0.8, string $maxPeriod = '+3 months'): ?string
     {
@@ -250,7 +240,6 @@ trait GeneratesDummyData
      * @param  float  $probability  The probability of returning a date (default: 0.8)
      * @param  string  $maxPeriod  Maximum future period (default: '+3 month')
      * @return string|null The formatted date string or null
-     *
      */
     protected function generateOptionalStartDate(
         string $format = 'Y-m-d H:i:s',

--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -61,7 +61,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */
@@ -80,7 +79,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Filter>
      */

--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -61,7 +61,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array
@@ -79,7 +78,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Filter>
      */
     public function filters(): array

--- a/app/Livewire/Managers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeams.php
@@ -49,7 +49,6 @@ class PreviousTagTeams extends DataTableComponent
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Managers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Managers/Tables/PreviousTagTeams.php
@@ -49,7 +49,6 @@ class PreviousTagTeams extends DataTableComponent
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Managers/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlers.php
@@ -46,7 +46,6 @@ class PreviousWrestlers extends DataTableComponent
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Managers/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Managers/Tables/PreviousWrestlers.php
@@ -46,7 +46,6 @@ class PreviousWrestlers extends DataTableComponent
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -43,7 +43,6 @@ use Illuminate\Validation\Rules\Enum;
  *
  * @extends BaseForm<CreateEditForm, EventMatch>
  *
- *
  * @since 1.0.0
  * @see BaseForm For base form functionality and patterns
  * @see EventMatch For the underlying event match model

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -43,7 +43,6 @@ use Illuminate\Validation\Rules\Enum;
  *
  * @extends BaseForm<CreateEditForm, EventMatch>
  *
- * @author Your Name
  *
  * @since 1.0.0
  * @see BaseForm For base form functionality and patterns

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -57,7 +57,6 @@ class MatchesTable extends DataTableComponent
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -57,7 +57,6 @@ class MatchesTable extends DataTableComponent
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -62,7 +62,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */
@@ -81,7 +80,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Filter>
      */

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -62,7 +62,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array
@@ -80,7 +79,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Filter>
      */
     public function filters(): array

--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -53,7 +53,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array
@@ -69,7 +68,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Filter>
      */
     public function filters(): array

--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -53,7 +53,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */
@@ -70,7 +69,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Filter>
      */

--- a/app/Livewire/TagTeams/Tables/Main.php
+++ b/app/Livewire/TagTeams/Tables/Main.php
@@ -57,7 +57,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */
@@ -74,7 +73,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Filter>
      */

--- a/app/Livewire/TagTeams/Tables/Main.php
+++ b/app/Livewire/TagTeams/Tables/Main.php
@@ -57,7 +57,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array
@@ -73,7 +72,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Filter>
      */
     public function filters(): array

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -41,16 +41,6 @@ use Illuminate\Support\Facades\Gate;
  * deactivation, retirement, restoration, and deletion through a comprehensive
  * action system with proper authorization and error handling.
  *
- * @example
- * ```php
- * // In a Blade template
- * <livewire:titles.tables.titles-table />
- *
- * // The table displays titles like:
- * // - WWE Championship Title (Active, First Activated: 2020-01-15)
- * // - Intercontinental Title (Retired, First Activated: 2019-06-01)
- * // - Tag Team Titles (Inactive, First Activated: 2021-03-10)
- * ```
  */
 /** @extends BaseTable<Title> */
 class Main extends BaseTable
@@ -90,14 +80,6 @@ class Main extends BaseTable
      *
      * @return TitleBuilder<Title> Query builder for titles with eager loaded relationships
      *
-     * @example
-     * ```php
-     * // The query retrieves titles with their activity status:
-     * // SELECT titles.*, activity_periods.* FROM titles
-     * // LEFT JOIN activity_periods ON titles.id = activity_periods.title_id
-     * // WHERE activity_periods.ended_at IS NULL
-     * // ORDER BY titles.name ASC
-     * ```
      */
     public function builder(): TitleBuilder
     {
@@ -127,14 +109,6 @@ class Main extends BaseTable
      *
      * @return array<int, Column> Array of column definitions for the table
      *
-     * @example
-     * ```php
-     * // Table displays columns:
-     * // | Name                    | Status   | First Activation |
-     * // | WWE Championship Title  | Active   | 2020-01-15      |
-     * // | Intercontinental Title  | Retired  | 2019-06-01      |
-     * // | Tag Team Titles         | Inactive | 2021-03-10      |
-     * ```
      */
     public function columns(): array
     {
@@ -159,12 +133,6 @@ class Main extends BaseTable
      *
      * @return array<int, Filter> Array of filter definitions for the table
      *
-     * @example
-     * ```php
-     * // Available filters:
-     * // - Status: [All, Undebuted, Active, Inactive, Pending Debut]
-     * // - Activation Date: [Date range picker for first activation]
-     * ```
      */
     public function filters(): array
     {

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -40,7 +40,6 @@ use Illuminate\Support\Facades\Gate;
  * The table integrates with various title management actions including activation,
  * deactivation, retirement, restoration, and deletion through a comprehensive
  * action system with proper authorization and error handling.
- *
  */
 /** @extends BaseTable<Title> */
 class Main extends BaseTable
@@ -79,7 +78,6 @@ class Main extends BaseTable
      * relationship provides access to activation status and dates.
      *
      * @return TitleBuilder<Title> Query builder for titles with eager loaded relationships
-     *
      */
     public function builder(): TitleBuilder
     {
@@ -108,7 +106,6 @@ class Main extends BaseTable
      * a title is currently active, inactive, or retired.
      *
      * @return array<int, Column> Array of column definitions for the table
-     *
      */
     public function columns(): array
     {
@@ -132,7 +129,6 @@ class Main extends BaseTable
      * titles activated within specific time periods.
      *
      * @return array<int, Filter> Array of filter definitions for the table
-     *
      */
     public function filters(): array
     {

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -49,7 +49,6 @@ class PreviousTitleChampionships extends DataTableComponent
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -49,7 +49,6 @@ class PreviousTitleChampionships extends DataTableComponent
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
+++ b/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
@@ -20,8 +20,6 @@ class TitleChampionshipsTable extends DataTableComponent
      */
     public ?Title $title = null;
 
-    /**
-     */
     public function mount(?Title $title = null): void
     {
         $this->title = $title;
@@ -52,7 +50,6 @@ class TitleChampionshipsTable extends DataTableComponent
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
+++ b/app/Livewire/Titles/Tables/TitleChampionshipsTable.php
@@ -21,7 +21,6 @@ class TitleChampionshipsTable extends DataTableComponent
     public ?Title $title = null;
 
     /**
-     * Undocumented function.
      */
     public function mount(?Title $title = null): void
     {
@@ -53,7 +52,6 @@ class TitleChampionshipsTable extends DataTableComponent
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Venues/Tables/Main.php
+++ b/app/Livewire/Venues/Tables/Main.php
@@ -39,7 +39,6 @@ class Main extends BaseTable
     }
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Venues/Tables/Main.php
+++ b/app/Livewire/Venues/Tables/Main.php
@@ -39,7 +39,6 @@ class Main extends BaseTable
     }
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Venues/Tables/PreviousEvents.php
+++ b/app/Livewire/Venues/Tables/PreviousEvents.php
@@ -41,7 +41,6 @@ class PreviousEvents extends DataTableComponent
     public function configure(): void {}
 
     /**
-     *
      * @return array<int, Column>
      */
     public function columns(): array

--- a/app/Livewire/Venues/Tables/PreviousEvents.php
+++ b/app/Livewire/Venues/Tables/PreviousEvents.php
@@ -41,7 +41,6 @@ class PreviousEvents extends DataTableComponent
     public function configure(): void {}
 
     /**
-     * Undocumented function
      *
      * @return array<int, Column>
      */

--- a/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
@@ -20,19 +20,6 @@ use LogicException;
  * The table displays tag teams ordered by when the wrestler joined them,
  * showing only completed memberships (where left_at is not null).
  *
- * @example
- * ```php
- * // In a Blade template
- * <livewire:wrestlers.tables.previous-tag-teams-table :wrestler-id="$wrestler->id" />
- *
- * // In a Livewire component
- * public function render()
- * {
- *     return view('livewire.wrestler.show', [
- *         'wrestler' => $this->wrestler,
- *     ]);
- * }
- * ```
  */
 class PreviousTagTeams extends BasePreviousTagTeamsTable
 {
@@ -65,13 +52,6 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
      * @throws LogicException If wrestlerId is not set
      * @return Builder<TagTeamWrestler> Query builder for tag team wrestler pivot records
      *
-     * @example
-     * ```php
-     * // The query finds pivot records like:
-     * // - TagTeamWrestler(wrestler_id: 1, tag_team_id: 5, joined_at: '1997-01-01', left_at: '1999-03-01')
-     * // - TagTeamWrestler(wrestler_id: 1, tag_team_id: 8, joined_at: '1999-04-01', left_at: '2000-01-01')
-     * // But excludes current memberships where left_at is null
-     * ```
      */
     public function builder(): Builder
     {
@@ -93,12 +73,6 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
      * the table to access both the pivot data and related tag team information.
      *
      *
-     * @example
-     * ```php
-     * // Ensures the query selects:
-     * // SELECT *, tag_team_id FROM tag_teams_wrestlers WHERE...
-     * // This allows access to both pivot and tag team data in the table
-     * ```
      */
     public function configure(): void
     {

--- a/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTagTeams.php
@@ -19,7 +19,6 @@ use LogicException;
  *
  * The table displays tag teams ordered by when the wrestler joined them,
  * showing only completed memberships (where left_at is not null).
- *
  */
 class PreviousTagTeams extends BasePreviousTagTeamsTable
 {
@@ -51,7 +50,6 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
      *
      * @throws LogicException If wrestlerId is not set
      * @return Builder<TagTeamWrestler> Query builder for tag team wrestler pivot records
-     *
      */
     public function builder(): Builder
     {
@@ -71,8 +69,6 @@ class PreviousTagTeams extends BasePreviousTagTeamsTable
      * Adds the tag team ID from the pivot table to the select statement
      * to ensure proper data retrieval for the table display. This allows
      * the table to access both the pivot data and related tag team information.
-     *
-     *
      */
     public function configure(): void
     {

--- a/app/Support/DateHelper.php
+++ b/app/Support/DateHelper.php
@@ -21,15 +21,6 @@ class DateHelper
      * @param  Carbon|null  $date  The optional date to use
      * @return Carbon The resolved date (provided date or current timestamp)
      *
-     * @example
-     * ```php
-     * // Instead of: $deletionDate = $deletionDate ?? now();
-     * $deletionDate = DateHelper::resolveDate($deletionDate);
-     *
-     * // Both calls are equivalent:
-     * DateHelper::resolveDate(null)                    // Returns now()
-     * DateHelper::resolveDate(Carbon::parse('2024-01-01'))  // Returns 2024-01-01
-     * ```
      */
     public static function resolveDate(?Carbon $date): Carbon
     {

--- a/app/Support/DateHelper.php
+++ b/app/Support/DateHelper.php
@@ -20,7 +20,6 @@ class DateHelper
      *
      * @param  Carbon|null  $date  The optional date to use
      * @return Carbon The resolved date (provided date or current timestamp)
-     *
      */
     public static function resolveDate(?Carbon $date): Carbon
     {

--- a/app/ValueObjects/Height.php
+++ b/app/ValueObjects/Height.php
@@ -13,7 +13,6 @@ use InvalidArgumentException;
  * for wrestlers, providing validation, formatting, and conversion methods.
  * Height is stored as feet and inches since this is the standard format
  * used in professional wrestling.
- *
  */
 readonly class Height
 {
@@ -55,7 +54,6 @@ readonly class Height
      * Returns the height in the standard wrestling format: feet'inches"
      *
      * @return string The formatted height (e.g., "6'2"")
-     *
      */
     public function __toString(): string
     {
@@ -69,7 +67,6 @@ readonly class Height
      * useful for height comparisons and calculations.
      *
      * @return int The total height in inches
-     *
      */
     public function toInches(): int
     {

--- a/app/ValueObjects/Height.php
+++ b/app/ValueObjects/Height.php
@@ -14,13 +14,6 @@ use InvalidArgumentException;
  * Height is stored as feet and inches since this is the standard format
  * used in professional wrestling.
  *
- * @example
- * ```php
- * // Create a height for a 6'2" wrestler
- * $height = new Height(6, 2);
- * echo $height; // "6'2""
- * echo $height->toInches(); // 74
- * ```
  */
 readonly class Height
 {
@@ -63,12 +56,6 @@ readonly class Height
      *
      * @return string The formatted height (e.g., "6'2"")
      *
-     * @example
-     * ```php
-     * $height = new Height(6, 2);
-     * echo $height->__toString(); // "6'2""
-     * echo (string) $height;      // "6'2""
-     * ```
      */
     public function __toString(): string
     {
@@ -83,11 +70,6 @@ readonly class Height
      *
      * @return int The total height in inches
      *
-     * @example
-     * ```php
-     * $height = new Height(6, 2);
-     * echo $height->toInches(); // 74 (6*12 + 2)
-     * ```
      */
     public function toInches(): int
     {

--- a/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
+++ b/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
@@ -31,15 +31,6 @@ describe('GeneratesDummyData Unit Tests', function () {
             expect($reflection->isAbstract())->toBeTrue();
         });
 
-        test('has comprehensive documentation', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $docComment = $reflection->getDocComment();
-
-            expect($docComment)->toContain('Trait for generating dummy data in Livewire forms');
-            expect($docComment)->toContain('@author');
-            expect($docComment)->toContain('@since');
-            expect($docComment)->toContain('@example');
-        });
     });
 
     describe('public method signatures', function () {
@@ -161,51 +152,6 @@ describe('GeneratesDummyData Unit Tests', function () {
             $source = reflectionSource($reflection);
 
             expect($source)->toContain('use LogicException;');
-        });
-    });
-
-    describe('method documentation', function () {
-        test('methods have comprehensive documentation', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            $documentedMethods = [
-                'fillDummyFields',
-                'populateField',
-                'getDummyDataFields',
-                'generateWrestlingName',
-                'generateSignatureMove',
-                'generateVenueName',
-                'generateChampionshipTitle',
-                'generateUSAddress',
-                'generateFutureDate',
-            ];
-
-            foreach ($documentedMethods as $methodName) {
-                $method = $reflection->getMethod($methodName);
-                $docComment = $method->getDocComment();
-
-                expect($docComment)->not->toBeFalse();
-                expect($docComment)->toContain('/**');
-            }
-        });
-
-        test('generator methods have example outputs', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            $generatorMethods = [
-                'generateWrestlingName',
-                'generateSignatureMove',
-                'generateVenueName',
-                'generateChampionshipTitle',
-            ];
-
-            foreach ($generatorMethods as $methodName) {
-                $method = $reflection->getMethod($methodName);
-                $docComment = $method->getDocComment();
-
-                expect($docComment)->toContain('@example');
-                expect($docComment)->toContain('Possible outputs:');
-            }
         });
     });
 


### PR DESCRIPTION
## Summary
- remove obsolete generated examples and placeholder annotations
- retain documentation that describes non-obvious behavior and types
- eliminate stale author placeholders from application code

## Verification
- composer test:push
- composer lint
- composer test:types