### PR TITLE
refactor: raise PHPStan to level 7

### DIFF
--- a/app/Actions/Lifecycle/EndActivityPeriodAction.php
+++ b/app/Actions/Lifecycle/EndActivityPeriodAction.php
@@ -24,8 +24,9 @@ class EndActivityPeriodAction
 
         DB::transaction(function () use ($activeable, $endedAt, $context): void {
             $lockedActiveable = $activeable->newQueryWithoutScopes()
+                ->whereKey($activeable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($activeable->getKey());
+                ->firstOrFail();
 
             if (! $lockedActiveable instanceof HasActivityPeriods) {
                 throw new LogicException(class_basename($activeable).' does not support activity periods.');

--- a/app/Actions/Lifecycle/StartActivityPeriodAction.php
+++ b/app/Actions/Lifecycle/StartActivityPeriodAction.php
@@ -21,8 +21,9 @@ class StartActivityPeriodAction
     ): ActivityPeriod {
         return DB::transaction(function () use ($activeable, $startedAt, $rescheduleFuturePeriod): ActivityPeriod {
             $lockedActiveable = $activeable->newQueryWithoutScopes()
+                ->whereKey($activeable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($activeable->getKey());
+                ->firstOrFail();
 
             if (! $lockedActiveable instanceof HasActivityPeriods) {
                 throw new LogicException(class_basename($activeable).' does not support activity periods.');

--- a/app/Actions/Managers/EmployAction.php
+++ b/app/Actions/Managers/EmployAction.php
@@ -37,7 +37,7 @@ class EmployAction
         $startDate = DateHelper::resolveDate($startDate);
 
         DB::transaction(function () use ($manager, $startDate): void {
-            $lockedManager = Manager::query()->lockForUpdate()->findOrFail($manager->getKey());
+            $lockedManager = Manager::query()->whereKey($manager->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanEmploy($lockedManager);
 
             $this->employmentPeriods->start($lockedManager, $startDate, LifecycleTransitionType::Employed);

--- a/app/Actions/Managers/HealAction.php
+++ b/app/Actions/Managers/HealAction.php
@@ -39,7 +39,7 @@ class HealAction
         $recoveryDate = DateHelper::resolveDate($recoveryDate);
 
         DB::transaction(function () use ($manager, $recoveryDate): void {
-            $lockedManager = Manager::query()->lockForUpdate()->findOrFail($manager->getKey());
+            $lockedManager = Manager::query()->whereKey($manager->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanHeal($lockedManager);
 
             $this->injuryPeriods->end($lockedManager, $recoveryDate, LifecycleTransitionType::Healed);

--- a/app/Actions/Managers/InjureAction.php
+++ b/app/Actions/Managers/InjureAction.php
@@ -38,7 +38,7 @@ class InjureAction
         $injureDate = DateHelper::resolveDate($injureDate);
 
         DB::transaction(function () use ($manager, $injureDate): void {
-            $lockedManager = Manager::query()->lockForUpdate()->findOrFail($manager->getKey());
+            $lockedManager = Manager::query()->whereKey($manager->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanInjure($lockedManager);
 
             $this->injuryPeriods->start($lockedManager, $injureDate, LifecycleTransitionType::Injured);

--- a/app/Actions/Managers/ReinstateAction.php
+++ b/app/Actions/Managers/ReinstateAction.php
@@ -38,7 +38,7 @@ final class ReinstateAction
         $reinstatementDate = DateHelper::resolveDate($reinstatementDate);
 
         DB::transaction(function () use ($manager, $reinstatementDate): void {
-            $lockedManager = Manager::query()->lockForUpdate()->findOrFail($manager->getKey());
+            $lockedManager = Manager::query()->whereKey($manager->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanReinstate($lockedManager);
 
             $this->suspensionPeriods->end($lockedManager, $reinstatementDate, LifecycleTransitionType::Reinstated);

--- a/app/Actions/Managers/ReleaseAction.php
+++ b/app/Actions/Managers/ReleaseAction.php
@@ -43,7 +43,7 @@ class ReleaseAction
         $releaseDate = DateHelper::resolveDate($releaseDate);
 
         DB::transaction(function () use ($manager, $releaseDate): void {
-            $lockedManager = Manager::query()->lockForUpdate()->findOrFail($manager->getKey());
+            $lockedManager = Manager::query()->whereKey($manager->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRelease($lockedManager);
 
             $this->employmentPeriods->end($lockedManager, $releaseDate, LifecycleTransitionType::Released);

--- a/app/Actions/Managers/RetireAction.php
+++ b/app/Actions/Managers/RetireAction.php
@@ -47,7 +47,7 @@ class RetireAction
         $retirementDate = DateHelper::resolveDate($retirementDate);
 
         DB::transaction(function () use ($manager, $retirementDate): void {
-            $lockedManager = Manager::query()->lockForUpdate()->findOrFail($manager->getKey());
+            $lockedManager = Manager::query()->whereKey($manager->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRetire($lockedManager);
 
             if ($lockedManager->isEmployed()) {

--- a/app/Actions/Managers/SuspendAction.php
+++ b/app/Actions/Managers/SuspendAction.php
@@ -38,7 +38,7 @@ class SuspendAction
         $suspensionDate = DateHelper::resolveDate($suspensionDate);
 
         DB::transaction(function () use ($manager, $suspensionDate): void {
-            $lockedManager = Manager::query()->lockForUpdate()->findOrFail($manager->getKey());
+            $lockedManager = Manager::query()->whereKey($manager->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanSuspend($lockedManager);
 
             $this->suspensionPeriods->start($lockedManager, $suspensionDate, LifecycleTransitionType::Suspended);

--- a/app/Actions/Managers/UnretireAction.php
+++ b/app/Actions/Managers/UnretireAction.php
@@ -41,7 +41,7 @@ class UnretireAction
         $unretiredDate = DateHelper::resolveDate($unretiredDate);
 
         DB::transaction(function () use ($manager, $unretiredDate, $employImmediately): void {
-            $lockedManager = Manager::query()->withTrashed()->lockForUpdate()->findOrFail($manager->getKey());
+            $lockedManager = Manager::query()->withTrashed()->whereKey($manager->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanUnretire($lockedManager);
             $this->retirementPeriods->end($lockedManager, $unretiredDate, LifecycleTransitionType::Unretired);
 

--- a/app/Actions/Matches/AddMatchForEventAction.php
+++ b/app/Actions/Matches/AddMatchForEventAction.php
@@ -26,8 +26,9 @@ class AddMatchForEventAction
 
         return DB::transaction(function () use ($event, $eventMatchData): EventMatch {
             $lockedEvent = Event::query()
+                ->whereKey($event->getKey())
                 ->lockForUpdate()
-                ->findOrFail($event->getKey());
+                ->firstOrFail();
             $lastMatchNumber = $lockedEvent->matches()
                 ->withTrashed()
                 ->max('match_number');

--- a/app/Actions/Matches/ApplyMatchTitleOutcomesAction.php
+++ b/app/Actions/Matches/ApplyMatchTitleOutcomesAction.php
@@ -26,8 +26,9 @@ class ApplyMatchTitleOutcomesAction
         DB::transaction(function () use ($match, $result): void {
             $lockedMatch = EventMatch::query()
                 ->with('event')
+                ->whereKey($match->id)
                 ->lockForUpdate()
-                ->findOrFail($match->id);
+                ->firstOrFail();
             $titleIds = $lockedMatch->titles()->pluck((new Title())->qualifyColumn('id'));
 
             if ($titleIds->isEmpty()) {

--- a/app/Actions/Matches/DeleteAction.php
+++ b/app/Actions/Matches/DeleteAction.php
@@ -16,7 +16,7 @@ class DeleteAction
     public function handle(EventMatch $eventMatch, ?Carbon $deletedAt = null): void
     {
         DB::transaction(function () use ($eventMatch, $deletedAt): void {
-            $lockedMatch = EventMatch::query()->lockForUpdate()->findOrFail($eventMatch->getKey());
+            $lockedMatch = EventMatch::query()->whereKey($eventMatch->getKey())->lockForUpdate()->firstOrFail();
 
             $this->deletionState->delete($lockedMatch, $deletedAt ?? now());
         });

--- a/app/Actions/Matches/RecordResultAction.php
+++ b/app/Actions/Matches/RecordResultAction.php
@@ -22,10 +22,10 @@ class RecordResultAction
     public function handle(EventMatch $match, MatchResultData $result): EventMatch
     {
         return DB::transaction(function () use ($match, $result): EventMatch {
-            $lockedMatch = EventMatch::query()->lockForUpdate()->findOrFail($match->id);
+            $lockedMatch = EventMatch::query()->whereKey($match->id)->lockForUpdate()->firstOrFail();
             $lockedWinningSide = $result->winningSide === null
                 ? null
-                : MatchSide::query()->lockForUpdate()->findOrFail($result->winningSide->id);
+                : MatchSide::query()->whereKey($result->winningSide->id)->lockForUpdate()->firstOrFail();
             $lockedCompetitors = MatchCompetitor::query()
                 ->whereBelongsTo($lockedMatch, 'eventMatch')
                 ->lockForUpdate()

--- a/app/Actions/Matches/UpdateMatchAction.php
+++ b/app/Actions/Matches/UpdateMatchAction.php
@@ -23,8 +23,9 @@ class UpdateMatchAction
 
         return DB::transaction(function () use ($match, $data): EventMatch {
             $lockedMatch = EventMatch::query()
+                ->whereKey($match->id)
                 ->lockForUpdate()
-                ->findOrFail($match->id);
+                ->firstOrFail();
 
             if ($lockedMatch->match_finish !== null) {
                 throw InvalidMatchConfigurationException::resultAlreadyRecorded();

--- a/app/Actions/Referees/EmployAction.php
+++ b/app/Actions/Referees/EmployAction.php
@@ -37,7 +37,7 @@ class EmployAction
         $employmentDate = DateHelper::resolveDate($employmentDate);
 
         DB::transaction(function () use ($referee, $employmentDate): void {
-            $lockedReferee = Referee::query()->lockForUpdate()->findOrFail($referee->getKey());
+            $lockedReferee = Referee::query()->whereKey($referee->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanEmploy($lockedReferee);
 
             $this->employmentPeriods->start($lockedReferee, $employmentDate, LifecycleTransitionType::Employed);

--- a/app/Actions/Referees/HealAction.php
+++ b/app/Actions/Referees/HealAction.php
@@ -39,7 +39,7 @@ class HealAction
         $recoveryDate = DateHelper::resolveDate($recoveryDate);
 
         DB::transaction(function () use ($referee, $recoveryDate): void {
-            $lockedReferee = Referee::query()->lockForUpdate()->findOrFail($referee->getKey());
+            $lockedReferee = Referee::query()->whereKey($referee->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanHeal($lockedReferee);
 
             $this->injuryPeriods->end($lockedReferee, $recoveryDate, LifecycleTransitionType::Healed);

--- a/app/Actions/Referees/InjureAction.php
+++ b/app/Actions/Referees/InjureAction.php
@@ -38,7 +38,7 @@ class InjureAction
         $injureDate = DateHelper::resolveDate($injureDate);
 
         DB::transaction(function () use ($referee, $injureDate): void {
-            $lockedReferee = Referee::query()->lockForUpdate()->findOrFail($referee->getKey());
+            $lockedReferee = Referee::query()->whereKey($referee->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanInjure($lockedReferee);
 
             $this->injuryPeriods->start($lockedReferee, $injureDate, LifecycleTransitionType::Injured);

--- a/app/Actions/Referees/ReinstateAction.php
+++ b/app/Actions/Referees/ReinstateAction.php
@@ -38,7 +38,7 @@ class ReinstateAction
         $reinstatementDate = DateHelper::resolveDate($reinstatementDate);
 
         DB::transaction(function () use ($referee, $reinstatementDate): void {
-            $lockedReferee = Referee::query()->lockForUpdate()->findOrFail($referee->getKey());
+            $lockedReferee = Referee::query()->whereKey($referee->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanReinstate($lockedReferee);
 
             $this->suspensionPeriods->end($lockedReferee, $reinstatementDate, LifecycleTransitionType::Reinstated);

--- a/app/Actions/Referees/ReleaseAction.php
+++ b/app/Actions/Referees/ReleaseAction.php
@@ -42,7 +42,7 @@ class ReleaseAction
         $releaseDate = DateHelper::resolveDate($releaseDate);
 
         DB::transaction(function () use ($referee, $releaseDate): void {
-            $lockedReferee = Referee::query()->lockForUpdate()->findOrFail($referee->getKey());
+            $lockedReferee = Referee::query()->whereKey($referee->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRelease($lockedReferee);
 
             if ($lockedReferee->isSuspended()) {

--- a/app/Actions/Referees/RetireAction.php
+++ b/app/Actions/Referees/RetireAction.php
@@ -46,7 +46,7 @@ class RetireAction
         $retirementDate = DateHelper::resolveDate($retirementDate);
 
         DB::transaction(function () use ($referee, $retirementDate): void {
-            $lockedReferee = Referee::query()->lockForUpdate()->findOrFail($referee->getKey());
+            $lockedReferee = Referee::query()->whereKey($referee->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRetire($lockedReferee);
 
             if ($lockedReferee->isEmployed()) {

--- a/app/Actions/Referees/SuspendAction.php
+++ b/app/Actions/Referees/SuspendAction.php
@@ -38,7 +38,7 @@ class SuspendAction
         $suspensionDate = DateHelper::resolveDate($suspensionDate);
 
         DB::transaction(function () use ($referee, $suspensionDate): void {
-            $lockedReferee = Referee::query()->lockForUpdate()->findOrFail($referee->getKey());
+            $lockedReferee = Referee::query()->whereKey($referee->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanSuspend($lockedReferee);
 
             $this->suspensionPeriods->start($lockedReferee, $suspensionDate, LifecycleTransitionType::Suspended);

--- a/app/Actions/Referees/UnretireAction.php
+++ b/app/Actions/Referees/UnretireAction.php
@@ -41,7 +41,7 @@ class UnretireAction
         $unretiredDate = DateHelper::resolveDate($unretiredDate);
 
         DB::transaction(function () use ($referee, $unretiredDate): void {
-            $lockedReferee = Referee::query()->withTrashed()->lockForUpdate()->findOrFail($referee->getKey());
+            $lockedReferee = Referee::query()->withTrashed()->whereKey($referee->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanUnretire($lockedReferee);
             $this->retirementPeriods->end($lockedReferee, $unretiredDate, LifecycleTransitionType::Unretired);
             $this->employmentPeriods->start($lockedReferee, $unretiredDate, LifecycleTransitionType::Employed);

--- a/app/Actions/Stables/DeleteAction.php
+++ b/app/Actions/Stables/DeleteAction.php
@@ -29,8 +29,9 @@ class DeleteAction
         DB::transaction(function () use ($stable): void {
             $lockedStable = Stable::query()
                 ->withTrashed()
+                ->whereKey($stable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($stable->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanDelete($lockedStable);
             $this->deletionState->delete($lockedStable, now());

--- a/app/Actions/Stables/DisbandAction.php
+++ b/app/Actions/Stables/DisbandAction.php
@@ -49,8 +49,9 @@ class DisbandAction
         DB::transaction(function () use ($stable, $disbandDate): void {
             $lockedStable = Stable::query()
                 ->withTrashed()
+                ->whereKey($stable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($stable->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanDisband($lockedStable);
             $this->endActivityPeriodAction->handle($lockedStable, $disbandDate);

--- a/app/Actions/Stables/EstablishAction.php
+++ b/app/Actions/Stables/EstablishAction.php
@@ -54,8 +54,9 @@ class EstablishAction
             function () use ($stable, $activationDate, $endDate): ActivityPeriod {
                 $lockedStable = Stable::query()
                     ->withTrashed()
+                    ->whereKey($stable->getKey())
                     ->lockForUpdate()
-                    ->findOrFail($stable->getKey());
+                    ->firstOrFail();
 
                 $this->eligibility->ensureCanEstablish($lockedStable);
 

--- a/app/Actions/Stables/MergeStablesAction.php
+++ b/app/Actions/Stables/MergeStablesAction.php
@@ -43,8 +43,8 @@ class MergeStablesAction
                 ? [$primaryStable, $secondaryStable]
                 : [$secondaryStable, $primaryStable];
 
-            $firstLockedStable = Stable::query()->lockForUpdate()->findOrFail($firstStable->getKey());
-            $secondLockedStable = Stable::query()->lockForUpdate()->findOrFail($secondStable->getKey());
+            $firstLockedStable = Stable::query()->whereKey($firstStable->getKey())->lockForUpdate()->firstOrFail();
+            $secondLockedStable = Stable::query()->whereKey($secondStable->getKey())->lockForUpdate()->firstOrFail();
 
             $lockedPrimaryStable = $firstLockedStable->is($primaryStable)
                 ? $firstLockedStable

--- a/app/Actions/Stables/RestoreAction.php
+++ b/app/Actions/Stables/RestoreAction.php
@@ -30,8 +30,9 @@ class RestoreAction
         DB::transaction(function () use ($stable): void {
             $lockedStable = Stable::query()
                 ->withTrashed()
+                ->whereKey($stable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($stable->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanRestore($lockedStable);
             $this->deletionState->restore($lockedStable, now());

--- a/app/Actions/Stables/RetireAction.php
+++ b/app/Actions/Stables/RetireAction.php
@@ -59,8 +59,9 @@ class RetireAction
         DB::transaction(function () use ($stable, $retirementDate, $operationalDate): void {
             $lockedStable = Stable::query()
                 ->withTrashed()
+                ->whereKey($stable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($stable->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanRetire($lockedStable);
 

--- a/app/Actions/Stables/ReuniteAction.php
+++ b/app/Actions/Stables/ReuniteAction.php
@@ -45,8 +45,9 @@ class ReuniteAction
         DB::transaction(function () use ($stable, $reuniteDate): void {
             $lockedStable = Stable::query()
                 ->withTrashed()
+                ->whereKey($stable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($stable->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanReunite($lockedStable);
             $this->startActivityPeriodAction->handle($lockedStable, $reuniteDate);

--- a/app/Actions/Stables/SplitStableAction.php
+++ b/app/Actions/Stables/SplitStableAction.php
@@ -45,8 +45,9 @@ class SplitStableAction
     ): Stable {
         return DB::transaction(function () use ($originalStable, $newStableName, $membersForNewStable, $date): Stable {
             $lockedStable = Stable::query()
+                ->whereKey($originalStable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($originalStable->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanSplit($lockedStable);
 

--- a/app/Actions/Stables/UnretireAction.php
+++ b/app/Actions/Stables/UnretireAction.php
@@ -53,8 +53,9 @@ class UnretireAction
         DB::transaction(function () use ($stable, $unretiredDate, $establishImmediately, $requireFormerMembers): void {
             $lockedStable = Stable::query()
                 ->withTrashed()
+                ->whereKey($stable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($stable->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanUnretire($lockedStable, $requireFormerMembers);
             $this->retirementPeriods->end($lockedStable, $unretiredDate, LifecycleTransitionType::Unretired);

--- a/app/Actions/Stables/UpdateAction.php
+++ b/app/Actions/Stables/UpdateAction.php
@@ -45,8 +45,9 @@ class UpdateAction
 
         return DB::transaction(function () use ($stable, $stableData): Stable {
             $lockedStable = Stable::query()
+                ->whereKey($stable->getKey())
                 ->lockForUpdate()
-                ->findOrFail($stable->getKey());
+                ->firstOrFail();
 
             $lockedStable->update([
                 'name' => $stableData->getTrimmedName(),

--- a/app/Actions/TagTeams/DeleteAction.php
+++ b/app/Actions/TagTeams/DeleteAction.php
@@ -57,7 +57,7 @@ class DeleteAction
         $deletionDate = DateHelper::resolveDate($deletionDate);
 
         DB::transaction(function () use ($tagTeam, $deletionDate): void {
-            $lockedTagTeam = TagTeam::query()->withTrashed()->lockForUpdate()->findOrFail($tagTeam->getKey());
+            $lockedTagTeam = TagTeam::query()->withTrashed()->whereKey($tagTeam->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanDelete($lockedTagTeam);
 
             $this->endCurrentRelationships->handle($lockedTagTeam, $deletionDate);

--- a/app/Actions/TagTeams/EmployAction.php
+++ b/app/Actions/TagTeams/EmployAction.php
@@ -42,7 +42,7 @@ class EmployAction
         $employmentDate = DateHelper::resolveDate($employmentDate);
 
         DB::transaction(function () use ($tagTeam, $employmentDate): void {
-            $lockedTagTeam = TagTeam::query()->lockForUpdate()->findOrFail($tagTeam->getKey());
+            $lockedTagTeam = TagTeam::query()->whereKey($tagTeam->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanEmploy($lockedTagTeam);
 
             $this->employmentPeriods->start($lockedTagTeam, $employmentDate, LifecycleTransitionType::Employed);

--- a/app/Actions/TagTeams/ReinstateAction.php
+++ b/app/Actions/TagTeams/ReinstateAction.php
@@ -40,7 +40,7 @@ class ReinstateAction
         $reinstatementDate = DateHelper::resolveDate($reinstatementDate);
 
         DB::transaction(function () use ($tagTeam, $reinstatementDate): void {
-            $lockedTagTeam = TagTeam::query()->lockForUpdate()->findOrFail($tagTeam->getKey());
+            $lockedTagTeam = TagTeam::query()->whereKey($tagTeam->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanReinstate($lockedTagTeam);
 
             $this->suspensionPeriods->end($lockedTagTeam, $reinstatementDate, LifecycleTransitionType::Reinstated);

--- a/app/Actions/TagTeams/ReleaseAction.php
+++ b/app/Actions/TagTeams/ReleaseAction.php
@@ -43,7 +43,7 @@ class ReleaseAction
         $releaseDate = DateHelper::resolveDate($releaseDate);
 
         DB::transaction(function () use ($tagTeam, $releaseDate): void {
-            $lockedTagTeam = TagTeam::query()->lockForUpdate()->findOrFail($tagTeam->getKey());
+            $lockedTagTeam = TagTeam::query()->whereKey($tagTeam->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRelease($lockedTagTeam);
 
             $this->employmentPeriods->end($lockedTagTeam, $releaseDate, LifecycleTransitionType::Released);

--- a/app/Actions/TagTeams/RestoreAction.php
+++ b/app/Actions/TagTeams/RestoreAction.php
@@ -30,7 +30,7 @@ class RestoreAction
     public function handle(TagTeam $tagTeam): void
     {
         DB::transaction(function () use ($tagTeam): void {
-            $lockedTagTeam = TagTeam::query()->withTrashed()->lockForUpdate()->findOrFail($tagTeam->getKey());
+            $lockedTagTeam = TagTeam::query()->withTrashed()->whereKey($tagTeam->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRestore($lockedTagTeam);
 
             $this->deletionState->restore($lockedTagTeam, now());

--- a/app/Actions/TagTeams/RetireAction.php
+++ b/app/Actions/TagTeams/RetireAction.php
@@ -47,7 +47,7 @@ class RetireAction
         $retirementDate = DateHelper::resolveDate($retirementDate);
 
         DB::transaction(function () use ($tagTeam, $retirementDate, $retireMembers): void {
-            $lockedTagTeam = TagTeam::query()->lockForUpdate()->findOrFail($tagTeam->getKey());
+            $lockedTagTeam = TagTeam::query()->whereKey($tagTeam->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRetire($lockedTagTeam);
 
             if ($lockedTagTeam->isEmployed()) {

--- a/app/Actions/TagTeams/SuspendAction.php
+++ b/app/Actions/TagTeams/SuspendAction.php
@@ -39,7 +39,7 @@ class SuspendAction
         $suspensionDate = DateHelper::resolveDate($suspensionDate);
 
         DB::transaction(function () use ($tagTeam, $suspensionDate): void {
-            $lockedTagTeam = TagTeam::query()->lockForUpdate()->findOrFail($tagTeam->getKey());
+            $lockedTagTeam = TagTeam::query()->whereKey($tagTeam->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanSuspend($lockedTagTeam);
 
             $this->suspensionPeriods->start($lockedTagTeam, $suspensionDate, LifecycleTransitionType::Suspended);

--- a/app/Actions/TagTeams/UnretireAction.php
+++ b/app/Actions/TagTeams/UnretireAction.php
@@ -53,7 +53,7 @@ class UnretireAction
         $unretiredDate = DateHelper::resolveDate($unretiredDate);
 
         DB::transaction(function () use ($tagTeam, $unretiredDate, $unretireMembers, $employImmediately, $requireAvailablePartners): void {
-            $lockedTagTeam = TagTeam::query()->lockForUpdate()->findOrFail($tagTeam->getKey());
+            $lockedTagTeam = TagTeam::query()->whereKey($tagTeam->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanUnretire($lockedTagTeam, $requireAvailablePartners);
 
             $this->retirementPeriods->end($lockedTagTeam, $unretiredDate, LifecycleTransitionType::Unretired);

--- a/app/Actions/Titles/ActivateAction.php
+++ b/app/Actions/Titles/ActivateAction.php
@@ -34,8 +34,9 @@ class ActivateAction
 
         DB::transaction(function () use ($title, $activationDate): void {
             $lockedTitle = Title::query()
+                ->whereKey($title->getKey())
                 ->lockForUpdate()
-                ->findOrFail($title->getKey());
+                ->firstOrFail();
 
             // If the title is retired, first unretire it
             if ($lockedTitle->isRetired()) {

--- a/app/Actions/Titles/DebutAction.php
+++ b/app/Actions/Titles/DebutAction.php
@@ -43,8 +43,9 @@ class DebutAction
 
         DB::transaction(function () use ($title, $debutDate, $notes): void {
             $lockedTitle = Title::query()
+                ->whereKey($title->getKey())
                 ->lockForUpdate()
-                ->findOrFail($title->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanDebut($lockedTitle);
 

--- a/app/Actions/Titles/DeleteAction.php
+++ b/app/Actions/Titles/DeleteAction.php
@@ -46,8 +46,9 @@ class DeleteAction
 
         DB::transaction(function () use ($title, $deletionDate): void {
             $lockedTitle = Title::query()
+                ->whereKey($title->getKey())
                 ->lockForUpdate()
-                ->findOrFail($title->getKey());
+                ->firstOrFail();
 
             // Handle title status cleanup based on current state
             if ($lockedTitle->isCurrentlyActive()) {

--- a/app/Actions/Titles/PullAction.php
+++ b/app/Actions/Titles/PullAction.php
@@ -45,8 +45,9 @@ class PullAction
 
         DB::transaction(function () use ($title, $pullDate, $notes): void {
             $lockedTitle = Title::query()
+                ->whereKey($title->getKey())
                 ->lockForUpdate()
-                ->findOrFail($title->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanPull($lockedTitle);
             $this->endActivityPeriod->handle($lockedTitle, $pullDate);

--- a/app/Actions/Titles/ReinstateAction.php
+++ b/app/Actions/Titles/ReinstateAction.php
@@ -43,8 +43,9 @@ class ReinstateAction
 
         DB::transaction(function () use ($title, $reinstateDate, $notes): void {
             $lockedTitle = Title::query()
+                ->whereKey($title->getKey())
                 ->lockForUpdate()
-                ->findOrFail($title->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanReinstate($lockedTitle);
 

--- a/app/Actions/Titles/RetireAction.php
+++ b/app/Actions/Titles/RetireAction.php
@@ -45,8 +45,9 @@ class RetireAction
 
         DB::transaction(function () use ($title, $retirementDate, $operationalDate): void {
             $lockedTitle = Title::query()
+                ->whereKey($title->getKey())
                 ->lockForUpdate()
-                ->findOrFail($title->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanRetire($lockedTitle);
 

--- a/app/Actions/Titles/UnretireAction.php
+++ b/app/Actions/Titles/UnretireAction.php
@@ -41,8 +41,9 @@ class UnretireAction
         DB::transaction(function () use ($title, $unretiredDate): void {
             $lockedTitle = Title::query()
                 ->withTrashed()
+                ->whereKey($title->getKey())
                 ->lockForUpdate()
-                ->findOrFail($title->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanUnretire($lockedTitle);
             $this->retirementPeriods->end($lockedTitle, $unretiredDate, LifecycleTransitionType::Unretired);

--- a/app/Actions/Wrestlers/EmployAction.php
+++ b/app/Actions/Wrestlers/EmployAction.php
@@ -41,7 +41,7 @@ class EmployAction
         $employmentDate = DateHelper::resolveDate($employmentDate);
 
         DB::transaction(function () use ($wrestler, $employmentDate): void {
-            $lockedWrestler = Wrestler::query()->lockForUpdate()->findOrFail($wrestler->getKey());
+            $lockedWrestler = Wrestler::query()->whereKey($wrestler->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanEmploy($lockedWrestler);
 
             $this->employmentPeriods->start($lockedWrestler, $employmentDate, LifecycleTransitionType::Employed);

--- a/app/Actions/Wrestlers/HealAction.php
+++ b/app/Actions/Wrestlers/HealAction.php
@@ -34,7 +34,7 @@ class HealAction
         $recoveryDate = DateHelper::resolveDate($recoveryDate);
 
         DB::transaction(function () use ($wrestler, $recoveryDate): void {
-            $lockedWrestler = Wrestler::query()->lockForUpdate()->findOrFail($wrestler->getKey());
+            $lockedWrestler = Wrestler::query()->whereKey($wrestler->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanHeal($lockedWrestler);
 
             $this->injuryPeriods->end($lockedWrestler, $recoveryDate, LifecycleTransitionType::Healed);

--- a/app/Actions/Wrestlers/InjureAction.php
+++ b/app/Actions/Wrestlers/InjureAction.php
@@ -39,8 +39,9 @@ class InjureAction
 
         DB::transaction(function () use ($wrestler, $injuryDate): void {
             $lockedWrestler = Wrestler::query()
+                ->whereKey($wrestler->getKey())
                 ->lockForUpdate()
-                ->findOrFail($wrestler->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanInjure($lockedWrestler);
 

--- a/app/Actions/Wrestlers/ReinstateAction.php
+++ b/app/Actions/Wrestlers/ReinstateAction.php
@@ -37,7 +37,7 @@ class ReinstateAction
         $reinstatementDate = DateHelper::resolveDate($reinstatementDate);
 
         DB::transaction(function () use ($wrestler, $reinstatementDate): void {
-            $lockedWrestler = Wrestler::query()->lockForUpdate()->findOrFail($wrestler->getKey());
+            $lockedWrestler = Wrestler::query()->whereKey($wrestler->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanReinstate($lockedWrestler);
 
             $this->suspensionPeriods->end($lockedWrestler, $reinstatementDate, LifecycleTransitionType::Reinstated);

--- a/app/Actions/Wrestlers/ReleaseAction.php
+++ b/app/Actions/Wrestlers/ReleaseAction.php
@@ -44,7 +44,7 @@ class ReleaseAction
         $releaseDate = DateHelper::resolveDate($releaseDate);
 
         DB::transaction(function () use ($wrestler, $releaseDate): void {
-            $lockedWrestler = Wrestler::query()->lockForUpdate()->findOrFail($wrestler->getKey());
+            $lockedWrestler = Wrestler::query()->whereKey($wrestler->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRelease($lockedWrestler);
 
             $this->employmentPeriods->end($lockedWrestler, $releaseDate, LifecycleTransitionType::Released);

--- a/app/Actions/Wrestlers/RetireAction.php
+++ b/app/Actions/Wrestlers/RetireAction.php
@@ -47,7 +47,7 @@ class RetireAction
         $retirementDate = DateHelper::resolveDate($retirementDate);
 
         DB::transaction(function () use ($wrestler, $retirementDate): void {
-            $lockedWrestler = Wrestler::query()->lockForUpdate()->findOrFail($wrestler->getKey());
+            $lockedWrestler = Wrestler::query()->whereKey($wrestler->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanRetire($lockedWrestler);
 
             if ($lockedWrestler->isEmployed()) {

--- a/app/Actions/Wrestlers/SuspendAction.php
+++ b/app/Actions/Wrestlers/SuspendAction.php
@@ -39,8 +39,9 @@ class SuspendAction
 
         DB::transaction(function () use ($wrestler, $suspensionDate): void {
             $lockedWrestler = Wrestler::query()
+                ->whereKey($wrestler->getKey())
                 ->lockForUpdate()
-                ->findOrFail($wrestler->getKey());
+                ->firstOrFail();
 
             $this->eligibility->ensureCanSuspend($lockedWrestler);
 

--- a/app/Actions/Wrestlers/UnretireAction.php
+++ b/app/Actions/Wrestlers/UnretireAction.php
@@ -42,7 +42,7 @@ class UnretireAction
         $unretirementDate = DateHelper::resolveDate($unretirementDate);
 
         DB::transaction(function () use ($wrestler, $unretirementDate, $employImmediately): void {
-            $lockedWrestler = Wrestler::query()->withTrashed()->lockForUpdate()->findOrFail($wrestler->getKey());
+            $lockedWrestler = Wrestler::query()->withTrashed()->whereKey($wrestler->getKey())->lockForUpdate()->firstOrFail();
             $this->eligibility->ensureCanUnretire($lockedWrestler);
             $this->retirementPeriods->end($lockedWrestler, $unretirementDate, LifecycleTransitionType::Unretired);
 

--- a/app/Http/Middleware/AddWrestlingContext.php
+++ b/app/Http/Middleware/AddWrestlingContext.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Http\Middleware;
 
+use App\Models\Events\Event;
 use Closure;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Context;
@@ -93,7 +94,7 @@ class AddWrestlingContext
         // Add event context
         if ($event = $route->parameter('event')) {
             Context::add('event_id', $event->id ?? $event);
-            if (is_object($event) && isset($event->name)) {
+            if ($event instanceof Event) {
                 Context::add('event_name', $event->name);
                 Context::add('event_date', $event->date?->toDateString());
             }

--- a/app/Rules/Wrestlers/CanJoinTagTeam.php
+++ b/app/Rules/Wrestlers/CanJoinTagTeam.php
@@ -14,7 +14,13 @@ class CanJoinTagTeam implements ValidationRule
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $wrestler = Wrestler::query()->find($value);
+        if (! is_int($value) && ! is_string($value)) {
+            $fail('The selected wrestler is invalid.');
+
+            return;
+        }
+
+        $wrestler = Wrestler::query()->whereKey($value)->first();
 
         if (! $wrestler) {
             $fail('The selected wrestler is invalid.');

--- a/app/Rules/Wrestlers/IsNotInjured.php
+++ b/app/Rules/Wrestlers/IsNotInjured.php
@@ -12,7 +12,13 @@ class IsNotInjured implements ValidationRule
 {
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $wrestler = Wrestler::query()->findOrFail($value);
+        if (! is_int($value) && ! is_string($value)) {
+            $fail('The selected wrestler is invalid.');
+
+            return;
+        }
+
+        $wrestler = Wrestler::query()->whereKey($value)->firstOrFail();
 
         if ($wrestler->isInjured()) {
             $fail("{$wrestler->name} is injured and cannot join the stable.");

--- a/app/Rules/Wrestlers/NotRepresentedBySelectedTagTeam.php
+++ b/app/Rules/Wrestlers/NotRepresentedBySelectedTagTeam.php
@@ -22,7 +22,13 @@ class NotRepresentedBySelectedTagTeam implements ValidationRule
             return;
         }
 
-        $wrestler = Wrestler::query()->findOrFail($value);
+        if (! is_int($value) && ! is_string($value)) {
+            $fail('The selected wrestler is invalid.');
+
+            return;
+        }
+
+        $wrestler = Wrestler::query()->whereKey($value)->firstOrFail();
         $currentTagTeam = $wrestler->currentTagTeam()->first();
 
         if ($currentTagTeam && $this->tagTeamIds->contains($currentTagTeam->getKey())) {

--- a/app/Services/StableMembershipService.php
+++ b/app/Services/StableMembershipService.php
@@ -6,11 +6,11 @@ namespace App\Services;
 
 use App\Data\Stables\StableMembershipData;
 use App\Models\Roster\Stables\Stable;
-use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
 
 class StableMembershipService
 {
@@ -63,7 +63,9 @@ class StableMembershipService
             return;
         }
 
-        $relationship->attach($members->modelKeys(), [
+        $relationship->attach($members->map(
+            fn (Model $member): int|string => $member->getKey(),
+        )->all(), [
             'joined_at' => $date,
             'left_at' => null,
         ]);

--- a/app/View/Filters/FirstActivationFilter.php
+++ b/app/View/Filters/FirstActivationFilter.php
@@ -7,6 +7,7 @@ namespace App\View\Filters;
 use App\Livewire\Table\Filters\DateRangeFilter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class FirstActivationFilter extends DateRangeFilter
 {
@@ -30,7 +31,7 @@ class FirstActivationFilter extends DateRangeFilter
         ])
             ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
             ->filter(function (Builder $query, array $dateRange): void {
-                $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
+                $query->withWhereHas($this->filterRelationshipName, function (Builder|Relation $query) use ($dateRange): void {
                     /** @var array{'minDate': string, 'maxDate': string} $dateRange */
                     $query
                         ->where(function (Builder $query) use ($dateRange): void {

--- a/app/View/Filters/FirstEmploymentFilter.php
+++ b/app/View/Filters/FirstEmploymentFilter.php
@@ -7,6 +7,7 @@ namespace App\View\Filters;
 use App\Livewire\Table\Filters\DateRangeFilter;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\Relation;
 
 class FirstEmploymentFilter extends DateRangeFilter
 {
@@ -31,7 +32,7 @@ class FirstEmploymentFilter extends DateRangeFilter
             ->setFilterPillValues([0 => 'minDate', 1 => 'maxDate'])
             ->filter(function (Builder $query, array $dateRange): void {
                 /** @var array{'minDate': string, 'maxDate': string} $dateRange */
-                $query->withWhereHas($this->filterRelationshipName, function (Builder $query) use ($dateRange): void {
+                $query->withWhereHas($this->filterRelationshipName, function (Builder|Relation $query) use ($dateRange): void {
                     $query
                         ->where(function (Builder $query) use ($dateRange): void {
                             $query->whereBetween(

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 6  # ✅ Reasonable for a Laravel project (go up to 8+ for stricter static analysis)
+  level: 7
 
   paths:
     - app  # ✅ Standard — analyzes all app code

--- a/tests/Unit/Http/Middleware/AddWrestlingContextTest.php
+++ b/tests/Unit/Http/Middleware/AddWrestlingContextTest.php
@@ -3,8 +3,10 @@
 declare(strict_types=1);
 
 use App\Http\Middleware\AddWrestlingContext;
+use App\Models\Events\Event;
 use App\Models\Users\User;
 use Illuminate\Http\Request;
+use Illuminate\Routing\Route;
 use Illuminate\Session\ArraySessionHandler;
 use Illuminate\Session\Store;
 use Illuminate\Support\Facades\Context;
@@ -30,6 +32,35 @@ test('adds the authenticated user full name to the request context', function ()
 
         expect($response->isSuccessful())->toBeTrue()
             ->and(Context::get('user_name'))->toBe('Jeffrey Davidson');
+    } finally {
+        Context::flush();
+    }
+});
+
+test('adds event details for a model-bound event route', function () {
+    $event = Event::factory()->make([
+        'id' => 123,
+        'name' => 'Summer Slam',
+        'date' => '2026-08-17',
+    ]);
+    $request = Request::create('/events/123');
+    $route = new Route(['GET'], '/events/{event}', fn (): Response => new Response());
+    $route->bind($request);
+    $route->setParameter('event', $event);
+    $request->setRouteResolver(fn (): Route => $route);
+
+    Context::flush();
+
+    try {
+        $response = resolve(AddWrestlingContext::class)->handle(
+            $request,
+            fn (): Response => new Response(),
+        );
+
+        expect($response->isSuccessful())->toBeTrue()
+            ->and(Context::get('event_id'))->toBe(123)
+            ->and(Context::get('event_name'))->toBe('Summer Slam')
+            ->and(Context::get('event_date'))->toBe('2026-08-17');
     } finally {
         Context::flush();
     }


### PR DESCRIPTION
## Summary
- raise application PHPStan from level 6 to level 7 without a baseline
- make locked single-record queries unambiguous with whereKey and firstOrFail
- narrow validation inputs, relation callbacks, middleware route models, and stable membership collections
- cover model-bound event context with a regression test

## Verification
- composer test:push
- composer test:types
- 711 affected action tests
- focused middleware and stable membership service tests