### PR TITLE
refactor: share lifecycle period persistence

### DIFF
--- a/app/Lifecycle/EmploymentPeriodManager.php
+++ b/app/Lifecycle/EmploymentPeriodManager.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace App\Lifecycle;
 
-use App\Actions\Lifecycle\RecordLifecycleTransitionAction;
 use App\Enums\Lifecycle\LifecycleDimension;
 use App\Enums\Lifecycle\LifecycleTransitionType;
 use App\Models\Contracts\Employable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 
 final class EmploymentPeriodManager
 {
-    public function __construct(private RecordLifecycleTransitionAction $recordLifecycleTransition) {}
+    public function __construct(private LifecyclePeriodWriter $periodWriter) {}
 
     /**
      * @param  Model&Employable<*>  $employable
@@ -24,21 +22,13 @@ final class EmploymentPeriodManager
         Carbon $date,
         ?LifecycleTransitionType $transition = null,
     ): void {
-        DB::transaction(function () use ($employable, $date, $transition): void {
-            $employable->employments()->create([
-                'started_at' => $date,
-                'ended_at' => null,
-            ]);
-
-            if ($transition !== null) {
-                $this->recordLifecycleTransition->handle(
-                    $employable,
-                    LifecycleDimension::Employment,
-                    $transition,
-                    $date,
-                );
-            }
-        });
+        $this->periodWriter->start(
+            $employable,
+            $employable->employments(),
+            LifecycleDimension::Employment,
+            $date,
+            $transition,
+        );
     }
 
     /**
@@ -49,19 +39,12 @@ final class EmploymentPeriodManager
         Carbon $date,
         ?LifecycleTransitionType $transition = null,
     ): void {
-        DB::transaction(function () use ($employable, $date, $transition): void {
-            $employable->currentEmployment()->update([
-                'ended_at' => $date,
-            ]);
-
-            if ($transition !== null) {
-                $this->recordLifecycleTransition->handle(
-                    $employable,
-                    LifecycleDimension::Employment,
-                    $transition,
-                    $date,
-                );
-            }
-        });
+        $this->periodWriter->end(
+            $employable,
+            $employable->currentEmployment(),
+            LifecycleDimension::Employment,
+            $date,
+            $transition,
+        );
     }
 }

--- a/app/Lifecycle/InjuryPeriodManager.php
+++ b/app/Lifecycle/InjuryPeriodManager.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace App\Lifecycle;
 
-use App\Actions\Lifecycle\RecordLifecycleTransitionAction;
 use App\Enums\Lifecycle\LifecycleDimension;
 use App\Enums\Lifecycle\LifecycleTransitionType;
 use App\Models\Contracts\Injurable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 
 final class InjuryPeriodManager
 {
-    public function __construct(private RecordLifecycleTransitionAction $recordLifecycleTransition) {}
+    public function __construct(private LifecyclePeriodWriter $periodWriter) {}
 
     /**
      * @param  Model&Injurable<*>  $injurable
@@ -24,21 +22,13 @@ final class InjuryPeriodManager
         Carbon $date,
         ?LifecycleTransitionType $transition = null,
     ): void {
-        DB::transaction(function () use ($injurable, $date, $transition): void {
-            $injurable->injuries()->create([
-                'started_at' => $date,
-                'ended_at' => null,
-            ]);
-
-            if ($transition !== null) {
-                $this->recordLifecycleTransition->handle(
-                    $injurable,
-                    LifecycleDimension::Injury,
-                    $transition,
-                    $date,
-                );
-            }
-        });
+        $this->periodWriter->start(
+            $injurable,
+            $injurable->injuries(),
+            LifecycleDimension::Injury,
+            $date,
+            $transition,
+        );
     }
 
     /**
@@ -49,19 +39,12 @@ final class InjuryPeriodManager
         Carbon $date,
         ?LifecycleTransitionType $transition = null,
     ): void {
-        DB::transaction(function () use ($injurable, $date, $transition): void {
-            $injurable->currentInjury()->update([
-                'ended_at' => $date,
-            ]);
-
-            if ($transition !== null) {
-                $this->recordLifecycleTransition->handle(
-                    $injurable,
-                    LifecycleDimension::Injury,
-                    $transition,
-                    $date,
-                );
-            }
-        });
+        $this->periodWriter->end(
+            $injurable,
+            $injurable->currentInjury(),
+            LifecycleDimension::Injury,
+            $date,
+            $transition,
+        );
     }
 }

--- a/app/Lifecycle/LifecyclePeriodWriter.php
+++ b/app/Lifecycle/LifecyclePeriodWriter.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Actions\Lifecycle\RecordLifecycleTransitionAction;
+use App\Enums\Lifecycle\LifecycleDimension;
+use App\Enums\Lifecycle\LifecycleTransitionType;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+
+final class LifecyclePeriodWriter
+{
+    public function __construct(private RecordLifecycleTransitionAction $recordLifecycleTransition) {}
+
+    /**
+     * @param  MorphMany<*, *>  $periods
+     */
+    public function start(
+        Model $subject,
+        MorphMany $periods,
+        LifecycleDimension $dimension,
+        Carbon $date,
+        ?LifecycleTransitionType $transition = null,
+    ): void {
+        DB::transaction(function () use ($subject, $periods, $dimension, $date, $transition): void {
+            $periods->create([
+                'started_at' => $date,
+                'ended_at' => null,
+            ]);
+
+            $this->recordTransition($subject, $dimension, $transition, $date);
+        });
+    }
+
+    /**
+     * @param  MorphOne<*, *>  $currentPeriod
+     */
+    public function end(
+        Model $subject,
+        MorphOne $currentPeriod,
+        LifecycleDimension $dimension,
+        Carbon $date,
+        ?LifecycleTransitionType $transition = null,
+    ): void {
+        DB::transaction(function () use ($subject, $currentPeriod, $dimension, $date, $transition): void {
+            $currentPeriod->update([
+                'ended_at' => $date,
+            ]);
+
+            $this->recordTransition($subject, $dimension, $transition, $date);
+        });
+    }
+
+    private function recordTransition(
+        Model $subject,
+        LifecycleDimension $dimension,
+        ?LifecycleTransitionType $transition,
+        Carbon $date,
+    ): void {
+        if ($transition === null) {
+            return;
+        }
+
+        $this->recordLifecycleTransition->handle($subject, $dimension, $transition, $date);
+    }
+}

