### PR TITLE
refactor: raise PHPStan to level 9

### DIFF
--- a/.ai/rules/app.md
+++ b/.ai/rules/app.md
@@ -19,3 +19,6 @@ Use now() and today() for the current timestamp or date. Use Carbon constructors
 
 ## Classify exception boundaries by failure source
 Use typed BaseBusinessException subclasses for domain-rule rejections. Use LogicException for impossible programmer or configuration states, including missing convention-derived model classes and invalid trait hosts. Reserve InvalidArgumentException for invalid values supplied by a caller; do not directly construct generic Exception.
+
+## Use Laravel before custom infrastructure
+Prefer Laravel's native framework abstractions and APIs before introducing custom helpers, normalization, infrastructure, or replacement patterns. Preserve Eloquent and framework types through typed models, relationships, builders, casts, validation, and collections; add custom code only when Laravel does not provide the required behavior.

--- a/app/Actions/Lifecycle/EndActivityPeriodAction.php
+++ b/app/Actions/Lifecycle/EndActivityPeriodAction.php
@@ -39,7 +39,12 @@ class EndActivityPeriodAction
                 ->first();
 
             if (! $currentActivityPeriod) {
-                throw new LogicException(class_basename($activeable)." {$activeable->getKey()} does not have a current activity period.");
+                $activeableKey = $activeable->getKey();
+                $activeableIdentifier = is_int($activeableKey) || is_string($activeableKey)
+                    ? $activeableKey
+                    : 'unknown';
+
+                throw new LogicException(class_basename($activeable)." {$activeableIdentifier} does not have a current activity period.");
             }
 
             if ($endedAt->lt($currentActivityPeriod->started_at)) {

--- a/app/Actions/Lifecycle/StartActivityPeriodAction.php
+++ b/app/Actions/Lifecycle/StartActivityPeriodAction.php
@@ -41,7 +41,12 @@ class StartActivityPeriodAction
             }
 
             if ($openActivityPeriod) {
-                throw new LogicException(class_basename($activeable)." {$activeable->getKey()} already has an open activity period.");
+                $activeableKey = $activeable->getKey();
+                $activeableIdentifier = is_int($activeableKey) || is_string($activeableKey)
+                    ? $activeableKey
+                    : 'unknown';
+
+                throw new LogicException(class_basename($activeable)." {$activeableIdentifier} already has an open activity period.");
             }
 
             return $lockedActiveable->activityPeriods()->create([

--- a/app/Actions/Matches/AddCompetitorsToMatchAction.php
+++ b/app/Actions/Matches/AddCompetitorsToMatchAction.php
@@ -8,7 +8,6 @@ use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Models\Matches\EventMatch;
 use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 
@@ -42,8 +41,7 @@ class AddCompetitorsToMatchAction
     public function handle(EventMatch $eventMatch, Collection $competitors): void
     {
         // Validate competitor distribution before processing
-        $competitorArray = $competitors->toArray();
-        if (! $this->validateCompetitorDistribution($competitorArray)) {
+        if (! $this->validateCompetitorDistribution($competitors)) {
             throw InvalidMatchConfigurationException::insufficientSides(2);
         }
 
@@ -60,24 +58,28 @@ class AddCompetitorsToMatchAction
      *
      * @param  EventMatch  $eventMatch  The match to add competitors to
      * @param  int  $sideNumber  The side number (1, 2, 3, etc.)
-     * @param  array<string, array<int, Wrestler|TagTeam>>  $sideCompetitors  Competitors for this side
+     * @param  array{wrestlers?: array<int, Wrestler>, tag_teams?: array<int, TagTeam>}  $sideCompetitors  Competitors for this side
      */
     private function addSideCompetitors(EventMatch $eventMatch, int $sideNumber, array $sideCompetitors): void
     {
         // Add wrestlers to this side
-        if (Arr::exists($sideCompetitors, 'wrestlers') && ! empty($sideCompetitors['wrestlers'])) {
+        $wrestlers = $sideCompetitors['wrestlers'] ?? [];
+
+        if ($wrestlers !== []) {
             $this->addWrestlersToMatchAction->handle(
                 $eventMatch,
-                collect((array) Arr::get($sideCompetitors, 'wrestlers')),
+                collect($wrestlers),
                 $sideNumber
             );
         }
 
         // Add tag teams to this side
-        if (Arr::exists($sideCompetitors, 'tag_teams') && ! empty($sideCompetitors['tag_teams'])) {
+        $tagTeams = $sideCompetitors['tag_teams'] ?? [];
+
+        if ($tagTeams !== []) {
             $this->addTagTeamsToMatchAction->handle(
                 $eventMatch,
-                collect((array) Arr::get($sideCompetitors, 'tag_teams')),
+                collect($tagTeams),
                 $sideNumber
             );
         }
@@ -86,10 +88,10 @@ class AddCompetitorsToMatchAction
     /**
      * Validate match competitors for proper side distribution.
      *
-     * @param  array<int, array<string, mixed>>  $competitors  Competitors organized by side
+     * @param  Collection<int, covariant array{wrestlers?: array<int, Wrestler>, tag_teams?: array<int, TagTeam>}>  $competitors  Competitors organized by side
      * @return bool True if competitor distribution is valid for the match type
      */
-    private function validateCompetitorDistribution(array $competitors): bool
+    private function validateCompetitorDistribution(Collection $competitors): bool
     {
         // Ensure we have at least 2 sides with competitors
         $sidesWithCompetitors = 0;

--- a/app/Actions/Matches/AddMatchForEventAction.php
+++ b/app/Actions/Matches/AddMatchForEventAction.php
@@ -29,13 +29,14 @@ class AddMatchForEventAction
                 ->whereKey($event->getKey())
                 ->lockForUpdate()
                 ->firstOrFail();
-            $lastMatchNumber = $lockedEvent->matches()
+            $lastMatch = $lockedEvent->matches()
                 ->withTrashed()
-                ->max('match_number');
+                ->orderByDesc('match_number')
+                ->first(['match_number']);
 
             $createdMatch = EventMatch::query()->create([
                 'event_id' => $lockedEvent->id,
-                'match_number' => ($lastMatchNumber ?? 0) + 1,
+                'match_number' => ($lastMatch->match_number ?? 0) + 1,
                 'match_type' => $eventMatchData->matchType,
                 'match_stipulation_id' => $eventMatchData->matchStipulation?->id,
                 'preview' => $eventMatchData->preview,

--- a/app/Actions/Stables/SplitStableAction.php
+++ b/app/Actions/Stables/SplitStableAction.php
@@ -9,6 +9,8 @@ use App\Data\Stables\StableMembershipData;
 use App\Exceptions\Roster\Stables\CannotBeSplitException;
 use App\Lifecycle\StableRestructuringEligibility;
 use App\Models\Roster\Stables\Stable;
+use App\Models\Roster\TagTeams\TagTeam;
+use App\Models\Roster\Wrestlers\Wrestler;
 use App\Services\StableMembershipService;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
@@ -79,10 +81,15 @@ class SplitStableAction
         }
 
         $currentMembers = $this->membershipService->currentMembers($originalStable);
-        $nonMemberNames = [
-            ...$membersForNewStable->wrestlers?->diff($currentMembers->wrestlers ?? [])->pluck('name')->all() ?? [],
-            ...$membersForNewStable->tagTeams?->diff($currentMembers->tagTeams ?? [])->pluck('name')->all() ?? [],
-        ];
+        $nonMemberWrestlerNames = $membersForNewStable->wrestlers
+            ?->diff($currentMembers->wrestlers ?? [])
+            ->map(fn (Wrestler $wrestler): string => $wrestler->name)
+            ->all() ?? [];
+        $nonMemberTagTeamNames = $membersForNewStable->tagTeams
+            ?->diff($currentMembers->tagTeams ?? [])
+            ->map(fn (TagTeam $tagTeam): string => $tagTeam->name)
+            ->all() ?? [];
+        $nonMemberNames = [...$nonMemberWrestlerNames, ...$nonMemberTagTeamNames];
 
         if ($nonMemberNames !== []) {
             throw CannotBeSplitException::membersDoNotBelongToStable($nonMemberNames);

--- a/app/Casts/AddressCast.php
+++ b/app/Casts/AddressCast.php
@@ -8,6 +8,7 @@ use App\Enums\Shared\UnitedStatesState;
 use App\ValueObjects\Address;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 use InvalidArgumentException;
 
 /** @implements CastsAttributes<Address, Address> */
@@ -17,10 +18,10 @@ class AddressCast implements CastsAttributes
     public function get(Model $model, string $key, mixed $value, array $attributes): Address
     {
         return new Address(
-            streetAddress: (string) $attributes['street_address'],
-            city: (string) $attributes['city'],
-            state: UnitedStatesState::from((string) $attributes['state']),
-            zipcode: (string) $attributes['zipcode'],
+            streetAddress: Arr::string($attributes, 'street_address'),
+            city: Arr::string($attributes, 'city'),
+            state: UnitedStatesState::from(Arr::string($attributes, 'state')),
+            zipcode: Arr::string($attributes, 'zipcode'),
         );
     }
 

--- a/app/Casts/HeightCast.php
+++ b/app/Casts/HeightCast.php
@@ -7,6 +7,7 @@ namespace App\Casts;
 use App\ValueObjects\Height;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 /**
  * @implements CastsAttributes<Height, Height|int>
@@ -15,7 +16,7 @@ class HeightCast implements CastsAttributes
 {
     public function get(Model $model, string $key, mixed $value, array $attributes): Height
     {
-        return Height::fromInches((int) $value);
+        return Height::fromInches(Arr::integer(['value' => $value], 'value'));
     }
 
     public function set(Model $model, string $key, mixed $value, array $attributes): int
@@ -24,6 +25,6 @@ class HeightCast implements CastsAttributes
             return $value->toInches();
         }
 
-        return Height::fromInches((int) $value)->toInches();
+        return Height::fromInches(Arr::integer(['value' => $value], 'value'))->toInches();
     }
 }

--- a/app/Casts/PhoneNumberCast.php
+++ b/app/Casts/PhoneNumberCast.php
@@ -8,6 +8,7 @@ use App\ValueObjects\PhoneNumber;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Contracts\Database\Eloquent\SerializesCastableAttributes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 /**
  * @implements CastsAttributes<PhoneNumber, PhoneNumber|string>
@@ -20,7 +21,7 @@ class PhoneNumberCast implements CastsAttributes, SerializesCastableAttributes
             return null;
         }
 
-        return new PhoneNumber((string) $value);
+        return new PhoneNumber(Arr::string(['value' => $value], 'value'));
     }
 
     public function set(Model $model, string $key, mixed $value, array $attributes): ?string
@@ -29,9 +30,11 @@ class PhoneNumberCast implements CastsAttributes, SerializesCastableAttributes
             return null;
         }
 
-        return $value instanceof PhoneNumber
-            ? $value->toDigits()
-            : (new PhoneNumber((string) $value))->toDigits();
+        if ($value instanceof PhoneNumber) {
+            return $value->toDigits();
+        }
+
+        return (new PhoneNumber($value))->toDigits();
     }
 
     public function serialize(Model $model, string $key, mixed $value, array $attributes): ?string
@@ -40,6 +43,10 @@ class PhoneNumberCast implements CastsAttributes, SerializesCastableAttributes
             return null;
         }
 
-        return $value instanceof PhoneNumber ? $value->toDigits() : (string) $value;
+        if ($value instanceof PhoneNumber) {
+            return $value->toDigits();
+        }
+
+        return Arr::string(['value' => $value], 'value');
     }
 }

--- a/app/Casts/WeightCast.php
+++ b/app/Casts/WeightCast.php
@@ -7,19 +7,22 @@ namespace App\Casts;
 use App\ValueObjects\Weight;
 use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
 
 /** @implements CastsAttributes<Weight, Weight|int> */
 class WeightCast implements CastsAttributes
 {
     public function get(Model $model, string $key, mixed $value, array $attributes): Weight
     {
-        return new Weight((int) $value);
+        return new Weight(Arr::integer(['value' => $value], 'value'));
     }
 
     public function set(Model $model, string $key, mixed $value, array $attributes): int
     {
-        return $value instanceof Weight
-            ? $value->toPounds()
-            : (new Weight((int) $value))->toPounds();
+        if ($value instanceof Weight) {
+            return $value->toPounds();
+        }
+
+        return (new Weight(Arr::integer(['value' => $value], 'value')))->toPounds();
     }
 }

--- a/app/Exceptions/BaseBusinessException.php
+++ b/app/Exceptions/BaseBusinessException.php
@@ -32,7 +32,15 @@ abstract class BaseBusinessException extends Exception
 
     protected static function formatModelContext(Model $model): string
     {
-        $name = $model->getAttribute('name') ?? "ID: {$model->getKey()}";
+        $name = $model->getAttribute('name');
+
+        if (! is_string($name)) {
+            $modelKey = $model->getKey();
+            $modelIdentifier = is_int($modelKey) || is_string($modelKey)
+                ? $modelKey
+                : 'unknown';
+            $name = "ID: {$modelIdentifier}";
+        }
 
         return class_basename($model)." '{$name}'";
     }

--- a/app/Lifecycle/MatchOutcomeRequirements.php
+++ b/app/Lifecycle/MatchOutcomeRequirements.php
@@ -56,7 +56,9 @@ class MatchOutcomeRequirements
             return;
         }
 
-        $entryOrders = $competitors->pluck('entry_order')->all();
+        $entryOrders = $competitors
+            ->map(fn (MatchCompetitor $competitor): ?int => $competitor->entry_order)
+            ->all();
 
         if (! $this->isConsecutiveSequence($entryOrders, $competitors->count())) {
             throw InvalidMatchOutcomeException::invalidEntryOrder();

--- a/app/Lifecycle/StableActivityEligibility.php
+++ b/app/Lifecycle/StableActivityEligibility.php
@@ -9,6 +9,8 @@ use App\Exceptions\Roster\Stables\CannotBeDisbandedException;
 use App\Exceptions\Roster\Stables\CannotBeEstablishedException;
 use App\Exceptions\Roster\Stables\CannotBeReunitedException;
 use App\Models\Roster\Stables\Stable;
+use App\Models\Roster\TagTeams\TagTeam;
+use App\Models\Roster\Wrestlers\Wrestler;
 
 final class StableActivityEligibility
 {
@@ -114,9 +116,13 @@ final class StableActivityEligibility
 
         $unavailableKeyMembers = $this->formerMemberEligibility->unavailableKeyMembersFor($stable);
         if ($unavailableKeyMembers->isNotEmpty()) {
+            $unavailableMemberNames = $unavailableKeyMembers
+                ->map(fn (Wrestler|TagTeam $member): string => $member->name)
+                ->implode(', ');
+
             throw CannotBeReunitedException::keyMembersUnavailable(
                 $stable,
-                $unavailableKeyMembers->pluck('name')->join(', '),
+                $unavailableMemberNames,
             );
         }
     }

--- a/app/Lifecycle/StableRestructuringEligibility.php
+++ b/app/Lifecycle/StableRestructuringEligibility.php
@@ -105,13 +105,13 @@ final class StableRestructuringEligibility
                 || $wrestler->isSuspended()
                 || $wrestler->isInjured()
                 || $wrestler->isRetired(),
-        )->pluck('name')->all() ?? [];
+        )->map(fn (Wrestler $wrestler): string => $wrestler->name)->all() ?? [];
 
         $unavailableTagTeams = $members->tagTeams?->filter(
             fn (TagTeam $tagTeam): bool => ! $tagTeam->isEmployed()
                 || $tagTeam->isSuspended()
                 || $tagTeam->isRetired(),
-        )->pluck('name')->all() ?? [];
+        )->map(fn (TagTeam $tagTeam): string => $tagTeam->name)->all() ?? [];
 
         return [...$unavailableWrestlers, ...$unavailableTagTeams];
     }

--- a/app/Lifecycle/StableRetirementEligibility.php
+++ b/app/Lifecycle/StableRetirementEligibility.php
@@ -8,6 +8,8 @@ use App\Data\Stables\StableMembershipData;
 use App\Exceptions\Roster\Stables\CannotBeRetiredException;
 use App\Exceptions\Roster\Stables\CannotBeUnretiredException;
 use App\Models\Roster\Stables\Stable;
+use App\Models\Roster\TagTeams\TagTeam;
+use App\Models\Roster\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Builder;
 
 final class StableRetirementEligibility
@@ -92,9 +94,13 @@ final class StableRetirementEligibility
         $unavailableKeyMembers = $this->formerMemberEligibility->unavailableKeyMembersFor($stable);
 
         if ($unavailableKeyMembers->isNotEmpty()) {
+            $unavailableMemberNames = $unavailableKeyMembers
+                ->map(fn (Wrestler|TagTeam $member): string => $member->name)
+                ->implode(', ');
+
             throw CannotBeUnretiredException::keyMembersUnavailable(
                 $stable,
-                $unavailableKeyMembers->pluck('name')->join(', '),
+                $unavailableMemberNames,
             );
         }
     }

--- a/app/Lifecycle/TagTeamRetirementEligibility.php
+++ b/app/Lifecycle/TagTeamRetirementEligibility.php
@@ -86,9 +86,13 @@ final class TagTeamRetirementEligibility
         );
 
         if ($unavailablePartners->isNotEmpty()) {
+            $unavailablePartnerNames = $unavailablePartners
+                ->map(fn (Wrestler $wrestler): string => $wrestler->name)
+                ->implode(', ');
+
             throw CannotBeUnretiredException::keyPartnersUnavailable(
                 $tagTeam,
-                $unavailablePartners->pluck('name')->join(', '),
+                $unavailablePartnerNames,
             );
         }
     }

--- a/app/Rules/Shared/CanChangeDebutDate.php
+++ b/app/Rules/Shared/CanChangeDebutDate.php
@@ -7,6 +7,7 @@ namespace App\Rules\Shared;
 use App\Models\Roster\Stables\Stable;
 use App\Models\Titles\Title;
 use Closure;
+use DateTimeInterface;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Support\Carbon;
 
@@ -22,6 +23,12 @@ class CanChangeDebutDate implements ValidationRule
 
         $currentActivityPeriod = $this->model->currentActivityPeriod;
         if (! $currentActivityPeriod) {
+            return;
+        }
+
+        if (! $value instanceof DateTimeInterface && ! is_float($value) && ! is_int($value) && ! is_string($value)) {
+            $fail('The debut date must be a valid date.');
+
             return;
         }
 

--- a/app/Rules/Shared/CanChangeEmploymentDate.php
+++ b/app/Rules/Shared/CanChangeEmploymentDate.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Rules\Shared;
 
 use Closure;
+use DateTimeInterface;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
@@ -24,6 +25,12 @@ class CanChangeEmploymentDate implements ValidationRule
             return;
         }
 
+        if (! $value instanceof DateTimeInterface && ! is_float($value) && ! is_int($value) && ! is_string($value)) {
+            $fail('The employment date must be a valid date.');
+
+            return;
+        }
+
         $targetDate = Carbon::parse($value);
 
         if ($model->isEmployed()) {
@@ -36,6 +43,8 @@ class CanChangeEmploymentDate implements ValidationRule
 
     private function getModelName(Model $model): string
     {
-        return $model->getAttribute('name') ?? class_basename($model);
+        $name = $model->getAttribute('name');
+
+        return is_string($name) ? $name : class_basename($model);
     }
 }

--- a/app/Rules/Wrestlers/NotRepresentedBySelectedTagTeam.php
+++ b/app/Rules/Wrestlers/NotRepresentedBySelectedTagTeam.php
@@ -31,7 +31,13 @@ class NotRepresentedBySelectedTagTeam implements ValidationRule
         $wrestler = Wrestler::query()->whereKey($value)->firstOrFail();
         $currentTagTeam = $wrestler->currentTagTeam()->first();
 
-        if ($currentTagTeam && $this->tagTeamIds->contains($currentTagTeam->getKey())) {
+        if (! $currentTagTeam) {
+            return;
+        }
+
+        $currentTagTeamKey = $currentTagTeam->getKey();
+
+        if ((is_int($currentTagTeamKey) || is_string($currentTagTeamKey)) && $this->tagTeamIds->contains($currentTagTeamKey)) {
             $fail('This wrestler is already represented in the stable through their tag team.');
         }
     }

--- a/app/Services/MatchAssignmentConflictService.php
+++ b/app/Services/MatchAssignmentConflictService.php
@@ -23,15 +23,19 @@ final class MatchAssignmentConflictService
     public function ensureWrestlersCanBeAssigned(EventMatch $eventMatch, Collection $wrestlers): void
     {
         $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
-        $conflictingWrestlerId = MatchCompetitor::query()
-            ->forCompetitorIds(Wrestler::class, $wrestlers->pluck('id'))
+        $conflictingCompetitor = MatchCompetitor::query()
+            ->forCompetitorIds(
+                Wrestler::class,
+                $wrestlers->map(fn (Wrestler $wrestler): int => $wrestler->id),
+            )
             ->forEventIds($conflictingEventIds)
-            ->value('competitor_id');
+            ->first(['competitor_id']);
 
-        if ($conflictingWrestlerId === null) {
+        if ($conflictingCompetitor === null) {
             return;
         }
 
+        $conflictingWrestlerId = $conflictingCompetitor->competitor_id;
         $wrestler = $wrestlers->firstWhere('id', $conflictingWrestlerId);
 
         throw SchedulingConflictException::competitorAlreadyBooked(
@@ -46,15 +50,19 @@ final class MatchAssignmentConflictService
     public function ensureTagTeamsCanBeAssigned(EventMatch $eventMatch, Collection $tagTeams): void
     {
         $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
-        $conflictingTagTeamId = MatchCompetitor::query()
-            ->forCompetitorIds(TagTeam::class, $tagTeams->pluck('id'))
+        $conflictingCompetitor = MatchCompetitor::query()
+            ->forCompetitorIds(
+                TagTeam::class,
+                $tagTeams->map(fn (TagTeam $tagTeam): int => $tagTeam->id),
+            )
             ->forEventIds($conflictingEventIds)
-            ->value('competitor_id');
+            ->first(['competitor_id']);
 
-        if ($conflictingTagTeamId === null) {
+        if ($conflictingCompetitor === null) {
             return;
         }
 
+        $conflictingTagTeamId = $conflictingCompetitor->competitor_id;
         $tagTeam = $tagTeams->firstWhere('id', $conflictingTagTeamId);
 
         throw SchedulingConflictException::competitorAlreadyBooked(
@@ -77,7 +85,7 @@ final class MatchAssignmentConflictService
 
         $conflictingReferee = EventMatch::query()
             ->forEventIds($conflictingEventIds)
-            ->withAnyRefereeIds($referees->pluck('id'))
+            ->withAnyRefereeIds($referees->map(fn (Referee $referee): int => $referee->id))
             ->with('referees:id,first_name,last_name,full_name')
             ->get()
             ->flatMap->referees
@@ -98,7 +106,7 @@ final class MatchAssignmentConflictService
         $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
         $conflictingTitleId = EventMatch::query()
             ->forEventIds($conflictingEventIds)
-            ->withAnyTitleIds($titles->pluck('id'))
+            ->withAnyTitleIds($titles->map(fn (Title $title): int => $title->id))
             ->with('titles:id,name')
             ->get()
             ->flatMap->titles
@@ -131,6 +139,7 @@ final class MatchAssignmentConflictService
             })
             ->orderBy('id')
             ->lockForUpdate()
-            ->pluck('id');
+            ->get(['id'])
+            ->map(fn (Event $conflictingEvent): int => $conflictingEvent->id);
     }
 }

--- a/app/Services/StableMembershipService.php
+++ b/app/Services/StableMembershipService.php
@@ -9,6 +9,7 @@ use App\Models\Roster\Stables\Stable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
@@ -64,7 +65,7 @@ class StableMembershipService
         }
 
         $relationship->attach($members->map(
-            fn (Model $member): int|string => $member->getKey(),
+            fn (Model $member): int => Arr::integer(['key' => $member->getKey()], 'key'),
         )->all(), [
             'joined_at' => $date,
             'left_at' => null,

--- a/database/factories/Titles/TitleFactory.php
+++ b/database/factories/Titles/TitleFactory.php
@@ -27,7 +27,7 @@ class TitleFactory extends Factory
         $titleType = fake()->randomElement(TitleType::cases());
 
         return [
-            'name' => str(fake()->unique()->words(2, true))->title()->append($titleType->value === 'singles' ? ' Title' : ' Titles'),
+            'name' => $this->generateTitleName($titleType),
             'type' => $titleType,
         ];
     }
@@ -82,12 +82,18 @@ class TitleFactory extends Factory
 
     public function singles(): static
     {
-        return $this->state(fn () => ['type' => TitleType::Singles]);
+        return $this->state(fn () => [
+            'name' => $this->generateTitleName(TitleType::Singles),
+            'type' => TitleType::Singles,
+        ]);
     }
 
     public function tagTeam(): static
     {
-        return $this->state(fn () => ['type' => TitleType::TagTeam]);
+        return $this->state(fn () => [
+            'name' => $this->generateTitleName(TitleType::TagTeam),
+            'type' => TitleType::TagTeam,
+        ]);
     }
 
     public function undebuted(): static
@@ -116,5 +122,13 @@ class TitleFactory extends Factory
 
         return $this
             ->has(ActivityPeriod::factory()->started($startDate), 'activityPeriods');
+    }
+
+    private function generateTitleName(TitleType $titleType): string
+    {
+        return str(fake()->unique()->words(2, true))
+            ->title()
+            ->append($titleType === TitleType::Singles ? ' Title' : ' Titles')
+            ->toString();
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,5 @@
 parameters:
-  level: 8
+  level: 9
 
   paths:
     - app  # ✅ Standard — analyzes all app code

--- a/tests/Unit/Rules/Shared/CanChangeDebutDateUnitTest.php
+++ b/tests/Unit/Rules/Shared/CanChangeDebutDateUnitTest.php
@@ -79,3 +79,20 @@ test('rejects changing the start date of an active model', function (string $mod
     'stable' => Stable::class,
     'title' => Title::class,
 ]);
+
+test('rejects an invalid debut date value for an active model', function () {
+    $stable = Stable::factory()
+        ->has(ActivityPeriod::factory()->started(now()->subWeek()), 'activityPeriods')
+        ->create();
+    $message = null;
+
+    (new CanChangeDebutDate($stable))->validate(
+        'debut_date',
+        [],
+        validationFailureCallback(function (string $failure) use (&$message): void {
+            $message = $failure;
+        }),
+    );
+
+    expect($message)->toBe('The debut date must be a valid date.');
+});

--- a/tests/Unit/Rules/Shared/CanChangeEmploymentDateUnitTest.php
+++ b/tests/Unit/Rules/Shared/CanChangeEmploymentDateUnitTest.php
@@ -24,6 +24,27 @@ use Illuminate\Support\Carbon;
  * @see CanChangeEmploymentDate
  */
 describe('CanChangeEmploymentDate Validation Rule Unit Tests', function () {
+    test('rejects an invalid employment date value', function () {
+        $model = new class extends Model
+        {
+            public function isEmployed(): bool
+            {
+                return true;
+            }
+        };
+        $message = null;
+
+        (new CanChangeEmploymentDate($model))->validate(
+            'started_at',
+            [],
+            validationFailureCallback(function (string $failure) use (&$message): void {
+                $message = $failure;
+            }),
+        );
+
+        expect($message)->toBe('The employment date must be a valid date.');
+    });
+
     describe('model validation with employment methods', function () {
         test('validation passes when model is not employed', function () {
             // Arrange

--- a/tests/Unit/database/Factories/Titles/TitleFactoryTest.php
+++ b/tests/Unit/database/Factories/Titles/TitleFactoryTest.php
@@ -31,20 +31,30 @@ describe('TitleFactory Unit Tests', function () {
             $title = Title::factory()->make();
 
             // Assert
-            expect((string) $title->name)->toBeString();
-            expect((string) $title->name)->toContain('Title');
+            expect($title->name)->toBeString();
+            expect($title->name)->toEndWith($title->type === TitleType::Singles ? 'Title' : 'Titles');
             expect($title->status)->toBeInstanceOf(TitleStatus::class);
             expect($title->type)->toBeInstanceOf(TitleType::class);
         });
 
-        test('generates realistic title names', function () {
+        test('generates realistic singles title names', function () {
             // Arrange & Act
-            $title = Title::factory()->make();
+            $title = Title::factory()->singles()->make();
 
             // Assert
-            expect((string) $title->name)->toBeString();
-            expect(mb_strlen((string) $title->name))->toBeGreaterThan(5);
-            expect((string) $title->name)->toContain('Title');
+            expect($title->name)->toBeString();
+            expect(mb_strlen($title->name))->toBeGreaterThan(5);
+            expect($title->name)->toEndWith('Title');
+        });
+
+        test('generates realistic tag team title names', function () {
+            // Arrange & Act
+            $title = Title::factory()->tagTeam()->make();
+
+            // Assert
+            expect($title->name)->toBeString();
+            expect(mb_strlen($title->name))->toBeGreaterThan(6);
+            expect($title->name)->toEndWith('Titles');
         });
     });
 


### PR DESCRIPTION
## Summary
- raise application PHPStan from level 8 to level 9 without a baseline
- preserve framework type information through Eloquent models and typed collections
- use Laravel typed Arr accessors for cast boundaries
- narrow validation inputs and typed lifecycle/member names
- record the Laravel-first project rule for future development

## Verification
- composer test:push
- composer test:types
- 105 focused tests with 225 assertions
- 100% type coverage