### PR TITLE
refactor: separate match outcome requirements

### DIFF
--- a/app/Lifecycle/MatchEliminationRequirement.php
+++ b/app/Lifecycle/MatchEliminationRequirement.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Data\Matches\MatchEliminationData;
+use App\Data\Matches\MatchResultData;
+use App\Exceptions\Matches\InvalidMatchOutcomeException;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Support\ConsecutiveIntegerSequence;
+use Illuminate\Database\Eloquent\Collection;
+
+final class MatchEliminationRequirement
+{
+    public function __construct(private readonly ConsecutiveIntegerSequence $sequence) {}
+
+    /**
+     * @param  Collection<int, MatchCompetitor>  $competitors
+     */
+    public function ensureSatisfied(
+        EventMatch $match,
+        MatchResultData $result,
+        Collection $competitors,
+    ): void {
+        if (! $match->match_type->recordsIndividualEliminations()) {
+            if ($result->eliminations->isNotEmpty()) {
+                throw InvalidMatchOutcomeException::eliminationsNotSupported();
+            }
+
+            return;
+        }
+
+        $competitorsById = $competitors->keyBy('id');
+        $eliminatedCompetitorIds = $result->eliminations
+            ->map(fn (MatchEliminationData $elimination): int => $elimination->competitor->id);
+
+        if ($eliminatedCompetitorIds->unique()->count() !== $eliminatedCompetitorIds->count()) {
+            throw InvalidMatchOutcomeException::duplicateEliminatedCompetitor();
+        }
+
+        $orders = $result->eliminations
+            ->map(fn (MatchEliminationData $elimination): int => $elimination->order)
+            ->all();
+
+        if (! $this->sequence->isValid($orders)) {
+            throw InvalidMatchOutcomeException::invalidEliminationOrder();
+        }
+
+        foreach ($result->eliminations as $elimination) {
+            $this->ensureParticipantsBelongToMatch($elimination, $competitorsById);
+        }
+
+        $this->ensureChronology($result);
+
+        if (! $result->finish->requiresWinningSide()) {
+            return;
+        }
+
+        $winningSideId = $result->winningSide?->id;
+        $winningCompetitorIds = collect($competitors
+            ->where('match_side_id', $winningSideId)
+            ->modelKeys());
+
+        if ($eliminatedCompetitorIds->intersect($winningCompetitorIds)->isNotEmpty()) {
+            throw InvalidMatchOutcomeException::winnerEliminated();
+        }
+
+        $expectedEliminatedCompetitorIds = collect($competitors
+            ->where('match_side_id', '!=', $winningSideId)
+            ->modelKeys());
+
+        if ($eliminatedCompetitorIds->sort()->values()->all() !== $expectedEliminatedCompetitorIds->sort()->values()->all()) {
+            throw InvalidMatchOutcomeException::incompleteEliminationHistory();
+        }
+    }
+
+    /**
+     * @param  Collection<int, MatchCompetitor>  $competitorsById
+     */
+    private function ensureParticipantsBelongToMatch(
+        MatchEliminationData $elimination,
+        Collection $competitorsById,
+    ): void {
+        if (! $competitorsById->has($elimination->competitor->id)) {
+            throw InvalidMatchOutcomeException::competitorFromAnotherMatch();
+        }
+
+        if ($elimination->eliminatedBy === null) {
+            return;
+        }
+
+        if (! $competitorsById->has($elimination->eliminatedBy->id)) {
+            throw InvalidMatchOutcomeException::eliminatorFromAnotherMatch();
+        }
+
+        if ($elimination->competitor->is($elimination->eliminatedBy)) {
+            throw InvalidMatchOutcomeException::selfElimination();
+        }
+    }
+
+    private function ensureChronology(MatchResultData $result): void
+    {
+        $eliminationOrders = $result->eliminations
+            ->mapWithKeys(fn (MatchEliminationData $elimination): array => [
+                $elimination->competitor->id => $elimination->order,
+            ]);
+
+        foreach ($result->eliminations as $elimination) {
+            if ($elimination->eliminatedBy === null) {
+                continue;
+            }
+
+            $eliminatorExitOrder = $eliminationOrders->get($elimination->eliminatedBy->id);
+
+            if (is_int($eliminatorExitOrder) && $eliminatorExitOrder <= $elimination->order) {
+                throw InvalidMatchOutcomeException::eliminationAfterEliminatorExited();
+            }
+        }
+    }
+}

