### PR TITLE
refactor: raise PHPStan to level 8

### DIFF
--- a/app/Casts/AddressCast.php
+++ b/app/Casts/AddressCast.php
@@ -8,6 +8,7 @@ use App\Enums\Shared\UnitedStatesState;
 use App\ValueObjects\Address;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
 
 /** @implements CastsAttributes<Address, Address> */
 class AddressCast implements CastsAttributes
@@ -29,6 +30,10 @@ class AddressCast implements CastsAttributes
      */
     public function set(Model $model, string $key, mixed $value, array $attributes): array
     {
+        if (! $value instanceof Address) {
+            throw new InvalidArgumentException('The address attribute must be an Address value object.');
+        }
+
         return $value->toAttributes();
     }
 }

--- a/app/Rules/Shared/CanChangeEmploymentDate.php
+++ b/app/Rules/Shared/CanChangeEmploymentDate.php
@@ -18,22 +18,24 @@ class CanChangeEmploymentDate implements ValidationRule
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if (! $this->model || ! method_exists($this->model, 'isEmployed')) {
+        $model = $this->model;
+
+        if (! $model || ! method_exists($model, 'isEmployed')) {
             return;
         }
 
         $targetDate = Carbon::parse($value);
 
-        if ($this->model->isEmployed()) {
-            if (method_exists($this->model, 'employedOn') && ! $this->model->employedOn($targetDate)) {
-                $modelName = $this->getModelName();
+        if ($model->isEmployed()) {
+            if (method_exists($model, 'employedOn') && ! $model->employedOn($targetDate)) {
+                $modelName = $this->getModelName($model);
                 $fail("The employment date cannot be changed while {$modelName} is currently employed.");
             }
         }
     }
 
-    private function getModelName(): string
+    private function getModelName(Model $model): string
     {
-        return $this->model->getAttribute('name') ?? class_basename($this->model);
+        return $model->getAttribute('name') ?? class_basename($model);
     }
 }

--- a/app/Services/MatchAssignmentConflictService.php
+++ b/app/Services/MatchAssignmentConflictService.php
@@ -34,7 +34,10 @@ final class MatchAssignmentConflictService
 
         $wrestler = $wrestlers->firstWhere('id', $conflictingWrestlerId);
 
-        throw SchedulingConflictException::competitorAlreadyBooked('Wrestler', $wrestler->name);
+        throw SchedulingConflictException::competitorAlreadyBooked(
+            'Wrestler',
+            $wrestler === null ? "ID: {$conflictingWrestlerId}" : (string) $wrestler->name,
+        );
     }
 
     /**
@@ -54,7 +57,10 @@ final class MatchAssignmentConflictService
 
         $tagTeam = $tagTeams->firstWhere('id', $conflictingTagTeamId);
 
-        throw SchedulingConflictException::competitorAlreadyBooked('Tag team', $tagTeam->name);
+        throw SchedulingConflictException::competitorAlreadyBooked(
+            'Tag team',
+            $tagTeam === null ? "ID: {$conflictingTagTeamId}" : (string) $tagTeam->name,
+        );
     }
 
     /**

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 7
+  level: 8
 
   paths:
     - app  # ✅ Standard — analyzes all app code

--- a/tests/Unit/Casts/AddressCastTest.php
+++ b/tests/Unit/Casts/AddressCastTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Casts\AddressCast;
 use App\Enums\Shared\UnitedStatesState;
 use App\Models\Events\Venue;
 use App\ValueObjects\Address;
@@ -28,4 +29,12 @@ test('it stores an address across the existing venue columns', function () {
         ->and($venue->getRawOriginal('city'))->toBe('New York')
         ->and($venue->getRawOriginal('state'))->toBe('New York')
         ->and($venue->getRawOriginal('zipcode'))->toBe('10001');
+});
+
+test('it rejects values that are not addresses', function () {
+    $cast = new AddressCast();
+    $venue = Venue::factory()->make();
+
+    expect(fn () => $cast->set($venue, 'address', null, []))
+        ->toThrow(InvalidArgumentException::class, 'The address attribute must be an Address value object.');
 });


### PR DESCRIPTION
## Summary
- raise application PHPStan from level 7 to level 8 without a baseline
- reject invalid values at the Address cast boundary
- preserve the narrowed employment model while validating employment dates
- handle theoretically missing competitor models when reporting scheduling conflicts

## Verification
- composer test:push
- composer test:types
- composer test:types:pest
- 47 focused cast, validation rule, and match assignment tests