### PR TITLE
refactor: remove duplicate modal view configuration

### DIFF
--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -19,8 +19,6 @@ abstract class BaseFormModal extends BaseModal
 
     abstract protected function getModelClass(): string;
 
-    abstract protected function getModalPath(): string;
-
     public bool $isModalOpen = false;
 
     public function openModal(mixed $modelId = null): void
@@ -61,8 +59,6 @@ abstract class BaseFormModal extends BaseModal
 
     public function mount(mixed $modelId = null): void
     {
-        $this->modalFormPath = $this->getModalPath();
-
         $modelClass = $this->getModelClass();
         $this->modelType = new $modelClass();
 

--- a/app/Livewire/Base/BaseModal.php
+++ b/app/Livewire/Base/BaseModal.php
@@ -22,8 +22,6 @@ abstract class BaseModal extends ModalComponent
     /** @var TModelType */
     protected Model $modelType;
 
-    protected string $modalFormPath;
-
     protected string $modelTitleField = 'name';
 
     public function mount(int|string|null $modelId = null): void

--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -39,11 +39,6 @@ class FormModal extends BaseFormModal
         return Event::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.events.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         return [
@@ -94,6 +89,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.events.modals.form-modal');
+        return view('livewire.events.modals.form-modal');
     }
 }

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -41,11 +41,6 @@ class FormModal extends BaseFormModal
         return Manager::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.managers.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         return [
@@ -72,6 +67,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.managers.modals.form-modal');
+        return view('livewire.managers.modals.form-modal');
     }
 }

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -59,11 +59,6 @@ class FormModal extends BaseFormModal
         return EventMatch::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.matches.modals.form-modal';
-    }
-
     protected function storeForm(): bool
     {
         $this->form->validate();
@@ -155,6 +150,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.matches.modals.form-modal');
+        return view('livewire.matches.modals.form-modal');
     }
 }

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -40,11 +40,6 @@ class FormModal extends BaseFormModal
         return Referee::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.referees.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         return [
@@ -114,6 +109,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.referees.modals.form-modal');
+        return view('livewire.referees.modals.form-modal');
     }
 }

--- a/app/Livewire/Stables/Modals/FormModal.php
+++ b/app/Livewire/Stables/Modals/FormModal.php
@@ -41,11 +41,6 @@ class FormModal extends BaseFormModal
         return Stable::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.stables.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         return [
@@ -80,6 +75,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.stables.modals.form-modal');
+        return view('livewire.stables.modals.form-modal');
     }
 }

--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -40,11 +40,6 @@ class FormModal extends BaseFormModal
         return TagTeam::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.tag-teams.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         $wrestlerIds = Wrestler::query()
@@ -78,6 +73,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.tag-teams.modals.form-modal');
+        return view('livewire.tag-teams.modals.form-modal');
     }
 }

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -35,11 +35,6 @@ class FormModal extends BaseFormModal
         return Title::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.titles.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         return [
@@ -88,6 +83,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.titles.modals.form-modal');
+        return view('livewire.titles.modals.form-modal');
     }
 }

--- a/app/Livewire/Users/Modals/FormModal.php
+++ b/app/Livewire/Users/Modals/FormModal.php
@@ -34,11 +34,6 @@ class FormModal extends BaseFormModal
         return User::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.users.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         return [
@@ -120,6 +115,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.users.modals.form-modal');
+        return view('livewire.users.modals.form-modal');
     }
 }