--- a/app/Lifecycle/MatchEntryOrderRequirement.php
+++ b/app/Lifecycle/MatchEntryOrderRequirement.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Enums\MatchType;
+use App\Exceptions\Matches\InvalidMatchOutcomeException;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Support\ConsecutiveIntegerSequence;
+use Illuminate\Database\Eloquent\Collection;
+
+final class MatchEntryOrderRequirement
+{
+    public function __construct(private readonly ConsecutiveIntegerSequence $sequence) {}
+
+    /**
+     * @param  Collection<int, MatchCompetitor>  $competitors
+     */
+    public function ensureSatisfied(EventMatch $match, Collection $competitors): void
+    {
+        if ($match->match_type !== MatchType::RoyalRumble) {
+            return;
+        }
+
+        $entryOrders = $competitors
+            ->map(fn (MatchCompetitor $competitor): ?int => $competitor->entry_order)
+            ->all();
+
+        if (! $this->sequence->isValid($entryOrders)) {
+            throw InvalidMatchOutcomeException::invalidEntryOrder();
+        }
+    }
+}

--- a/app/Lifecycle/MatchOutcomeRequirements.php
+++ b/app/Lifecycle/MatchOutcomeRequirements.php
@@ -4,182 +4,26 @@ declare(strict_types=1);
 
 namespace App\Lifecycle;
 
-use App\Data\Matches\MatchEliminationData;
 use App\Data\Matches\MatchResultData;
