### PR TITLE
refactor: move match submission to modal

### DIFF
--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -4,13 +4,10 @@ declare(strict_types=1);
 
 namespace App\Livewire\Matches\Forms;
 
-use App\Actions\Matches\AddMatchForEventAction;
-use App\Actions\Matches\UpdateMatchAction;
 use App\Data\Matches\EventMatchData;
 use App\Enums\MatchType;
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Concerns\HasStandardValidationAttributes;
-use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
@@ -55,19 +52,6 @@ class CreateEditForm extends BaseForm
      * @var EventMatch|null Current event match model or null for creation
      */
     protected ?Model $formModel = null;
-
-    /**
-     * Event identifier for match association.
-     *
-     * Links the match to a specific wrestling event where it will take place.
-     * This is always required since matches cannot exist without an event.
-     * Provided by route model binding, not user input.
-     *
-     * Default value of 0 indicates uninitialized - will be set during component mount.
-     *
-     * @var int Event database ID
-     */
-    public int $eventId = 0;
 
     /**
      * Match promotional preview content for marketing purposes.
@@ -134,32 +118,6 @@ class CreateEditForm extends BaseForm
     }
 
     /**
-     * Store a new event match.
-     *
-     * Creates a new match with all relationships properly synced.
-     *
-     * @return bool True if the match was successfully created
-     */
-    public function store(): bool
-    {
-        $this->validate();
-
-        $data = $this->toData();
-
-        if ($this->isCreating()) {
-            $event = Event::query()->findOrFail($this->eventId);
-            $this->formModel = resolve(AddMatchForEventAction::class)->handle($event, $data);
-        } else {
-            $match = EventMatch::query()->findOrFail($this->modelId);
-            $this->formModel = resolve(UpdateMatchAction::class)->handle($match, $data);
-        }
-
-        $this->modelId = $this->formModel->getKey();
-
-        return true;
-    }
-
-    /**
      * Load additional data when editing existing event match records.
      *
      * Handles complex relationship data loading for edit operations,
@@ -220,7 +178,7 @@ class CreateEditForm extends BaseForm
      * Excludes relationship data which is handled separately through
      * the relationship synchronization system.
      */
