### PR TITLE
refactor: extract match competitor rules

### DIFF
--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -6,9 +6,8 @@ namespace App\Livewire\Matches\Forms;
 
 use App\Data\Matches\EventMatchData;
 use App\Enums\MatchType;
-use App\Enums\Titles\TitleStatus;
 use App\Livewire\Base\BaseForm;
-use App\Livewire\Concerns\HasStandardValidationAttributes;
+use App\Livewire\Matches\Support\MatchCompetitorRuleSet;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
@@ -19,84 +18,27 @@ use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Titles\Title;
 use App\Rules\Matches\CompetitorsNotDuplicated;
 use App\Rules\Matches\CorrectNumberOfSides;
-use Closure;
+use App\Rules\Titles\IsActive;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 use LogicException;
 
-/**
- * Livewire form component for managing event match creation and editing.
- *
- * This form handles the complete lifecycle of wrestling match management within
- * events, including competitor assignments, referee assignments, title stakes,
- * and match type specifications. Provides specialized validation for complex
- * wrestling match requirements and relationship management.
- *
- * Key Responsibilities:
- * - Event match information management (preview, match type)
- * - Competitor relationship management (wrestlers, tag teams)
- * - Official assignments (referees)
- * - Championship title stakes and implications
- * - Match-specific validation and business rules
- *
- * @extends BaseForm<EventMatch>
- *
- * @since 1.0.0
- * @see BaseForm For base form functionality and patterns
- * @see EventMatch For the underlying event match model
- */
+/** @extends BaseForm<EventMatch> */
 class CreateEditForm extends BaseForm
 {
-    /**
-     * Match promotional preview content for marketing purposes.
-     *
-     * Used in promotional materials, match cards, and event advertising
-     * to generate interest and provide match context to fans.
-     *
-     * @var string Marketing preview text for the match
-     */
     public ?string $preview = '';
 
-    /**
-     * Match type for match style specification.
-     *
-     * Determines the rules, structure, and requirements for the wrestling
-     * match (singles, tag team, ladder match, cage match, etc.).
-     *
-     * @var MatchType|null Match type enum
-     */
     public ?MatchType $matchType = null;
 
     public ?int $matchStipulationId = null;
 
-    /**
-     * Array of competitors organized by sides in the match.
-     *
-     * Each side contains wrestlers and potentially tag teams for that side.
-     * Structure: [0 => ['wrestlers' => [1, 2]], 1 => ['wrestlers' => [3, 4]]]
-     *
-     * @var array<int, array{wrestlers?: array<int>, tag_teams?: array<int>}> Competitors grouped by side
-     */
+    /** @var array<int, array{wrestlers?: array<int>, tag_teams?: array<int>}> */
     public array $competitors = [];
 
-    /**
-     * Array of referee IDs assigned to officiate the match.
-     *
-     * Most matches have one referee, but special matches may require
-     * additional officials for proper oversight.
-     *
-     * @var array<int> Referee database IDs
-     */
+    /** @var array<int> */
     public array $referees = [];
 
-    /**
-     * Array of title IDs at stake in the match.
-     *
-     * Empty array for non-title matches, populated for championship
-     * matches with title implications.
-     *
-     * @var array<int> Title database IDs
-     */
+    /** @var array<int> */
     public array $titles = [];
 
     public function resetCompetitorsFor(MatchType $matchType): void
@@ -111,27 +53,12 @@ class CreateEditForm extends BaseForm
         ]);
     }
 
-    /**
-     * Load additional data when editing existing event match records.
-     *
-     * Handles complex relationship data loading for edit operations,
-     * retrieving competitor assignments, referee assignments, and title
-     * stakes from the event match's relationship system.
-     *
-     * Relationship Loading:
-     * - Loads match type from relationship
-     * - Loads competitor IDs from many-to-many relationships
-     * - Loads referee assignments
-     * - Loads title stakes for championship matches
-     */
     public function loadExtraData(): void
     {
-        // Only process if we have an event match model
         if (! $this->formModel instanceof EventMatch) {
             return;
         }
 
-        // Load match type from enum property
         $this->matchType = $this->formModel->match_type;
         $this->matchStipulationId = $this->formModel->match_stipulation_id;
 
@@ -172,13 +99,6 @@ class CreateEditForm extends BaseForm
             : $competitorsBySide;
     }
 
-    /**
-     * Prepare event match data for model storage.
-     *
-     * Transforms form fields into model-compatible data structure.
-     * Excludes relationship data which is handled separately through
-     * the relationship synchronization system.
-     */
     public function toData(): EventMatchData
     {
         $matchType = $this->requiredMatchType();
@@ -212,30 +132,7 @@ class CreateEditForm extends BaseForm
         );
     }
 