-use App\Enums\MatchType;
-use App\Exceptions\Matches\InvalidMatchOutcomeException;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use Illuminate\Database\Eloquent\Collection;
 
 class MatchOutcomeRequirements
 {
+    public function __construct(
+        private readonly MatchWinningSideRequirement $winningSide,
+        private readonly MatchEntryOrderRequirement $entryOrder,
+        private readonly MatchEliminationRequirement $eliminations,
+    ) {}
+
     /**
      * @param  Collection<int, MatchCompetitor>  $competitors
      */
     public function ensureSatisfied(EventMatch $match, MatchResultData $result, Collection $competitors): void
     {
-        $this->ensureWinningSideIsValid($match, $result);
-        $this->ensureEntryOrderIsValid($match, $competitors);
-        $this->ensureEliminationsAreValid($match, $result, $competitors);
-    }
-
-    private function ensureWinningSideIsValid(EventMatch $match, MatchResultData $result): void
-    {
-        if ($result->finish->requiresWinningSide() && $result->winningSide === null) {
-            throw InvalidMatchOutcomeException::missingWinningSide();
-        }
-
-        if (! $result->finish->requiresWinningSide() && $result->winningSide !== null) {
-            throw InvalidMatchOutcomeException::unexpectedWinningSide();
-        }
-
-        if ($result->winningSide === null) {
-            return;
-        }
-
-        if ($result->winningSide->match_id !== $match->id) {
-            throw InvalidMatchOutcomeException::winningSideFromAnotherMatch();
-        }
-
-        if (! $result->winningSide->competitors()->exists()) {
-            throw InvalidMatchOutcomeException::winningSideWithoutCompetitors();
-        }
-    }
-
-    /**
-     * @param  Collection<int, MatchCompetitor>  $competitors
-     */
-    private function ensureEntryOrderIsValid(EventMatch $match, Collection $competitors): void
-    {
-        if ($match->match_type !== MatchType::RoyalRumble) {
-            return;
-        }
-
-        $entryOrders = $competitors
-            ->map(fn (MatchCompetitor $competitor): ?int => $competitor->entry_order)
-            ->all();
-
-        if (! $this->isConsecutiveSequence($entryOrders, $competitors->count())) {
-            throw InvalidMatchOutcomeException::invalidEntryOrder();
-        }
-    }
-
-    /**
-     * @param  Collection<int, MatchCompetitor>  $competitors
-     */
-    private function ensureEliminationsAreValid(
-        EventMatch $match,
-        MatchResultData $result,
-        Collection $competitors,
-    ): void {
-        if (! $match->match_type->recordsIndividualEliminations()) {
-            if ($result->eliminations->isNotEmpty()) {
-                throw InvalidMatchOutcomeException::eliminationsNotSupported();
-            }
-
-            return;
-        }
-
-        $competitorsById = $competitors->keyBy('id');
-        $eliminatedCompetitorIds = $result->eliminations
-            ->map(fn (MatchEliminationData $elimination): int => $elimination->competitor->id);
-
-        if ($eliminatedCompetitorIds->unique()->count() !== $eliminatedCompetitorIds->count()) {
-            throw InvalidMatchOutcomeException::duplicateEliminatedCompetitor();
-        }
-
-        $orders = $result->eliminations
-            ->map(fn (MatchEliminationData $elimination): int => $elimination->order)
-            ->all();
-
-        if (! $this->isConsecutiveSequence($orders, $result->eliminations->count())) {
-            throw InvalidMatchOutcomeException::invalidEliminationOrder();
-        }
-
-        foreach ($result->eliminations as $elimination) {
-            $this->ensureEliminationParticipantsBelongToMatch($elimination, $competitorsById);
-        }
-
-        $this->ensureEliminationChronology($result);
-
-        if (! $result->finish->requiresWinningSide()) {
-            return;
-        }
-
-        $winningSideId = $result->winningSide?->id;
-        $winningCompetitorIds = collect($competitors
-            ->where('match_side_id', $winningSideId)
-            ->modelKeys());
-
-        if ($eliminatedCompetitorIds->intersect($winningCompetitorIds)->isNotEmpty()) {
-            throw InvalidMatchOutcomeException::winnerEliminated();
-        }
-
-        $expectedEliminatedCompetitorIds = collect($competitors
-            ->where('match_side_id', '!=', $winningSideId)
-            ->modelKeys());
-
-        if ($eliminatedCompetitorIds->sort()->values()->all() !== $expectedEliminatedCompetitorIds->sort()->values()->all()) {
-            throw InvalidMatchOutcomeException::incompleteEliminationHistory();
-        }
-    }
-
-    /**
-     * @param  Collection<int, MatchCompetitor>  $competitorsById
-     */
-    private function ensureEliminationParticipantsBelongToMatch(
-        MatchEliminationData $elimination,
-        Collection $competitorsById,
-    ): void {
-        if (! $competitorsById->has($elimination->competitor->id)) {
-            throw InvalidMatchOutcomeException::competitorFromAnotherMatch();
-        }
-
-        if ($elimination->eliminatedBy === null) {
-            return;
-        }
-
-        if (! $competitorsById->has($elimination->eliminatedBy->id)) {
-            throw InvalidMatchOutcomeException::eliminatorFromAnotherMatch();
-        }
-
-        if ($elimination->competitor->is($elimination->eliminatedBy)) {
-            throw InvalidMatchOutcomeException::selfElimination();
-        }
-    }
-
-    private function ensureEliminationChronology(MatchResultData $result): void
-    {
-        $eliminationOrders = $result->eliminations
-            ->mapWithKeys(fn (MatchEliminationData $elimination): array => [
-                $elimination->competitor->id => $elimination->order,
-            ]);
-
-        foreach ($result->eliminations as $elimination) {
-            if ($elimination->eliminatedBy === null) {
-                continue;
-            }
-
-            $eliminatorExitOrder = $eliminationOrders->get($elimination->eliminatedBy->id);
-
-            if (is_int($eliminatorExitOrder) && $eliminatorExitOrder <= $elimination->order) {
-                throw InvalidMatchOutcomeException::eliminationAfterEliminatorExited();
-            }
-        }
-    }
-
-    /**
-     * @param  array<int, int|null>  $values
-     */
-    private function isConsecutiveSequence(array $values, int $count): bool
-    {
-        if ($count === 0) {
-            return $values === [];
-        }
-
-        sort($values);
-
-        return $values === range(1, $count);
+        $this->winningSide->ensureSatisfied($match, $result);
+        $this->entryOrder->ensureSatisfied($match, $competitors);
+        $this->eliminations->ensureSatisfied($match, $result, $competitors);
     }
 }

