### PR TITLE
test: replace vacuous seeder assertions

### DIFF
--- a/tests/Integration/Database/Seeders/EventsTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/EventsTableSeederTest.php
@@ -27,7 +27,6 @@ describe('EventsTableSeeder Integration Tests', function () {
             // Act & Assert - Should not throw any exceptions
             expect(fn () => Artisan::call('db:seed', ['--class' => 'EventsTableSeeder']))
                 ->not()->toThrow(Exception::class);
-            expect(true)->toBeTrue();
         });
 
         test('creates events in database', function () {
@@ -36,7 +35,6 @@ describe('EventsTableSeeder Integration Tests', function () {
 
             // Assert - Should create multiple events
             expect(Event::count())->toBeGreaterThan(0);
-            expect(true)->toBeTrue();
         });
     });
 
@@ -50,6 +48,8 @@ describe('EventsTableSeeder Integration Tests', function () {
             $events = Event::take(10)->get();
 
             // Assert
+            expect($events)->not->toBeEmpty();
+
             foreach ($events as $event) {
                 expect($event->name)->toBeString();
                 expect($event->name)->not->toBeEmpty();
@@ -59,7 +59,6 @@ describe('EventsTableSeeder Integration Tests', function () {
                     expect($event->venue_id)->toBeInt();
                 }
             }
-            expect(true)->toBeTrue();
         });
 
         test('events have realistic names', function () {
@@ -67,11 +66,12 @@ describe('EventsTableSeeder Integration Tests', function () {
             $events = Event::take(5)->get();
 
             // Assert
+            expect($events)->not->toBeEmpty();
+
             foreach ($events as $event) {
                 expect(mb_strlen($event->name))->toBeGreaterThanOrEqual(3);
                 expect($event->name)->not->toContain('Test');
             }
-            expect(true)->toBeTrue();
         });
 
         test('events have valid dates', function () {
@@ -79,12 +79,13 @@ describe('EventsTableSeeder Integration Tests', function () {
             $events = Event::take(10)->get();
 
             // Assert
+            expect($events)->not->toBeEmpty();
+
             foreach ($events as $event) {
                 expect($event->date)->toBeInstanceOf(Carbon::class);
                 // Events should be in the past or future (not null)
                 expect($event->date)->not()->toBeNull();
             }
-            expect(true)->toBeTrue();
         });
     });
 
@@ -106,6 +107,8 @@ describe('EventsTableSeeder Integration Tests', function () {
             $events = Event::take(10)->get();
 
             // Assert
+            expect($events)->not->toBeEmpty();
+
             foreach ($events as $event) {
                 // venue_id can be null for future events without assigned venues
                 if ($event->venue_id !== null) {
@@ -113,7 +116,6 @@ describe('EventsTableSeeder Integration Tests', function () {
                     expect($event->venue_id)->toBeGreaterThan(0);
                 }
             }
-            expect(true)->toBeTrue();
         });
 
         test('events can load venue relationships', function () {
@@ -139,7 +141,6 @@ describe('EventsTableSeeder Integration Tests', function () {
 
             // Assert - Should maintain or increase count
             expect(Event::count())->toBeGreaterThanOrEqual($initialCount);
-            expect(true)->toBeTrue();
         });
     });
 });

--- a/tests/Integration/Database/Seeders/MatchesTableSeederTest.php
+++ b/tests/Integration/Database/Seeders/MatchesTableSeederTest.php
@@ -27,7 +27,6 @@ describe('MatchesTableSeeder Integration Tests', function () {
             // Act & Assert - Should not throw any exceptions
             expect(fn () => Artisan::call('db:seed', ['--class' => 'MatchesTableSeeder']))
                 ->not()->toThrow(Exception::class);
-            expect(true)->toBeTrue();
         });
 
         test('creates event matches in database', function () {
@@ -36,7 +35,6 @@ describe('MatchesTableSeeder Integration Tests', function () {
 
             // Assert - Should create multiple event matches
             expect(EventMatch::count())->toBeGreaterThan(0);
-            expect(true)->toBeTrue();
         });
     });
 
@@ -50,13 +48,14 @@ describe('MatchesTableSeeder Integration Tests', function () {
             $eventMatches = EventMatch::take(10)->get();
 
             // Assert
+            expect($eventMatches)->not->toBeEmpty();
+
             foreach ($eventMatches as $eventMatch) {
                 expect($eventMatch->event_id)->toBeInt();
                 expect($eventMatch->match_type)->toBeInstanceOf(MatchType::class);
                 expect($eventMatch->match_number)->toBeInt();
                 expect($eventMatch->match_number)->toBeGreaterThan(0);
             }
-            expect(true)->toBeTrue();
         });
 
         test('event matches have valid order sequence', function () {
@@ -64,24 +63,29 @@ describe('MatchesTableSeeder Integration Tests', function () {
             $eventMatches = EventMatch::take(10)->get();
 
             // Assert
+            expect($eventMatches)->not->toBeEmpty();
+
             foreach ($eventMatches as $eventMatch) {
                 expect($eventMatch->match_number)->toBeBetween(1, 20); // Reasonable match number range
             }
-            expect(true)->toBeTrue();
         });
 
-        test('event matches can have preview text', function () {
+        test('event matches have valid preview text', function () {
             // Arrange
-            $eventMatches = EventMatch::whereNotNull('preview')->take(5)->get();
+            $eventMatches = EventMatch::take(10)->get();
 
             // Assert
+            expect($eventMatches)->not->toBeEmpty();
+
             foreach ($eventMatches as $eventMatch) {
-                if ($eventMatch->preview) {
-                    expect($eventMatch->preview)->toBeString();
-                    expect($eventMatch->preview)->not->toBeEmpty();
+                if ($eventMatch->preview === null) {
+                    expect($eventMatch->preview)->toBeNull();
+
+                    continue;
                 }
+
+                expect($eventMatch->preview)->not->toBeEmpty();
             }
-            expect(true)->toBeTrue();
         });
     });
 
@@ -95,11 +99,12 @@ describe('MatchesTableSeeder Integration Tests', function () {
             $eventMatches = EventMatch::take(10)->get();
 
             // Assert
+            expect($eventMatches)->not->toBeEmpty();
+
             foreach ($eventMatches as $eventMatch) {
                 expect($eventMatch->event_id)->toBeInt();
                 expect($eventMatch->event_id)->toBeGreaterThan(0);
             }
-            expect(true)->toBeTrue();
         });
 
         test('event matches have valid match type associations', function () {
@@ -107,10 +112,11 @@ describe('MatchesTableSeeder Integration Tests', function () {
             $eventMatches = EventMatch::take(10)->get();
 
             // Assert
+            expect($eventMatches)->not->toBeEmpty();
+
             foreach ($eventMatches as $eventMatch) {
                 expect($eventMatch->match_type)->toBeInstanceOf(MatchType::class);
             }
-            expect(true)->toBeTrue();
         });
 
         test('event matches can load relationships', function () {
@@ -120,7 +126,6 @@ describe('MatchesTableSeeder Integration Tests', function () {
             // Assert
             expect($eventMatch->event()->firstOrFail()->name)->toBeString();
             expect($eventMatch->match_type)->toBeInstanceOf(MatchType::class);
-            expect(true)->toBeTrue();
         });
 
         test('seeder creates consistent data', function () {
@@ -132,7 +137,6 @@ describe('MatchesTableSeeder Integration Tests', function () {
 
             // Assert - Should maintain or increase count
             expect(EventMatch::count())->toBeGreaterThanOrEqual($initialCount);
-            expect(true)->toBeTrue();
         });
     });
 });


### PR DESCRIPTION
## Summary
- remove literal always-true assertions from the event and match seeder integration suites
- assert seeded collections are populated before validating each record
- validate nullable match preview values without allowing an empty query to pass silently

## Verification
- focused seeder tests: 18 passed, 206 assertions
- Pest PHPStan: passed
- Pint with Blade formatting: passed
- full application suite: 3,377 passed, 10,952 assertions
- Rector and application PHPStan: passed

## Local browser runner
The browser phase produced no output for several minutes on two bounded attempts and was stopped; this change only touches database seeder integration tests. GitHub Actions will run the browser job independently.