--- a/app/Livewire/Venues/Modals/FormModal.php
+++ b/app/Livewire/Venues/Modals/FormModal.php
@@ -34,11 +34,6 @@ class FormModal extends BaseFormModal
         return Venue::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.venues.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         /**
@@ -68,7 +63,7 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.venues.modals.form-modal');
+        return view('livewire.venues.modals.form-modal');
     }
 
     protected function storeForm(): bool

--- a/app/Livewire/Wrestlers/Modals/FormModal.php
+++ b/app/Livewire/Wrestlers/Modals/FormModal.php
@@ -34,11 +34,6 @@ class FormModal extends BaseFormModal
         return Wrestler::class;
     }
 
-    protected function getModalPath(): string
-    {
-        return 'livewire.wrestlers.modals.form-modal';
-    }
-
     protected function getDummyDataFields(): array
     {
         return [
@@ -69,6 +64,6 @@ class FormModal extends BaseFormModal
 
     public function render(): View
     {
-        return view($this->modalFormPath ?? 'livewire.wrestlers.modals.form-modal');
+        return view('livewire.wrestlers.modals.form-modal');
     }
 }

--- a/docs/architecture/livewire/component-architecture.md
+++ b/docs/architecture/livewire/component-architecture.md
@@ -80,7 +80,7 @@ the form, builds modal titles, and resets or restores form state.
 
 `BaseFormModal` coordinates the shared submission lifecycle:
 
-1. initialize the concrete model and form types;
+1. initialize the concrete model type while Livewire initializes the typed form;
 2. mount create or edit state;
 3. delegate domain submission to `storeForm()`;
 4. dispatch table refresh and form-submitted events; and

--- a/docs/architecture/livewire/modal-patterns.md
+++ b/docs/architecture/livewire/modal-patterns.md
@@ -22,11 +22,7 @@ It does not validate input or persist a model.
 ```php
 abstract class BaseFormModal extends BaseModal
 {
-    abstract protected function getFormClass(): string;
-
     abstract protected function getModelClass(): string;
-
-    abstract protected function getModalPath(): string;
 
     abstract protected function storeForm(): bool;
 
@@ -50,9 +46,9 @@ abstract class BaseFormModal extends BaseModal
 }
 ```
 
-The three class metadata methods configure modal infrastructure. They are distinct
-from the removed form-level model metadata: the modal genuinely needs the concrete
-form class, model class, and Blade path to mount itself.
+The modal supplies only the concrete model class needed for edit-mode lookup.
+Livewire initializes the typed public form property, and each component's
+`render()` method owns its Blade view directly.
 
 ## Domain modal pattern
 
@@ -60,7 +56,7 @@ A standard domain modal:
 
 1. declares its typed form property;
 2. receives create and update Actions through Livewire's `boot()` injection;
-3. provides the form, model, and view classes;
+3. provides the model class used for edit-mode lookup;
 4. validates and authorizes at the interaction boundary;
 5. converts input with `toData()`; and
 6. delegates persistence to the appropriate Action.

--- a/tests/Integration/Livewire/Wrestlers/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Modals/FormModalTest.php
@@ -28,13 +28,10 @@ describe('FormModal Configuration', function () {
         expect($method->invoke($modal))->toBe(Wrestler::class);
     });
 
-    it('returns correct modal path', function () {
-        $modal = new FormModal();
-        $reflection = new ReflectionClass($modal);
-        $method = $reflection->getMethod('getModalPath');
-        $method->setAccessible(true);
+    it('renders the wrestler modal view', function () {
+        $component = testLivewire(FormModal::class);
 
-        expect($method->invoke($modal))->toBe('livewire.wrestlers.modals.form-modal');
+        expect($component->instance()->render()->name())->toBe('livewire.wrestlers.modals.form-modal');
     });
 });
 

--- a/tests/Unit/Livewire/Base/BaseFormModalTest.php
+++ b/tests/Unit/Livewire/Base/BaseFormModalTest.php
@@ -48,7 +48,6 @@ describe('BaseFormModal Unit Tests', function () {
             $abstractMethodNames = array_map(fn ($method) => $method->getName(), $abstractMethods);
 
             expect($abstractMethodNames)->toContain('getModelClass');
-            expect($abstractMethodNames)->toContain('getModalPath');
         });
     });
 
@@ -62,11 +61,6 @@ describe('BaseFormModal Unit Tests', function () {
             expect($getModelClass->isProtected())->toBeTrue();
             expect(reflectionReturnTypeName($getModelClass))->toBe('string');
 
-            // getModalPath method
-            $getModalPath = $reflection->getMethod('getModalPath');
-            expect($getModalPath->isAbstract())->toBeTrue();
-            expect($getModalPath->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($getModalPath))->toBe('string');
         });
     });
 

--- a/tests/Unit/Livewire/Concerns/BaseModalTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseModalTest.php
@@ -63,15 +63,10 @@ describe('BaseModal Unit Tests', function () {
             expect(reflectionTypeName($property))->toBe('Illuminate\\Database\\Eloquent\\Model');
         });
 
-        test('has string configuration properties', function () {
+        test('has model title configuration', function () {
             $reflection = new ReflectionClass(BaseModal::class);
 
-            expect($reflection->hasProperty('modalFormPath'))->toBeTrue();
             expect($reflection->hasProperty('modelTitleField'))->toBeTrue();
-
-            $modalFormPath = $reflection->getProperty('modalFormPath');
-            expect($modalFormPath->isProtected())->toBeTrue();
-            expect(reflectionTypeName($modalFormPath))->toBe('string');
 
             $modelTitleField = $reflection->getProperty('modelTitleField');
             expect($modelTitleField->isProtected())->toBeTrue();


### PR DESCRIPTION
## Summary
- remove redundant modal view-path metadata from the base hierarchy
- let each modal render its Blade view directly
- replace the reflection-based path assertion with rendered-view coverage
- align Livewire architecture documentation with native form initialization and component-owned views

## Verification
- composer lint
- focused modal tests: 317 passed, 806 assertions
- composer test:types
- composer test:push passed type coverage, Rector, formatting, and both PHPStan configurations; the final parallel Pest process exceeded Composer's fixed 300-second timeout