--- a/app/Lifecycle/MatchWinningSideRequirement.php
+++ b/app/Lifecycle/MatchWinningSideRequirement.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Data\Matches\MatchResultData;
+use App\Exceptions\Matches\InvalidMatchOutcomeException;
+use App\Models\Matches\EventMatch;
+
+final class MatchWinningSideRequirement
+{
+    public function ensureSatisfied(EventMatch $match, MatchResultData $result): void
+    {
+        if ($result->finish->requiresWinningSide() && $result->winningSide === null) {
+            throw InvalidMatchOutcomeException::missingWinningSide();
+        }
+
+        if (! $result->finish->requiresWinningSide() && $result->winningSide !== null) {
+            throw InvalidMatchOutcomeException::unexpectedWinningSide();
+        }
+
+        if ($result->winningSide === null) {
+            return;
+        }
+
+        if ($result->winningSide->match_id !== $match->id) {
+            throw InvalidMatchOutcomeException::winningSideFromAnotherMatch();
+        }
+
+        if (! $result->winningSide->competitors()->exists()) {
+            throw InvalidMatchOutcomeException::winningSideWithoutCompetitors();
+        }
+    }
+}

--- a/app/Support/ConsecutiveIntegerSequence.php
+++ b/app/Support/ConsecutiveIntegerSequence.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Support;
+
+final class ConsecutiveIntegerSequence
+{
+    /**
+     * @param  array<int, int|null>  $values
+     */
+    public function isValid(array $values): bool
+    {
+        if ($values === []) {
+            return true;
+        }
+
+        sort($values);
+
+        return $values === range(1, count($values));
+    }
+}

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -31,6 +31,8 @@ The match system handles complex wrestling match scenarios with flexible competi
 
 Match configuration and participant availability are separate failure boundaries. `InvalidMatchConfigurationException` describes an incomplete or structurally invalid match, such as missing referees, missing competitors, insufficient populated sides, or an invalid side number. `EntityNotAvailableException` describes a wrestler, tag team, referee, or title whose current state prevents assignment. `SchedulingConflictException` is reserved for an actual collision between bookings, times, or resources and must not substitute for either boundary.
 
+Recorded outcomes are checked by `MatchOutcomeRequirements`, which explicitly composes focused winning-side, entry-order, and elimination-history requirements. Each requirement owns one cohesive rule family and raises `InvalidMatchOutcomeException`; the coordinator preserves their deterministic validation order without using a dynamic specification registry or mutation pipeline.
+
 ## Event Card Scheduling
 
 Match assignments observe these collision rules:

--- a/tests/Unit/Support/ConsecutiveIntegerSequenceTest.php
+++ b/tests/Unit/Support/ConsecutiveIntegerSequenceTest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\ConsecutiveIntegerSequence;
+
+test('recognizes consecutive one-based integer sequences', function (array $values, bool $isValid) {
+    expect(resolve(ConsecutiveIntegerSequence::class)->isValid($values))->toBe($isValid);
+})->with([
+    'empty sequence' => [[], true],
+    'single value' => [[1], true],
+    'ordered sequence' => [[1, 2, 3], true],
+    'unordered sequence' => [[3, 1, 2], true],
+    'starts after one' => [[2, 3], false],
+    'contains a gap' => [[1, 3], false],
+    'contains a duplicate' => [[1, 2, 2], false],
+    'contains a missing value' => [[1, null, 3], false],
+]);


### PR DESCRIPTION
## Summary
- split match outcome validation into focused winning-side, entry-order, and elimination requirements
- preserve explicit deterministic orchestration in MatchOutcomeRequirements
- reuse a composed ConsecutiveIntegerSequence helper instead of inheritance or a trait
- document the match outcome requirement boundary

## Verification
- 36 focused tests passed with 71 assertions
- application and Pest PHPStan passed
- Rector, Pint with Blade, and 3,385 application tests passed
- Browser tests remain delegated to GitHub Actions because the local sandbox cannot bind the Pest Browser port