### PR TITLE
fix: authorize modal submissions

### DIFF
--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -6,10 +6,13 @@ namespace App\Livewire\Base;
 
 use App\Livewire\Concerns\GeneratesDummyData;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * @template TForm of BaseForm
  * @template TModel of Model
+ *
+ * @property TForm $form
  *
  * @extends BaseModal<TForm, TModel>
  */
@@ -44,6 +47,8 @@ abstract class BaseFormModal extends BaseModal
             $this->form->setModel($this->model);
         }
 
+        $this->authorizeSubmission();
+
         if (! $this->storeForm()) {
             return false;
         }
@@ -57,6 +62,19 @@ abstract class BaseFormModal extends BaseModal
     }
 
     abstract protected function storeForm(): bool;
+
+    private function authorizeSubmission(): void
+    {
+        $modelClass = $this->getModelClass();
+
+        if ($this->form->isCreating()) {
+            Gate::authorize('create', $modelClass);
+
+            return;
+        }
+
+        Gate::authorize('update', $modelClass::query()->findOrFail($this->form->modelId));
+    }
 
     public function mount(mixed $modelId = null): void
     {

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -65,10 +65,8 @@ class FormModal extends BaseFormModal
 
         if ($this->form->isEditing()) {
             $match = EventMatch::query()->findOrFail($this->form->modelId);
-            Gate::authorize('update', $match);
             $storedMatch = $this->updateMatchAction->handle($match, $this->form->toData());
         } else {
-            Gate::authorize('create', EventMatch::class);
             $event = Event::query()->findOrFail($this->eventId);
             $storedMatch = $this->addMatchForEventAction->handle($event, $this->form->toData());
         }

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -25,12 +25,6 @@ parameters:
 			path: app/Http/Middleware/AddWrestlingContext.php
 
 		-
-			message: '#^Access to an undefined property App\\Livewire\\Base\\BaseFormModal\<TForm of App\\Livewire\\Base\\BaseForm, TModel of Illuminate\\Database\\Eloquent\\Model\>\:\:\$form\.$#'
-			identifier: property.notFound
-			count: 2
-			path: app/Livewire/Base/BaseFormModal.php
-
-		-
 			message: '#^Instanceof between Illuminate\\View\\View and Illuminate\\Contracts\\View\\View will always evaluate to true\.$#'
 			identifier: instanceof.alwaysTrue
 			count: 1

--- a/tests/Integration/Livewire/Managers/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Managers/Modals/FormModalTest.php
@@ -24,6 +24,10 @@ use App\Models\Roster\Managers\Manager;
  * @see FormModal
  * @see Form
  */
+beforeEach(function () {
+    $this->actingAs(administrator());
+});
+
 describe('Managers FormModal Tests', function () {
     describe('modal rendering and state management', function () {
         test('modal opens and closes correctly', function () {
@@ -477,5 +481,38 @@ describe('Managers FormModal Tests', function () {
             // Based on Laravel validation, last_name is required, so this should have errors
             $component->assertHasErrors(['form.last_name']);
         });
+    });
+});
+
+describe('submission authorization', function () {
+    test('rejects an unauthorized create submission', function () {
+        $this->actingAs(basicUser());
+
+        testLivewire(FormModal::class)
+            ->set('form.first_name', 'Unauthorized')
+            ->set('form.last_name', 'Manager')
+            ->call('submitForm')
+            ->assertForbidden();
+
+        expect(Manager::query()
+            ->where('first_name', 'Unauthorized')
+            ->where('last_name', 'Manager')
+            ->exists())->toBeFalse();
+    });
+
+    test('rejects an unauthorized update submission', function () {
+        $manager = Manager::factory()->create([
+            'first_name' => 'Original',
+            'last_name' => 'Manager',
+        ]);
+        $this->actingAs(basicUser());
+
+        testLivewire(FormModal::class)
+            ->call('openModal', $manager->id)
+            ->set('form.first_name', 'Unauthorized')
+            ->call('submitForm')
+            ->assertForbidden();
+
+        expect($manager->refresh()->first_name)->toBe('Original');
     });
 });

--- a/tests/Integration/Livewire/Referees/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Referees/Modals/FormModalTest.php
@@ -26,6 +26,10 @@ use App\Models\Roster\Referees\Referee;
  * @see FormModal
  * @see RefereeForm
  */
+beforeEach(function () {
+    $this->actingAs(administrator());
+});
+
 describe('Referees FormModal Tests', function () {
     describe('modal rendering and state management', function () {
         test('modal opens and closes correctly', function () {

--- a/tests/Integration/Livewire/TagTeams/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/TagTeams/Modals/FormModalTest.php
@@ -27,6 +27,10 @@ use App\Models\Roster\Wrestlers\Wrestler;
  * @see FormModal
  * @see Form
  */
+beforeEach(function () {
+    $this->actingAs(administrator());
+});
+
 describe('TagTeams FormModal Tests', function () {
     describe('modal rendering and state management', function () {
         test('modal opens and closes correctly', function () {


### PR DESCRIPTION
## Summary
- authorize create and update operations at the shared Livewire form submission boundary
- resolve update authorization targets from persisted model identifiers
- remove duplicate match-modal submission authorization
- explicitly authenticate legacy modal test suites and cover direct submission bypass attempts
- remove the resolved BaseFormModal PHPStan baseline entry

## Verification
- composer lint
- composer test:types
- focused Livewire modal suite: 161 tests, 410 assertions
- composer test:push: type coverage, Rector, formatting, and both PHPStan configurations passed; the final unchanged parallel Pest command exceeded Composer process timeout at 300 seconds