### PR TITLE
refactor: harden Livewire static analysis

### DIFF
--- a/app/Livewire/Base/BaseForm.php
+++ b/app/Livewire/Base/BaseForm.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Base;
 use Illuminate\Database\Eloquent\Model;
 use Livewire\Attributes\Locked;
 use Livewire\Form;
+use LogicException;
 
 /**
  * @template TModel of Model
@@ -23,7 +24,13 @@ abstract class BaseForm extends Form
     public function setModel(?Model $formModel): void
     {
         $this->formModel = $formModel;
-        $this->modelId = $formModel?->getKey();
+        $modelId = $formModel?->getKey();
+
+        if (! is_int($modelId) && ! is_string($modelId) && $modelId !== null) {
+            throw new LogicException('Livewire forms require integer or string model keys.');
+        }
+
+        $this->modelId = $modelId;
 
         if ($formModel !== null) {
             $this->fill($formModel->getAttributes());

--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -25,7 +25,7 @@ abstract class BaseFormModal extends BaseModal
 
     public bool $isModalOpen = false;
 
-    public function openModal(mixed $modelId = null): void
+    public function openModal(int|string|null $modelId = null): void
     {
         $this->mount($modelId);
         $this->isModalOpen = true;
@@ -76,7 +76,7 @@ abstract class BaseFormModal extends BaseModal
         Gate::authorize('update', $modelClass::query()->findOrFail($this->form->modelId));
     }
 
-    public function mount(mixed $modelId = null): void
+    public function mount(int|string|null $modelId = null): void
     {
         $this->modelClass = $this->getModelClass();
 

--- a/app/Livewire/Base/BaseModal.php
+++ b/app/Livewire/Base/BaseModal.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Base;
 
 use Illuminate\Database\Eloquent\Model;
 use LivewireUI\Modal\ModalComponent;
+use LogicException;
 
 /**
  * @template TModelForm of BaseForm
@@ -34,7 +35,14 @@ abstract class BaseModal extends ModalComponent
         }
 
         $id = is_numeric($modelId) ? (int) $modelId : $modelId;
-        $this->model = $this->modelClass::query()->findOrFail($id);
+        $modelClass = $this->modelClass;
+        $model = $modelClass::query()->findOrFail($id);
+
+        if (! $model instanceof $modelClass) {
+            throw new LogicException("Expected an instance of {$modelClass}.");
+        }
+
+        $this->model = $model;
         $this->modelForm->setModel($this->model);
     }
 

--- a/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
@@ -41,8 +41,10 @@ abstract class BasePreviousTagTeamsTable extends DataTableComponent
     {
         return [
             LinkColumn::make(__('tag-teams.name'))
-                ->title(fn (TagTeamWrestler $row) => $row->tagTeam->name)
-                ->location(fn (TagTeamWrestler $row) => route('tag-teams.show', $row->tagTeam)),
+                ->title(fn (TagTeamWrestler $row) => $this->tagTeamName($row))
+                ->location(fn (TagTeamWrestler $row) => $row->tagTeam === null
+                    ? null
+                    : route('tag-teams.show', $row->tagTeam)),
             LinkColumn::make(__('tag-teams.partner'))
                 ->title(fn (TagTeamWrestler $row) => $this->getPartnerName($row))
                 ->location(fn (TagTeamWrestler $row) => $this->getPartnerRoute($row)),
@@ -51,5 +53,12 @@ abstract class BasePreviousTagTeamsTable extends DataTableComponent
             DateColumn::make(__('stables.date_left'), 'left_at')
                 ->outputFormat('Y-m-d'),
         ];
+    }
+
+    private function tagTeamName(TagTeamWrestler $row): string
+    {
+        $tagTeam = $row->tagTeam;
+
+        return $tagTeam->name ?? 'N/A';
     }
 }

--- a/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
@@ -41,8 +41,10 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
     {
         return [
             LinkColumn::make(__('titles.name'))
-                ->title(fn (TitleChampionship $row) => $row->title->name)
-                ->location(fn (TitleChampionship $row) => route('titles.show', $row->title)),
+                ->title(fn (TitleChampionship $row) => $this->titleName($row))
+                ->location(fn (TitleChampionship $row) => $row->title === null
+                    ? null
+                    : route('titles.show', $row->title)),
             LinkColumn::make(__('championships.previous_champion'))
                 ->title(fn (TitleChampionship $row) => $row->previousChampionship?->champion->name ?? 'N/A')
                 ->location(fn (TitleChampionship $row) => $this->championLocation($row)),
@@ -68,5 +70,12 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
             ),
             default => null,
         };
+    }
+
+    private function titleName(TitleChampionship $championship): string
+    {
+        $title = $championship->title;
+
+        return $title->name ?? 'N/A';
     }
 }

--- a/app/Livewire/Components/Tables/Filters/FirstActivityPeriodFilter.php
+++ b/app/Livewire/Components/Tables/Filters/FirstActivityPeriodFilter.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Components\Tables\Filters;
 use App\Livewire\Table\Filters\DateRangeFilter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class FirstActivityPeriodFilter extends DateRangeFilter
 {
@@ -30,7 +31,7 @@ class FirstActivityPeriodFilter extends DateRangeFilter
         ])
             ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
             ->filter(function (Builder $query, array $dateRange): void {
-                $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
+                $query->withWhereHas($this->filterRelationshipName, function (Builder|Relation $query) use ($dateRange): void {
                     /** @var array{'minDate': string, 'maxDate': string} $dateRange */
                     $query
                         ->where(function (Builder $query) use ($dateRange): void {

--- a/app/Livewire/Components/Tables/Filters/FirstEmploymentFilter.php
+++ b/app/Livewire/Components/Tables/Filters/FirstEmploymentFilter.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Components\Tables\Filters;
 use App\Livewire\Table\Filters\DateRangeFilter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class FirstEmploymentFilter extends DateRangeFilter
 {
@@ -31,7 +32,7 @@ class FirstEmploymentFilter extends DateRangeFilter
             ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
             ->filter(function (Builder $query, array $dateRange): void {
                 /** @var array{'minDate': string, 'maxDate': string} $dateRange */
-                $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
+                $query->withWhereHas($this->filterRelationshipName, function (Builder|Relation $query) use ($dateRange): void {
                     $query
                         ->where(function (Builder $query) use ($dateRange): void {
                             $query->whereBetween(

--- a/app/Livewire/Concerns/Data/PresentsManagersList.php
+++ b/app/Livewire/Concerns/Data/PresentsManagersList.php
@@ -15,6 +15,9 @@ trait PresentsManagersList
     #[Computed(cache: true, key: 'managers-list', seconds: 180)]
     public function getManagers(): array
     {
-        return Manager::select('id', 'full_name')->get()->pluck('full_name', 'id')->toArray();
+        return Manager::query()
+            ->get(['id', 'full_name'])
+            ->mapWithKeys(fn (Manager $manager): array => [$manager->id => $manager->full_name])
+            ->all();
     }
 }

--- a/app/Livewire/Concerns/Data/PresentsRefereesList.php
+++ b/app/Livewire/Concerns/Data/PresentsRefereesList.php
@@ -15,9 +15,9 @@ trait PresentsRefereesList
     #[Computed(cache: false)]
     public function getReferees(): array
     {
-        return Referee::select('id', 'full_name')
-            ->get()
-            ->pluck('full_name', 'id')
-            ->toArray();
+        return Referee::query()
+            ->get(['id', 'full_name'])
+            ->mapWithKeys(fn (Referee $referee): array => [$referee->id => $referee->full_name])
+            ->all();
     }
 }

--- a/app/Livewire/Concerns/Data/PresentsTagTeamsList.php
+++ b/app/Livewire/Concerns/Data/PresentsTagTeamsList.php
@@ -15,6 +15,9 @@ trait PresentsTagTeamsList
     #[Computed(cache: true, key: 'tag-teams-list', seconds: 180)]
     public function getTagTeams(): array
     {
-        return TagTeam::select('id', 'name')->pluck('name', 'id')->toArray();
+        return TagTeam::query()
+            ->get(['id', 'name'])
+            ->mapWithKeys(fn (TagTeam $tagTeam): array => [$tagTeam->id => $tagTeam->name])
+            ->all();
     }
 }

--- a/app/Livewire/Concerns/Data/PresentsTitlesList.php
+++ b/app/Livewire/Concerns/Data/PresentsTitlesList.php
@@ -15,6 +15,9 @@ trait PresentsTitlesList
     #[Computed(cache: true, key: 'titles-list', seconds: 180)]
     public function getTitles(): array
     {
-        return Title::select('id', 'name')->pluck('name', 'id')->toArray();
+        return Title::query()
+            ->get(['id', 'name'])
+            ->mapWithKeys(fn (Title $title): array => [$title->id => $title->name])
+            ->all();
     }
 }

--- a/app/Livewire/Concerns/Data/PresentsVenuesList.php
+++ b/app/Livewire/Concerns/Data/PresentsVenuesList.php
@@ -17,8 +17,8 @@ trait PresentsVenuesList
     {
         return Venue::query()
             ->alphabetical()
-            ->select('id', 'name')
-            ->pluck('name', 'id')
-            ->toArray();
+            ->get(['id', 'name'])
+            ->mapWithKeys(fn (Venue $venue): array => [$venue->id => $venue->name])
+            ->all();
     }
 }

--- a/app/Livewire/Concerns/Data/PresentsWrestlersList.php
+++ b/app/Livewire/Concerns/Data/PresentsWrestlersList.php
@@ -15,6 +15,9 @@ trait PresentsWrestlersList
     #[Computed(cache: false)]
     public function getWrestlers(): array
     {
-        return Wrestler::select('id', 'name')->pluck('name', 'id')->toArray();
+        return Wrestler::query()
+            ->get(['id', 'name'])
+            ->mapWithKeys(fn (Wrestler $wrestler): array => [$wrestler->id => $wrestler->name])
+            ->all();
     }
 }

--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Livewire\Concerns;
 
+use Closure;
 use DateTime;
 use LogicException;
 
@@ -37,7 +38,11 @@ trait GeneratesDummyData
         $fields = $this->getDummyDataFields();
 
         foreach ($fields as $field => $generator) {
-            $value = is_callable($generator) ? $generator() : $generator;
+            $value = $generator;
+
+            if (is_callable($generator)) {
+                $value = $generator();
+            }
 
             // Try to populate fields using available patterns
             $this->populateField($field, $value);
@@ -97,7 +102,7 @@ trait GeneratesDummyData
             fn () => fake()->firstName().' "'.fake()->word().'" '.fake()->lastName(),
         ];
 
-        $pattern = fake()->randomElement($patterns);
+        $pattern = $this->randomGenerator($patterns);
 
         return ucwords($pattern());
     }
@@ -126,10 +131,10 @@ trait GeneratesDummyData
         $useModifier = fake()->boolean(60);
 
         if ($useModifier) {
-            return fake()->randomElement($modifiers).' '.fake()->randomElement($moveTypes);
+            return $this->randomString($modifiers).' '.$this->randomString($moveTypes);
         }
 
-        return fake()->randomElement($moveTypes);
+        return $this->randomString($moveTypes);
     }
 
     /**
@@ -152,10 +157,10 @@ trait GeneratesDummyData
         $usePrefix = fake()->boolean(70);
 
         if ($usePrefix) {
-            return fake()->randomElement($prefixes).' '.fake()->randomElement($suffixes);
+            return $this->randomString($prefixes).' '.$this->randomString($suffixes);
         }
 
-        return fake()->city().' '.fake()->randomElement($suffixes);
+        return fake()->city().' '.$this->randomString($suffixes);
     }
 
     /**
@@ -178,7 +183,7 @@ trait GeneratesDummyData
             'Women\'s', 'Tag Team', 'World Heavyweight', 'Universal', 'Raw Women\'s',
         ];
 
-        return fake()->randomElement($categories).' '.fake()->randomElement($titleTypes);
+        return $this->randomString($categories).' '.$this->randomString($titleTypes);
     }
 
     /**
@@ -202,7 +207,7 @@ trait GeneratesDummyData
         return [
             'street_address' => fake()->streetAddress(),
             'city' => fake()->city(),
-            'state' => fake()->randomElement($stateAbbreviations),
+            'state' => $this->randomString($stateAbbreviations),
             'zipcode' => (int) fake()->numerify('#####'),
         ];
     }
@@ -261,5 +266,22 @@ trait GeneratesDummyData
     protected function generateOptionalEmploymentDate(float $probability = 0.8): ?string
     {
         return $this->generateOptionalStartDate('Y-m-d', $probability);
+    }
+
+    /**
+     * @param  non-empty-list<string>  $values
+     */
+    private function randomString(array $values): string
+    {
+        return $values[array_rand($values)];
+    }
+
+    /**
+     * @param  non-empty-list<Closure(): string>  $generators
+     * @return Closure(): string
+     */
+    private function randomGenerator(array $generators): Closure
+    {
+        return $generators[array_rand($generators)];
     }
 }

--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -273,7 +273,13 @@ trait GeneratesDummyData
      */
     private function randomString(array $values): string
     {
-        return $values[array_rand($values)];
+        $value = fake()->randomElement($values);
+
+        if (! is_string($value)) {
+            throw new LogicException('Expected the random value to be a string.');
+        }
+
+        return $value;
     }
 
     /**
@@ -282,6 +288,12 @@ trait GeneratesDummyData
      */
     private function randomGenerator(array $generators): Closure
     {
-        return $generators[array_rand($generators)];
+        $generator = fake()->randomElement($generators);
+
+        if (! $generator instanceof Closure) {
+            throw new LogicException('Expected the random value to be a generator.');
+        }
+
+        return $generator;
     }
 }

