### PR TITLE
docs: align Livewire form architecture

### DIFF
--- a/docs/architecture/livewire/component-architecture.md
+++ b/docs/architecture/livewire/component-architecture.md
@@ -1,352 +1,143 @@
 # Livewire Component Architecture
 
-## Overview
+Ringside uses class-based Livewire components with external Blade views. Livewire
+is the UI boundary; domain behavior remains in Actions and focused domain services.
 
-This document provides a comprehensive guide to the Livewire component architecture in Ringside. Our architecture follows a standardized pattern that ensures consistency, maintainability, and scalability across all domain entities.
+## Layers
 
-## Architecture Principles
-
-### 1. Single Responsibility Principle
-Each component has a focused purpose:
-- **Forms** handle data input, validation, and persistence
-- **Modals** manage modal display and form integration
-- **Tables** display and manage data collections
-- **Actions** handle specific business operations
-
-### 2. Template Method Pattern
-Base classes provide common functionality while allowing customization through abstract methods:
-- `BaseForm` - Form lifecycle management
-- `BaseModal` - Modal state management
-- `BaseFormModal` - Combined form and modal functionality
-- `BaseTable` - Table display and filtering
-
-### 3. Composition over Inheritance
-Components use traits for shared functionality:
-- `GeneratesDummyData` - Test data generation
-- `HasStandardValidationAttributes` - Validation messaging
-- Typed form data is passed to domain Actions for employment and activity-period persistence.
-
-## Component Hierarchy
-
-```
-app/Livewire/
-├── Base/
-│   ├── BaseForm.php           # Form lifecycle management
-│   ├── BaseModal.php          # Modal state management
-│   └── BaseFormModal.php      # Combined form+modal functionality
-├── Concerns/
-│   ├── GeneratesDummyData.php # Test data generation
-│   └── Data/
-│       └── PresentsVenuesList.php # Domain-specific data presentation
-└── {Domain}/
-    ├── Forms/
-    │   └── CreateEditForm.php  # Domain-specific form implementation
-    ├── Modals/
-    │   └── FormModal.php       # Domain-specific modal implementation
-    ├── Tables/
-    │   └── {Domain}Table.php   # Domain-specific table implementation
-    └── Components/
-        └── Actions.php # Domain-specific actions
+```text
+Blade view
+    ↓ binds input and invokes component methods
+Livewire form + modal
+    ↓ validates, authorizes, and builds typed data
+Action
+    ↓ enforces business rules and coordinates persistence
+Eloquent models, Builders, and relationships
 ```
 
-## Base Classes
+### Forms
+
+Forms hold editable state, define validation, hydrate edit values, and construct
+typed data objects. They do not provide generic Eloquent persistence.
+
+### Modals
+
+Modals own the user interaction:
+
+- resolve or receive their create and update Actions;
+- authorize protected operations;
+- validate their form;
+- choose the create or update path;
+- call the Action with typed data; and
+- dispatch UI refresh and close events after success.
+
+### Actions
+
+Actions are the application boundary for mutations. They own business rules,
+transactions, model writes, and relationship changes. A Livewire component resolves
+Actions from Laravel's container and calls `handle()`.
+
+### Models and Builders
+
+Models remain the Eloquent data layer. Typed custom Builders own reusable query
+behavior. Livewire query components may query Eloquent directly and compose those
+Builder methods.
+
+## Directory convention
+
+```text
+app/Livewire/{Domain}/
+├── Components/
+├── Forms/
+│   └── CreateEditForm.php
+├── Modals/
+│   └── FormModal.php
+└── Tables/
+
+resources/views/livewire/{domain}/
+├── components/
+├── modals/
+└── tables/
+```
+
+Shared mechanics live under `app/Livewire/Base` or a focused concern. Domain rules
+do not move into a base component merely because several screens invoke them.
+
+## Shared base classes
 
 ### BaseForm
 
-The foundational form class that provides:
-- **Model Management**: Automatic model binding and persistence
-- **Validation**: Standardized validation patterns
-- **Lifecycle Hooks**: `loadExtraData()`, `getModelData()`, `rules()`
-- **Type Safety**: Generic type parameters for model binding
-
-```php
-/**
- * @template TModel of Model
- * @extends BaseForm<TModel>
- */
-abstract class BaseForm extends Form
-{
-    abstract protected function getModelClass(): string;
-    abstract protected function getModelData(): array;
-    abstract protected function rules(): array;
-    
-    public function loadExtraData(): void {}
-    public function setModel(?Model $model): void {}
-    public function store(): bool {}
-}
-```
+`BaseForm` centralizes model hydration, locked model identity, create/edit state,
+modal-title display values, and validation hooks. It does not know a concrete model
+class and does not persist records.
 
 ### BaseModal
 
-Core modal functionality providing:
-- **State Management**: Modal open/close state
-- **Model Binding**: Automatic model resolution
-- **Event Handling**: Modal lifecycle events
-- **View Resolution**: Dynamic view path handling
-
-```php
-/**
- * @template TForm of BaseForm
- * @template TModel of Model
- */
-abstract class BaseModal extends Component
-{
-    abstract protected function getFormClass(): string;
-    abstract protected function getModelClass(): string;
-    abstract protected function getModalPath(): string;
-    
-    public function openModal(mixed $modelId = null): void {}
-    public function closeModal(): void {}
-    public function mount(mixed $modelId = null): void {}
-}
-```
+`BaseModal` loads the model selected by a locked identifier, connects the model to
+the form, builds modal titles, and resets or restores form state.
 
 ### BaseFormModal
 
-Combines BaseModal with form-specific functionality:
-- **Form Integration**: Automatic form instantiation
-- **Dummy Data**: Test data generation capabilities
-- **Unified API**: Single interface for form modals
+`BaseFormModal` coordinates the shared submission lifecycle:
 
-```php
-/**
- * @template TForm of BaseForm
- * @template TModel of Model
- * @extends BaseModal<TForm, TModel>
- */
-abstract class BaseFormModal extends BaseModal
-{
-    use GeneratesDummyData;
-    
-    public BaseForm $form;
-    
-    public function save(): void {}
-    public function submitForm(): bool {}
-    protected function getDummyDataFields(): array {}
-}
+1. initialize the concrete model and form types;
+2. mount create or edit state;
+3. delegate domain submission to `storeForm()`;
+4. dispatch table refresh and form-submitted events; and
+5. close the modal after a successful submission.
+
+Each domain modal implements `storeForm()` because only the domain boundary knows
+which Actions and typed data belong to the operation.
+
+## Mutation flow
+
+```text
+User submits modal
+    ↓
+Modal validates form
+    ↓
+Modal authorizes operation
+    ↓
+Form constructs typed Data object
+    ↓
+Modal calls create/update Action
+    ↓
+Action performs transaction and persistence
+    ↓
+Modal dispatches UI events
 ```
 
-## Component Lifecycle
+Validation failures remain attached to Livewire form fields. Business exceptions
+are caught only at a user-interaction boundary and translated into an appropriate
+message. Programmer and infrastructure failures continue through Laravel's normal
+exception reporting.
 
-### Form Lifecycle
+## Authorization and input security
 