--- a/app/Lifecycle/RetirementPeriodManager.php
+++ b/app/Lifecycle/RetirementPeriodManager.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace App\Lifecycle;
 
-use App\Actions\Lifecycle\RecordLifecycleTransitionAction;
 use App\Enums\Lifecycle\LifecycleDimension;
 use App\Enums\Lifecycle\LifecycleTransitionType;
 use App\Models\Contracts\Retirable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 
 final class RetirementPeriodManager
 {
-    public function __construct(private RecordLifecycleTransitionAction $recordLifecycleTransition) {}
+    public function __construct(private LifecyclePeriodWriter $periodWriter) {}
 
     /**
      * @param  Model&Retirable<*>  $retirable
@@ -24,21 +22,13 @@ final class RetirementPeriodManager
         Carbon $date,
         ?LifecycleTransitionType $transition = null,
     ): void {
-        DB::transaction(function () use ($retirable, $date, $transition): void {
-            $retirable->retirements()->create([
-                'started_at' => $date,
-                'ended_at' => null,
-            ]);
-
-            if ($transition !== null) {
-                $this->recordLifecycleTransition->handle(
-                    $retirable,
-                    LifecycleDimension::Retirement,
-                    $transition,
-                    $date,
-                );
-            }
-        });
+        $this->periodWriter->start(
+            $retirable,
+            $retirable->retirements(),
+            LifecycleDimension::Retirement,
+            $date,
+            $transition,
+        );
     }
 
     /**
@@ -49,19 +39,12 @@ final class RetirementPeriodManager
         Carbon $date,
         ?LifecycleTransitionType $transition = null,
     ): void {
-        DB::transaction(function () use ($retirable, $date, $transition): void {
-            $retirable->currentRetirement()->update([
-                'ended_at' => $date,
-            ]);
-
-            if ($transition !== null) {
-                $this->recordLifecycleTransition->handle(
-                    $retirable,
-                    LifecycleDimension::Retirement,
-                    $transition,
-                    $date,
-                );
-            }
-        });
+        $this->periodWriter->end(
+            $retirable,
+            $retirable->currentRetirement(),
+            LifecycleDimension::Retirement,
+            $date,
+            $transition,
+        );
     }
 }

--- a/app/Lifecycle/SuspensionPeriodManager.php
+++ b/app/Lifecycle/SuspensionPeriodManager.php
@@ -4,17 +4,15 @@ declare(strict_types=1);
 
 namespace App\Lifecycle;
 
-use App\Actions\Lifecycle\RecordLifecycleTransitionAction;
 use App\Enums\Lifecycle\LifecycleDimension;
 use App\Enums\Lifecycle\LifecycleTransitionType;
 use App\Models\Contracts\Suspendable;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Facades\DB;
 
 final class SuspensionPeriodManager
 {
-    public function __construct(private RecordLifecycleTransitionAction $recordLifecycleTransition) {}
+    public function __construct(private LifecyclePeriodWriter $periodWriter) {}
 
     /**
      * @param  Model&Suspendable<*>  $suspendable
@@ -24,21 +22,13 @@ final class SuspensionPeriodManager
         Carbon $date,
         ?LifecycleTransitionType $transition = null,
     ): void {
-        DB::transaction(function () use ($suspendable, $date, $transition): void {
-            $suspendable->suspensions()->create([
-                'started_at' => $date,
-                'ended_at' => null,
-            ]);
-
-            if ($transition !== null) {
-                $this->recordLifecycleTransition->handle(
-                    $suspendable,
-                    LifecycleDimension::Suspension,
-                    $transition,
-                    $date,
-                );
-            }
-        });
+        $this->periodWriter->start(
+            $suspendable,
+            $suspendable->suspensions(),
+            LifecycleDimension::Suspension,
+            $date,
+            $transition,
+        );
     }
 
     /**
@@ -49,19 +39,12 @@ final class SuspensionPeriodManager
         Carbon $date,
         ?LifecycleTransitionType $transition = null,
     ): void {
-        DB::transaction(function () use ($suspendable, $date, $transition): void {
-            $suspendable->currentSuspension()->update([
-                'ended_at' => $date,
-            ]);
-
-            if ($transition !== null) {
-                $this->recordLifecycleTransition->handle(
-                    $suspendable,
-                    LifecycleDimension::Suspension,
-                    $transition,
-                    $date,
-                );
-            }
-        });
+        $this->periodWriter->end(
+            $suspendable,
+            $suspendable->currentSuspension(),
+            LifecycleDimension::Suspension,
+            $date,
+            $transition,
+        );
     }
 }


### PR DESCRIPTION
## Summary
- centralize lifecycle period writes and transition auditing in a focused internal writer
- retain typed employment, injury, suspension, and retirement manager boundaries
- preserve atomic period and audit persistence without relationship-name strings

## Verification
- 30 focused lifecycle tests (85 assertions)
- PHPStan
- Rector
- full pre-push suite reached only the existing local Blade color-environment conflict; CI runs that check in a clean environment