### PR TITLE
refactor: store modal model class

### DIFF
--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -17,6 +17,7 @@ abstract class BaseFormModal extends BaseModal
 {
     use GeneratesDummyData;
 
+    /** @return class-string<TModel> */
     abstract protected function getModelClass(): string;
 
     public bool $isModalOpen = false;
@@ -59,8 +60,7 @@ abstract class BaseFormModal extends BaseModal
 
     public function mount(mixed $modelId = null): void
     {
-        $modelClass = $this->getModelClass();
-        $this->modelType = new $modelClass();
+        $this->modelClass = $this->getModelClass();
 
         $this->modelForm = $this->form;
 

--- a/app/Livewire/Base/BaseModal.php
+++ b/app/Livewire/Base/BaseModal.php
@@ -19,8 +19,8 @@ abstract class BaseModal extends ModalComponent
     /** @var TModelForm */
     protected BaseForm $modelForm;
 
-    /** @var TModelType */
-    protected Model $modelType;
+    /** @var class-string<TModelType> */
+    protected string $modelClass;
 
     protected string $modelTitleField = 'name';
 
@@ -34,7 +34,7 @@ abstract class BaseModal extends ModalComponent
         }
 
         $id = is_numeric($modelId) ? (int) $modelId : $modelId;
-        $this->model = $this->modelType::query()->findOrFail($id);
+        $this->model = $this->modelClass::query()->findOrFail($id);
         $this->modelForm->setModel($this->model);
     }
 
@@ -44,7 +44,7 @@ abstract class BaseModal extends ModalComponent
             return 'Edit '.$this->modelForm->generateModelEditName($this->modelTitleField);
         }
 
-        return 'Add '.(isset($this->modelType) ? class_basename($this->modelType) : 'Record');
+        return 'Add '.(isset($this->modelClass) ? class_basename($this->modelClass) : 'Record');
     }
 
     public function clear(): void

--- a/tests/Unit/Livewire/Concerns/BaseModalTest.php
+++ b/tests/Unit/Livewire/Concerns/BaseModalTest.php
@@ -53,14 +53,14 @@ describe('BaseModal Unit Tests', function () {
             expect($property->isProtected())->toBeTrue();
         });
 
-        test('has modelType property', function () {
+        test('has model class configuration', function () {
             $reflection = new ReflectionClass(BaseModal::class);
 
-            expect($reflection->hasProperty('modelType'))->toBeTrue();
+            expect($reflection->hasProperty('modelClass'))->toBeTrue();
 
-            $property = $reflection->getProperty('modelType');
+            $property = $reflection->getProperty('modelClass');
             expect($property->isProtected())->toBeTrue();
-            expect(reflectionTypeName($property))->toBe('Illuminate\\Database\\Eloquent\\Model');
+            expect(reflectionTypeName($property))->toBe('string');
         });
 
         test('has model title configuration', function () {


### PR DESCRIPTION
## Summary
- store modal model metadata as a typed class-string
- avoid constructing an unused Eloquent model during modal mount
- preserve the pre-mount modal title fallback
- update base modal structure coverage for the class-string property

## Verification
- composer lint
- focused modal tests: 317 passed, 805 assertions
- composer test:types
- composer test:push passed type coverage, Rector, formatting, and both PHPStan configurations; the final parallel Pest process exceeded Composer's fixed 300-second timeout