### PR TITLE
refactor: remove Livewire model persistence

### DIFF
--- a/app/Livewire/Base/BaseForm.php
+++ b/app/Livewire/Base/BaseForm.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Livewire\Base;
 
 use Illuminate\Database\Eloquent\Model;
-use Illuminate\Validation\ValidationException;
 use Livewire\Attributes\Locked;
 use Livewire\Form;
 
@@ -57,37 +56,6 @@ abstract class BaseForm extends Form
 
     protected function loadExtraData(): void {}
 
-    /** @throws ValidationException */
-    public function store(): bool
-    {
-        $this->validate();
-
-        return $this->storeModel();
-    }
-
-    protected function storeModel(): bool
-    {
-        if ($this->isCreating()) {
-            $modelClass = $this->getModelClass();
-            $this->formModel = $modelClass::query()->create($this->getModelData());
-            $this->modelId = $this->formModel->getKey();
-
-            return true;
-        }
-
-        if ($this->formModel === null) {
-            $modelClass = $this->getModelClass();
-            $this->formModel = $modelClass::query()->findOrFail($this->modelId);
-        }
-
-        $this->formModel->update($this->getModelData());
-
-        return true;
-    }
-
-    /** @return array<string, mixed> */
-    abstract protected function getModelData(): array;
-
     /** @return array<string, array<int, mixed>> */
     abstract protected function rules(): array;
 
@@ -96,7 +64,4 @@ abstract class BaseForm extends Form
     {
         return [];
     }
-
-    /** @return class-string<Model> */
-    abstract protected function getModelClass(): string;
 }

--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -59,10 +59,7 @@ abstract class BaseFormModal extends BaseModal
         return true;
     }
 
-    protected function storeForm(): bool
-    {
-        return $this->form->store();
-    }
+    abstract protected function storeForm(): bool;
 
     public function mount(mixed $modelId = null): void
     {

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -57,6 +57,11 @@ class FormModal extends BaseFormModal
         return 'livewire.matches.modals.form-modal';
     }
 
+    protected function storeForm(): bool
+    {
+        return $this->form->store();
+    }
+
     /** @return array<int, string> */
     #[Computed(cache: true, key: 'active-match-stipulations-list', seconds: 180)]
     public function getMatchStipulations(): array

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -27,7 +27,7 @@ parameters:
 		-
 			message: '#^Access to an undefined property App\\Livewire\\Base\\BaseFormModal\<TForm of App\\Livewire\\Base\\BaseForm, TModel of Illuminate\\Database\\Eloquent\\Model\>\:\:\$form\.$#'
 			identifier: property.notFound
-			count: 3
+			count: 2
 			path: app/Livewire/Base/BaseFormModal.php
 
 		-

--- a/tests/Feature/Architecture/RuntimeBoundaryTest.php
+++ b/tests/Feature/Architecture/RuntimeBoundaryTest.php
@@ -31,3 +31,17 @@ test('Livewire components do not instantiate other Livewire components', functio
 
     expect($componentConstructions)->toBeEmpty();
 });
+
+test('Livewire components do not write directly through Eloquent models', function () {
+    $directWrites = [];
+
+    foreach (Finder::create()->files()->in(app_path('Livewire'))->name('*.php') as $file) {
+        if (! preg_match('/(?:->|::)\s*(?:create|update)\s*\(/', $file->getContents())) {
+            continue;
+        }
+
+        $directWrites[] = $file->getRelativePathname();
+    }
+
+    expect($directWrites)->toBeEmpty();
+});

--- a/tests/Unit/Livewire/Base/LivewireBaseFormTest.php
+++ b/tests/Unit/Livewire/Base/LivewireBaseFormTest.php
@@ -40,7 +40,6 @@ describe('BaseForm Unit Tests', function () {
             $abstractMethodNames = array_map(fn ($method) => $method->getName(), $abstractMethods);
 
             expect($abstractMethodNames)->toContain('rules');
-            expect($abstractMethodNames)->toContain('getModelData');
         });
     });
 
@@ -54,11 +53,6 @@ describe('BaseForm Unit Tests', function () {
             expect($rules->isProtected())->toBeTrue();
             expect(reflectionReturnTypeName($rules))->toBe('array');
 
-            // getModelData method
-            $getModelData = $reflection->getMethod('getModelData');
-            expect($getModelData->isAbstract())->toBeTrue();
-            expect($getModelData->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($getModelData))->toBe('array');
         });
     });
 
@@ -70,7 +64,6 @@ describe('BaseForm Unit Tests', function () {
             $concreteMethodNames = array_map(fn ($method) => $method->getName(), $concreteMethods);
 
             expect($concreteMethodNames)->toContain('fill');
-            expect($concreteMethodNames)->toContain('store');
             expect($concreteMethodNames)->toContain('validationAttributes');
         });
     });
@@ -109,7 +102,6 @@ describe('BaseForm Unit Tests', function () {
             // Should have concrete methods for common workflow
             $concreteMethods = $reflection->getMethods(ReflectionMethod::IS_PUBLIC | ReflectionMethod::IS_PROTECTED);
             $concreteMethodNames = array_map(fn ($method) => $method->getName(), $concreteMethods);
-            expect($concreteMethodNames)->toContain('store');
             expect($concreteMethodNames)->toContain('fill');
         });
     });
@@ -122,8 +114,6 @@ describe('BaseForm Unit Tests', function () {
             $rules = $reflection->getMethod('rules');
             expect($rules->isProtected())->toBeTrue();
 
-            $getModelData = $reflection->getMethod('getModelData');
-            expect($getModelData->isProtected())->toBeTrue();
         });
     });
 


### PR DESCRIPTION
## Summary
- remove direct Eloquent create and update behavior from BaseForm
- require each Livewire form modal to own its persistence orchestration
- add an architecture regression test preventing direct Eloquent writes in Livewire components
- reduce the corresponding PHPStan baseline count

## Verification
- composer lint
- composer test:types
- 42 focused tests, 85 assertions