-    private function toData(): EventMatchData
+    public function toData(): EventMatchData
     {
         $matchType = $this->matchType;
         $sides = $matchType->usesIndividualCompetitorSides()
@@ -280,7 +238,6 @@ class CreateEditForm extends BaseForm
     protected function rules(): array
     {
         $baseRules = [
-            // eventId removed - it's context from route model binding, not user input
             'matchType' => ['required', new Enum(MatchType::class)],
             'matchStipulationId' => [
                 'nullable',

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\Livewire\Matches\Modals;
 
+use App\Actions\Matches\AddMatchForEventAction;
+use App\Actions\Matches\UpdateMatchAction;
 use App\Enums\MatchType;
 use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Concerns\Data\PresentsMatchTypesList;
@@ -14,6 +16,7 @@ use App\Livewire\Concerns\Data\PresentsWrestlersList;
 use App\Livewire\Matches\Enums\CompetitorSelectionLayout;
 use App\Livewire\Matches\Forms\CreateEditForm;
 use App\Livewire\Matches\Support\MatchFormDummyData;
+use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchStipulation;
 use Illuminate\Support\Facades\Gate;
@@ -37,9 +40,18 @@ class FormModal extends BaseFormModal
 
     private MatchFormDummyData $dummyData;
 
-    public function boot(MatchFormDummyData $dummyData): void
-    {
+    private AddMatchForEventAction $addMatchForEventAction;
+
+    private UpdateMatchAction $updateMatchAction;
+
+    public function boot(
+        MatchFormDummyData $dummyData,
+        AddMatchForEventAction $addMatchForEventAction,
+        UpdateMatchAction $updateMatchAction,
+    ): void {
         $this->dummyData = $dummyData;
+        $this->addMatchForEventAction = $addMatchForEventAction;
+        $this->updateMatchAction = $updateMatchAction;
     }
 
     protected function getFormClass(): string
@@ -59,7 +71,21 @@ class FormModal extends BaseFormModal
 
     protected function storeForm(): bool
     {
-        return $this->form->store();
+        $this->form->validate();
+
+        if ($this->form->isEditing()) {
+            $match = EventMatch::query()->findOrFail($this->form->modelId);
+            Gate::authorize('update', $match);
+            $storedMatch = $this->updateMatchAction->handle($match, $this->form->toData());
+        } else {
+            Gate::authorize('create', EventMatch::class);
+            $event = Event::query()->findOrFail($this->eventId);
+            $storedMatch = $this->addMatchForEventAction->handle($event, $this->form->toData());
+        }
+
+        $this->form->setModel($storedMatch);
+
+        return true;
     }
 
     /** @return array<int, string> */
@@ -77,15 +103,6 @@ class FormModal extends BaseFormModal
     protected function getDummyDataFields(): array
     {
         return $this->dummyData->generate();
-    }
-
-    public function mount(mixed $modelId = null): void
-    {
-        parent::mount($modelId);
-
-        if ($this->eventId > 0) {
-            $this->form->eventId = $this->eventId;
-        }
     }
 
     public function openModal(mixed $modelId = null): void

--- a/docs/architecture/livewire/form-patterns.md
+++ b/docs/architecture/livewire/form-patterns.md
@@ -159,11 +159,6 @@ protected function storeForm(): bool
 }
 ```
 
-The Matches form is a temporary exception: its `store()` method currently resolves
-the match Actions because match submission assembles a complex competitor payload.
-That orchestration should move to the Matches modal without moving match invariants
-out of the Actions.
-
 ## Testing
 
 Test forms for validation, hydration, and data conversion. Test modals for Action

--- a/docs/architecture/livewire/modal-patterns.md
+++ b/docs/architecture/livewire/modal-patterns.md
@@ -142,13 +142,6 @@ Domain modals may extend the shared lifecycle for behavior such as:
 Keep those additions UI-focused. Reusable queries belong on Builders, and business
 state transitions belong in Actions or lifecycle collaborators.
 
-## Matches exception
-
-The Matches modal currently delegates `storeForm()` to the Matches form, whose
-`store()` method assembles the complex competitor data and calls match Actions.
-This is transitional. The target boundary is the same as other domains: the form
-builds typed data and the modal calls the Actions.
-
 ## Testing
 
 - Assert authorization at modal entry and submission boundaries.

--- a/tests/ArchitectureTest.php
+++ b/tests/ArchitectureTest.php
@@ -84,6 +84,10 @@ arch('controllers do not use models directly')
     ->expect('App\\Http\\Controllers')
     ->not->toUse('App\\Models\\*');
 
+arch('match forms do not orchestrate actions')
+    ->expect('App\\Livewire\\Matches\\Forms')
+    ->not->toUse('App\\Actions\\*');
+
 arch('models are only used in repositories')
     ->expect('App\\Models')
     ->toOnlyBeUsedIn('App\\Repositories')

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -392,7 +392,7 @@ describe('FormModal Edit Operations', function () {
         $component = livewire(FormModal::class, ['eventId' => $this->event->id])
             ->call('openModal', $match->id);
 
-        $component->assertSet('form.eventId', $this->event->id);
+        $component->assertSet('eventId', $this->event->id);
         $component->assertSet('form.matchType', MatchType::Singles);
         $component->assertSet('form.preview', 'Original preview');
     });
@@ -554,8 +554,7 @@ describe('FormModal State Management', function () {
             ->call('openModal', $match->id)
             ->call('openModal');
 
-        // eventId should remain set since it comes from route context, not form data
-        $component->assertSet('form.eventId', $this->event->id);
+        $component->assertSet('eventId', $this->event->id);
         $component->assertSet('form.matchType', null);
         $component->assertSet('form.competitors', []);
     });


### PR DESCRIPTION
## Summary
- remove Action orchestration and event context from the Match form
- make the Match modal validate, authorize, and call create/update Actions
- expose only typed data conversion from the form
- add an architecture guard preventing Match forms from depending on Actions
- remove the documented transitional Matches exception

## Verification
- Match FormModal integration tests (39 tests, 82 assertions)
- focused architecture rule
- composer test:types
- composer test:push