### PR TITLE
test: replace workflow placeholder assertions

### DIFF
--- a/tests/Feature/Livewire/Wrestlers/Tables/PreviousManagersTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/PreviousManagersTest.php
@@ -33,14 +33,18 @@ describe('PreviousManagers Configuration', function () {
         expect($component->instance()->databaseTableName)->toBe('wrestlers_managers');
     });
 
-    it('adds correct additional selects', function () {
+    it('defines the manager history columns', function () {
         $component = testLivewire(PreviousManagers::class, ['wrestlerId' => $this->wrestler->id]);
 
-        $component->instance()->configure();
+        $fields = collect($component->instance()->columns())
+            ->map->getField()
+            ->all();
 
-        // This would need to be tested differently depending on how additionalSelects is implemented
-        // For now, we'll just ensure configure() runs without error
-        expect(true)->toBeTrue();
+        expect($fields)->toBe([
+            'manager.full_name',
+            'hired_at',
+            'fired_at',
+        ]);
     });
 });
 

--- a/tests/Feature/Workflows/AuthenticationWorkflowTest.php
+++ b/tests/Feature/Workflows/AuthenticationWorkflowTest.php
@@ -191,8 +191,5 @@ describe('Session Management', function () {
         actingAs($admin)
             ->get(route('titles.index'))
             ->assertOk();
-
-        // Then: All requests succeed without re-authentication
-        expect(true)->toBeTrue(); // Test passes if no assertions fail
     });
 });

--- a/tests/Feature/Workflows/NavigationWorkflowTest.php
+++ b/tests/Feature/Workflows/NavigationWorkflowTest.php
@@ -217,9 +217,6 @@ describe('Content Discovery and Search Navigation Workflow', function () {
         actingAs($admin)
             ->get(route('venues.index'))
             ->assertOk();
-
-        // Then: All sections are accessible and searchable
-        expect(true)->toBeTrue(); // Test passes if no assertions fail
     });
 });
 
@@ -323,10 +320,6 @@ describe('Mobile and Responsive Navigation Workflow', function () {
                 ->get(route($route))
                 ->assertOk();
         }
-
-        // Then: All sections should be accessible regardless of viewport
-        // (Actual responsive testing would require browser testing tools)
-        expect(true)->toBeTrue();
     });
 });
 
@@ -385,8 +378,5 @@ describe('Performance and Loading Navigation Workflow', function () {
                 ->get(route($route))
                 ->assertOk();
         }
-
-        // Then: All sections should load successfully with populated data
-        expect(true)->toBeTrue();
     });
 });


### PR DESCRIPTION
## Summary
- remove always-true assertions that duplicated successful HTTP response assertions
- replace a hollow Livewire configuration test with exact manager-history column assertions
- remove comments that described placeholder coverage rather than application behavior

## Verification
- focused tests: 28 passed, 196 assertions
- Pest PHPStan: passed
- Pint with Blade formatting: passed
- Rector, application PHPStan, type coverage, and application suite passed
- application suite: 3,377 tests, 10,948 assertions

## Local browser runner
The browser phase produced no output beyond the duration observed in CI and was stopped. These changes only affect PHP Feature tests; GitHub Actions will run Browser Tests independently.