### PR TITLE
refactor: remove dead form metadata

### DIFF
--- a/app/Livewire/Events/Forms/CreateEditForm.php
+++ b/app/Livewire/Events/Forms/CreateEditForm.php
@@ -130,20 +130,8 @@ class CreateEditForm extends BaseForm
      * - Passes through date with proper Carbon/string handling
      * - Maintains other fields with appropriate data types
      *
-     * @return array<string, mixed> Model data ready for persistence
-     *
      * @see Event For model field requirements and relationships
      */
-    protected function getModelData(): array
-    {
-        return [
-            'name' => $this->name,
-            'date' => $this->date,
-            'venue_id' => $this->venue_id,
-            'preview' => $this->preview,
-        ];
-    }
-
     public function toData(): EventData
     {
         return new EventData(
@@ -167,11 +155,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<Event> The Event model class
      */
-    protected function getModelClass(): string
-    {
-        return Event::class;
-    }
-
     /**
      * Define validation rules for event form fields.
      *

--- a/app/Livewire/Managers/Forms/CreateEditForm.php
+++ b/app/Livewire/Managers/Forms/CreateEditForm.php
@@ -115,19 +115,7 @@ class CreateEditForm extends BaseForm
      * Includes personal identification data while excluding employment
      * information which is handled separately through the employment
      * relationship system for proper data separation and integrity.
-     *
-     * @return array<string, mixed> Model data ready for persistence
      */
-    protected function getModelData(): array
-    {
-        return [
-            'first_name' => $this->first_name,
-            'last_name' => $this->last_name,
-        ];
-        // Note: employment data is managed separately through
-        // the employment relationship system
-    }
-
     public function toData(): ManagerData
     {
         return new ManagerData(
@@ -150,11 +138,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<Manager> The Manager model class
      */
-    protected function getModelClass(): string
-    {
-        return Manager::class;
-    }
-
     /**
      * Define validation rules for manager form fields.
      *

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -219,19 +219,7 @@ class CreateEditForm extends BaseForm
      * Transforms form fields into model-compatible data structure.
      * Excludes relationship data which is handled separately through
      * the relationship synchronization system.
-     *
-     * @return array<string, mixed> Model data ready for persistence
      */
-    protected function getModelData(): array
-    {
-        return [
-            'event_id' => $this->eventId,
-            'preview' => $this->preview,
-            'match_type' => $this->matchType,
-            'match_stipulation_id' => $this->matchStipulationId,
-        ];
-    }
-
     private function toData(): EventMatchData
     {
         $matchType = $this->matchType;
@@ -273,11 +261,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<EventMatch> The EventMatch model class
      */
-    protected function getModelClass(): string
-    {
-        return EventMatch::class;
-    }
-
     /**
      * Define validation rules for event match form fields.
      *

--- a/app/Livewire/Referees/Forms/CreateEditForm.php
+++ b/app/Livewire/Referees/Forms/CreateEditForm.php
@@ -114,19 +114,7 @@ class CreateEditForm extends BaseForm
      * Includes personal identification data while excluding employment
      * information which is handled separately through the employment
      * relationship system for proper data separation.
-     *
-     * @return array<string, mixed> Model data ready for persistence
      */
-    protected function getModelData(): array
-    {
-        return [
-            'first_name' => $this->first_name,
-            'last_name' => $this->last_name,
-        ];
-        // Note: employment data is managed separately through
-        // the employment relationship system
-    }
-
     public function toData(): RefereeData
     {
         return new RefereeData(
@@ -149,11 +137,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<Referee> The Referee model class
      */
-    protected function getModelClass(): string
-    {
-        return Referee::class;
-    }
-
     /**
      * Define validation rules for referee form fields.
      *

--- a/app/Livewire/Stables/Forms/CreateEditForm.php
+++ b/app/Livewire/Stables/Forms/CreateEditForm.php
@@ -158,15 +158,6 @@ class CreateEditForm extends BaseForm
      *
      * @return array<string, mixed> Model data ready for persistence
      */
-    protected function getModelData(): array
-    {
-        return [
-            'name' => $this->name,
-        ];
-        // Note: start_date is NOT included here because activation dates
-        // are managed separately through the stable's activation relationship system
-    }
-
     /**
      * Get the model class for stable form operations.
      *
@@ -175,11 +166,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<Stable> The Stable model class
      */
-    protected function getModelClass(): string
-    {
-        return Stable::class;
-    }
-
     /**
      * Define validation rules for stable form fields.
      *

--- a/app/Livewire/TagTeams/Forms/CreateEditForm.php
+++ b/app/Livewire/TagTeams/Forms/CreateEditForm.php
@@ -182,15 +182,6 @@ class CreateEditForm extends BaseForm
      *
      * @return array<string, mixed> Model data ready for persistence
      */
-    protected function getModelData(): array
-    {
-        return [
-            'name' => $this->name,
-            'signature_move' => $this->signature_move ?: null,
-        ];
-        // Note: wrestler relationships and employment data handled separately
-    }
-
     /**
      * Get the model class for tag team form operations.
      *
@@ -199,11 +190,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<TagTeam> The TagTeam model class
      */
-    protected function getModelClass(): string
-    {
-        return TagTeam::class;
-    }
-
     /**
      * Define validation rules for tag team form fields.
      *

--- a/app/Livewire/Titles/Forms/CreateEditForm.php
+++ b/app/Livewire/Titles/Forms/CreateEditForm.php
@@ -116,19 +116,7 @@ class CreateEditForm extends BaseForm
      * Only includes the title name as activation dates are managed
      * separately through the title's activation relationship system
      * to maintain proper separation of concerns.
-     *
-     * @return array<string, mixed> Model data ready for persistence
      */
-    protected function getModelData(): array
-    {
-        return [
-            'name' => $this->name,
-            'type' => $this->type,
-        ];
-        // Note: start_date is NOT included here because activation dates
-        // are managed separately through the title's activation relationship system
-    }
-
     public function toData(): TitleData
     {
         return new TitleData(
@@ -151,11 +139,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<Title> The Title model class
      */
-    protected function getModelClass(): string
-    {
-        return Title::class;
-    }
-
     /**
      * Define validation rules for championship title fields.
      *

--- a/app/Livewire/Users/Forms/CreateEditForm.php
+++ b/app/Livewire/Users/Forms/CreateEditForm.php
@@ -124,28 +124,8 @@ class CreateEditForm extends BaseForm
      * - Password is only included when provided (allows updates without password change)
      * - Uses bcrypt hashing for maximum security
      *
-     * @return array<string, mixed> Model data ready for persistence
-     *
      * @see Hash::make() For secure password hashing
      */
-    protected function getModelData(): array
-    {
-        $data = [
-            'first_name' => $this->first_name,
-            'last_name' => $this->last_name,
-            'email' => $this->email,
-            'role' => $this->role,
-        ];
-
-        // Only include password if provided (allows profile updates without password change)
-        if (! empty($this->password)) {
-            // Model handles password hashing via Attribute cast
-            $data['password'] = $this->password;
-        }
-
-        return $data;
-    }
-
     public function toData(): UserData
     {
         return new UserData(
@@ -170,11 +150,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<User> The User model class
      */
-    protected function getModelClass(): string
-    {
-        return User::class;
-    }
-
     /**
      * Define validation rules for user form fields.
      *

--- a/app/Livewire/Venues/Forms/CreateEditForm.php
+++ b/app/Livewire/Venues/Forms/CreateEditForm.php
@@ -121,22 +121,7 @@ class CreateEditForm extends BaseForm
      * Transforms form fields into model-compatible data structure ready
      * for database persistence. All venue fields are passed through directly
      * as they represent simple scalar values without complex transformations.
-     *
-     * @return array<string, mixed> Model data ready for persistence
      */
-    protected function getModelData(): array
-    {
-        return [
-            'name' => $this->name,
-            'address' => new Address(
-                streetAddress: $this->street_address,
-                city: $this->city,
-                state: UnitedStatesState::from($this->state),
-                zipcode: (string) $this->zipcode,
-            ),
-        ];
-    }
-
     public function toData(): VenueData
     {
         return new VenueData(
@@ -161,11 +146,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<Venue> The Venue model class
      */
-    protected function getModelClass(): string
-    {
-        return Venue::class;
-    }
-
     /**
      * Define validation rules for venue form fields.
      *

--- a/app/Livewire/Wrestlers/Forms/CreateEditForm.php
+++ b/app/Livewire/Wrestlers/Forms/CreateEditForm.php
@@ -169,24 +169,9 @@ class CreateEditForm extends BaseForm
      * - Converts Height to total inches for database storage
      * - Passes through other fields with appropriate typing
      *
-     * @return array<string, mixed> Model data ready for persistence
-     *
      * @see Height::__construct() For height object creation
      * @see Height::toInches() For database storage format
      */
-    protected function getModelData(): array
-    {
-        $height = new Height($this->height_feet, $this->height_inches);
-
-        return [
-            'name' => $this->name,
-            'hometown' => $this->hometown,
-            'height' => $height->toInches(),
-            'weight' => $this->weight,
-            'signature_move' => $this->signature_move,
-        ];
-    }
-
     public function toData(): WrestlerData
     {
         return new WrestlerData(
@@ -212,11 +197,6 @@ class CreateEditForm extends BaseForm
      *
      * @return class-string<Wrestler> The Wrestler model class
      */
-    protected function getModelClass(): string
-    {
-        return Wrestler::class;
-    }
-
     /**
      * Define validation rules for wrestler form fields.
      *

--- a/tests/Integration/Livewire/Venues/Forms/Support/VenueFormTestProxy.php
+++ b/tests/Integration/Livewire/Venues/Forms/Support/VenueFormTestProxy.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Tests\Integration\Livewire\Venues\Forms\Support;
 
 use App\Livewire\Venues\Forms\CreateEditForm;
-use App\Models\Events\Venue;
 
 final class VenueFormTestProxy extends CreateEditForm
 {
@@ -13,18 +12,6 @@ final class VenueFormTestProxy extends CreateEditForm
     public function rulesForTesting(): array
     {
         return $this->rules();
-    }
-
-    /** @return array<string, mixed> */
-    public function modelDataForTesting(): array
-    {
-        return $this->getModelData();
-    }
-
-    /** @return class-string<Venue> */
-    public function modelClassForTesting(): string
-    {
-        return $this->getModelClass();
     }
 
     /** @return array<string, string> */

--- a/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
+++ b/tests/Integration/Livewire/Venues/Forms/VenueFormIntegrationTest.php
@@ -2,11 +2,7 @@
 
 declare(strict_types=1);
 
-use App\Enums\Shared\UnitedStatesState;
 use App\Livewire\Base\BaseForm;
-use App\Models\Events\Venue;
-use App\ValueObjects\Address;
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 use Illuminate\Validation\Rules\Unique;
@@ -22,7 +18,6 @@ use Tests\Integration\Livewire\Venues\Forms\Support\VenueFormTestProxy;
  * - Venue name uniqueness constraints
  * - State validation against database
  * - ZIP code format enforcement
- * - Data transformation and model mapping
  * - Complete address management functionality
  *
  * These tests verify that the VenueForm correctly implements
@@ -98,29 +93,6 @@ describe('VenueForm Integration Tests', function () {
         });
     });
 
-    describe('data transformation methods', function () {
-        test('getModelClass returns correct Venue class', function () {
-            expect($this->form->modelClassForTesting())->toBe(Venue::class);
-        });
-
-        test('getModelData transforms complete venue data correctly', function () {
-            $this->form->name = 'Madison Square Garden';
-            $this->form->street_address = '4 Pennsylvania Plaza';
-            $this->form->city = 'New York';
-            $this->form->state = 'New York';
-            $this->form->zipcode = '10001';
-
-            $data = $this->form->modelDataForTesting();
-
-            expect($data)->toBeArray();
-            expect($data)->toHaveKeys(['name', 'address']);
-            expect($data['name'])->toBe('Madison Square Garden')
-                ->and($data['address'])->toEqual(
-                    new Address('4 Pennsylvania Plaza', 'New York', UnitedStatesState::NewYork, '10001'),
-                );
-        });
-    });
-
     describe('validation attributes customization', function () {
         test('validationAttributes provides readable field names', function () {
             $attributes = $this->form->validationAttributesForTesting();
@@ -168,14 +140,6 @@ describe('VenueForm Integration Tests', function () {
     describe('form inheritance and structure', function () {
         test('extends BaseForm correctly', function () {
             expect($this->form)->toBeInstanceOf(BaseForm::class);
-        });
-
-        test('implements required abstract methods', function () {
-            $requiredMethods = ['getModelClass', 'getModelData', 'rules'];
-
-            foreach ($requiredMethods as $method) {
-                expect(method_exists($this->form, $method))->toBeTrue("Method {$method} should exist");
-            }
         });
 
         test('has public form properties for venue data', function () {


### PR DESCRIPTION
## Summary
- remove unused model-class metadata from Livewire forms
- remove obsolete model-data transformation methods now that modal actions own persistence
- align Venue form tests with the reduced form boundary

## Verification
- composer lint
- focused Venue form tests (13 tests, 37 assertions)
- composer test:push