-1. **Instantiation**: Component created with optional model ID
-2. **Mount**: `mount($modelId)` called to initialize state
-3. **Model Binding**: If model ID provided, model loaded and bound
-4. **Extra Data Loading**: `loadExtraData()` called for additional setup
-5. **Validation**: Real-time validation on property updates
-6. **Submission**: `store()` method handles persistence
-7. **Success**: Events dispatched, component state updated
+- Treat every public property as untrusted request input.
+- Lock identifiers that must not change client-side.
+- Call `Gate::authorize()` immediately before protected Livewire operations.
+- Validate before constructing Action input.
+- Never rely on a hidden input or disabled field as authorization.
 
-### Modal Lifecycle
+## Read behavior
 
-1. **Component Creation**: Modal component instantiated
-2. **Open Modal**: `openModal($modelId)` called
-3. **Mount/Remount**: Component mounted with model context
-4. **Form Initialization**: Form component created and configured
-5. **Display**: Modal rendered with form content
-6. **Form Submission**: Form validation and persistence
-7. **Close**: Modal closed on success or user action
+Use computed properties for data that should be derived on each request instead of
+serializing constrained Eloquent collections into component state. Put reusable
+query constraints on typed Eloquent Builders.
 
-## Domain Implementation Pattern
+## Views
 
-### Directory Structure
-Each domain follows this standardized structure:
+Keep markup in external Blade files paired with class-based components. Use
+`wire:key` in rendered loops, loading states for visible async work, and named
+Livewire events that express the completed UI operation.
 
-```
-app/Livewire/{Domain}/
-├── Forms/
-│   └── CreateEditForm.php      # Handles create/edit operations
-├── Modals/
-│   └── FormModal.php           # Modal wrapper for forms
-├── Tables/
-│   ├── Main.php                # Main entity table
-│   └── Previous{Related}.php   # Relationship tables
-└── Components/
-    └── Actions.php             # Business action handlers
-```
+## Testing boundaries
 
-### Naming Conventions
+- Form tests cover validation, hydration, and typed-data conversion.
+- Modal tests cover authorization, Action delegation, and emitted events.
+- Action tests cover mutations, transactions, and business invariants.
+- Browser tests cover behavior that depends on client-side Livewire interaction.
 