-    /**
-     * Get the model class for event match form operations.
-     *
-     * Specifies the EventMatch model class for type-safe model operations
-     * including creation, updates, and relationship management.
-     *
-     * @return class-string<EventMatch> The EventMatch model class
-     */
-    /**
-     * Define validation rules for event match form fields.
-     *
-     * Provides comprehensive validation for all event match data including
-     * match type requirements, competitor assignments, referee assignments,
-     * and promotional content validation.
-     *
-     * Validation Requirements:
-     * - Preview: Required promotional content
-     * - Match Type: Required, must exist in match_types table
-     * - Competitors: Required array, minimum participants based on match type
-     * - Referees: Required array, at least one referee
-     * - Titles: Optional array for championship matches
-     *
-     * @return array<string, array<int, mixed>> Laravel validation rules array
-     */
+    /** @return array<string, array<int, mixed>> */
     protected function rules(): array
     {
         $baseRules = [
@@ -249,25 +146,10 @@ class CreateEditForm extends BaseForm
             'referees' => ['required', 'array', 'min:1'],
             'referees.*' => ['integer', 'exists:referees,id'],
             'titles' => ['sometimes', 'array'],
-            'titles.*' => [
-                'integer',
-                'exists:titles,id',
-                function (string $attribute, mixed $value, Closure $fail): void {
-                    if (! is_int($value)) {
-                        return;
-                    }
-
-                    $title = Title::query()->find($value);
-
-                    if ($title !== null && $title->status !== TitleStatus::Active) {
-                        $fail('The selected title must be active.');
-                    }
-                },
-            ],
+            'titles.*' => ['integer', 'exists:titles,id', new IsActive()],
         ];
 
-        // Add dynamic competitor validation based on match type
-        $competitorRules = $this->getCompetitorValidationRules();
+        $competitorRules = (new MatchCompetitorRuleSet($this->matchType))->rules();
         $competitorRules['competitors'] = [
             ...$competitorRules['competitors'],
             new CorrectNumberOfSides(),
@@ -277,132 +159,13 @@ class CreateEditForm extends BaseForm
         return array_merge($baseRules, $competitorRules);
     }
 
-    /**
-     * Get validation rules for competitors based on the match type.
-     *
-     * @return array<string, array<string>>
-     */
-    private function getCompetitorValidationRules(): array
-    {
-        // If no match type is selected yet, use basic validation
-        if (! $this->matchType) {
-            return [
-                'competitors' => ['sometimes', 'array'],
-                'competitors.*.wrestlers' => ['sometimes', 'array'],
-                'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.*.tag_teams' => ['sometimes', 'array'],
-                'competitors.*.tag_teams.*' => ['integer', 'exists:tag_teams,id'],
-            ];
-        }
-
-        return $this->getValidationForMatchType($this->matchType);
-    }
-
     private function requiredMatchType(): MatchType
     {
         return $this->matchType
             ?? throw new LogicException('A match type is required before building match data.');
     }
 
-    /**
-     * Get specific validation rules for a match type.
-     *
-     * @return array<string, array<string>>
-     */
-    private function getValidationForMatchType(MatchType $matchType): array
-    {
-        $matchTypeValue = $matchType->value;
-
-        // Singles Match: 2 sides, 1 wrestler each
-        if ($matchType === MatchType::Singles) {
-            return [
-                'competitors' => ['required', 'array', 'size:2'],
-                'competitors.0.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.1.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.1.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-            ];
-        }
-
-        // Tag Team Match: 2 sides, 2+ wrestlers or tag teams
-        if (in_array($matchType, [MatchType::TagTeam, MatchType::SixManTagTeam, MatchType::EightManTagTeam, MatchType::TenManTagTeam, MatchType::TornadoTagTeam], true)) {
-            return [
-                'competitors' => ['required', 'array', 'size:2'],
-                'competitors.0' => ['required', 'array'],
-                'competitors.0.wrestlers' => ['sometimes', 'array', 'min:2'],
-                'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.0.tag_teams' => ['sometimes', 'array', 'min:1'],
-                'competitors.0.tag_teams.*' => ['integer', 'exists:tag_teams,id'],
-                'competitors.1' => ['required', 'array'],
-                'competitors.1.wrestlers' => ['sometimes', 'array', 'min:2'],
-                'competitors.1.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.1.tag_teams' => ['sometimes', 'array', 'min:1'],
-                'competitors.1.tag_teams.*' => ['integer', 'exists:tag_teams,id'],
-            ];
-        }
-
-        // Triple Threat: 3 sides, 1 wrestler each
-        if (in_array($matchType, [MatchType::TripleThreat, MatchType::Triangle], true)) {
-            return [
-                'competitors' => ['required', 'array', 'size:3'],
-                'competitors.0.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.1.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.1.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.2.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.2.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-            ];
-        }
-
-        // Fatal Four Way: 4 sides, 1 wrestler each
-        if ($matchType === MatchType::Fatal4Way) {
-            return [
-                'competitors' => ['required', 'array', 'size:4'],
-                'competitors.0.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.1.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.1.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.2.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.2.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-                'competitors.3.wrestlers' => ['required', 'array', 'size:1'],
-                'competitors.3.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-            ];
-        }
-
-        if ($matchType->usesIndividualCompetitorSides()) {
-            $maximumCompetitors = $matchType->getMaximumCompetitors();
-            $wrestlerRules = ['required', 'array', 'min:'.$matchType->getMinimumCompetitors()];
-
-            if ($maximumCompetitors !== null) {
-                $wrestlerRules[] = 'max:'.$maximumCompetitors;
-            }
-
-            return [
-                'competitors' => ['required', 'array', 'size:1'],
-                'competitors.0.wrestlers' => $wrestlerRules,
-                'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-            ];
-        }
-
-        // Default: Basic validation for unknown match types
-        return [
-            'competitors' => ['required', 'array', 'min:2'],
-            'competitors.*.wrestlers' => ['sometimes', 'array'],
-            'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
-            'competitors.*.tag_teams' => ['sometimes', 'array'],
-            'competitors.*.tag_teams.*' => ['integer', 'exists:tag_teams,id'],
-        ];
-    }
-
-    /**
-     * Get custom validation attributes specific to event match forms.
-     *
-     * Provides event match-specific field name mappings for validation
-     * error messages, extending the standard validation attributes from
-     * the HasStandardValidationAttributes trait.
-     *
-     * @return array<string, string> Field name mappings for validation messages
-     */
+    /** @return array<string, string> */
     protected function getCustomValidationAttributes(): array
     {
         return [

--- a/app/Livewire/Matches/Support/MatchCompetitorRuleSet.php
+++ b/app/Livewire/Matches/Support/MatchCompetitorRuleSet.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Livewire\Matches\Support;
+
+use App\Enums\MatchType;
+
+final readonly class MatchCompetitorRuleSet
+{
+    public function __construct(private ?MatchType $matchType) {}
+
+    /** @return array<string, array<int, mixed>> */
+    public function rules(): array
+    {
+        if ($this->matchType === null) {
+            return $this->unselectedMatchTypeRules();
+        }
+
+        if ($this->matchType->usesIndividualCompetitorSides()) {
+            return $this->individualEntrantRules($this->matchType);
+        }
+
+        return match ($this->matchType) {
+            MatchType::Singles => $this->individualSideRules(2),
+            MatchType::TripleThreat,
+            MatchType::Triangle => $this->individualSideRules(3),
+            MatchType::Fatal4Way => $this->individualSideRules(4),
+            MatchType::TagTeam,
+            MatchType::SixManTagTeam,
+            MatchType::EightManTagTeam,
+            MatchType::TenManTagTeam,
+            MatchType::TornadoTagTeam => $this->tagTeamRules(),
+            default => $this->genericRules(),
+        };
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    private function unselectedMatchTypeRules(): array
+    {
+        return [
+            'competitors' => ['sometimes', 'array'],
+            'competitors.*.wrestlers' => ['sometimes', 'array'],
+            'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
+            'competitors.*.tag_teams' => ['sometimes', 'array'],
+            'competitors.*.tag_teams.*' => ['integer', 'exists:tag_teams,id'],
+        ];
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    private function individualSideRules(int $sideCount): array
+    {
+        $rules = ['competitors' => ['required', 'array', "size:{$sideCount}"]];
+
+        foreach (range(0, $sideCount - 1) as $sideIndex) {
+            $rules["competitors.{$sideIndex}.wrestlers"] = ['required', 'array', 'size:1'];
+            $rules["competitors.{$sideIndex}.wrestlers.*"] = ['integer', 'exists:wrestlers,id'];
+        }
+
+        return $rules;
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    private function tagTeamRules(): array
+    {
+        $rules = ['competitors' => ['required', 'array', 'size:2']];
+
+        foreach (range(0, 1) as $sideIndex) {
+            $rules["competitors.{$sideIndex}"] = ['required', 'array'];
+            $rules["competitors.{$sideIndex}.wrestlers"] = ['sometimes', 'array', 'min:2'];
+            $rules["competitors.{$sideIndex}.wrestlers.*"] = ['integer', 'exists:wrestlers,id'];
+            $rules["competitors.{$sideIndex}.tag_teams"] = ['sometimes', 'array', 'min:1'];
+            $rules["competitors.{$sideIndex}.tag_teams.*"] = ['integer', 'exists:tag_teams,id'];
+        }
+
+        return $rules;
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    private function individualEntrantRules(MatchType $matchType): array
+    {
+        $wrestlerRules = ['required', 'array', 'min:'.$matchType->getMinimumCompetitors()];
+        $maximumCompetitors = $matchType->getMaximumCompetitors();
+
+        if ($maximumCompetitors !== null) {
+            $wrestlerRules[] = "max:{$maximumCompetitors}";
+        }
+
+        return [
+            'competitors' => ['required', 'array', 'size:1'],
+            'competitors.0.wrestlers' => $wrestlerRules,
+            'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
+        ];
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    private function genericRules(): array
+    {
+        return [
+            'competitors' => ['required', 'array', 'min:2'],
+            'competitors.*.wrestlers' => ['sometimes', 'array'],
+            'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
+            'competitors.*.tag_teams' => ['sometimes', 'array'],
+            'competitors.*.tag_teams.*' => ['integer', 'exists:tag_teams,id'],
+        ];
+    }
+}

--- a/tests/Unit/Livewire/Matches/Support/MatchCompetitorRuleSetTest.php
+++ b/tests/Unit/Livewire/Matches/Support/MatchCompetitorRuleSetTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MatchType;
+use App\Livewire\Matches\Support\MatchCompetitorRuleSet;
+
+it('builds fixed individual-side rules', function (MatchType $matchType, int $sideCount) {
+    $rules = (new MatchCompetitorRuleSet($matchType))->rules();
+
+    expect($rules['competitors'])->toContain("size:{$sideCount}");
+
+    foreach (range(0, $sideCount - 1) as $sideIndex) {
+        expect($rules["competitors.{$sideIndex}.wrestlers"])->toContain('size:1');
+    }
+})->with([
+    'singles' => [MatchType::Singles, 2],
+    'triple threat' => [MatchType::TripleThreat, 3],
+    'triangle' => [MatchType::Triangle, 3],
+    'fatal four way' => [MatchType::Fatal4Way, 4],
+]);
+
+it('builds tag team selection rules', function (MatchType $matchType) {
+    $rules = (new MatchCompetitorRuleSet($matchType))->rules();
+
+    expect($rules['competitors'])->toContain('size:2')
+        ->and($rules['competitors.0.wrestlers'])->toContain('min:2')
+        ->and($rules['competitors.0.tag_teams'])->toContain('min:1')
+        ->and($rules['competitors.1.wrestlers'])->toContain('min:2')
+        ->and($rules['competitors.1.tag_teams'])->toContain('min:1');
+})->with([
+    MatchType::TagTeam,
+    MatchType::SixManTagTeam,
+    MatchType::EightManTagTeam,
+    MatchType::TenManTagTeam,
+    MatchType::TornadoTagTeam,
+]);
+
+it('builds individual entrant limits', function (MatchType $matchType, string $minimum, ?string $maximum) {
+    $rules = (new MatchCompetitorRuleSet($matchType))->rules();
+
+    expect($rules['competitors'])->toContain('size:1')
+        ->and($rules['competitors.0.wrestlers'])->toContain($minimum);
+
+    if ($maximum === null) {
+        expect($rules['competitors.0.wrestlers'])->not->toContain('max:30');
+
+        return;
+    }
+
+    expect($rules['competitors.0.wrestlers'])->toContain($maximum);
+})->with([
+    'battle royal' => [MatchType::BattleRoyal, 'min:3', null],
+    'royal rumble' => [MatchType::RoyalRumble, 'min:10', 'max:30'],
+]);
+
+it('uses permissive nested rules until a match type is selected', function () {
+    $rules = (new MatchCompetitorRuleSet(null))->rules();
+
+    expect($rules['competitors'])->toContain('sometimes')
+        ->and($rules)->toHaveKeys([
+            'competitors.*.wrestlers',
+            'competitors.*.wrestlers.*',
+            'competitors.*.tag_teams',
+            'competitors.*.tag_teams.*',
+        ]);
+});
+
+it('uses generic side rules for asymmetric match types', function (MatchType $matchType) {
+    $rules = (new MatchCompetitorRuleSet($matchType))->rules();
+
+    expect($rules['competitors'])->toContain('min:2')
+        ->and($rules)->toHaveKeys([
+            'competitors.*.wrestlers',
+            'competitors.*.tag_teams',
+        ]);
+})->with([
+    MatchType::TwoOnOneHandicap,
+    MatchType::ThreeOnTwoHandicap,
+    MatchType::Gauntlet,
+]);


### PR DESCRIPTION
## Summary
- extract match-type competitor validation into a focused immutable rule-set
- reuse the existing active-title validation rule instead of an inline database closure
- remove stale narrative docblocks from the Livewire form

## Verification
- composer test:push (Rector, Pint, PHPStan, 3,400 non-browser tests passed; browser phase was stopped after several minutes without output)
- focused Match form suites: 62 tests, 168 assertions