### PR TITLE
refactor: use Livewire form initialization

### DIFF
--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -17,8 +17,6 @@ abstract class BaseFormModal extends BaseModal
 {
     use GeneratesDummyData;
 
-    abstract protected function getFormClass(): string;
-
     abstract protected function getModelClass(): string;
 
     abstract protected function getModalPath(): string;
@@ -67,11 +65,6 @@ abstract class BaseFormModal extends BaseModal
 
         $modelClass = $this->getModelClass();
         $this->modelType = new $modelClass();
-
-        if (! isset($this->form)) {
-            $formClass = $this->getFormClass();
-            $this->form = new $formClass($this, 'form');
-        }
 
         $this->modelForm = $this->form;
 

--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -34,11 +34,6 @@ class FormModal extends BaseFormModal
         $this->updateAction = $updateAction;
     }
 
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
-    }
-
     protected function getModelClass(): string
     {
         return Event::class;

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -7,7 +7,6 @@ namespace App\Livewire\Managers\Modals;
 use App\Actions\Managers\CreateAction;
 use App\Actions\Managers\UpdateAction;
 use App\Livewire\Base\BaseFormModal;
-use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\Managers\Forms\CreateEditForm;
 use App\Models\Roster\Managers\Manager;
 use Illuminate\View\View;
@@ -17,8 +16,6 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
-    use GeneratesDummyData;
-
     public function mount(mixed $modelId = null): void
     {
         parent::mount($modelId);
@@ -37,11 +34,6 @@ class FormModal extends BaseFormModal
     {
         $this->createAction = $createAction;
         $this->updateAction = $updateAction;
-    }
-
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -54,11 +54,6 @@ class FormModal extends BaseFormModal
         $this->updateMatchAction = $updateMatchAction;
     }
 
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
-    }
-
     protected function getModelClass(): string
     {
         return EventMatch::class;

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -7,7 +7,6 @@ namespace App\Livewire\Referees\Modals;
 use App\Actions\Referees\CreateAction;
 use App\Actions\Referees\UpdateAction;
 use App\Livewire\Base\BaseFormModal;
-use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\Referees\Forms\CreateEditForm;
 use App\Models\Roster\Referees\Referee;
 use Illuminate\View\View;
@@ -17,8 +16,6 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
-    use GeneratesDummyData;
-
     /**
      * Store original model data for resetting purposes
      *
@@ -36,11 +33,6 @@ class FormModal extends BaseFormModal
     {
         $this->createAction = $createAction;
         $this->updateAction = $updateAction;
-    }
-
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Stables/Modals/FormModal.php
+++ b/app/Livewire/Stables/Modals/FormModal.php
@@ -10,7 +10,6 @@ use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Concerns\Data\PresentsManagersList;
 use App\Livewire\Concerns\Data\PresentsTagTeamsList;
 use App\Livewire\Concerns\Data\PresentsWrestlersList;
-use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\Stables\Forms\CreateEditForm;
 use App\Models\Roster\Stables\Stable;
 use Illuminate\Support\Str;
@@ -21,7 +20,6 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
-    use GeneratesDummyData;
     use PresentsManagersList;
     use PresentsTagTeamsList;
     use PresentsWrestlersList;
@@ -36,11 +34,6 @@ class FormModal extends BaseFormModal
     {
         $this->createAction = $createAction;
         $this->updateAction = $updateAction;
-    }
-
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -9,7 +9,6 @@ use App\Actions\TagTeams\UpdateAction;
 use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Concerns\Data\PresentsManagersList;
 use App\Livewire\Concerns\Data\PresentsWrestlersList;
-use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\TagTeams\Forms\CreateEditForm;
 use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
@@ -21,7 +20,6 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
-    use GeneratesDummyData;
     use PresentsManagersList;
     use PresentsWrestlersList;
 
@@ -35,11 +33,6 @@ class FormModal extends BaseFormModal
     {
         $this->createAction = $createAction;
         $this->updateAction = $updateAction;
-    }
-
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -7,7 +7,6 @@ namespace App\Livewire\Titles\Modals;
 use App\Actions\Titles\CreateAction;
 use App\Actions\Titles\UpdateAction;
 use App\Livewire\Base\BaseFormModal;
-use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\Titles\Forms\CreateEditForm;
 use App\Models\Titles\Title;
 use Illuminate\Support\Facades\Gate;
@@ -19,8 +18,6 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
-    use GeneratesDummyData;
-
     public CreateEditForm $form;
 
     private CreateAction $createAction;
@@ -31,11 +28,6 @@ class FormModal extends BaseFormModal
     {
         $this->createAction = $createAction;
         $this->updateAction = $updateAction;
-    }
-
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/app/Livewire/Users/Modals/FormModal.php
+++ b/app/Livewire/Users/Modals/FormModal.php
@@ -29,11 +29,6 @@ class FormModal extends BaseFormModal
         $this->updateAction = $updateAction;
     }
 
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
-    }
-
     protected function getModelClass(): string
     {
         return User::class;

--- a/app/Livewire/Venues/Modals/FormModal.php
+++ b/app/Livewire/Venues/Modals/FormModal.php
@@ -29,11 +29,6 @@ class FormModal extends BaseFormModal
         $this->updateAction = $updateAction;
     }
 
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
-    }
-
     protected function getModelClass(): string
     {
         return Venue::class;

--- a/app/Livewire/Wrestlers/Modals/FormModal.php
+++ b/app/Livewire/Wrestlers/Modals/FormModal.php
@@ -7,7 +7,6 @@ namespace App\Livewire\Wrestlers\Modals;
 use App\Actions\Wrestlers\CreateAction;
 use App\Actions\Wrestlers\UpdateAction;
 use App\Livewire\Base\BaseFormModal;
-use App\Livewire\Concerns\GeneratesDummyData;
 use App\Livewire\Wrestlers\Forms\CreateEditForm;
 use App\Models\Roster\Wrestlers\Wrestler;
 use Illuminate\Support\Str;
@@ -18,8 +17,6 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
-    use GeneratesDummyData;
-
     public CreateEditForm $form;
 
     private CreateAction $createAction;
@@ -30,11 +27,6 @@ class FormModal extends BaseFormModal
     {
         $this->createAction = $createAction;
         $this->updateAction = $updateAction;
-    }
-
-    protected function getFormClass(): string
-    {
-        return CreateEditForm::class;
     }
 
     protected function getModelClass(): string

--- a/tests/Integration/Livewire/Events/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Events/Modals/FormModalTest.php
@@ -17,13 +17,10 @@ beforeEach(function () {
 });
 
 describe('FormModal Configuration', function () {
-    it('returns correct form class', function () {
-        $modal = new FormModal();
-        $reflection = new ReflectionClass($modal);
-        $method = $reflection->getMethod('getFormClass');
-        $method->setAccessible(true);
+    it('initializes the event form', function () {
+        $component = livewire(FormModal::class);
 
-        expect($method->invoke($modal))->toBe(CreateEditForm::class);
+        expect($component->get('form'))->toBeInstanceOf(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -25,13 +25,10 @@ beforeEach(function () {
 });
 
 describe('FormModal Configuration', function () {
-    it('returns correct form class', function () {
-        $modal = new FormModal();
-        $reflection = new ReflectionClass($modal);
-        $method = $reflection->getMethod('getFormClass');
-        $method->setAccessible(true);
+    it('initializes the match form', function () {
+        $component = livewire(FormModal::class, ['eventId' => $this->event->id]);
 
-        expect($method->invoke($modal))->toBe(CreateEditForm::class);
+        expect($component->get('form'))->toBeInstanceOf(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {

--- a/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
@@ -19,13 +19,10 @@ beforeEach(function () {
 });
 
 describe('FormModal Configuration', function () {
-    it('returns correct form class', function () {
-        $modal = new FormModal();
-        $reflection = new ReflectionClass($modal);
-        $method = $reflection->getMethod('getFormClass');
-        $method->setAccessible(true);
+    it('initializes the stable form', function () {
+        $component = livewire(FormModal::class);
 
-        expect($method->invoke($modal))->toBe(CreateEditForm::class);
+        expect($component->get('form'))->toBeInstanceOf(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {

--- a/tests/Integration/Livewire/Titles/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Titles/Modals/FormModalTest.php
@@ -16,13 +16,10 @@ beforeEach(function () {
 });
 
 describe('FormModal Configuration', function () {
-    it('returns correct form class', function () {
-        $modal = new FormModal();
-        $reflection = new ReflectionClass($modal);
-        $method = $reflection->getMethod('getFormClass');
-        $method->setAccessible(true);
+    it('initializes the title form', function () {
+        $component = livewire(FormModal::class);
 
-        expect($method->invoke($modal))->toBe(CreateEditForm::class);
+        expect($component->get('form'))->toBeInstanceOf(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {

--- a/tests/Integration/Livewire/Users/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Users/Modals/FormModalTest.php
@@ -14,13 +14,10 @@ beforeEach(function () {
 });
 
 describe('FormModal Configuration', function () {
-    it('uses correct user form class', function () {
-        $modal = new FormModal();
-        $reflection = new ReflectionClass($modal);
-        $method = $reflection->getMethod('getFormClass');
-        $method->setAccessible(true);
+    it('initializes the user form', function () {
+        $component = livewire(FormModal::class);
 
-        expect($method->invoke($modal))->toBe(CreateEditForm::class);
+        expect($component->get('form'))->toBeInstanceOf(CreateEditForm::class);
     });
 
     it('uses correct model type', function () {

--- a/tests/Integration/Livewire/Wrestlers/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Modals/FormModalTest.php
@@ -13,13 +13,10 @@ beforeEach(function () {
 });
 
 describe('FormModal Configuration', function () {
-    it('returns correct form class', function () {
-        $modal = new FormModal();
-        $reflection = new ReflectionClass($modal);
-        $method = $reflection->getMethod('getFormClass');
-        $method->setAccessible(true);
+    it('initializes the wrestler form', function () {
+        $component = testLivewire(FormModal::class);
 
-        expect($method->invoke($modal))->toBe(CreateEditForm::class);
+        expect($component->get('form'))->toBeInstanceOf(CreateEditForm::class);
     });
 
     it('returns correct model class', function () {

--- a/tests/Unit/Livewire/Base/BaseFormModalTest.php
+++ b/tests/Unit/Livewire/Base/BaseFormModalTest.php
@@ -47,7 +47,6 @@ describe('BaseFormModal Unit Tests', function () {
             $abstractMethods = $reflection->getMethods(ReflectionMethod::IS_ABSTRACT);
             $abstractMethodNames = array_map(fn ($method) => $method->getName(), $abstractMethods);
 
-            expect($abstractMethodNames)->toContain('getFormClass');
             expect($abstractMethodNames)->toContain('getModelClass');
             expect($abstractMethodNames)->toContain('getModalPath');
         });
@@ -56,12 +55,6 @@ describe('BaseFormModal Unit Tests', function () {
     describe('method signatures', function () {
         test('abstract methods have correct signatures', function () {
             $reflection = new ReflectionClass(BaseFormModal::class);
-
-            // getFormClass method
-            $getFormClass = $reflection->getMethod('getFormClass');
-            expect($getFormClass->isAbstract())->toBeTrue();
-            expect($getFormClass->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($getFormClass))->toBe('string');
 
             // getModelClass method
             $getModelClass = $reflection->getMethod('getModelClass');


### PR DESCRIPTION
## Summary
- rely on Livewire 4 to initialize typed public form properties
- remove the manual form-class factory from BaseFormModal
- remove redundant GeneratesDummyData declarations from concrete modals
- replace reflection-based form-class tests with runtime initialization assertions

## Verification
- composer lint
- focused modal tests: 186 passed, 424 assertions
- composer test:types
- composer test:push passed type coverage, Rector, formatting, and both PHPStan configurations; the final parallel Pest process exceeded Composer's fixed 300-second timeout