--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -58,7 +58,7 @@ class FormModal extends BaseFormModal
         return 'Create Event';
     }
 
-    public function openModal(mixed $modelId = null): void
+    public function openModal(int|string|null $modelId = null): void
     {
         // Check authorization before opening modal
         if ($modelId !== null) {

--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -79,8 +79,9 @@ class Main extends BaseTable
     {
         $venues = Venue::query()
             ->alphabetical()
-            ->pluck('name', 'id')
-            ->toArray();
+            ->get(['id', 'name'])
+            ->mapWithKeys(fn (Venue $venue): array => [$venue->id => $venue->name])
+            ->all();
 
         $statusOptions = ['' => __('core.all')];
 

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -16,7 +16,7 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
-    public function mount(mixed $modelId = null): void
+    public function mount(int|string|null $modelId = null): void
     {
         parent::mount($modelId);
 

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Matches\Forms;
 
 use App\Data\Matches\EventMatchData;
 use App\Enums\MatchType;
+use App\Enums\Titles\TitleStatus;
 use App\Livewire\Base\BaseForm;
 use App\Livewire\Concerns\HasStandardValidationAttributes;
 use App\Models\Matches\EventMatch;
@@ -21,6 +22,7 @@ use App\Rules\Matches\CorrectNumberOfSides;
 use Closure;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
+use LogicException;
 
 /**
  * Livewire form component for managing event match creation and editing.
@@ -133,8 +135,12 @@ class CreateEditForm extends BaseForm
         $this->matchType = $this->formModel->match_type;
         $this->matchStipulationId = $this->formModel->match_stipulation_id;
 
-        $this->referees = $this->formModel->referees->pluck('id')->toArray();
-        $this->titles = $this->formModel->titles->pluck('id')->toArray();
+        $this->referees = $this->formModel->referees
+            ->map(fn (Referee $referee): int => $referee->id)
+            ->all();
+        $this->titles = $this->formModel->titles
+            ->map(fn (Title $title): int => $title->id)
+            ->all();
         $competitorsBySide = $this->formModel->sides()
             ->with('competitors.competitor')
             ->get()
@@ -142,12 +148,12 @@ class CreateEditForm extends BaseForm
                 return [
                     'wrestlers' => $side->competitors
                         ->filter(fn (MatchCompetitor $competitor): bool => $competitor->competitor instanceof Wrestler)
-                        ->pluck('competitor_id')
+                        ->map(fn (MatchCompetitor $competitor): int => $competitor->competitor_id)
                         ->values()
                         ->all(),
                     'tag_teams' => $side->competitors
                         ->filter(fn (MatchCompetitor $competitor): bool => $competitor->competitor instanceof TagTeam)
-                        ->pluck('competitor_id')
+                        ->map(fn (MatchCompetitor $competitor): int => $competitor->competitor_id)
                         ->values()
                         ->all(),
                 ];
@@ -155,9 +161,12 @@ class CreateEditForm extends BaseForm
             ->values()
             ->all();
 
-        $this->competitors = $this->matchType->usesIndividualCompetitorSides()
+        $this->competitors = $this->requiredMatchType()->usesIndividualCompetitorSides()
             ? [[
-                'wrestlers' => collect($competitorsBySide)->pluck('wrestlers')->flatten()->values()->all(),
+                'wrestlers' => collect($competitorsBySide)
+                    ->flatMap(fn (array $side): array => $side['wrestlers'])
+                    ->values()
+                    ->all(),
                 'tag_teams' => [],
             ]]
             : $competitorsBySide;
@@ -172,7 +181,7 @@ class CreateEditForm extends BaseForm
      */
     public function toData(): EventMatchData
     {
-        $matchType = $this->matchType;
+        $matchType = $this->requiredMatchType();
         $sides = $matchType->usesIndividualCompetitorSides()
             ? collect($this->competitors[0]['wrestlers'] ?? [])
                 ->values()
@@ -244,8 +253,13 @@ class CreateEditForm extends BaseForm
                 'integer',
                 'exists:titles,id',
                 function (string $attribute, mixed $value, Closure $fail) {
-                    $title = Title::find($value);
-                    if ($title && $title->status->value !== 'active') {
+                    if (! is_int($value)) {
+                        return;
+                    }
+
+                    $title = Title::query()->find($value);
+
+                    if ($title !== null && $title->status !== TitleStatus::Active) {
                         $fail('The selected title must be active.');
                     }
                 },
@@ -282,6 +296,12 @@ class CreateEditForm extends BaseForm
         }
 
         return $this->getValidationForMatchType($this->matchType);
+    }
+
+    private function requiredMatchType(): MatchType
+    {
+        return $this->matchType
+            ?? throw new LogicException('A match type is required before building match data.');
     }
 
     /**

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -83,7 +83,10 @@ class FormModal extends BaseFormModal
         return MatchStipulation::query()
             ->where('is_active', true)
             ->orderBy('name')
-            ->pluck('name', 'id')
+            ->get(['id', 'name'])
+            ->mapWithKeys(fn (MatchStipulation $stipulation): array => [
+                $stipulation->id => $stipulation->name,
+            ])
             ->all();
     }
 
@@ -93,7 +96,7 @@ class FormModal extends BaseFormModal
         return $this->dummyData->generate();
     }
 
-    public function openModal(mixed $modelId = null): void
+    public function openModal(int|string|null $modelId = null): void
     {
         if ($modelId === null) {
             Gate::authorize('create', EventMatch::class);
@@ -126,7 +129,11 @@ class FormModal extends BaseFormModal
 
     public function updatedFormMatchType(mixed $value): void
     {
-        $matchType = $value instanceof MatchType ? $value : MatchType::tryFrom((string) $value);
+        $matchType = match (true) {
+            $value instanceof MatchType => $value,
+            is_string($value) => MatchType::tryFrom($value),
+            default => null,
+        };
 
         if ($matchType !== null) {
             $this->form->resetCompetitorsFor($matchType);

--- a/app/Livewire/Matches/Support/MatchFormDummyData.php
+++ b/app/Livewire/Matches/Support/MatchFormDummyData.php
@@ -29,7 +29,8 @@ final class MatchFormDummyData
             ->filter(fn (Wrestler $wrestler): bool => RosterBookingEligibility::allows($wrestler))
             ->shuffle()
             ->take(2)
-            ->modelKeys();
+            ->map(fn (Wrestler $wrestler): int => $wrestler->id)
+            ->all();
 
         $refereeIds = Referee::query()
             ->employed()
@@ -37,7 +38,8 @@ final class MatchFormDummyData
             ->filter(fn (Referee $referee): bool => RosterBookingEligibility::allows($referee))
             ->shuffle()
             ->take(1)
-            ->modelKeys();
+            ->map(fn (Referee $referee): int => $referee->id)
+            ->all();
 
         return [
             'matchType' => MatchType::Singles,
@@ -47,7 +49,9 @@ final class MatchFormDummyData
             ],
             'referees' => $refereeIds,
             'titles' => fake()->boolean(30)
-                ? Title::query()->active()->inRandomOrder()->limit(1)->pluck('id')->all()
+                ? Title::query()->active()->inRandomOrder()->limit(1)->get(['id'])
+                    ->map(fn (Title $title): int => $title->id)
+                    ->all()
                 : [],
             'preview' => fake()->paragraph(2),
         ];

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -11,8 +11,11 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Columns\LinkColumn;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
+use App\Models\Roster\TagTeams\TagTeam;
+use App\Models\Roster\Wrestlers\Wrestler;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\Gate;
+use LogicException;
 
 /** @extends BaseTable<EventMatch> */
 class Main extends BaseTable
@@ -62,7 +65,9 @@ class Main extends BaseTable
             Column::make(__('event-matches.competitors'))
                 ->label(fn (EventMatch $row): string => $row->competitors
                     ->competitorModelsBySidePosition()
-                    ->map(fn (Collection $side): string => $side->pluck('name')->join(' & '))
+                    ->map(fn (Collection $side): string => $side
+                        ->map(fn (mixed $competitor): string => $this->competitorName($competitor))
+                        ->join(' & '))
                     ->join(' vs ')),
             Column::make(__('event-matches.result'))
                 ->label(function (EventMatch $row): string {
@@ -90,5 +95,13 @@ class Main extends BaseTable
         resolve(DeleteAction::class)->handle($eventMatch);
 
         session()->flash('status', 'Match successfully deleted.');
+    }
+
+    private function competitorName(mixed $competitor): string
+    {
+        return match (true) {
+            $competitor instanceof Wrestler, $competitor instanceof TagTeam => $competitor->name,
+            default => throw new LogicException('Match competitors must be Wrestlers or Tag Teams.'),
+        };
     }
 }

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -19,7 +19,7 @@ class FormModal extends BaseFormModal
     /**
      * Store original model data for resetting purposes
      *
-     * @var array<string, mixed>|null
+     * @var array{first_name: string, last_name: string, employment_date: string}|null
      */
     public ?array $originalModelData = null;
 
@@ -64,7 +64,7 @@ class FormModal extends BaseFormModal
         return true;
     }
 
-    public function mount(mixed $modelId = null): void
+    public function mount(int|string|null $modelId = null): void
     {
         parent::mount($modelId);
 
@@ -72,7 +72,7 @@ class FormModal extends BaseFormModal
         $this->modelTitleField = 'full_name';
     }
 
-    public function openModal(mixed $modelId = null): void
+    public function openModal(int|string|null $modelId = null): void
     {
         parent::openModal($modelId);
 

--- a/app/Livewire/Stables/Forms/CreateEditForm.php
+++ b/app/Livewire/Stables/Forms/CreateEditForm.php
@@ -16,6 +16,7 @@ use App\Rules\Wrestlers\IsNotInjured;
 use App\Rules\Wrestlers\NotRepresentedBySelectedTagTeam;
 use Illuminate\Support\Carbon;
 use Illuminate\Validation\Rule;
+use LogicException;
 
 /**
  * Livewire form component for managing stable creation and editing.
@@ -194,7 +195,7 @@ class CreateEditForm extends BaseForm
                 'bail',
                 'integer',
                 'exists:wrestlers,id',
-                new CanJoinStable(Wrestler::class, $this->modelId, $stableStartDate),
+                new CanJoinStable(Wrestler::class, $this->stableId(), $stableStartDate),
                 new IsNotInjured(),
                 new NotRepresentedBySelectedTagTeam(collect($this->tag_teams)),
             ],
@@ -203,7 +204,7 @@ class CreateEditForm extends BaseForm
                 'bail',
                 'integer',
                 'exists:tag_teams,id',
-                new CanJoinStable(TagTeam::class, $this->modelId, $stableStartDate),
+                new CanJoinStable(TagTeam::class, $this->stableId(), $stableStartDate),
             ],
         ];
 
@@ -222,6 +223,19 @@ class CreateEditForm extends BaseForm
         }
 
         return Carbon::parse($this->started_at);
+    }
+
+    private function stableId(): ?int
+    {
+        if ($this->modelId === null || is_int($this->modelId)) {
+            return $this->modelId;
+        }
+
+        if (ctype_digit($this->modelId)) {
+            return (int) $this->modelId;
+        }
+
+        throw new LogicException('Stable forms require integer model keys.');
     }
 
     /**

--- a/app/Livewire/Table/Column.php
+++ b/app/Livewire/Table/Column.php
@@ -8,6 +8,7 @@ use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
 
+/** @phpstan-consistent-constructor */
 class Column
 {
     protected string $field;
@@ -126,9 +127,7 @@ class Column
     public function resolveValue(mixed $row): string
     {
         if ($this->viewPath) {
-            $view = view($this->viewPath, ['row' => $row]);
-
-            return $view instanceof View ? $view->render() : (string) $view;
+            return view($this->viewPath, ['row' => $row])->render();
         }
 
         if ($this->labelCallback) {

--- a/app/Livewire/Table/Column.php
+++ b/app/Livewire/Table/Column.php
@@ -7,6 +7,9 @@ namespace App\Livewire\Table;
 use Closure;
 use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Str;
+use LogicException;
+use Stringable;
 
 /** @phpstan-consistent-constructor */
 class Column
@@ -25,6 +28,7 @@ class Column
 
     protected ?Closure $labelCallback = null;
 
+    /** @var view-string|null */
     protected ?string $viewPath = null;
 
     public function __construct(
@@ -82,6 +86,7 @@ class Column
         return $this;
     }
 
+    /** @param view-string $viewPath */
     public function view(string $viewPath): static
     {
         $this->viewPath = $viewPath;
@@ -133,9 +138,26 @@ class Column
         if ($this->labelCallback) {
             $result = ($this->labelCallback)($row, $this);
 
-            return $result instanceof View ? $result->render() : (string) $result;
+            return $result instanceof View ? $result->render() : $this->resolveStringValue($result);
         }
 
-        return (string) data_get($row, $this->field, '');
+        return $this->resolveStringValue(data_get($row, $this->field, ''));
+    }
+
+    private function resolveStringValue(mixed $value): string
+    {
+        if ($value === null) {
+            return '';
+        }
+
+        if (is_string($value)) {
+            return Str::of($value)->toString();
+        }
+
+        if (is_int($value) || is_float($value) || is_bool($value) || $value instanceof Stringable) {
+            return Str::of((string) $value)->toString();
+        }
+
+        throw new LogicException('Table column values must be stringable.');
     }
 }

--- a/app/Livewire/Table/Columns/DateColumn.php
+++ b/app/Livewire/Table/Columns/DateColumn.php
@@ -6,6 +6,8 @@ namespace App\Livewire\Table\Columns;
 
 use App\Livewire\Table\Column;
 use Carbon\Carbon;
+use DateTimeInterface;
+use LogicException;
 
 class DateColumn extends Column
 {
@@ -44,9 +46,15 @@ class DateColumn extends Column
             return $this->emptyValue;
         }
 
-        $date = $value instanceof Carbon
-            ? $value
-            : Carbon::createFromFormat($this->inputFormat, (string) $value);
+        if ($value instanceof DateTimeInterface) {
+            return Carbon::instance($value)->format($this->outputFormat);
+        }
+
+        if (! is_string($value)) {
+            throw new LogicException('Date column values must be date objects or formatted strings.');
+        }
+
+        $date = Carbon::createFromFormat($this->inputFormat, $value);
 
         return $date ? $date->format($this->outputFormat) : $this->emptyValue;
     }

--- a/app/Livewire/Table/DataTableComponent.php
+++ b/app/Livewire/Table/DataTableComponent.php
@@ -199,7 +199,9 @@ abstract class DataTableComponent extends Component
     protected function applySorting(Builder $query): void
     {
         if ($this->sortField !== '') {
-            $query->orderBy($this->sortField, $this->sortDirection);
+            $direction = $this->sortDirection === 'desc' ? 'desc' : 'asc';
+
+            $query->orderBy($this->sortField, $direction);
         }
     }
 

--- a/app/Livewire/Table/Filters/DateRangeFilter.php
+++ b/app/Livewire/Table/Filters/DateRangeFilter.php
@@ -7,6 +7,7 @@ namespace App\Livewire\Table\Filters;
 use App\Livewire\Table\Filter;
 use Illuminate\Database\Eloquent\Builder;
 
+/** @phpstan-consistent-constructor */
 class DateRangeFilter extends Filter
 {
     /** @var array<string, mixed> */

--- a/app/Livewire/Table/Filters/SelectFilter.php
+++ b/app/Livewire/Table/Filters/SelectFilter.php
@@ -9,7 +9,7 @@ use App\Livewire\Table\Filter;
 /** @phpstan-consistent-constructor */
 class SelectFilter extends Filter
 {
-    /** @var array<string, string> */
+    /** @var array<int|string, string> */
     protected array $options = [];
 
     public static function make(string $name, ?string $key = null): static
@@ -18,7 +18,7 @@ class SelectFilter extends Filter
     }
 
     /**
-     * @param  array<string, string>  $options
+     * @param  array<int|string, string>  $options
      */
     public function options(array $options): static
     {
@@ -28,7 +28,7 @@ class SelectFilter extends Filter
     }
 
     /**
-     * @return array<string, string>
+     * @return array<int|string, string>
      */
     public function getOptions(): array
     {

--- a/app/Livewire/Table/Filters/SelectFilter.php
+++ b/app/Livewire/Table/Filters/SelectFilter.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Table\Filters;
 
 use App\Livewire\Table\Filter;
 
+/** @phpstan-consistent-constructor */
 class SelectFilter extends Filter
 {
     /** @var array<string, string> */

--- a/app/Livewire/TagTeams/Forms/CreateEditForm.php
+++ b/app/Livewire/TagTeams/Forms/CreateEditForm.php
@@ -134,13 +134,13 @@ class CreateEditForm extends BaseForm
 
         // Load current wrestler assignments
         $currentWrestlers = $this->formModel->currentWrestlers;
-        if ($currentWrestlers->isNotEmpty()) {
-            $this->wrestlerA = $currentWrestlers->first()->getKey();
-            $this->wrestlerB = $currentWrestlers->skip(1)->first()->getKey();
-        }
+        $this->wrestlerA = $currentWrestlers->first()?->id;
+        $this->wrestlerB = $currentWrestlers->skip(1)->first()?->id;
 
         // Load current manager assignments
-        $this->managers = $this->formModel->currentManagers->pluck('id')->toArray();
+        $this->managers = $this->formModel->currentManagers
+            ->map(fn (Manager $manager): int => $manager->id)
+            ->all();
     }
 
     public function toData(): TagTeamData

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -38,7 +38,7 @@ class FormModal extends BaseFormModal
     protected function getDummyDataFields(): array
     {
         return [
-            'name' => fn () => Str::of(fake()->words(2, true))->title()->append(' Title')->value(),
+            'name' => fn () => Str::of(fake()->word().' '.fake()->word())->title()->append(' Title')->value(),
             'type' => fn () => fake()->randomElement(['singles', 'tag-team']),
             'start_date' => fn () => $this->generateOptionalStartDate('Y-m-d', 0.6, '-1 year', 'now'),
         ];
@@ -53,7 +53,7 @@ class FormModal extends BaseFormModal
         return 'Create Title';
     }
 
-    public function openModal(mixed $modelId = null): void
+    public function openModal(int|string|null $modelId = null): void
     {
         // Authorization check - only administrators can access title management
         if ($modelId) {

--- a/app/Livewire/Users/Modals/FormModal.php
+++ b/app/Livewire/Users/Modals/FormModal.php
@@ -46,7 +46,7 @@ class FormModal extends BaseFormModal
         ];
     }
 
-    public function openModal(mixed $modelId = null): void
+    public function openModal(int|string|null $modelId = null): void
     {
         // Check authorization before opening modal
         if ($modelId !== null) {

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -23,27 +23,3 @@ parameters:
 			identifier: property.notFound
 			count: 1
 			path: app/Http/Middleware/AddWrestlingContext.php
-
-		-
-			message: '#^Instanceof between Illuminate\\View\\View and Illuminate\\Contracts\\View\\View will always evaluate to true\.$#'
-			identifier: instanceof.alwaysTrue
-			count: 1
-			path: app/Livewire/Table/Column.php
-
-		-
-			message: '#^Unsafe usage of new static\(\)\.$#'
-			identifier: new.static
-			count: 1
-			path: app/Livewire/Table/Column.php
-
-		-
-			message: '#^Unsafe usage of new static\(\)\.$#'
-			identifier: new.static
-			count: 1
-			path: app/Livewire/Table/Filters/DateRangeFilter.php
-
-		-
-			message: '#^Unsafe usage of new static\(\)\.$#'
-			identifier: new.static
-			count: 1
-			path: app/Livewire/Table/Filters/SelectFilter.php

--- a/tests/Unit/Livewire/Concerns/Data/PresentsManagersListTest.php
+++ b/tests/Unit/Livewire/Concerns/Data/PresentsManagersListTest.php
@@ -108,9 +108,10 @@ describe('PresentsManagersList Unit Tests', function () {
             $source = reflectionSource($reflection);
 
             // Check for expected query implementation
-            expect($source)->toContain('Manager::select(\'id\', \'full_name\')');
-            expect($source)->toContain('->pluck(\'full_name\', \'id\')');
-            expect($source)->toContain('->toArray()');
+            expect($source)->toContain('Manager::query()');
+            expect($source)->toContain("->get(['id', 'full_name'])");
+            expect($source)->toContain('->mapWithKeys(');
+            expect($source)->toContain('->all()');
         });
     });
 
@@ -204,15 +205,15 @@ describe('PresentsManagersList Unit Tests', function () {
             $source = reflectionSource($reflection);
 
             // Check for field selection optimization
-            expect($source)->toContain('select(\'id\', \'full_name\')');
+            expect($source)->toContain("get(['id', 'full_name'])");
         });
 
-        test('uses efficient pluck method', function () {
+        test('keys the list by manager id', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
             $source = reflectionSource($reflection);
 
-            // Check for pluck usage
-            expect($source)->toContain('pluck(\'full_name\', \'id\')');
+            expect($source)->toContain('mapWithKeys(');
+            expect($source)->toContain('[$manager->id => $manager->full_name]');
         });
     });
 

--- a/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
+++ b/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
@@ -169,7 +169,10 @@ describe('GeneratesDummyData Unit Tests', function () {
 
             expect($publicMethods)->toHaveCount(1); // fillDummyFields
             expect(count($protectedMethods))->toBeGreaterThan(5); // generators + abstract
-            expect($privateMethods)->toHaveCount(1); // populateField
+            expect(array_values(array_map(
+                fn (ReflectionMethod $method): string => $method->getName(),
+                $privateMethods
+            )))->toEqualCanonicalizing(['populateField', 'randomString', 'randomGenerator']);
         });
 
         test('has no properties', function () {

--- a/tests/Unit/Livewire/Table/ColumnTest.php
+++ b/tests/Unit/Livewire/Table/ColumnTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Table\Column;
+use App\Livewire\Table\Columns\LinkColumn;
+
+test('make preserves the requested column type', function () {
+    $column = LinkColumn::make('Wrestler');
+
+    expect($column)
+        ->toBeInstanceOf(LinkColumn::class)
+        ->and($column->getField())->toBe('wrestler');
+});
+
+test('view columns render their configured view', function () {
+    $column = Column::make('Divider')->view('components.auth.form-divider');
+
+    expect($column->resolveValue(null))
+        ->toContain('items-center')
+        ->toContain('Or');
+});

--- a/tests/Unit/Livewire/Table/Filters/FilterFactoriesTest.php
+++ b/tests/Unit/Livewire/Table/Filters/FilterFactoriesTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Livewire\Components\Tables\Filters\FirstActivityPeriodFilter;
+use App\Livewire\Table\Filters\SelectFilter;
+
+test('date range filter factory preserves the requested filter type', function () {
+    $filter = FirstActivityPeriodFilter::make('Activity Period');
+
+    expect($filter)
+        ->toBeInstanceOf(FirstActivityPeriodFilter::class)
+        ->and($filter->getKey())->toBe('activity_period');
+});
+
+test('select filter factory creates a configured filter', function () {
+    $filter = SelectFilter::make('Status')->options([
+        'active' => 'Active',
+    ]);
+
+    expect($filter->getKey())->toBe('status')
+        ->and($filter->getOptions())->toBe([
+            'active' => 'Active',
+        ]);
+});


### PR DESCRIPTION
## Summary
- remove every app/Livewire suppression from the PHPStan baseline
- make table column and filter factories enforce consistent constructor contracts
- harden modal model identifiers and generic model resolution
- type computed option lists, match form hydration, dummy data, filters, and table display boundaries
- validate runtime values at Livewire hydration and polymorphic boundaries
- make the entire app/Livewire directory pass PHPStan level 9

## Verification
- app/Livewire PHPStan level 9: 0 errors
- composer test:types
- composer lint
- focused Livewire suite: 248 tests, 622 assertions
- composer test:push: type coverage, Rector, formatting, and both PHPStan configurations passed; the final unchanged parallel Pest command exceeded Composer process timeout at 300 seconds