-- **Forms**: `CreateEditForm` - Handles both create and edit operations
-- **Modals**: `FormModal` - Wraps CreateEditForm in modal interface
-- **Tables**: `Main` - Main entity display table, `Previous{Related}` - Relationship tables
-- **Components**: `Actions` - Business action handlers
-
-### Implementation Requirements
-
-Each domain component must:
-1. **Extend appropriate base class**
-2. **Implement required abstract methods**
-3. **Follow naming conventions**
-4. **Include comprehensive documentation**
-5. **Provide test coverage**
-
-## Generic Type Safety
-
-### Type Parameters
-
-Components use generic type parameters for type safety:
-
-```php
-/**
- * @template TModel of Model
- * @extends BaseForm<TModel>
- */
-class CreateEditForm extends BaseForm
-{
-    protected function getModelClass(): string
-    {
-        return Event::class; // @phpstan-ignore-line
-    }
-}
-```
-
-### Benefits
-
-- **IDE Support**: Better autocomplete and error detection
-- **Static Analysis**: PHPStan can verify type correctness
-- **Runtime Safety**: Type hints prevent incorrect usage
-- **Documentation**: Clear contracts for component usage
-
-### Typed Table Rows
-
-`DataTableComponent` is generic over the Eloquent model returned by its `builder()` method. Every concrete table declares that row model through an `@extends` annotation, and generic intermediate table bases forward their model template to `DataTableComponent`.
-
-This keeps search, filters, sorting, and pagination attached to the concrete Builder type instead of widening every table to `Builder<Model>`. Fixed-purpose table bases, such as previous-match and championship-history tables, bind their known row model directly.
-
-## Integration Patterns
-
-### Form-Modal Integration
-
-```php
-// FormModal provides the modal wrapper
-class FormModal extends BaseFormModal
-{
-    // Form class configuration
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
-    }
-    
-    // Model class configuration
-    protected function getModelClass(): string
-    {
-        return Event::class;
-    }
-    
-    // View path configuration
-    protected function getModalPath(): string
-    {
-        return 'livewire.events.modals.form-modal';
-    }
-}
-```
-
-### Component Communication
-
-Components communicate through:
-- **Events**: `$this->dispatch('event-name', $data)`
-- **Properties**: Reactive public properties
-- **Method Calls**: Direct method invocation
-- **URL Parameters**: Route model binding
-
-## Performance Considerations
-
-### Lazy Loading
-- Use `#[Lazy]` attribute for expensive computations
-- Implement `#[Computed]` for cached calculations
-- Defer non-critical operations
-
-### Memory Management
-- Avoid storing large objects in component state
-- Use database queries instead of in-memory collections
-- Implement proper cleanup in component destruction
-
-### Caching
-- Cache expensive calculations using `#[Computed]`
-- Implement query result caching where appropriate
-- Use Livewire's built-in caching mechanisms
-
-## Error Handling
-
-### Validation Errors
-- Use Laravel's validation system
-- Provide clear error messages
-- Implement field-specific validation rules
-
-### Exception Handling
-- Catch and handle exceptions gracefully
-- Provide user-friendly error messages
-- Log errors for debugging
-
-### Fallback Behavior
-- Implement fallback UI for error states
-- Provide retry mechanisms where appropriate
-- Maintain component state during errors
-
-## Testing Strategy
-
-### Unit Tests
-- Test individual component methods
-- Mock dependencies and external services
-- Verify business logic correctness
-
-### Integration Tests
-- Test component rendering
-- Verify form submission workflows
-- Test modal state management
-
-### Feature Tests
-- Test complete user workflows
-- Verify event dispatching
-- Test component interaction
-
-## Migration Path
-
-### From Legacy Components
-1. **Assess Current Component**: Understand existing functionality
-2. **Plan Migration**: Identify required changes
-3. **Implement Base Classes**: Extend appropriate base classes
-4. **Update Tests**: Ensure comprehensive test coverage
-5. **Deploy Gradually**: Use feature flags for safe deployment
-
-### Breaking Changes
-- Document all breaking changes
-- Provide migration guides
-- Offer backward compatibility where possible
-- Communicate changes clearly
-
-## Best Practices
-
-### Code Organization
-- Group related functionality together
-- Use descriptive method and property names
-- Follow PSR-12 coding standards
-- Include comprehensive PHPDoc comments
-
-### Component Design
-- Keep components focused and small
-- Avoid tight coupling between components
-- Use dependency injection for external services
-- Implement proper error boundaries
-
-### State Management
-- Minimize component state
-- Use reactive properties appropriately
-- Implement proper state validation
-- Handle state hydration correctly
-
-## Related Documentation
-
-- [Form Patterns](form-patterns.md) - Detailed form implementation patterns
-- [Modal Patterns](modal-patterns.md) - Modal component best practices
-- [Testing Guide](../../guides/livewire/testing-guide.md) - Comprehensive testing strategies
-- [Migration Guide](../../guides/livewire/migration-guide.md) - Migration from legacy patterns
-
-## References
-
-- [Laravel Livewire Documentation](https://laravel-livewire.com/docs)
-- [Laravel Validation](https://laravel.com/docs/validation)
-- [PHPStan Generic Types](https://phpstan.org/blog/generics-in-php-using-phpdocs)
-- [Template Method Pattern](https://refactoring.guru/design-patterns/template-method)
+Prefer behavioral assertions over reflection tests that require incidental private
+or protected methods.

--- a/docs/architecture/livewire/form-patterns.md
+++ b/docs/architecture/livewire/form-patterns.md
@@ -1,616 +1,172 @@
 # Livewire Form Patterns
 
-## Overview
+Ringside uses Livewire form objects as typed input boundaries. A form owns public
+input state, validation, edit-state hydration, and conversion to a domain data
+object. It does not directly create or update Eloquent records.
 
-This document details the comprehensive form patterns used in Ringside's Livewire architecture. Our form system provides a consistent, type-safe approach to handling data input, validation, and persistence across all domain entities.
+## Responsibility boundary
 
-## Form Architecture
+| Layer | Responsibility |
+| --- | --- |
+| Form | Input state, validation rules, validation labels, edit hydration, and `toData()` conversion |
+| Modal | Authorization, submission orchestration, Action resolution, and UI events |
+| Action | Business rules, transactions, persistence, and relationship changes |
+| Model | Eloquent state and relationships |
 
-### Core Components
+Public Livewire properties are untrusted input. Validate them before constructing
+data objects or calling Actions. Model identifiers remain locked against client-side
+changes and protected operations are authorized at the modal boundary.
 
-#### BaseForm
-The foundation class that provides:
-- **Model Management**: Automatic model binding and lifecycle
-- **Validation**: Integrated Laravel validation
-- **Data Transformation**: Input/output data mapping
-- **Type Safety**: Generic type parameters for model binding
+## BaseForm
+
+`App\Livewire\Base\BaseForm` provides only behavior shared by all create/edit forms:
+
+- stores a locked model identifier;
+- hydrates editable attributes through `setModel()`;
+- distinguishes create and edit state;
+- provides modal-title display values;
+- invokes the optional `loadExtraData()` hook; and
+- requires each form to define its validation rules.
+
+It deliberately has no `store()`, `getModelClass()`, or `getModelData()` method.
 
 ```php
-/**
- * @template TModel of Model
- */
 abstract class BaseForm extends Form
 {
     protected ?Model $formModel = null;
-    
-    abstract protected function getModelClass(): string;
-    abstract protected function getModelData(): array;
+
+    #[Locked]
+    public int|string|null $modelId = null;
+
+    public function setModel(?Model $formModel): void;
+
+    public function isCreating(): bool;
+
+    public function isEditing(): bool;
+
+    protected function loadExtraData(): void;
+
     abstract protected function rules(): array;
-    
-    public function loadExtraData(): void {}
-    public function setModel(?Model $model): void {}
-    public function store(): bool {}
 }
 ```
 
-#### CreateEditForm Pattern
-All domain forms follow the `CreateEditForm` pattern:
-- **Unified Interface**: Single form handles both create and edit operations
-- **Model Binding**: Automatic model detection and data population
-- **Validation**: Context-aware validation rules
-- **Data Mapping**: Consistent data transformation patterns
+## Domain forms
 
-### Implementation Pattern
+Each domain form extends `BaseForm` and normally contains:
+
+1. typed public properties matching the editable fields;
+2. `rules()` and, when useful, `validationAttributes()`;
+3. `loadExtraData()` for state stored outside the model's direct attributes;
+4. `toData()` to construct the Action's typed input; and
+5. a typed model lookup used by edit Actions when required.
 
 ```php
-/**
- * @extends BaseForm<Event>
- */
-class CreateEditForm extends BaseForm
+final class CreateEditForm extends BaseForm
 {
-    // Form properties - match model attributes
-    public string $name = '';
-    public Carbon|string|null $date = '';
-    public int $venue_id = 0;
-    public ?string $preview = '';
-    
-    // Model configuration
-    protected function getModelClass(): string
-    {
-        return Event::class;
-    }
-    
-    // Data transformation
-    protected function getModelData(): array
-    {
-        return [
-            'name' => $this->name,
-            'date' => $this->date,
-            'venue_id' => $this->venue_id,
-            'preview' => $this->preview,
-        ];
-    }
-    
-    // Validation rules
-    protected function rules(): array
-    {
-        return [
-            'name' => ['required', 'string', 'max:255', 
-                Rule::unique('events', 'name')->ignore($this->formModel)],
-            'date' => ['nullable', 'date', 
-                new DateCanBeChanged($this->formModel)],
-            'venue_id' => ['required_with:date', 'integer', 
-                Rule::exists('venues', 'id')],
-            'preview' => ['nullable', 'string'],
-        ];
-    }
-}
-```
+    public string $first_name = '';
 
-## Form Lifecycle
+    public string $last_name = '';
 
-### 1. Instantiation
-Form components are created by parent components:
-```php
-// In BaseFormModal
-$formClass = $this->getFormClass();
-$this->form = new $formClass($this, 'form');
-```
+    public ?string $employment_date = null;
 
-### 2. Model Binding
-When editing existing models:
-```php
-public function setModel(?Model $model): void
-{
-    $this->formModel = $model;
-    
-    if ($model) {
-        $this->fill($model->toArray());
-        $this->loadExtraData();
-    }
-}
-```
-
-### 3. Extra Data Loading
-Hook for additional data setup:
-```php
-public function loadExtraData(): void
-{
-    // Load related data, set computed properties, etc.
-    if ($this->formModel && isset($this->formModel->venue_id)) {
-        $this->venue_id = $this->formModel->venue_id;
-    }
-}
-```
-
-### 4. Validation
-Real-time validation on property updates:
-```php
-// Automatic validation on property changes
-public function updated($propertyName): void
-{
-    $this->validateOnly($propertyName);
-}
-```
-
-### 5. Submission
-Form persistence and event handling:
-```php
-public function store(): bool
-{
-    $this->validate();
-    
-    $modelData = $this->getModelData();
-    $modelClass = $this->getModelClass();
-    
-    if ($this->formModel) {
-        $this->formModel->update($modelData);
-        $this->dispatch('modelUpdated', $this->formModel->id);
-    } else {
-        $model = $modelClass::create($modelData);
-        $this->dispatch('modelCreated', $model->id);
-    }
-    
-    return true;
-}
-```
-
-## Validation Patterns
-
-### Context-Aware Validation
-Rules adapt based on create vs edit context:
-```php
-protected function rules(): array
-{
-    return [
-        'name' => [
-            'required',
-            'string',
-            'max:255',
-            Rule::unique('events', 'name')->ignore($this->formModel)
-        ],
-        'email' => [
-            'required',
-            'email',
-            Rule::unique('users', 'email')->ignore($this->formModel)
-        ],
-    ];
-}
-```
-
-### Custom Validation Rules
-Domain-specific validation logic:
-```php
-protected function rules(): array
-{
-    return [
-        'date' => [
-            'nullable',
-            'date',
-            new DateCanBeChanged($this->formModel)
-        ],
-        'employment_date' => [
-            'nullable',
-            'date',
-            new EmploymentDateRule($this->formModel)
-        ],
-    ];
-}
-```
-
-### Validation Attributes
-Custom field names for error messages:
-```php
-protected function getCustomValidationAttributes(): array
-{
-    return [
-        'date' => 'event date',
-        'venue_id' => 'venue',
-        'preview' => 'event preview',
-    ];
-}
-```
-
-## Data Handling Patterns
-
-### Input Transformation
-Transform form inputs for model storage:
-```php
-protected function getModelData(): array
-{
-    return [
-        'name' => $this->name,
-        'date' => $this->date,
-        'venue_id' => $this->venue_id,
-        'preview' => $this->preview,
-        // Transform complex data
-        'metadata' => json_encode($this->metadata),
-        'status' => $this->status ?? 'active',
-    ];
-}
-```
-
-### Output Transformation
-Transform model data for form display:
-```php
-public function loadExtraData(): void
-{
-    if ($this->formModel) {
-        // Transform complex data for display
-        $this->metadata = json_decode($this->formModel->metadata, true);
-        $this->venue_id = $this->formModel->venue_id;
-    }
-}
-```
-
-## Relationship Handling
-
-### Belongs To Relationships
-```php
-class CreateEditForm extends BaseForm
-{
-    public int $venue_id = 0;
-    
-    // Access related model
-    public function getVenueProperty(): ?Venue
-    {
-        return $this->venue_id ? Venue::find($this->venue_id) : null;
-    }
-    
-    // Validation includes relationship
-    protected function rules(): array
-    {
-        return [
-            'venue_id' => ['required', 'integer', Rule::exists('venues', 'id')],
-        ];
-    }
-}
-```
-
-### Has Many Relationships
-```php
-class CreateEditForm extends BaseForm
-{
-    public array $tags = [];
-    
-    public function loadExtraData(): void
-    {
-        if ($this->formModel) {
-            $this->tags = $this->formModel->tags->pluck('id')->toArray();
-        }
-    }
-    
-    protected function getModelData(): array
-    {
-        return [
-            'name' => $this->name,
-            // Handle relationships separately
-        ];
-    }
-    
-    public function store(): bool
-    {
-        $this->validate();
-        
-        $modelData = $this->getModelData();
-        $modelClass = $this->getModelClass();
-        
-        if ($this->formModel) {
-            $this->formModel->update($modelData);
-            $this->formModel->tags()->sync($this->tags);
-        } else {
-            $model = $modelClass::create($modelData);
-            $model->tags()->sync($this->tags);
-        }
-        
-        return true;
-    }
-}
-```
-
-## Action Integration
-
-Forms validate input and produce typed data. The owning modal resolves persistence Actions so employment and other lifecycle records are written inside the domain transaction.
-
-```php
-class CreateEditForm extends BaseForm
-{
     public function toData(): ManagerData
     {
         return new ManagerData(
             first_name: $this->first_name,
             last_name: $this->last_name,
-            employment_date: $this->employment_date ? Carbon::parse($this->employment_date) : null,
+            employment_date: $this->employment_date === null
+                ? null
+                : Carbon::parse($this->employment_date),
         );
     }
-}
 
-class FormModal extends BaseFormModal
-{
-    protected function storeForm(): bool
+    public function manager(): Manager
     {
-        $this->form->validate();
-
-        $this->form->isCreating()
-            ? $this->createAction->handle($this->form->toData())
-            : $this->updateAction->handle($this->form->manager(), $this->form->toData());
-
-        return true;
+        return Manager::query()->findOrFail($this->modelId);
     }
-}
-```
 
-### Data Presentation
-```php
-class CreateEditForm extends BaseForm
-{
-    use PresentsVenuesList;
-    
-    public int $venue_id = 0;
-    
-    // Trait provides getVenues() method
-    public function getVenuesProperty(): Collection
+    protected function rules(): array
     {
-        return $this->getVenues();
+        return [
+            'first_name' => ['required', 'string', 'max:255'],
+            'last_name' => ['required', 'string', 'max:255'],
+        ];
     }
 }
 ```
 
-## Error Handling
+Do not expose generic model-class or model-data metadata merely to support a base
+persistence method. The modal already knows which model and Actions it coordinates.
 
-### Validation Errors
-```php
-public function store(): bool
-{
-    try {
-        $this->validate();
-        
-        $modelData = $this->getModelData();
-        // ... persistence logic
-        
-        return true;
-    } catch (ValidationException $e) {
-        // Validation errors automatically handled by Livewire
-        return false;
-    }
-}
-```
+## Validation
 
-### Business Logic Errors
-```php
-public function store(): bool
-{
-    try {
-        $this->validate();
-        
-        $modelData = $this->getModelData();
-        $modelClass = $this->getModelClass();
-        
-        // Business logic validation
-        if (!$this->canCreateModel($modelData)) {
-            $this->addError('general', 'Cannot create model due to business rules');
-            return false;
-        }
-        
-        $model = $modelClass::create($modelData);
-        
-        return true;
-    } catch (Exception $e) {
-        $this->addError('general', 'An error occurred while saving');
-        Log::error('Form submission error', ['error' => $e->getMessage()]);
-        return false;
-    }
-}
-```
+Form validation is the entry boundary for request-shaped eligibility rules. Use
+array rules and dedicated rule objects for reusable or domain-specific checks.
+Actions may assume their data object was constructed from validated input, while
+still enforcing transactional invariants that must hold for every caller.
 
-## Testing Patterns
-
-### Form Property Testing
-```php
-test('form properties are initialized correctly', function () {
-    $form = new CreateEditForm();
-    
-    expect($form->name)->toBe('');
-    expect($form->date)->toBe('');
-    expect($form->venue_id)->toBe(0);
-    expect($form->preview)->toBe('');
-});
-```
-
-### Validation Testing
-```php
-test('validates required fields', function () {
-    $form = new CreateEditForm();
-    
-    $form->name = '';
-    $form->validate();
-    
-    expect($form->getErrorBag()->has('name'))->toBeTrue();
-});
-```
-
-### Model Binding Testing
-```php
-test('loads model data correctly', function () {
-    $event = Event::factory()->create([
-        'name' => 'Test Event',
-        'date' => '2024-01-01',
-    ]);
-    
-    $form = new CreateEditForm();
-    $form->setModel($event);
-    
-    expect($form->name)->toBe('Test Event');
-    expect($form->date)->toBe('2024-01-01');
-});
-```
-
-## Performance Optimization
-
-### Lazy Loading
-```php
-class CreateEditForm extends BaseForm
-{
-    #[Lazy]
-    public function getVenuesProperty(): Collection
-    {
-        return Venue::active()->get();
-    }
-}
-```
-
-### Computed Properties
-```php
-class CreateEditForm extends BaseForm
-{
-    #[Computed]
-    public function availableVenues(): Collection
-    {
-        return Venue::active()
-            ->when($this->formModel, function ($query) {
-                return $query->orWhere('id', $this->formModel->venue_id);
-            })
-            ->get();
-    }
-}
-```
-
-### Database Optimization
-```php
-public function loadExtraData(): void
-{
-    if ($this->formModel) {
-        // Eager load relationships
-        $this->formModel->load(['venue', 'tags']);
-        
-        // Use specific queries instead of loading all data
-        $this->venue_id = $this->formModel->venue_id;
-    }
-}
-```
-
-## Advanced Patterns
-
-### Dynamic Form Fields
-```php
-class CreateEditForm extends BaseForm
-{
-    public array $dynamicFields = [];
-    
-    public function mount(): void
-    {
-        $this->dynamicFields = $this->getDynamicFields();
-    }
-    
-    protected function getDynamicFields(): array
-    {
-        // Return fields based on configuration
-        return config('forms.dynamic_fields', []);
-    }
-}
-```
-
-### Conditional Validation
 ```php
 protected function rules(): array
 {
-    $rules = [
-        'name' => ['required', 'string', 'max:255'],
+    return [
+        'employment_date' => [
+            'nullable',
+            'date',
+            new CanChangeEmploymentDate($this->formModel),
+        ],
     ];
-    
-    if ($this->type === 'special') {
-        $rules['special_field'] = ['required', 'string'];
-    }
-    
-    return $rules;
 }
 ```
 
-### Multi-Step Forms
+## Editing and extra data
+
+`BaseForm::setModel()` fills direct Eloquent attributes and then calls
+`loadExtraData()`. Override that hook only for values derived from casts or related
+records that cannot be filled from the model's attribute array.
+
 ```php
-class CreateEditForm extends BaseForm
+protected function loadExtraData(): void
 {
-    public int $currentStep = 1;
-    public array $steps = ['basic', 'details', 'review'];
-    
-    public function nextStep(): void
-    {
-        $this->validateCurrentStep();
-        $this->currentStep++;
+    if (! $this->formModel instanceof Manager) {
+        return;
     }
-    
-    protected function validateCurrentStep(): void
-    {
-        $stepRules = $this->getStepRules($this->currentStep);
-        $this->validate($stepRules);
-    }
+
+    $this->employment_date = $this->formModel
+        ->firstEmployment?->started_at?->toDateString();
 }
 ```
 
-## Common Pitfalls
+## Persistence
 
-### Model Hydration Issues
+The owning modal validates the form, converts it to typed data, and calls the
+appropriate create or update Action. This keeps transactions and business behavior
+out of UI state objects.
+
 ```php
-// ❌ WRONG - Model state may be lost
-public function store(): bool
+protected function storeForm(): bool
 {
-    $this->validate();
-    // Model might be null here due to hydration
-    $this->formModel->update($this->getModelData());
-}
+    $this->form->validate();
 
-// ✅ CORRECT - Always ensure model is set
-public function store(): bool
-{
-    $this->validate();
-    
-    if ($this->formModel) {
-        $this->formModel->update($this->getModelData());
-    } else {
-        $modelClass = $this->getModelClass();
-        $modelClass::create($this->getModelData());
+    if ($this->form->isEditing()) {
+        $this->updateAction->handle($this->form->manager(), $this->form->toData());
+
+        return true;
     }
+
+    $this->createAction->handle($this->form->toData());
+
+    return true;
 }
 ```
 
-### Validation Rule Context
-```php
-// ❌ WRONG - Ignores current model incorrectly
-'email' => Rule::unique('users', 'email')->ignore($this->id),
+The Matches form is a temporary exception: its `store()` method currently resolves
+the match Actions because match submission assembles a complex competitor payload.
+That orchestration should move to the Matches modal without moving match invariants
+out of the Actions.
 
-// ✅ CORRECT - Uses proper model context
-'email' => Rule::unique('users', 'email')->ignore($this->formModel),
-```
+## Testing
 
-## Best Practices
-
-### Form Design
-- Keep forms focused on single responsibility
-- Use meaningful property names
-- Implement proper type hints
-- Document complex validation rules
-
-### Data Handling
-- Transform data appropriately for storage
-- Handle null values gracefully
-- Validate relationships exist
-- Use transactions for complex operations
-
-### Error Handling
-- Provide clear error messages
-- Log errors for debugging
-- Handle edge cases gracefully
-- Test error scenarios
-
-### Performance
-- Use lazy loading for expensive operations
-- Implement computed properties for cached data
-- Optimize database queries
-- Avoid storing large objects in form state
-
-## Related Documentation
-
-- [Component Architecture](component-architecture.md) - Overall architecture patterns
-- [Modal Patterns](modal-patterns.md) - Modal integration patterns
-- [Testing Guide](../../guides/livewire/testing-guide.md) - Form testing strategies
-- [Migration Guide](../../guides/livewire/migration-guide.md) - Migration from legacy forms
+Test forms for validation, hydration, and data conversion. Test modals for Action
+coordination and user-facing events. Test persistence and domain invariants through
+the Action integration tests. Avoid reflection tests that freeze removed internal
+methods instead of proving behavior.

--- a/docs/architecture/livewire/modal-patterns.md
+++ b/docs/architecture/livewire/modal-patterns.md
@@ -1,779 +1,160 @@
 # Livewire Modal Patterns
 
-## Overview
+Ringside uses `wire-elements/modal` through class-based Livewire modal components.
+Domain form modals extend `BaseFormModal`; specialized workflows may extend
+`ModalComponent` directly when the create/edit lifecycle does not fit.
 
-This document covers the comprehensive modal patterns used in Ringside's Livewire architecture. Our modal system provides a consistent, reusable approach to displaying forms and content in overlay interfaces across all domain entities.
+## Base modal responsibilities
 
-## Modal Architecture
+`BaseModal` owns mechanics shared by model-backed modals:
 
-### Core Components
+- loads an existing model by identifier or initializes create state;
+- assigns the model to its form;
+- restores the original model state when clearing an edit form; and
+- derives a create or edit title.
 
-#### BaseModal
-The foundation class providing core modal functionality:
-- **State Management**: Modal open/close state handling
-- **Model Binding**: Automatic model resolution and context
-- **Lifecycle Management**: Mount/unmount operations
-- **Event Handling**: Modal-specific event dispatching
+It does not validate input or persist a model.
 
-```php
-/**
- * @template TForm of BaseForm
- * @template TModel of Model
- */
-abstract class BaseModal extends Component
-{
-    protected ?Model $model = null;
-    protected ?Model $modelType = null;
-    protected ?string $modalFormPath = null;
-    
-    abstract protected function getFormClass(): string;
-    abstract protected function getModelClass(): string;
-    abstract protected function getModalPath(): string;
-    
-    public function openModal(mixed $modelId = null): void {}
-    public function closeModal(): void {}
-    public function mount(mixed $modelId = null): void {}
-}
-```
+## Base form modal responsibilities
 
-#### BaseFormModal
-Extends BaseModal with form-specific functionality:
-- **Form Integration**: Automatic form component instantiation
-- **Dummy Data**: Test data generation for development
-- **Unified API**: Single interface for form-based modals
+`BaseFormModal` adds the shared form submission lifecycle:
 
 ```php
-/**
- * @template TForm of BaseForm
- * @template TModel of Model
- * @extends BaseModal<TForm, TModel>
- */
 abstract class BaseFormModal extends BaseModal
 {
-    use GeneratesDummyData;
-    
-    public BaseForm $form;
-    public bool $isModalOpen = false;
-    
-    public function save(): void {}
-    public function submitForm(): bool {}
-    protected function getDummyDataFields(): array {}
-}
-```
+    abstract protected function getFormClass(): string;
 
-### Modal Types
+    abstract protected function getModelClass(): string;
 
-#### Form Modals
-Most common modal type - displays forms for create/edit operations:
-```php
-class FormModal extends BaseFormModal
-{
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
-    }
-    
-    protected function getModelClass(): string
-    {
-        return Event::class;
-    }
-    
-    protected function getModalPath(): string
-    {
-        return 'livewire.events.modals.form-modal';
-    }
-}
-```
+    abstract protected function getModalPath(): string;
 
-#### Confirmation Modals
-For dangerous operations requiring user confirmation:
-```php
-class ConfirmationModal extends BaseModal
-{
-    public string $title = '';
-    public string $message = '';
-    public string $confirmText = 'Confirm';
-    public string $cancelText = 'Cancel';
-    
-    public function confirm(): void
-    {
-        $this->dispatch('confirmed');
-        $this->closeModal();
-    }
-}
-```
+    abstract protected function storeForm(): bool;
 
-#### Information Modals
-For displaying read-only information:
-```php
-class InfoModal extends BaseModal
-{
-    public array $data = [];
-    
-    public function openModal(mixed $modelId = null): void
-    {
-        $this->loadData($modelId);
-        parent::openModal($modelId);
-    }
-    
-    protected function loadData(mixed $modelId): void
-    {
-        $modelClass = $this->getModelClass();
-        $this->data = $modelClass::find($modelId)->toArray();
-    }
-}
-```
-
-## Modal Lifecycle
-
-### 1. Initialization
-Modal components are typically embedded in parent components:
-```php
-// In parent component
-class ManageEvents extends Component
-{
-    public FormModal $modal;
-    
-    public function createEvent(): void
-    {
-        $this->modal->openModal();
-    }
-    
-    public function editEvent(int $eventId): void
-    {
-        $this->modal->openModal($eventId);
-    }
-}
-```
-
-### 2. Opening Modal
-The `openModal()` method handles modal state and context:
-```php
-public function openModal(mixed $modelId = null): void
-{
-    // Ensure proper initialization
-    if (!isset($this->modalFormPath)) {
-        $this->mount($modelId);
-    } elseif ($modelId !== null) {
-        $this->mount($modelId);
-    }
-    
-    $this->isModalOpen = true;
-}
-```
-
-### 3. Model Resolution
-When editing existing models:
-```php
-public function mount(mixed $modelId = null): void
-{
-    $this->modalFormPath = $this->getModalPath();
-    
-    // Initialize model type
-    $modelClass = $this->getModelClass();
-    $this->modelType = new $modelClass();
-    
-    // Load specific model if provided
-    if ($modelId) {
-        $this->model = $modelClass::find($modelId);
-    }
-    
-    // Initialize form with model
-    if (isset($this->form) && $this->model) {
-        $this->form->setModel($this->model);
-    }
-}
-```
-
-### 4. Form Integration
-BaseFormModal automatically integrates with form components:
-```php
-public function mount(mixed $modelId = null): void
-{
-    // Initialize form if not exists
-    if (!isset($this->form)) {
-        $formClass = $this->getFormClass();
-        $this->form = new $formClass($this, 'form');
-    }
-    
-    // Link form and modal
-    $this->modelForm = $this->form;
-    
-    parent::mount($modelId);
-    
-    // Ensure form has model reference
-    if (isset($modelId) && isset($this->model)) {
-        $this->form->setModel($this->model);
-    }
-}
-```
-
-### 5. Submission Handling
-Form submission through modal interface:
-```php
-public function submitForm(): bool
-{
-    // Ensure form has correct model
-    if (isset($this->model) && $this->form) {
-        $this->form->setModel($this->model);
-    }
-    
-    $result = $this->form->store();
-    
-    if ($result) {
-        $this->closeModal();
-        $this->dispatch('form-submitted');
-    }
-    
-    return $result;
-}
-```
-
-### 6. Closing Modal
-Clean up modal state:
-```php
-public function closeModal(): void
-{
-    $this->isModalOpen = false;
-    $this->dispatch('closeModal');
-}
-```
-
-## View Integration
-
-### Modal Template Structure
-```blade
-<!-- livewire/events/modals/form-modal.blade.php -->
-<div>
-    @if($isModalOpen)
-        <!-- Modal Overlay -->
-        <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity">
-            <!-- Modal Dialog -->
-            <div class="fixed inset-0 z-10 overflow-y-auto">
-                <div class="flex min-h-full items-center justify-center">
-                    <!-- Modal Content -->
-                    <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
-                        <!-- Modal Header -->
-                        <div class="flex items-center justify-between mb-4">
-                            <h3 class="text-lg font-semibold text-gray-900">
-                                {{ $model ? 'Edit Event' : 'Create Event' }}
-                            </h3>
-                            <button wire:click="closeModal" class="text-gray-400 hover:text-gray-600">
-                                <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor">
-                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
-                                </svg>
-                            </button>
-                        </div>
-                        
-                        <!-- Modal Body -->
-                        <div class="space-y-4">
-                            <!-- Form Fields -->
-                            <div>
-                                <label for="name" class="block text-sm font-medium text-gray-700">Name</label>
-                                <input type="text" 
-                                       wire:model="form.name" 
-                                       id="name" 
-                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
-                                @error('form.name') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
-                            </div>
-                            
-                            <div>
-                                <label for="date" class="block text-sm font-medium text-gray-700">Date</label>
-                                <input type="datetime-local" 
-                                       wire:model="form.date" 
-                                       id="date" 
-                                       class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
-                                @error('form.date') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
-                            </div>
-                            
-                            <div>
-                                <label for="venue_id" class="block text-sm font-medium text-gray-700">Venue</label>
-                                <select wire:model="form.venue_id" 
-                                        id="venue_id" 
-                                        class="mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm">
-                                    <option value="">Select a venue</option>
-                                    @foreach($form->venues as $venue)
-                                        <option value="{{ $venue->id }}">{{ $venue->name }}</option>
-                                    @endforeach
-                                </select>
-                                @error('form.venue_id') <span class="text-red-500 text-sm">{{ $message }}</span> @enderror
-                            </div>
-                        </div>
-                        
-                        <!-- Modal Footer -->
-                        <div class="mt-6 flex justify-end space-x-3">
-                            <button wire:click="closeModal" 
-                                    class="inline-flex justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                                Cancel
-                            </button>
-                            <button wire:click="save" 
-                                    class="inline-flex justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
-                                {{ $model ? 'Update' : 'Create' }}
-                            </button>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        </div>
-    @endif
-</div>
-```
-
-### Parent Component Integration
-```blade
-<!-- manage-events.blade.php -->
-<div>
-    <!-- Page Header -->
-    <div class="flex justify-between items-center mb-6">
-        <h1 class="text-2xl font-bold text-gray-900">Events</h1>
-        <button wire:click="$refs.modal.openModal()" 
-                class="bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-2 px-4 rounded">
-            Create Event
-        </button>
-    </div>
-    
-    <!-- Events Table -->
-    <div class="bg-white shadow overflow-hidden sm:rounded-md">
-        @foreach($events as $event)
-            <div class="px-4 py-4 flex items-center justify-between">
-                <div>
-                    <h3 class="text-lg font-medium text-gray-900">{{ $event->name }}</h3>
-                    <p class="text-sm text-gray-500">{{ $event->date->format('F j, Y') }}</p>
-                </div>
-                <button wire:click="$refs.modal.openModal({{ $event->id }})" 
-                        class="text-indigo-600 hover:text-indigo-900">
-                    Edit
-                </button>
-            </div>
-        @endforeach
-    </div>
-    
-    <!-- Modal Component -->
-    <livewire:events.modals.form-modal x-ref="modal" />
-</div>
-```
-
-## Event Handling
-
-### Modal Events
-```php
-class FormModal extends BaseFormModal
-{
     public function submitForm(): bool
     {
-        $result = $this->form->store();
-        
-        if ($result) {
-            $this->closeModal();
-            
-            // Dispatch events for parent components
-            $this->dispatch('form-submitted');
-            $this->dispatch('closeModal');
-            
-            // Dispatch model-specific events
-            if ($this->model) {
-                $this->dispatch('eventUpdated', $this->model->id);
-            } else {
-                $this->dispatch('eventCreated');
-            }
+        if ($this->model !== null) {
+            $this->form->setModel($this->model);
         }
-        
-        return $result;
-    }
-}
-```
 
-### Parent Component Listeners
-```php
-class ManageEvents extends Component
-{
-    protected $listeners = [
-        'form-submitted' => 'refreshEvents',
-        'eventCreated' => 'refreshEvents',
-        'eventUpdated' => 'refreshEvents',
-    ];
-    
-    public function refreshEvents(): void
-    {
-        // Refresh events list
-        $this->events = Event::latest()->get();
-    }
-}
-```
-
-## Dummy Data Integration
-
-### Development Data Generation
-```php
-class FormModal extends BaseFormModal
-{
-    use GeneratesDummyData;
-    
-    protected function getDummyDataFields(): array
-    {
-        $venue = Venue::query()->inRandomOrder()->first();
-        
-        return [
-            'name' => fn() => Str::of(fake()->sentence(2))->title()->value(),
-            'date' => fn() => fake()->dateTimeBetween('now', '+3 month')->format('Y-m-d H:i:s'),
-            'venue_id' => fn() => $venue?->id ?? Venue::factory()->create()->id,
-            'preview' => fn() => fake()->text(200),
-        ];
-    }
-}
-```
-
-### Usage in Views
-```blade
-<!-- Development only -->
-@if(app()->environment('local'))
-    <button wire:click="fillDummyFields" 
-            class="text-sm text-gray-500 hover:text-gray-700">
-        Fill Test Data
-    </button>
-@endif
-```
-
-## Advanced Patterns
-
-### Nested Modals
-```php
-class FormModal extends BaseFormModal
-{
-    public bool $showConfirmation = false;
-    
-    public function save(): void
-    {
-        if ($this->model && $this->hasImportantChanges()) {
-            $this->showConfirmation = true;
-            return;
-        }
-        
-        $this->submitForm();
-    }
-    
-    public function confirmSave(): void
-    {
-        $this->showConfirmation = false;
-        $this->submitForm();
-    }
-}
-```
-
-### Dynamic Modal Content
-```php
-class FormModal extends BaseFormModal
-{
-    public string $modalSize = 'md';
-    public array $formSections = [];
-    
-    public function mount(mixed $modelId = null): void
-    {
-        parent::mount($modelId);
-        
-        // Configure modal based on model type
-        if ($this->model && $this->model->type === 'complex') {
-            $this->modalSize = 'lg';
-            $this->formSections = ['basic', 'advanced', 'metadata'];
-        }
-    }
-}
-```
-
-### Modal with Tabs
-```php
-class FormModal extends BaseFormModal
-{
-    public string $activeTab = 'basic';
-    public array $tabs = ['basic', 'details', 'settings'];
-    
-    public function switchTab(string $tab): void
-    {
-        $this->activeTab = $tab;
-    }
-    
-    public function save(): void
-    {
-        // Validate all tabs
-        foreach ($this->tabs as $tab) {
-            $this->validateTab($tab);
-        }
-        
-        $this->submitForm();
-    }
-}
-```
-
-## State Management
-
-### Modal State Persistence
-```php
-class FormModal extends BaseFormModal
-{
-    public bool $isModalOpen = false;
-    
-    public function openModal(mixed $modelId = null): void
-    {
-        // Clear previous state
-        $this->resetValidation();
-        $this->resetErrorBag();
-        
-        parent::openModal($modelId);
-        
-        $this->isModalOpen = true;
-    }
-    
-    public function closeModal(): void
-    {
-        $this->isModalOpen = false;
-        
-        // Reset form state
-        if ($this->form) {
-            $this->form->reset();
-        }
-    }
-}
-```
-
-### Conditional Modal Behavior
-```php
-class FormModal extends BaseFormModal
-{
-    public function openModal(mixed $modelId = null): void
-    {
-        // Check permissions
-        if (!$this->canOpenModal($modelId)) {
-            $this->dispatch('unauthorized');
-            return;
-        }
-        
-        parent::openModal($modelId);
-    }
-    
-    protected function canOpenModal(mixed $modelId): bool
-    {
-        if ($modelId && !$this->canEditModel($modelId)) {
+        if (! $this->storeForm()) {
             return false;
         }
-        
-        return $this->canCreateModel();
-    }
-}
-```
 
-## Testing Patterns
-
-### Modal State Testing
-```php
-test('modal opens and closes correctly', function () {
-    $component = Livewire::test(FormModal::class);
-    
-    // Initially closed
-    expect($component->instance()->isModalOpen)->toBeFalse();
-    
-    // Opens modal
-    $component->call('openModal');
-    expect($component->instance()->isModalOpen)->toBeTrue();
-    
-    // Closes modal
-    $component->call('closeModal');
-    expect($component->instance()->isModalOpen)->toBeFalse();
-});
-```
-
-### Form Integration Testing
-```php
-test('modal form submission works correctly', function () {
-    $venue = Venue::factory()->create();
-    
-    $component = Livewire::test(FormModal::class)
-        ->call('openModal')
-        ->set('form.name', 'Test Event')
-        ->set('form.date', '2024-01-01')
-        ->set('form.venue_id', $venue->id)
-        ->call('save');
-    
-    $component->assertDispatched('form-submitted');
-    expect($component->instance()->isModalOpen)->toBeFalse();
-    
-    $this->assertDatabaseHas('events', [
-        'name' => 'Test Event',
-        'date' => '2024-01-01',
-        'venue_id' => $venue->id,
-    ]);
-});
-```
-
-### Event Testing
-```php
-test('modal dispatches correct events', function () {
-    $component = Livewire::test(FormModal::class)
-        ->call('openModal')
-        ->set('form.name', 'Test Event')
-        ->call('save');
-    
-    $component->assertDispatched('form-submitted');
-    $component->assertDispatched('closeModal');
-    $component->assertDispatched('eventCreated');
-});
-```
-
-## Performance Optimization
-
-### Lazy Loading
-```php
-class FormModal extends BaseFormModal
-{
-    #[Lazy]
-    public function getVenuesProperty(): Collection
-    {
-        return Venue::active()->get();
-    }
-    
-    #[Computed]
-    public function availableVenues(): Collection
-    {
-        return $this->getVenuesProperty();
-    }
-}
-```
-
-### Deferred Loading
-```php
-class FormModal extends BaseFormModal
-{
-    public bool $showModal = false;
-    
-    public function openModal(mixed $modelId = null): void
-    {
-        $this->showModal = true;
-        
-        // Defer expensive operations
-        $this->skipRender();
-        
-        parent::openModal($modelId);
-    }
-}
-```
-
-## Error Handling
-
-### Modal Error States
-```php
-class FormModal extends BaseFormModal
-{
-    public bool $hasError = false;
-    public string $errorMessage = '';
-    
-    public function submitForm(): bool
-    {
-        try {
-            $result = $this->form->store();
-            
-            if ($result) {
-                $this->hasError = false;
-                $this->closeModal();
-            }
-            
-            return $result;
-        } catch (Exception $e) {
-            $this->hasError = true;
-            $this->errorMessage = 'An error occurred while saving.';
-            Log::error('Modal form submission error', ['error' => $e->getMessage()]);
-            
-            return false;
-        }
-    }
-}
-```
-
-### Validation Error Display
-```blade
-@if($hasError)
-    <div class="rounded-md bg-red-50 p-4 mb-4">
-        <div class="flex">
-            <div class="flex-shrink-0">
-                <svg class="h-5 w-5 text-red-400" viewBox="0 0 20 20" fill="currentColor">
-                    <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
-                </svg>
-            </div>
-            <div class="ml-3">
-                <p class="text-sm font-medium text-red-800">{{ $errorMessage }}</p>
-            </div>
-        </div>
-    </div>
-@endif
-```
-
-## Best Practices
-
-### Modal Design
-- Keep modals focused on single tasks
-- Use appropriate modal sizes for content
-- Provide clear actions (Save/Cancel)
-- Include proper loading states
-
-### State Management
-- Reset modal state on close
-- Handle form validation errors gracefully
-- Provide feedback for user actions
-- Maintain proper modal lifecycle
-
-### Performance
-- Use lazy loading for expensive operations
-- Implement proper caching strategies
-- Minimize modal re-rendering
-- Clean up resources on close
-
-### Accessibility
-- Include proper ARIA labels
-- Handle keyboard navigation
-- Provide focus management
-- Support screen readers
-
-## Common Pitfalls
-
-### Form State Issues
-```php
-// ❌ WRONG - Form state may be lost
-public function openModal(mixed $modelId = null): void
-{
-    $this->isModalOpen = true;
-    // Form may not have model context
-}
-
-// ✅ CORRECT - Ensure proper initialization
-public function openModal(mixed $modelId = null): void
-{
-    if (!isset($this->modalFormPath)) {
-        $this->mount($modelId);
-    }
-    $this->isModalOpen = true;
-}
-```
-
-### Event Handling
-```php
-// ❌ WRONG - Events may not be dispatched
-public function save(): void
-{
-    $this->form->store();
-    $this->closeModal();
-}
-
-// ✅ CORRECT - Check result and dispatch events
-public function save(): void
-{
-    if ($this->form->store()) {
-        $this->dispatch('form-submitted');
+        $this->dispatch('refreshDatatable');
         $this->closeModal();
+        $this->dispatch('closeModal');
+        $this->dispatch('form-submitted');
+
+        return true;
     }
 }
 ```
 
-## Related Documentation
+The three class metadata methods configure modal infrastructure. They are distinct
+from the removed form-level model metadata: the modal genuinely needs the concrete
+form class, model class, and Blade path to mount itself.
 
-- [Component Architecture](component-architecture.md) - Overall architecture patterns
-- [Form Patterns](form-patterns.md) - Form component implementation
-- [Testing Guide](../../guides/livewire/testing-guide.md) - Modal testing strategies
-- [Migration Guide](../../guides/livewire/migration-guide.md) - Migration from legacy modals
+## Domain modal pattern
+
+A standard domain modal:
+
+1. declares its typed form property;
+2. receives create and update Actions through Livewire's `boot()` injection;
+3. provides the form, model, and view classes;
+4. validates and authorizes at the interaction boundary;
+5. converts input with `toData()`; and
+6. delegates persistence to the appropriate Action.
+
+```php
+final class FormModal extends BaseFormModal
+{
+    public CreateEditForm $form;
+
+    private CreateAction $createAction;
+
+    private UpdateAction $updateAction;
+
+    public function boot(CreateAction $createAction, UpdateAction $updateAction): void
+    {
+        $this->createAction = $createAction;
+        $this->updateAction = $updateAction;
+    }
+
+    protected function storeForm(): bool
+    {
+        $this->form->validate();
+
+        if ($this->form->isEditing()) {
+            $this->updateAction->handle($this->form->manager(), $this->form->toData());
+
+            return true;
+        }
+
+        $this->createAction->handle($this->form->toData());
+
+        return true;
+    }
+}
+```
+
+Use method or `boot()` injection for Actions. Do not instantiate Actions manually
+and do not move their mutation logic into the modal.
+
+## Authorization
+
+Authorize immediately before a protected operation. For modals that expose create
+and edit entry points, authorize the corresponding ability when opening or
+submitting the modal. A locked model identifier protects transport integrity but
+does not replace authorization.
+
+```php
+public function openModal(mixed $modelId = null): void
+{
+    if ($modelId === null) {
+        Gate::authorize('create', EventMatch::class);
+    } else {
+        Gate::authorize('update', EventMatch::query()->findOrFail($modelId));
+    }
+
+    parent::openModal($modelId);
+}
+```
+
+## Success and failure behavior
+
+Return `false` from `storeForm()` only when the modal should remain open without a
+successful completion event. On success, `BaseFormModal` refreshes tables, closes
+the modal, and dispatches `form-submitted`.
+
+Catch `BaseBusinessException` only when the interaction needs to translate a domain
+failure into a user-facing message. Do not catch generic exceptions to hide
+programmer or infrastructure failures.
+
+## Specialized modal behavior
+
+Domain modals may extend the shared lifecycle for behavior such as:
+
+- loading option lists through computed properties;
+- resetting dependent fields after another field changes;
+- dispatching domain-specific success events; or
+- generating development-only dummy data.
+
+Keep those additions UI-focused. Reusable queries belong on Builders, and business
+state transitions belong in Actions or lifecycle collaborators.
+
+## Matches exception
+
+The Matches modal currently delegates `storeForm()` to the Matches form, whose
+`store()` method assembles the complex competitor data and calls match Actions.
+This is transitional. The target boundary is the same as other domains: the form
+builds typed data and the modal calls the Actions.
+
+## Testing
+
+- Assert authorization at modal entry and submission boundaries.
+- Verify the modal chooses the correct create or update Action.
+- Assert successful UI events and modal closure.
+- Keep validation matrices with the form tests.
+- Keep transaction and persistence assertions with Action integration tests.
+- Use browser tests only for client-side modal behavior that component tests cannot
+  prove.


### PR DESCRIPTION
## Summary
- redefine Livewire forms as state, validation, hydration, and typed-data boundaries
- document modals as authorization and Action orchestration boundaries
- document Actions as the owners of persistence and transactions
- replace stale generated examples and record the remaining Matches form exception
- retain flat resource-oriented Livewire domain directories

## Verification
- git diff --check
- composer test:push