### PR TITLE
refactor: update Rector for Laravel 13

### DIFF
--- a/app/Actions/Managers/EmployCurrentManagersAction.php
+++ b/app/Actions/Managers/EmployCurrentManagersAction.php
@@ -19,7 +19,7 @@ class EmployCurrentManagersAction
     {
         $managers = $manageable->currentManagers()
             ->get()
-            ->filter(fn (Manager $manager) => ! $manager->isEmployed() && ! $manager->hasFutureEmployment());
+            ->filter(fn (Manager $manager): bool => ! $manager->isEmployed() && ! $manager->hasFutureEmployment());
 
         foreach ($managers as $manager) {
             $this->employManager->handle($manager, $employmentDate);

--- a/app/Actions/TagTeams/EmployCurrentWrestlersAction.php
+++ b/app/Actions/TagTeams/EmployCurrentWrestlersAction.php
@@ -17,7 +17,7 @@ class EmployCurrentWrestlersAction
     {
         $wrestlers = $tagTeam->currentWrestlers()
             ->get()
-            ->filter(fn (Wrestler $wrestler) => ! $wrestler->isEmployed() && ! $wrestler->hasFutureEmployment());
+            ->filter(fn (Wrestler $wrestler): bool => ! $wrestler->isEmployed() && ! $wrestler->hasFutureEmployment());
 
         foreach ($wrestlers as $wrestler) {
             $this->employWrestler->handle($wrestler, $employmentDate);

--- a/app/Actions/TagTeams/ReinstateCurrentMembersAction.php
+++ b/app/Actions/TagTeams/ReinstateCurrentMembersAction.php
@@ -22,7 +22,7 @@ class ReinstateCurrentMembersAction
     {
         $wrestlers = $tagTeam->currentWrestlers()
             ->get()
-            ->filter(fn (Wrestler $wrestler) => $wrestler->isSuspended());
+            ->filter(fn (Wrestler $wrestler): bool => $wrestler->isSuspended());
 
         foreach ($wrestlers as $wrestler) {
             $this->reinstateWrestler->handle($wrestler, $reinstatementDate);
@@ -30,7 +30,7 @@ class ReinstateCurrentMembersAction
 
         $managers = $tagTeam->currentManagers()
             ->get()
-            ->filter(fn (Manager $manager) => $manager->isSuspended());
+            ->filter(fn (Manager $manager): bool => $manager->isSuspended());
 
         foreach ($managers as $manager) {
             $this->reinstateManager->handle($manager, $reinstatementDate);

--- a/app/Actions/TagTeams/RetireCurrentMembersAction.php
+++ b/app/Actions/TagTeams/RetireCurrentMembersAction.php
@@ -24,7 +24,7 @@ class RetireCurrentMembersAction
     {
         $wrestlers = $tagTeam->currentWrestlers()
             ->get()
-            ->filter(fn (Wrestler $wrestler) => $this->eligibility->canRetire($wrestler));
+            ->filter(fn (Wrestler $wrestler): bool => $this->eligibility->canRetire($wrestler));
 
         foreach ($wrestlers as $wrestler) {
             $this->retireWrestler->handle($wrestler, $retirementDate);
@@ -32,7 +32,7 @@ class RetireCurrentMembersAction
 
         $managers = $tagTeam->currentManagers()
             ->get()
-            ->filter(fn (Manager $manager) => $this->eligibility->canRetire($manager));
+            ->filter(fn (Manager $manager): bool => $this->eligibility->canRetire($manager));
 
         foreach ($managers as $manager) {
             $this->retireManager->handle($manager, $retirementDate);

--- a/app/Actions/TagTeams/SuspendCurrentMembersAction.php
+++ b/app/Actions/TagTeams/SuspendCurrentMembersAction.php
@@ -22,7 +22,7 @@ class SuspendCurrentMembersAction
     {
         $wrestlers = $tagTeam->currentWrestlers()
             ->get()
-            ->filter(fn (Wrestler $wrestler) => $wrestler->isEmployed() && ! $wrestler->isSuspended());
+            ->filter(fn (Wrestler $wrestler): bool => $wrestler->isEmployed() && ! $wrestler->isSuspended());
 
         foreach ($wrestlers as $wrestler) {
             $this->suspendWrestler->handle($wrestler, $suspensionDate);
@@ -30,7 +30,7 @@ class SuspendCurrentMembersAction
 
         $managers = $tagTeam->currentManagers()
             ->get()
-            ->filter(fn (Manager $manager) => $manager->isEmployed() && ! $manager->isSuspended());
+            ->filter(fn (Manager $manager): bool => $manager->isEmployed() && ! $manager->isSuspended());
 
         foreach ($managers as $manager) {
             $this->suspendManager->handle($manager, $suspensionDate);

--- a/app/Actions/TagTeams/UnretireCurrentMembersAction.php
+++ b/app/Actions/TagTeams/UnretireCurrentMembersAction.php
@@ -22,7 +22,7 @@ class UnretireCurrentMembersAction
     public function handle(TagTeam $tagTeam, Carbon $unretirementDate): void
     {
         $wrestlers = $tagTeam->currentWrestlers
-            ->filter(fn (Wrestler $wrestler) => $wrestler->isRetired());
+            ->filter(fn (Wrestler $wrestler): bool => $wrestler->isRetired());
 
         foreach ($wrestlers as $wrestler) {
             try {
@@ -33,7 +33,7 @@ class UnretireCurrentMembersAction
         }
 
         $managers = $tagTeam->currentManagers
-            ->filter(fn (Manager $manager) => $manager->isRetired());
+            ->filter(fn (Manager $manager): bool => $manager->isRetired());
 
         foreach ($managers as $manager) {
             try {

--- a/app/Builders/Concerns/HasNameSearch.php
+++ b/app/Builders/Concerns/HasNameSearch.php
@@ -21,7 +21,7 @@ trait HasNameSearch
     {
         $trimmedTerm = mb_trim($searchTerm);
 
-        return $this->where(function ($query) use ($trimmedTerm) {
+        return $this->where(function ($query) use ($trimmedTerm): void {
             $query->whereLike('first_name', $trimmedTerm)
                 ->orWhereLike('last_name', $trimmedTerm)
                 ->orWhereLike('first_name', $trimmedTerm.' %')

--- a/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousMatchesTable.php
@@ -44,7 +44,7 @@ abstract class BasePreviousMatchesTable extends DataTableComponent
         return [
             LinkColumn::make(__('events.name'), 'event.name')
                 ->title(fn (EventMatch $row) => $row->event->name)
-                ->location(fn (EventMatch $row) => route('events.show', $row->event)),
+                ->location(fn (EventMatch $row): string => route('events.show', $row->event)),
             DateColumn::make(__('events.date'), 'event.date')
                 ->inputFormat('Y-m-d H:i:s')
                 ->outputFormat('Y-m-d')

--- a/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTagTeamsTable.php
@@ -41,13 +41,13 @@ abstract class BasePreviousTagTeamsTable extends DataTableComponent
     {
         return [
             LinkColumn::make(__('tag-teams.name'))
-                ->title(fn (TagTeamWrestler $row) => $this->tagTeamName($row))
-                ->location(fn (TagTeamWrestler $row) => $row->tagTeam === null
+                ->title(fn (TagTeamWrestler $row): string => $this->tagTeamName($row))
+                ->location(fn (TagTeamWrestler $row): ?string => $row->tagTeam === null
                     ? null
                     : route('tag-teams.show', $row->tagTeam)),
             LinkColumn::make(__('tag-teams.partner'))
-                ->title(fn (TagTeamWrestler $row) => $this->getPartnerName($row))
-                ->location(fn (TagTeamWrestler $row) => $this->getPartnerRoute($row)),
+                ->title(fn (TagTeamWrestler $row): string => $this->getPartnerName($row))
+                ->location(fn (TagTeamWrestler $row): string => $this->getPartnerRoute($row)),
             DateColumn::make(__('stables.date_joined'), 'joined_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('stables.date_left'), 'left_at')

--- a/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
+++ b/app/Livewire/Base/Tables/BasePreviousTitleChampionshipsTable.php
@@ -41,13 +41,13 @@ abstract class BasePreviousTitleChampionshipsTable extends DataTableComponent
     {
         return [
             LinkColumn::make(__('titles.name'))
-                ->title(fn (TitleChampionship $row) => $this->titleName($row))
-                ->location(fn (TitleChampionship $row) => $row->title === null
+                ->title(fn (TitleChampionship $row): string => $this->titleName($row))
+                ->location(fn (TitleChampionship $row): ?string => $row->title === null
                     ? null
                     : route('titles.show', $row->title)),
             LinkColumn::make(__('championships.previous_champion'))
                 ->title(fn (TitleChampionship $row) => $row->previousChampionship?->champion->name ?? 'N/A')
-                ->location(fn (TitleChampionship $row) => $this->championLocation($row)),
+                ->location(fn (TitleChampionship $row): ?string => $this->championLocation($row)),
             DateColumn::make(__('championships.dates_held'), 'won_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('championships.dates_held'), 'lost_at')

--- a/app/Livewire/Concerns/Columns/HasActionColumn.php
+++ b/app/Livewire/Concerns/Columns/HasActionColumn.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Livewire\Concerns\Columns;
 
 use App\Livewire\Table\Column;
+use Illuminate\Contracts\View\Factory;
 
 /**
  * Provides action column functionality for Livewire table components.
@@ -20,7 +21,7 @@ trait HasActionColumn
     protected function getDefaultActionColumn(): Column
     {
         return Column::make(__('core.actions'))
-            ->label(fn ($row, Column $column) => view('components.tables.columns.action-column', [
+            ->label(fn ($row, Column $column): Factory|\Illuminate\Contracts\View\View => view('components.tables.columns.action-column', [
                 'path' => $this->routeBasePath,
                 'rowId' => $row->id,
             ]))

--- a/app/Livewire/Concerns/Data/PresentsManagersList.php
+++ b/app/Livewire/Concerns/Data/PresentsManagersList.php
@@ -12,7 +12,7 @@ trait PresentsManagersList
     /**
      * @return array<int|string,string|null>
      */
-    #[Computed(cache: true, key: 'managers-list', seconds: 180)]
+    #[Computed(seconds: 180, cache: true, key: 'managers-list')]
     public function getManagers(): array
     {
         return Manager::query()

--- a/app/Livewire/Concerns/Data/PresentsMatchTypesList.php
+++ b/app/Livewire/Concerns/Data/PresentsMatchTypesList.php
@@ -12,7 +12,7 @@ trait PresentsMatchTypesList
     /**
      * @return array<string,string>
      */
-    #[Computed(cache: true, key: 'match-types-list', seconds: 180)]
+    #[Computed(seconds: 180, cache: true, key: 'match-types-list')]
     public function getMatchTypes(): array
     {
         return MatchType::options();

--- a/app/Livewire/Concerns/Data/PresentsTagTeamsList.php
+++ b/app/Livewire/Concerns/Data/PresentsTagTeamsList.php
@@ -12,7 +12,7 @@ trait PresentsTagTeamsList
     /**
      * @return array<int|string,string|null>
      */
-    #[Computed(cache: true, key: 'tag-teams-list', seconds: 180)]
+    #[Computed(seconds: 180, cache: true, key: 'tag-teams-list')]
     public function getTagTeams(): array
     {
         return TagTeam::query()

--- a/app/Livewire/Concerns/Data/PresentsTitlesList.php
+++ b/app/Livewire/Concerns/Data/PresentsTitlesList.php
@@ -12,7 +12,7 @@ trait PresentsTitlesList
     /**
      * @return array<int|string,string|null>
      */
-    #[Computed(cache: true, key: 'titles-list', seconds: 180)]
+    #[Computed(seconds: 180, cache: true, key: 'titles-list')]
     public function getTitles(): array
     {
         return Title::query()

--- a/app/Livewire/Concerns/Data/PresentsVenuesList.php
+++ b/app/Livewire/Concerns/Data/PresentsVenuesList.php
@@ -12,7 +12,7 @@ trait PresentsVenuesList
     /**
      * @return array<int|string,string|null>
      */
-    #[Computed(cache: true, key: 'venues-list', seconds: 180)]
+    #[Computed(seconds: 180, cache: true, key: 'venues-list')]
     public function getVenues(): array
     {
         return Venue::query()

--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -96,10 +96,10 @@ trait GeneratesDummyData
     protected function generateWrestlingName(): string
     {
         $patterns = [
-            fn () => fake()->firstName().' '.fake()->lastName(),
-            fn () => fake()->word().' '.fake()->lastName(),
-            fn () => 'The '.fake()->word(),
-            fn () => fake()->firstName().' "'.fake()->word().'" '.fake()->lastName(),
+            fn (): string => fake()->firstName().' '.fake()->lastName(),
+            fn (): string => fake()->word().' '.fake()->lastName(),
+            fn (): string => 'The '.fake()->word(),
+            fn (): string => fake()->firstName().' "'.fake()->word().'" '.fake()->lastName(),
         ];
 
         $pattern = $this->randomGenerator($patterns);

--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -43,7 +43,7 @@ class FormModal extends BaseFormModal
     {
         return [
             'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
-            'date' => fn () => fake()->dateTimeBetween('now', '+3 month')->format('Y-m-d H:i:s'),
+            'date' => fn (): string => fake()->dateTimeBetween('now', '+3 month')->format('Y-m-d H:i:s'),
             'venue_id' => fn () => Venue::query()->inRandomOrder()->value('id'),
             'preview' => fn () => Str::of(fake()->text())->value(),
         ];

--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -67,7 +67,7 @@ class Main extends BaseTable
                 ->emptyValue('No Date Set'),
             LinkColumn::make(__('events.venue'))
                 ->title(fn (Event $row) => $row->venue ? $row->venue->name : 'No Venue')
-                ->location(fn (Event $row) => $row->venue ? route('venues.show', $row->venue) : ''),
+                ->location(fn (Event $row): string => $row->venue ? route('venues.show', $row->venue) : ''),
 
         ];
     }

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -46,7 +46,7 @@ class FormModal extends BaseFormModal
         return [
             'first_name' => fn () => fake()->firstName(),
             'last_name' => fn () => fake()->lastName(),
-            'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
+            'employment_date' => fn (): ?string => $this->generateOptionalEmploymentDate(),
         ];
     }
 

--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -67,7 +67,7 @@ class Main extends BaseTable
     {
         return [
             Column::make(__('managers.name'), 'full_name')
-                ->searchable(function (ManagerBuilder $builder, string $searchTerm) {
+                ->searchable(function (ManagerBuilder $builder, string $searchTerm): void {
                     $builder->whereNameMatches($searchTerm);
                 }),
             Column::make(__('core.status'), 'status')
@@ -93,7 +93,7 @@ class Main extends BaseTable
                     'unemployed' => 'Unemployed',
                     'retired' => 'Retired',
                 ])
-                ->filter(function (ManagerBuilder $builder, string $value) {
+                ->filter(function (ManagerBuilder $builder, string $value): void {
                     /** @var ManagerBuilder<Manager> $builder */
                     match ($value) {
                         'employed' => $builder->employed(),

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -252,7 +252,7 @@ class CreateEditForm extends BaseForm
             'titles.*' => [
                 'integer',
                 'exists:titles,id',
-                function (string $attribute, mixed $value, Closure $fail) {
+                function (string $attribute, mixed $value, Closure $fail): void {
                     if (! is_int($value)) {
                         return;
                     }

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -77,7 +77,7 @@ class FormModal extends BaseFormModal
     }
 
     /** @return array<int, string> */
-    #[Computed(cache: true, key: 'active-match-stipulations-list', seconds: 180)]
+    #[Computed(seconds: 180, cache: true, key: 'active-match-stipulations-list')]
     public function getMatchStipulations(): array
     {
         return MatchStipulation::query()

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -56,7 +56,7 @@ class Main extends BaseTable
         return [
             LinkColumn::make(__('event-matches.event'))
                 ->title(fn (EventMatch $row) => $row->event->name)
-                ->location(fn (EventMatch $row) => route('events.show', $row->event)),
+                ->location(fn (EventMatch $row): string => route('events.show', $row->event)),
             Column::make(__('event-matches.match_number'), 'match_number')
                 ->searchable(),
             Column::make(__('event-matches.match_type'), 'match_type')

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -45,7 +45,7 @@ class FormModal extends BaseFormModal
         return [
             'first_name' => fn () => fake()->firstName(),
             'last_name' => fn () => fake()->lastName(),
-            'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
+            'employment_date' => fn (): ?string => $this->generateOptionalEmploymentDate(),
         ];
     }
 

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -68,7 +68,7 @@ class Main extends BaseTable
     {
         return [
             Column::make(__('referees.name'), 'full_name')
-                ->searchable(function (RefereeBuilder $builder, string $searchTerm) {
+                ->searchable(function (RefereeBuilder $builder, string $searchTerm): void {
                     $builder->whereNameMatches($searchTerm);
                 }),
             Column::make(__('core.status'), 'status')
@@ -94,7 +94,7 @@ class Main extends BaseTable
                     'unemployed' => 'Unemployed',
                     'retired' => 'Retired',
                 ])
-                ->filter(function (RefereeBuilder $builder, string $value) {
+                ->filter(function (RefereeBuilder $builder, string $value): void {
                     /** @var RefereeBuilder<Referee> $builder */
                     match ($value) {
                         'employed' => $builder->employed(),

--- a/app/Livewire/Stables/Forms/CreateEditForm.php
+++ b/app/Livewire/Stables/Forms/CreateEditForm.php
@@ -209,7 +209,7 @@ class CreateEditForm extends BaseForm
         ];
 
         // Add validation that ended_at is after started_at if both are provided
-        if (! empty($this->started_at) && ! empty($this->ended_at)) {
+        if (! in_array($this->started_at, [null, '', '0'], true) && ! in_array($this->ended_at, [null, '', '0'], true)) {
             $rules['ended_at'][] = 'after:started_at';
         }
 

--- a/app/Livewire/Stables/Modals/FormModal.php
+++ b/app/Livewire/Stables/Modals/FormModal.php
@@ -45,7 +45,7 @@ class FormModal extends BaseFormModal
     {
         return [
             'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
-            'start_date' => fn () => $this->generateOptionalStartDate(),
+            'start_date' => fn (): ?string => $this->generateOptionalStartDate(),
         ];
     }
 

--- a/app/Livewire/Stables/Tables/PreviousTagTeams.php
+++ b/app/Livewire/Stables/Tables/PreviousTagTeams.php
@@ -48,7 +48,7 @@ class PreviousTagTeams extends DataTableComponent
         return [
             LinkColumn::make(__('tag-teams.name'))
                 ->title(fn (StableTagTeam $row) => $row->tagTeam->name ?? 'Unknown')
-                ->location(fn (StableTagTeam $row) => $row->tagTeam ? route('tag-teams.show', $row->tagTeam) : '#'),
+                ->location(fn (StableTagTeam $row): string => $row->tagTeam ? route('tag-teams.show', $row->tagTeam) : '#'),
             DateColumn::make(__('stables.date_joined'), 'joined_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('stables.date_left'), 'left_at')

--- a/app/Livewire/Stables/Tables/PreviousWrestlers.php
+++ b/app/Livewire/Stables/Tables/PreviousWrestlers.php
@@ -48,7 +48,7 @@ class PreviousWrestlers extends DataTableComponent
         return [
             LinkColumn::make(__('wrestlers.name'))
                 ->title(fn (StableWrestler $row) => $row->wrestler->name ?? 'Unknown')
-                ->location(fn (StableWrestler $row) => $row->wrestler ? route('wrestlers.show', $row->wrestler) : '#'),
+                ->location(fn (StableWrestler $row): string => $row->wrestler ? route('wrestlers.show', $row->wrestler) : '#'),
             DateColumn::make(__('stables.date_joined'), 'joined_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('stables.date_left'), 'left_at')

--- a/app/Livewire/Table/DataTableComponent.php
+++ b/app/Livewire/Table/DataTableComponent.php
@@ -129,7 +129,7 @@ abstract class DataTableComponent extends Component
         $columns = $this->columns();
 
         if (method_exists($this, 'appendColumns')) {
-            $columns = array_merge($columns, $this->appendColumns());
+            return array_merge($columns, $this->appendColumns());
         }
 
         return $columns;
@@ -167,7 +167,7 @@ abstract class DataTableComponent extends Component
         }
 
         $searchTerm = $this->search;
-        $searchableColumns = collect($this->getColumns())->filter(fn (Column $col) => $col->isSearchable());
+        $searchableColumns = collect($this->getColumns())->filter(fn (Column $col): bool => $col->isSearchable());
 
         if ($searchableColumns->isEmpty()) {
             return;

--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -50,7 +50,7 @@ class FormModal extends BaseFormModal
         return [
             'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
             'signature_move' => fn () => Str::of(fake()->optional(0.8)->sentence(3))->title()->value(),
-            'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
+            'employment_date' => fn (): ?string => $this->generateOptionalEmploymentDate(),
             'wrestlerA' => fn () => $wrestlerIds->first(),
             'wrestlerB' => fn () => $wrestlerIds->get(1),
         ];

--- a/app/Livewire/TagTeams/Tables/Main.php
+++ b/app/Livewire/TagTeams/Tables/Main.php
@@ -87,7 +87,7 @@ class Main extends BaseTable
                     'unemployed' => 'Unemployed',
                     'retired' => 'Retired',
                 ])
-                ->filter(function (TagTeamBuilder $builder, string $value) {
+                ->filter(function (TagTeamBuilder $builder, string $value): void {
                     /** @var TagTeamBuilder<TagTeam> $builder */
                     match ($value) {
                         'employed' => $builder->employed(),

--- a/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
+++ b/app/Livewire/TagTeams/Tables/PreviousWrestlers.php
@@ -48,7 +48,7 @@ class PreviousWrestlers extends DataTableComponent
         return [
             LinkColumn::make(__('wrestlers.name'))
                 ->title(fn (TagTeamWrestler $row) => $row->wrestler->name ?? 'Unknown')
-                ->location(fn (TagTeamWrestler $row) => $row->wrestler ? route('wrestlers.show', $row->wrestler) : '#'),
+                ->location(fn (TagTeamWrestler $row): string => $row->wrestler ? route('wrestlers.show', $row->wrestler) : '#'),
             DateColumn::make(__('tag-teams.date_joined'), 'joined_at')
                 ->outputFormat('Y-m-d'),
             DateColumn::make(__('tag-teams.date_left'), 'left_at')

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -40,7 +40,7 @@ class FormModal extends BaseFormModal
         return [
             'name' => fn () => Str::of(fake()->word().' '.fake()->word())->title()->append(' Title')->value(),
             'type' => fn () => fake()->randomElement(['singles', 'tag-team']),
-            'start_date' => fn () => $this->generateOptionalStartDate('Y-m-d', 0.6, '-1 year', 'now'),
+            'start_date' => fn (): ?string => $this->generateOptionalStartDate('Y-m-d', 0.6, '-1 year', 'now'),
         ];
     }
 

--- a/app/Livewire/Users/Modals/FormModal.php
+++ b/app/Livewire/Users/Modals/FormModal.php
@@ -40,9 +40,9 @@ class FormModal extends BaseFormModal
             'first_name' => fn () => fake()->firstName(),
             'last_name' => fn () => fake()->lastName(),
             'email' => fn () => fake()->unique()->safeEmail(),
-            'password' => fn () => 'password123',
-            'password_confirmation' => fn () => 'password123',
-            'role' => fn () => 'basic',
+            'password' => fn (): string => 'password123',
+            'password_confirmation' => fn (): string => 'password123',
+            'role' => fn (): string => 'basic',
         ];
     }
 

--- a/app/Livewire/Users/Tables/Main.php
+++ b/app/Livewire/Users/Tables/Main.php
@@ -35,7 +35,7 @@ class Main extends BaseTable
     {
         return [
             Column::make(__('users.name'), 'full_name')
-                ->searchable(function (UserBuilder $builder, string $searchTerm) {
+                ->searchable(function (UserBuilder $builder, string $searchTerm): void {
                     $builder->whereNameMatches($searchTerm);
                 }),
             Column::make(__('users.role'), 'role')

--- a/app/Livewire/Venues/Tables/PreviousEvents.php
+++ b/app/Livewire/Venues/Tables/PreviousEvents.php
@@ -48,7 +48,7 @@ class PreviousEvents extends DataTableComponent
         return [
             LinkColumn::make(__('events.name'), 'name')
                 ->title(fn (Event $row) => $row->name)
-                ->location(fn (Event $row) => route('events.show', $row)),
+                ->location(fn (Event $row): string => route('events.show', $row)),
             DateColumn::make(__('events.date'), 'date')
                 ->outputFormat('Y-m-d'),
         ];

--- a/app/Livewire/Wrestlers/Modals/FormModal.php
+++ b/app/Livewire/Wrestlers/Modals/FormModal.php
@@ -38,12 +38,12 @@ class FormModal extends BaseFormModal
     {
         return [
             'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
-            'hometown' => fn () => fake()->city().', '.fake()->stateAbbr(), // @phpstan-ignore-line
-            'height_feet' => fn () => fake()->numberBetween(5, 7),
-            'height_inches' => fn () => fake()->numberBetween(0, 11),
-            'weight' => fn () => fake()->numberBetween(180, 350),
+            'hometown' => fn (): string => fake()->city().', '.fake()->stateAbbr(), // @phpstan-ignore-line
+            'height_feet' => fn (): int => fake()->numberBetween(5, 7),
+            'height_inches' => fn (): int => fake()->numberBetween(0, 11),
+            'weight' => fn (): int => fake()->numberBetween(180, 350),
             'signature_move' => fn () => Str::of(fake()->optional(0.8)->sentence(3))->title()->value(),
-            'employment_date' => fn () => $this->generateOptionalEmploymentDate(),
+            'employment_date' => fn (): ?string => $this->generateOptionalEmploymentDate(),
         ];
     }
 

--- a/app/Livewire/Wrestlers/Tables/Main.php
+++ b/app/Livewire/Wrestlers/Tables/Main.php
@@ -88,7 +88,7 @@ class Main extends BaseTable
                     'unemployed' => 'Unemployed',
                     'retired' => 'Retired',
                 ])
-                ->filter(function (WrestlerBuilder $builder, string $value) {
+                ->filter(function (WrestlerBuilder $builder, string $value): void {
                     match ($value) {
                         'employed' => $builder->employed(),
                         'future_employment' => $builder->futureEmployed(),

--- a/app/Models/Matches/MatchCompetitor.php
+++ b/app/Models/Matches/MatchCompetitor.php
@@ -11,6 +11,7 @@ use App\Models\Roster\Wrestlers\Wrestler;
 use Database\Factories\Matches\MatchCompetitorFactory;
 use Illuminate\Database\Eloquent\Attributes\CollectedBy;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Collection;
@@ -54,6 +55,7 @@ use Illuminate\Support\Carbon;
 #[Fillable('match_id', 'match_side_id', 'competitor_id', 'competitor_type')]
 #[UseEloquentBuilder(MatchCompetitorBuilder::class)]
 #[UseFactory(MatchCompetitorFactory::class)]
+#[Table(name: 'events_matches_competitors')]
 class MatchCompetitor extends MorphPivot
 {
     /** @use HasFactory<MatchCompetitorFactory> */
@@ -86,13 +88,6 @@ class MatchCompetitor extends MorphPivot
     {
         return $this->hasMany(self::class, 'eliminated_by_match_competitor_id');
     }
-
-    /**
-     * The table associated with the model.
-     *
-     * @var string
-     */
-    protected $table = 'events_matches_competitors';
 
     /**
      * @return array<string, string>

--- a/app/Models/Roster/Stables/StableTagTeam.php
+++ b/app/Models/Roster/Stables/StableTagTeam.php
@@ -7,6 +7,7 @@ namespace App\Models\Roster\Stables;
 use App\Builders\Roster\StableMembershipBuilder;
 use App\Models\Roster\TagTeams\TagTeam;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -36,11 +37,9 @@ use Illuminate\Support\Carbon;
  */
 #[Fillable('stable_id', 'tag_team_id', 'joined_at', 'left_at')]
 #[UseEloquentBuilder(StableMembershipBuilder::class)]
+#[Table(name: 'stables_tag_teams')]
 class StableTagTeam extends Pivot
 {
-    /** @var string */
-    protected $table = 'stables_tag_teams';
-
     /** @return array<string, string> */
     protected function casts(): array
     {

--- a/app/Models/Roster/Stables/StableWrestler.php
+++ b/app/Models/Roster/Stables/StableWrestler.php
@@ -7,6 +7,7 @@ namespace App\Models\Roster\Stables;
 use App\Builders\Roster\StableMembershipBuilder;
 use App\Models\Roster\Wrestlers\Wrestler;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -36,11 +37,9 @@ use Illuminate\Support\Carbon;
  */
 #[Fillable('stable_id', 'wrestler_id', 'joined_at', 'left_at')]
 #[UseEloquentBuilder(StableMembershipBuilder::class)]
+#[Table(name: 'stables_wrestlers')]
 class StableWrestler extends Pivot
 {
-    /** @var string */
-    protected $table = 'stables_wrestlers';
-
     /** @return array<string, string> */
     protected function casts(): array
     {

--- a/app/Models/Roster/TagTeams/TagTeamManager.php
+++ b/app/Models/Roster/TagTeams/TagTeamManager.php
@@ -7,6 +7,7 @@ namespace App\Models\Roster\TagTeams;
 use App\Builders\Roster\ManagerAssignmentBuilder;
 use App\Models\Roster\Managers\Manager;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -36,10 +37,9 @@ use Illuminate\Support\Carbon;
  */
 #[Fillable('tag_team_id', 'manager_id', 'hired_at', 'fired_at')]
 #[UseEloquentBuilder(ManagerAssignmentBuilder::class)]
+#[Table(name: 'tag_teams_managers')]
 class TagTeamManager extends Pivot
 {
-    protected $table = 'tag_teams_managers';
-
     /**
      * Get the attributes that should be cast.
      *

--- a/app/Models/Roster/TagTeams/TagTeamWrestler.php
+++ b/app/Models/Roster/TagTeams/TagTeamWrestler.php
@@ -8,6 +8,7 @@ use App\Builders\Roster\TagTeamMembershipBuilder;
 use App\Models\Roster\Wrestlers\Wrestler;
 use Database\Factories\Roster\TagTeams\TagTeamWrestlerFactory;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Attributes\UseFactory;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -43,13 +44,11 @@ use Illuminate\Support\Carbon;
 #[Fillable('tag_team_id', 'wrestler_id', 'joined_at', 'left_at')]
 #[UseEloquentBuilder(TagTeamMembershipBuilder::class)]
 #[UseFactory(TagTeamWrestlerFactory::class)]
+#[Table(name: 'tag_teams_wrestlers')]
 class TagTeamWrestler extends Pivot
 {
     /** @use HasFactory<TagTeamWrestlerFactory> */
     use HasFactory;
-
-    /** @var string */
-    protected $table = 'tag_teams_wrestlers';
 
     /** @return array<string, string> */
     protected function casts(): array

--- a/app/Models/Roster/Wrestlers/WrestlerManager.php
+++ b/app/Models/Roster/Wrestlers/WrestlerManager.php
@@ -7,6 +7,7 @@ namespace App\Models\Roster\Wrestlers;
 use App\Builders\Roster\ManagerAssignmentBuilder;
 use App\Models\Roster\Managers\Manager;
 use Illuminate\Database\Eloquent\Attributes\Fillable;
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Attributes\UseEloquentBuilder;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\Pivot;
@@ -36,10 +37,9 @@ use Illuminate\Support\Carbon;
  */
 #[Fillable('wrestler_id', 'manager_id', 'hired_at', 'fired_at')]
 #[UseEloquentBuilder(ManagerAssignmentBuilder::class)]
+#[Table(name: 'wrestlers_managers')]
 class WrestlerManager extends Pivot
 {
-    protected $table = 'wrestlers_managers';
-
     /**
      * Get the attributes that should be cast.
      *

--- a/app/Rules/Matches/CompetitorsNotDuplicated.php
+++ b/app/Rules/Matches/CompetitorsNotDuplicated.php
@@ -13,7 +13,7 @@ class CompetitorsNotDuplicated implements ValidationRule
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
         // Handle non-array values gracefully
-        if (! is_array($value) || empty($value)) {
+        if (! is_array($value) || $value === []) {
             return;
         }
 

--- a/rector-pest.php
+++ b/rector-pest.php
@@ -2,14 +2,29 @@
 
 declare(strict_types=1);
 
+use Pest\Rector\Rules\ConvertAssertToExpectRector;
 use Pest\Rector\Rules\ConvertBeforeAllInDescribeRector;
+use Pest\Rector\Rules\ConvertExpectExceptionToThrowRector;
+use Pest\Rector\Rules\EnsureTypeChecksFirstRector;
 use Pest\Rector\Rules\FixInvalidRepeatValueRector;
 use Pest\Rector\Rules\Pest2ToPest3\TapToDeferRector;
 use Pest\Rector\Rules\Pest2ToPest3\ToHaveMethodOnClassRector;
 use Pest\Rector\Rules\Pest2ToPest3\UsesToExtendRector;
 use Pest\Rector\Rules\RemoveDebugExpectationsRector;
 use Pest\Rector\Rules\RemoveOnlyRector;
+use Pest\Rector\Rules\RemoveRedundantLiteralTypeExpectationRector;
 use Pest\Rector\Rules\RemoveRedundantPestUsesRector;
+use Pest\Rector\Rules\RemoveStaticTestClosureRector;
+use Pest\Rector\Rules\SimplifyExpectNotRector;
+use Pest\Rector\Rules\UseInstanceOfMatcherRector;
+use Pest\Rector\Rules\UseStrictEqualityMatchersRector;
+use Pest\Rector\Rules\UseToEndWithRector;
+use Pest\Rector\Rules\UseToHaveCountRector;
+use Pest\Rector\Rules\UseToHaveKeyRector;
+use Pest\Rector\Rules\UseToHaveKeysRector;
+use Pest\Rector\Rules\UseToStartWithRector;
+use Pest\Rector\Rules\UseToThrowRector;
+use Pest\Rector\Rules\UseTypeMatchersRector;
 use Rector\Config\RectorConfig;
 
 return RectorConfig::configure()
@@ -20,9 +35,24 @@ return RectorConfig::configure()
         TapToDeferRector::class,
         ToHaveMethodOnClassRector::class,
         UsesToExtendRector::class,
+        ConvertAssertToExpectRector::class,
+        ConvertExpectExceptionToThrowRector::class,
         ConvertBeforeAllInDescribeRector::class,
         FixInvalidRepeatValueRector::class,
         RemoveDebugExpectationsRector::class,
         RemoveOnlyRector::class,
+        RemoveRedundantLiteralTypeExpectationRector::class,
         RemoveRedundantPestUsesRector::class,
+        RemoveStaticTestClosureRector::class,
+        SimplifyExpectNotRector::class,
+        UseInstanceOfMatcherRector::class,
+        UseStrictEqualityMatchersRector::class,
+        UseToEndWithRector::class,
+        UseToHaveCountRector::class,
+        UseToHaveKeyRector::class,
+        UseToHaveKeysRector::class,
+        UseToStartWithRector::class,
+        UseToThrowRector::class,
+        UseTypeMatchersRector::class,
+        EnsureTypeChecksFirstRector::class,
     ]);

--- a/rector.php
+++ b/rector.php
@@ -2,24 +2,11 @@
 
 declare(strict_types=1);
 
-use Rector\CodeQuality\Rector\Attribute\SortAttributeNamedArgsRector;
-use Rector\CodeQuality\Rector\BooleanAnd\RepeatedAndNotEqualToNotInArrayRector;
-use Rector\CodeQuality\Rector\BooleanNot\NegatedAndsToPositiveOrsRector;
-use Rector\CodeQuality\Rector\Empty_\SimplifyEmptyCheckOnEmptyArrayRector;
 use Rector\CodeQuality\Rector\Identical\FlipTypeControlToUseExclusiveTypeRector;
-use Rector\CodeQuality\Rector\If_\SimplifyIfReturnBoolRector;
 use Rector\CodeQuality\Rector\New_\NewStaticToNewSelfRector;
-use Rector\CodeQuality\Rector\Ternary\UnnecessaryTernaryExpressionRector;
 use Rector\Config\RectorConfig;
-use Rector\EarlyReturn\Rector\Return_\ReturnBinaryOrToEarlyReturnRector;
-use Rector\EarlyReturn\Rector\StmtsAwareInterface\ReturnEarlyIfVariableRector;
 use Rector\Php71\Rector\FuncCall\RemoveExtraParametersRector;
-use Rector\Strict\Rector\Empty_\DisallowedEmptyRuleFixerRector;
 use Rector\Transform\Rector\String_\StringToClassConstantRector;
-use Rector\TypeDeclaration\Rector\ArrowFunction\AddArrowFunctionReturnTypeRector;
-use Rector\TypeDeclaration\Rector\Closure\AddClosureVoidReturnTypeWhereNoReturnRector;
-use Rector\TypeDeclaration\Rector\Closure\ClosureReturnTypeRector;
-use RectorLaravel\Rector\ClassMethod\MigrateToSimplifiedAttributeRector;
 use RectorLaravel\Set\LaravelLevelSetList;
 
 return RectorConfig::configure()
@@ -27,26 +14,13 @@ return RectorConfig::configure()
         __DIR__.'/app',
     ])
     ->withSets([
-        LaravelLevelSetList::UP_TO_LARAVEL_120,
+        LaravelLevelSetList::UP_TO_LARAVEL_130,
     ])
     ->withSkip([
         StringToClassConstantRector::class,
         NewStaticToNewSelfRector::class,
         FlipTypeControlToUseExclusiveTypeRector::class,
-        AddArrowFunctionReturnTypeRector::class,
-        AddClosureVoidReturnTypeWhereNoReturnRector::class,
-        SortAttributeNamedArgsRector::class,
-        SimplifyEmptyCheckOnEmptyArrayRector::class,
-        RepeatedAndNotEqualToNotInArrayRector::class,
-        DisallowedEmptyRuleFixerRector::class,
-        ReturnEarlyIfVariableRector::class,
         RemoveExtraParametersRector::class,
-        SimplifyIfReturnBoolRector::class,
-        ClosureReturnTypeRector::class,
-        UnnecessaryTernaryExpressionRector::class,
-        MigrateToSimplifiedAttributeRector::class,
-        ReturnBinaryOrToEarlyReturnRector::class,
-        NegatedAndsToPositiveOrsRector::class,
     ])
     ->withPreparedSets(
         deadCode: false,

--- a/tests/Integration/Actions/Stables/LifecycleTest.php
+++ b/tests/Integration/Actions/Stables/LifecycleTest.php
@@ -99,7 +99,6 @@ describe('Stable Activation Action Integration', function () {
             resolve(DisbandAction::class)->handle($this->activeStable, $disbandDate);
 
             $refreshedStable = freshModel($this->activeStable);
-            expect($refreshedStable->status === StableStatus::Inactive)->toBeTrue();
             expect($refreshedStable->status)->toBe(StableStatus::Inactive);
 
             // Verify activity period is ended
@@ -303,7 +302,7 @@ describe('Stable Activation Action Integration', function () {
             // Disband
             $disbandDate = Carbon::now()->subMonths(6);
             resolve(DisbandAction::class)->handle($stable, $disbandDate);
-            expect(freshModel($stable)->status === StableStatus::Inactive)->toBeTrue();
+            expect(freshModel($stable)->status)->toBe(StableStatus::Inactive);
 
             // Reunite
             $reuniteDate = Carbon::now()->subMonths(3);

--- a/tests/Integration/Livewire/Stables/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Stables/Tables/MainTest.php
@@ -179,7 +179,7 @@ describe('StablesTable Component', function () {
                 ->assertRedirect();
 
             // Verify stable is disbanded
-            expect(freshModel($activeStable)->status === StableStatus::Inactive)->toBeTrue();
+            expect(freshModel($activeStable)->status)->toBe(StableStatus::Inactive);
         });
 
         test('retire action integration works correctly', function () {
@@ -313,7 +313,7 @@ describe('StablesTable Component', function () {
             $component->call('disband', $disbandedStable)
                 ->assertRedirect();
 
-            expect(freshModel($disbandedStable)->status === StableStatus::Inactive)->toBeTrue();
+            expect(freshModel($disbandedStable)->status)->toBe(StableStatus::Inactive);
         });
     });
 

--- a/tests/Unit/Livewire/Concerns/Data/PresentsManagersListTest.php
+++ b/tests/Unit/Livewire/Concerns/Data/PresentsManagersListTest.php
@@ -67,10 +67,14 @@ describe('PresentsManagersList Unit Tests', function () {
     describe('computed attribute configuration', function () {
         test('Computed attribute has correct parameters', function () {
             $reflection = new ReflectionClass(PresentsManagersList::class);
-            $source = reflectionSource($reflection);
+            $method = $reflection->getMethod('getManagers');
+            $attributes = $method->getAttributes(Computed::class);
+            $computed = $attributes[0]->newInstance();
 
-            // Check for Computed attribute configuration
-            expect($source)->toContain('#[Computed(cache: true, key: \'managers-list\', seconds: 180)]');
+            expect($computed)
+                ->cache->toBeTrue()
+                ->key->toBe('managers-list')
+                ->seconds->toBe(180);
         });
     });
 

--- a/tests/Unit/Models/Roster/TagTeams/TagTeamTest.php
+++ b/tests/Unit/Models/Roster/TagTeams/TagTeamTest.php
@@ -51,7 +51,7 @@ describe('TagTeam Model Unit Tests', function () {
             $casts = $tagTeam->getCasts();
 
             // Status is computed attribute, no cast needed
-            expect(array_key_exists('status', $casts))->toBeFalse();
+            expect($casts)->not->toHaveKey('status');
         });
 
         test('has custom eloquent builder', function () {

--- a/tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php
+++ b/tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php
@@ -62,7 +62,7 @@ describe('Wrestler Model Unit Tests', function () {
 
             expect($casts['height'])->toBe(HeightCast::class);
             // Status is computed attribute, no cast needed
-            expect(array_key_exists('status', $casts))->toBeFalse();
+            expect($casts)->not->toHaveKey('status');
         });
 
         test('has custom eloquent builder', function () {


### PR DESCRIPTION
## Summary
- raise the Rector Laravel level set from Laravel 12 to Laravel 13
- adopt Laravel 13 native Table attributes for custom-table models
- enable previously skipped safe code-quality and return-type rules
- retain four targeted skips where automatic rewriting would obscure intent or hide API mistakes
- apply the newly enforced application transformations

## Retained Rector skips
- StringToClassConstantRector: guesses architectural constants from literals
- NewStaticToNewSelfRector: breaks intentional late-static exception factories
- FlipTypeControlToUseExclusiveTypeRector: replaces clear nullable checks with type checks
- RemoveExtraParametersRector: silently hides API mismatches

## Verification
- focused model, Livewire, and validation suites: 1,194 tests, 2,960 assertions
- type coverage: passed at 100%
- application PHPStan: passed
- Pest PHPStan: passed
- application and Pest Rector: passed and idempotent
- Pint with Blade: passed

The final parallel Pest stage repeatedly stopped producing output after every preceding gate passed. The affected suites were therefore run directly and passed; GitHub CI will run the complete workflow.