### PR TITLE
test: expand Pest Rector enforcement

### DIFF
--- a/rector-pest.php
+++ b/rector-pest.php
@@ -2,14 +2,29 @@
 
 declare(strict_types=1);
 
+use Pest\Rector\Rules\ConvertAssertToExpectRector;
 use Pest\Rector\Rules\ConvertBeforeAllInDescribeRector;
+use Pest\Rector\Rules\ConvertExpectExceptionToThrowRector;
+use Pest\Rector\Rules\EnsureTypeChecksFirstRector;
 use Pest\Rector\Rules\FixInvalidRepeatValueRector;
 use Pest\Rector\Rules\Pest2ToPest3\TapToDeferRector;
 use Pest\Rector\Rules\Pest2ToPest3\ToHaveMethodOnClassRector;
 use Pest\Rector\Rules\Pest2ToPest3\UsesToExtendRector;
 use Pest\Rector\Rules\RemoveDebugExpectationsRector;
 use Pest\Rector\Rules\RemoveOnlyRector;
+use Pest\Rector\Rules\RemoveRedundantLiteralTypeExpectationRector;
 use Pest\Rector\Rules\RemoveRedundantPestUsesRector;
+use Pest\Rector\Rules\RemoveStaticTestClosureRector;
+use Pest\Rector\Rules\SimplifyExpectNotRector;
+use Pest\Rector\Rules\UseInstanceOfMatcherRector;
+use Pest\Rector\Rules\UseStrictEqualityMatchersRector;
+use Pest\Rector\Rules\UseToEndWithRector;
+use Pest\Rector\Rules\UseToHaveCountRector;
+use Pest\Rector\Rules\UseToHaveKeyRector;
+use Pest\Rector\Rules\UseToHaveKeysRector;
+use Pest\Rector\Rules\UseToStartWithRector;
+use Pest\Rector\Rules\UseToThrowRector;
+use Pest\Rector\Rules\UseTypeMatchersRector;
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
@@ -20,9 +35,24 @@ return RectorConfig::configure()
         TapToDeferRector::class,
         ToHaveMethodOnClassRector::class,
         UsesToExtendRector::class,
+        ConvertAssertToExpectRector::class,
+        ConvertExpectExceptionToThrowRector::class,
         ConvertBeforeAllInDescribeRector::class,
         FixInvalidRepeatValueRector::class,
         RemoveDebugExpectationsRector::class,
         RemoveOnlyRector::class,
+        RemoveRedundantLiteralTypeExpectationRector::class,
         RemoveRedundantPestUsesRector::class,
+        RemoveStaticTestClosureRector::class,
+        SimplifyExpectNotRector::class,
+        UseInstanceOfMatcherRector::class,
+        UseStrictEqualityMatchersRector::class,
+        UseToEndWithRector::class,
+        UseToHaveCountRector::class,
+        UseToHaveKeyRector::class,
+        UseToHaveKeysRector::class,
+        UseToStartWithRector::class,
+        UseToThrowRector::class,
+        UseTypeMatchersRector::class,
+        EnsureTypeChecksFirstRector::class,
     ]);

--- a/tests/Integration/Actions/Stables/LifecycleTest.php
+++ b/tests/Integration/Actions/Stables/LifecycleTest.php
@@ -99,7 +99,6 @@ describe('Stable Activation Action Integration', function () {
             resolve(DisbandAction::class)->handle($this->activeStable, $disbandDate);
 
             $refreshedStable = freshModel($this->activeStable);
-            expect($refreshedStable->status === StableStatus::Inactive)->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Inactive);
 
             // Verify activity period is ended
@@ -303,7 +302,7 @@ describe('Stable Activation Action Integration', function () {
             // Disband
             $disbandDate = Carbon::now()->subMonths(6);
             resolve(DisbandAction::class)->handle($stable, $disbandDate);
-            expect(freshModel($stable)->status === StableStatus::Inactive)->toBeTrue();
+            expect(freshModel($stable)->status)->toBe(StableStatus::Inactive);
 
             // Reunite
             $reuniteDate = Carbon::now()->subMonths(3);

--- a/tests/Integration/Livewire/Stables/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Stables/Tables/MainTest.php
@@ -179,7 +179,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable is disbanded
-            expect(freshModel($activeStable)->status === StableStatus::Inactive)->toBeTrue();
+            expect(freshModel($activeStable)->status)->toBe(StableStatus::Inactive);
         });
 
         test('retire action integration works correctly', function () {
@@ -313,7 +313,7 @@ describe('StablesTable Component', function () {
             $component->call('disband', $disbandedStable)
                 ->assertRedirect();
 
-            expect(freshModel($disbandedStable)->status === StableStatus::Inactive)->toBeTrue();
+            expect(freshModel($disbandedStable)->status)->toBe(StableStatus::Inactive);
         });
     });
 

--- a/tests/Unit/Models/Roster/TagTeams/TagTeamTest.php
+++ b/tests/Unit/Models/Roster/TagTeams/TagTeamTest.php
@@ -51,7 +51,7 @@ describe('TagTeam Model Unit Tests', function () {
             $casts = $tagTeam->getCasts();
 
             // Status is computed attribute, no cast needed
-            expect(array_key_exists('status', $casts))->toBeFalse();
+            expect($casts)->not->toHaveKey('status');
         });
 
         test('has custom eloquent builder', function () {

--- a/tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php
+++ b/tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php
@@ -62,7 +62,7 @@ describe('Wrestler Model Unit Tests', function () {
 
             expect($casts['height'])->toBe(HeightCast::class);
             // Status is computed attribute, no cast needed
-            expect(array_key_exists('status', $casts))->toBeFalse();
+            expect($casts)->not->toHaveKey('status');
         });
 
         test('has custom eloquent builder', function () {


### PR DESCRIPTION
## Summary
- enable 15 additional curated Pest Rector rules
- adopt clearer strict equality and array-key expectations
- remove a duplicate lifecycle assertion exposed by the conversion

## Verification
- focused Pest suite: 65 tests, 183 assertions
- Pest type coverage: passed
- application PHPStan: passed
- Pest PHPStan: passed
- Rector: passed and idempotent
- Pint with Blade: passed

The final parallel Pest stage of composer test:push stopped producing output and was terminated after several minutes; all deterministic gates and directly affected tests passed.