### PR TITLE
refactor: normalize policy signatures

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -26,6 +26,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/{Models,Providers,Actions,Lifecycle}/** | .ai/rules/models-providers-actions-lifecycle.md |
 | app/{Models,ValueObjects,Casts}/** | .ai/rules/models-value-objects-casts.md |
 | app/Models/** | .ai/rules/models.md |
+| app/Policies/** | .ai/rules/policies.md |
 | app/{Livewire,Http/Requests,Actions,Services}/** | .ai/rules/requests-actions-services.md |
 | app/Http/Requests/** | .ai/rules/requests.md |
 | routes/**, routes/web.php | .ai/rules/routes.md |

--- a/.ai/rules/policies.md
+++ b/.ai/rules/policies.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/Policies/**'
+---
+
+# Policies
+
+## Use Laravel policy method signatures
+Use Laravel's conventional viewAny(User) and create(User) signatures for class-level abilities. Every instance-level ability must accept the authenticated User followed by the required concrete model; authorize those abilities with a model instance, never a model class.

--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -43,7 +43,7 @@ class Main extends BaseTable
 
     public function configure(): void
     {
-        Gate::authorize('viewList', Event::class);
+        Gate::authorize('viewAny', Event::class);
 
         $this->addAdditionalSelects([
             'events.venue_id',

--- a/app/Livewire/Managers/Tables/Main.php
+++ b/app/Livewire/Managers/Tables/Main.php
@@ -57,7 +57,7 @@ class Main extends BaseTable
 
     public function configure(): void
     {
-        Gate::authorize('viewList', Manager::class);
+        Gate::authorize('viewAny', Manager::class);
     }
 
     /**

--- a/app/Livewire/Matches/Tables/Main.php
+++ b/app/Livewire/Matches/Tables/Main.php
@@ -40,7 +40,7 @@ class Main extends BaseTable
 
     public function configure(): void
     {
-        Gate::authorize('viewList', EventMatch::class);
+        Gate::authorize('viewAny', EventMatch::class);
 
         $this->addAdditionalSelects([
             'events_matches.event_id',

--- a/app/Livewire/Matches/Tables/MatchesTable.php
+++ b/app/Livewire/Matches/Tables/MatchesTable.php
@@ -49,7 +49,7 @@ class MatchesTable extends DataTableComponent
 
     public function configure(): void
     {
-        Gate::authorize('viewList', EventMatch::class);
+        Gate::authorize('viewAny', EventMatch::class);
 
         $this->addAdditionalSelects([
             'events_matches.event_id',

--- a/app/Livewire/Referees/Tables/Main.php
+++ b/app/Livewire/Referees/Tables/Main.php
@@ -58,7 +58,7 @@ class Main extends BaseTable
 
     public function configure(): void
     {
-        Gate::authorize('viewList', Referee::class);
+        Gate::authorize('viewAny', Referee::class);
     }
 
     /**
@@ -220,7 +220,7 @@ class Main extends BaseTable
     {
         $referee = Referee::onlyTrashed()->findOrFail($refereeId);
 
-        Gate::authorize('restore', Referee::class);
+        Gate::authorize('restore', $referee);
 
         try {
             resolve(RestoreAction::class)->handle($referee);

--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -49,7 +49,7 @@ class Main extends BaseTable
 
     public function configure(): void
     {
-        Gate::authorize('viewList', Stable::class);
+        Gate::authorize('viewAny', Stable::class);
     }
 
     /**

--- a/app/Livewire/TagTeams/Tables/Main.php
+++ b/app/Livewire/TagTeams/Tables/Main.php
@@ -53,7 +53,7 @@ class Main extends BaseTable
 
     public function configure(): void
     {
-        Gate::authorize('viewList', TagTeam::class);
+        Gate::authorize('viewAny', TagTeam::class);
     }
 
     /**

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -95,7 +95,7 @@ class Main extends BaseTable
      */
     public function configure(): void
     {
-        Gate::authorize('viewList', Title::class);
+        Gate::authorize('viewAny', Title::class);
     }
 
     /**

--- a/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Titles/Tables/PreviousTitleChampionships.php
@@ -30,7 +30,7 @@ class PreviousTitleChampionships extends DataTableComponent
 
     public function configure(): void
     {
-        Gate::authorize('viewList', Title::class);
+        Gate::authorize('viewAny', Title::class);
     }
 
     /**

--- a/app/Livewire/Venues/Tables/Main.php
+++ b/app/Livewire/Venues/Tables/Main.php
@@ -35,7 +35,7 @@ class Main extends BaseTable
 
     public function configure(): void
     {
-        Gate::authorize('viewList', Venue::class);
+        Gate::authorize('viewAny', Venue::class);
     }
 
     /**

--- a/app/Livewire/Wrestlers/Tables/Main.php
+++ b/app/Livewire/Wrestlers/Tables/Main.php
@@ -51,7 +51,7 @@ class Main extends BaseTable
 
     public function configure(): void
     {
-        Gate::authorize('viewList', Wrestler::class);
+        Gate::authorize('viewAny', Wrestler::class);
     }
 
     /**

--- a/app/Policies/EventMatchPolicy.php
+++ b/app/Policies/EventMatchPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Matches\EventMatch;
 use App\Models\Users\User;
 
 /**
@@ -32,7 +33,7 @@ class EventMatchPolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -40,7 +41,7 @@ class EventMatchPolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, EventMatch $eventMatch): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -56,7 +57,7 @@ class EventMatchPolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, EventMatch $eventMatch): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -64,7 +65,7 @@ class EventMatchPolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, EventMatch $eventMatch): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -72,7 +73,7 @@ class EventMatchPolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, EventMatch $eventMatch): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Events\Event;
 use App\Models\Users\User;
 
 /**
@@ -32,7 +33,7 @@ class EventPolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -40,7 +41,7 @@ class EventPolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, Event $event): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -56,7 +57,7 @@ class EventPolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, Event $event): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -64,7 +65,7 @@ class EventPolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Event $event): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -72,7 +73,7 @@ class EventPolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, Event $event): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/ManagerPolicy.php
+++ b/app/Policies/ManagerPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Roster\Managers\Manager;
 use App\Models\Users\User;
 
 /**
@@ -32,7 +33,7 @@ class ManagerPolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -40,7 +41,7 @@ class ManagerPolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -56,7 +57,7 @@ class ManagerPolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -64,7 +65,7 @@ class ManagerPolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -72,7 +73,7 @@ class ManagerPolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -80,7 +81,7 @@ class ManagerPolicy
     /**
      * Only administrators can employ managers (handled by before hook).
      */
-    public function employ(User $user): bool
+    public function employ(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -88,7 +89,7 @@ class ManagerPolicy
     /**
      * Only administrators can release managers (handled by before hook).
      */
-    public function release(User $user): bool
+    public function release(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -96,7 +97,7 @@ class ManagerPolicy
     /**
      * Only administrators can retire managers (handled by before hook).
      */
-    public function retire(User $user): bool
+    public function retire(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -104,7 +105,7 @@ class ManagerPolicy
     /**
      * Only administrators can unretire managers (handled by before hook).
      */
-    public function unretire(User $user): bool
+    public function unretire(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -112,7 +113,7 @@ class ManagerPolicy
     /**
      * Only administrators can suspend managers (handled by before hook).
      */
-    public function suspend(User $user): bool
+    public function suspend(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -120,7 +121,7 @@ class ManagerPolicy
     /**
      * Only administrators can reinstate managers (handled by before hook).
      */
-    public function reinstate(User $user): bool
+    public function reinstate(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -128,7 +129,7 @@ class ManagerPolicy
     /**
      * Only administrators can injure managers (handled by before hook).
      */
-    public function injure(User $user): bool
+    public function injure(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -136,7 +137,7 @@ class ManagerPolicy
     /**
      * Only administrators can clear managers from injury (handled by before hook).
      */
-    public function clearFromInjury(User $user): bool
+    public function clearFromInjury(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -144,7 +145,7 @@ class ManagerPolicy
     /**
      * Only administrators can heal managers (alias for clearFromInjury, handled by before hook).
      */
-    public function heal(User $user): bool
+    public function heal(User $user, Manager $manager): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/MatchPolicy.php
+++ b/app/Policies/MatchPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Matches\EventMatch;
 use App\Models\Users\User;
 
 /**
@@ -32,7 +33,7 @@ class MatchPolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -40,7 +41,7 @@ class MatchPolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, EventMatch $eventMatch): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -56,7 +57,7 @@ class MatchPolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, EventMatch $eventMatch): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -64,7 +65,7 @@ class MatchPolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, EventMatch $eventMatch): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -72,7 +73,7 @@ class MatchPolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, EventMatch $eventMatch): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/RefereePolicy.php
+++ b/app/Policies/RefereePolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Roster\Referees\Referee;
 use App\Models\Users\User;
 
 /**
@@ -32,7 +33,7 @@ class RefereePolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -40,7 +41,7 @@ class RefereePolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -56,7 +57,7 @@ class RefereePolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -64,7 +65,7 @@ class RefereePolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -72,7 +73,7 @@ class RefereePolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -80,7 +81,7 @@ class RefereePolicy
     /**
      * Only administrators can employ referees (handled by before hook).
      */
-    public function employ(User $user): bool
+    public function employ(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -88,7 +89,7 @@ class RefereePolicy
     /**
      * Only administrators can release referees (handled by before hook).
      */
-    public function release(User $user): bool
+    public function release(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -96,7 +97,7 @@ class RefereePolicy
     /**
      * Only administrators can retire referees (handled by before hook).
      */
-    public function retire(User $user): bool
+    public function retire(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -104,7 +105,7 @@ class RefereePolicy
     /**
      * Only administrators can unretire referees (handled by before hook).
      */
-    public function unretire(User $user): bool
+    public function unretire(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -112,7 +113,7 @@ class RefereePolicy
     /**
      * Only administrators can suspend referees (handled by before hook).
      */
-    public function suspend(User $user): bool
+    public function suspend(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -120,7 +121,7 @@ class RefereePolicy
     /**
      * Only administrators can reinstate referees (handled by before hook).
      */
-    public function reinstate(User $user): bool
+    public function reinstate(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -128,7 +129,7 @@ class RefereePolicy
     /**
      * Only administrators can injure referees (handled by before hook).
      */
-    public function injure(User $user): bool
+    public function injure(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -136,7 +137,7 @@ class RefereePolicy
     /**
      * Only administrators can clear referees from injury (handled by before hook).
      */
-    public function clearFromInjury(User $user): bool
+    public function clearFromInjury(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -144,7 +145,7 @@ class RefereePolicy
     /**
      * Only administrators can heal referees (alias for clearFromInjury, handled by before hook).
      */
-    public function heal(User $user): bool
+    public function heal(User $user, Referee $referee): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/StablePolicy.php
+++ b/app/Policies/StablePolicy.php
@@ -33,7 +33,7 @@ class StablePolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -41,7 +41,7 @@ class StablePolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user, ?Stable $stable = null): bool
+    public function view(User $user, Stable $stable): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -57,7 +57,7 @@ class StablePolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user, ?Stable $stable = null): bool
+    public function update(User $user, Stable $stable): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -65,7 +65,7 @@ class StablePolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user, ?Stable $stable = null): bool
+    public function delete(User $user, Stable $stable): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -73,7 +73,7 @@ class StablePolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user, ?Stable $stable = null): bool
+    public function restore(User $user, Stable $stable): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -81,7 +81,7 @@ class StablePolicy
     /**
      * Only administrators can establish stables (handled by before hook).
      */
-    public function establish(User $user, ?Stable $stable = null): bool
+    public function establish(User $user, Stable $stable): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -89,7 +89,7 @@ class StablePolicy
     /**
      * Only administrators can disband stables (handled by before hook).
      */
-    public function disband(User $user, ?Stable $stable = null): bool
+    public function disband(User $user, Stable $stable): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -97,7 +97,7 @@ class StablePolicy
     /**
      * Only administrators can retire stables (handled by before hook).
      */
-    public function retire(User $user, ?Stable $stable = null): bool
+    public function retire(User $user, Stable $stable): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -105,7 +105,7 @@ class StablePolicy
     /**
      * Only administrators can unretire stables (handled by before hook).
      */
-    public function unretire(User $user, ?Stable $stable = null): bool
+    public function unretire(User $user, Stable $stable): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/TagTeamPolicy.php
+++ b/app/Policies/TagTeamPolicy.php
@@ -33,7 +33,7 @@ class TagTeamPolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -41,7 +41,7 @@ class TagTeamPolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user, ?TagTeam $tagTeam = null): bool
+    public function view(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -57,7 +57,7 @@ class TagTeamPolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user, ?TagTeam $tagTeam = null): bool
+    public function update(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -65,7 +65,7 @@ class TagTeamPolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user, ?TagTeam $tagTeam = null): bool
+    public function delete(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -73,7 +73,7 @@ class TagTeamPolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user, ?TagTeam $tagTeam = null): bool
+    public function restore(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -81,7 +81,7 @@ class TagTeamPolicy
     /**
      * Only administrators can employ tag teams (handled by before hook).
      */
-    public function employ(User $user, ?TagTeam $tagTeam = null): bool
+    public function employ(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -89,7 +89,7 @@ class TagTeamPolicy
     /**
      * Only administrators can release tag teams (handled by before hook).
      */
-    public function release(User $user, ?TagTeam $tagTeam = null): bool
+    public function release(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -97,7 +97,7 @@ class TagTeamPolicy
     /**
      * Only administrators can suspend tag teams (handled by before hook).
      */
-    public function suspend(User $user, ?TagTeam $tagTeam = null): bool
+    public function suspend(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -105,7 +105,7 @@ class TagTeamPolicy
     /**
      * Only administrators can reinstate tag teams (handled by before hook).
      */
-    public function reinstate(User $user, ?TagTeam $tagTeam = null): bool
+    public function reinstate(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -113,7 +113,7 @@ class TagTeamPolicy
     /**
      * Only administrators can retire tag teams (handled by before hook).
      */
-    public function retire(User $user, ?TagTeam $tagTeam = null): bool
+    public function retire(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -121,7 +121,7 @@ class TagTeamPolicy
     /**
      * Only administrators can unretire tag teams (handled by before hook).
      */
-    public function unretire(User $user, ?TagTeam $tagTeam = null): bool
+    public function unretire(User $user, TagTeam $tagTeam): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/TitlePolicy.php
+++ b/app/Policies/TitlePolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Titles\Title;
 use App\Models\Users\User;
 
 /**
@@ -32,7 +33,7 @@ class TitlePolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -40,7 +41,7 @@ class TitlePolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -56,7 +57,7 @@ class TitlePolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -64,7 +65,7 @@ class TitlePolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -72,7 +73,7 @@ class TitlePolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -80,7 +81,7 @@ class TitlePolicy
     /**
      * Only administrators can debut titles (handled by before hook).
      */
-    public function debut(User $user): bool
+    public function debut(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -88,7 +89,7 @@ class TitlePolicy
     /**
      * Only administrators can pull titles (handled by before hook).
      */
-    public function pull(User $user): bool
+    public function pull(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -96,7 +97,7 @@ class TitlePolicy
     /**
      * Only administrators can reinstate titles (handled by before hook).
      */
-    public function reinstate(User $user): bool
+    public function reinstate(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -104,7 +105,7 @@ class TitlePolicy
     /**
      * Only administrators can retire titles (handled by before hook).
      */
-    public function retire(User $user): bool
+    public function retire(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -112,7 +113,7 @@ class TitlePolicy
     /**
      * Only administrators can unretire titles (handled by before hook).
      */
-    public function unretire(User $user): bool
+    public function unretire(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -120,7 +121,7 @@ class TitlePolicy
     /**
      * Only administrators can activate titles (handled by before hook).
      */
-    public function activate(User $user): bool
+    public function activate(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -128,7 +129,7 @@ class TitlePolicy
     /**
      * Only administrators can deactivate titles (handled by before hook).
      */
-    public function deactivate(User $user): bool
+    public function deactivate(User $user, Title $title): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -32,7 +32,7 @@ class UserPolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -40,7 +40,7 @@ class UserPolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, User $targetUser): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -56,7 +56,7 @@ class UserPolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, User $targetUser): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -64,7 +64,7 @@ class UserPolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, User $targetUser): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -72,7 +72,7 @@ class UserPolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, User $targetUser): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/VenuePolicy.php
+++ b/app/Policies/VenuePolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Events\Venue;
 use App\Models\Users\User;
 
 /**
@@ -32,7 +33,7 @@ class VenuePolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -40,7 +41,7 @@ class VenuePolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, Venue $venue): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -56,7 +57,7 @@ class VenuePolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, Venue $venue): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -64,7 +65,7 @@ class VenuePolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Venue $venue): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -72,7 +73,7 @@ class VenuePolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, Venue $venue): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/app/Policies/WrestlerPolicy.php
+++ b/app/Policies/WrestlerPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Policies;
 
+use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Users\User;
 
 /**
@@ -33,7 +34,7 @@ class WrestlerPolicy
     /**
      * Only administrators can view entity lists (handled by before hook).
      */
-    public function viewList(User $user): bool
+    public function viewAny(User $user): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -41,7 +42,7 @@ class WrestlerPolicy
     /**
      * Only administrators can view individual entities (handled by before hook).
      */
-    public function view(User $user): bool
+    public function view(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -57,7 +58,7 @@ class WrestlerPolicy
     /**
      * Only administrators can update entities (handled by before hook).
      */
-    public function update(User $user): bool
+    public function update(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -65,7 +66,7 @@ class WrestlerPolicy
     /**
      * Only administrators can delete entities (handled by before hook).
      */
-    public function delete(User $user): bool
+    public function delete(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -73,7 +74,7 @@ class WrestlerPolicy
     /**
      * Only administrators can restore entities (handled by before hook).
      */
-    public function restore(User $user): bool
+    public function restore(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -81,7 +82,7 @@ class WrestlerPolicy
     /**
      * Only administrators can employ wrestlers (handled by before hook).
      */
-    public function employ(User $user): bool
+    public function employ(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -89,7 +90,7 @@ class WrestlerPolicy
     /**
      * Only administrators can release wrestlers (handled by before hook).
      */
-    public function release(User $user): bool
+    public function release(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -97,7 +98,7 @@ class WrestlerPolicy
     /**
      * Only administrators can retire wrestlers (handled by before hook).
      */
-    public function retire(User $user): bool
+    public function retire(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -105,7 +106,7 @@ class WrestlerPolicy
     /**
      * Only administrators can unretire wrestlers (handled by before hook).
      */
-    public function unretire(User $user): bool
+    public function unretire(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -113,7 +114,7 @@ class WrestlerPolicy
     /**
      * Only administrators can suspend wrestlers (handled by before hook).
      */
-    public function suspend(User $user): bool
+    public function suspend(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -121,7 +122,7 @@ class WrestlerPolicy
     /**
      * Only administrators can reinstate wrestlers (handled by before hook).
      */
-    public function reinstate(User $user): bool
+    public function reinstate(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -129,7 +130,7 @@ class WrestlerPolicy
     /**
      * Only administrators can injure wrestlers (handled by before hook).
      */
-    public function injure(User $user): bool
+    public function injure(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }
@@ -137,7 +138,7 @@ class WrestlerPolicy
     /**
      * Only administrators can clear wrestlers from injury (handled by before hook).
      */
-    public function clearFromInjury(User $user): bool
+    public function clearFromInjury(User $user, Wrestler $wrestler): bool
     {
         return false; // Will be bypassed by before hook for administrators
     }

--- a/docs/architecture/core-patterns.md
+++ b/docs/architecture/core-patterns.md
@@ -142,7 +142,7 @@ public function before(User $user, string $ability): ?bool
     return null; // Continue to individual method checks
 }
 
-public function viewList(User $user): bool
+public function viewAny(User $user): bool
 {
     return false; // Will be bypassed by before hook for administrators
 }

--- a/docs/guidelines/laravel.md
+++ b/docs/guidelines/laravel.md
@@ -59,7 +59,7 @@ class WrestlersController extends Controller
 
     public function index(): View
     {
-        $this->authorize('viewList', Wrestler::class);
+        $this->authorize('viewAny', Wrestler::class);
 
         return view('wrestlers.index');
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,30 +31,30 @@ Route::middleware('auth')->group(function () {
     Route::get('dashboard', DashboardController::class)->name('dashboard');
 
     Route::prefix('roster')->group(function () {
-        Route::get('stables', [StablesController::class, 'index'])->can('viewList', Stable::class)->name('stables.index');
+        Route::get('stables', [StablesController::class, 'index'])->can('viewAny', Stable::class)->name('stables.index');
         Route::get('stables/{stable}', [StablesController::class, 'show'])->can('view', 'stable')->name('stables.show');
-        Route::get('wrestlers', [WrestlersController::class, 'index'])->can('viewList', Wrestler::class)->name('wrestlers.index');
+        Route::get('wrestlers', [WrestlersController::class, 'index'])->can('viewAny', Wrestler::class)->name('wrestlers.index');
         Route::get('wrestlers/{wrestler}', [WrestlersController::class, 'show'])->can('view', 'wrestler')->name('wrestlers.show');
-        Route::get('managers', [ManagersController::class, 'index'])->can('viewList', Manager::class)->name('managers.index');
+        Route::get('managers', [ManagersController::class, 'index'])->can('viewAny', Manager::class)->name('managers.index');
         Route::get('managers/{manager}', [ManagersController::class, 'show'])->can('view', 'manager')->name('managers.show');
-        Route::get('referees', [RefereesController::class, 'index'])->can('viewList', Referee::class)->name('referees.index');
+        Route::get('referees', [RefereesController::class, 'index'])->can('viewAny', Referee::class)->name('referees.index');
         Route::get('referees/{referee}', [RefereesController::class, 'show'])->can('view', 'referee')->name('referees.show');
-        Route::get('tag-teams', [TagTeamsController::class, 'index'])->can('viewList', TagTeam::class)->name('tag-teams.index');
+        Route::get('tag-teams', [TagTeamsController::class, 'index'])->can('viewAny', TagTeam::class)->name('tag-teams.index');
         Route::get('tag-teams/{tagTeam}', [TagTeamsController::class, 'show'])->can('view', 'tagTeam')->name('tag-teams.show');
     });
 
-    Route::get('titles', [TitlesController::class, 'index'])->can('viewList', Title::class)->name('titles.index');
+    Route::get('titles', [TitlesController::class, 'index'])->can('viewAny', Title::class)->name('titles.index');
     Route::get('titles/{title}', [TitlesController::class, 'show'])->can('view', 'title')->name('titles.show');
 
-    Route::get('events/{event}/matches', [EventMatchesController::class, 'index'])->can('viewList', EventMatch::class)->name('events.matches.index');
-    Route::get('events', [EventsController::class, 'index'])->can('viewList', Event::class)->name('events.index');
+    Route::get('events/{event}/matches', [EventMatchesController::class, 'index'])->can('viewAny', EventMatch::class)->name('events.matches.index');
+    Route::get('events', [EventsController::class, 'index'])->can('viewAny', Event::class)->name('events.index');
     Route::get('events/{event}', [EventsController::class, 'show'])->can('view', 'event')->name('events.show');
 
-    Route::get('venues', [VenuesController::class, 'index'])->can('viewList', Venue::class)->name('venues.index');
+    Route::get('venues', [VenuesController::class, 'index'])->can('viewAny', Venue::class)->name('venues.index');
     Route::get('venues/{venue}', [VenuesController::class, 'show'])->can('view', 'venue')->name('venues.show');
 
     Route::prefix('user-management')->group(function () {
-        Route::get('users', [UsersController::class, 'index'])->can('viewList', User::class)->name('users.index');
+        Route::get('users', [UsersController::class, 'index'])->can('viewAny', User::class)->name('users.index');
         Route::get('users/{user}', [UsersController::class, 'show'])->can('view', 'user')->name('users.show');
     });
 });

--- a/tests/Integration/Actions/Users/RoleAuthorizationTest.php
+++ b/tests/Integration/Actions/Users/RoleAuthorizationTest.php
@@ -35,11 +35,11 @@ describe('User Role Integration Tests', function () {
             actingAs($this->administrator);
 
             // Administrator should pass all Gate checks across different models
-            expect(Gate::allows('viewList', User::class))->toBeTrue();
+            expect(Gate::allows('viewAny', User::class))->toBeTrue();
             expect(Gate::allows('create', User::class))->toBeTrue();
-            expect(Gate::allows('update', User::class))->toBeTrue();
-            expect(Gate::allows('delete', User::class))->toBeTrue();
-            expect(Gate::allows('restore', User::class))->toBeTrue();
+            expect(Gate::allows('update', $this->basicUser))->toBeTrue();
+            expect(Gate::allows('delete', $this->basicUser))->toBeTrue();
+            expect(Gate::allows('restore', $this->basicUser))->toBeTrue();
 
             // Administrator should also pass custom abilities
             expect(Gate::allows('manageUsers', User::class))->toBeTrue();
@@ -51,11 +51,11 @@ describe('User Role Integration Tests', function () {
             actingAs($this->basicUser);
 
             // Basic user should be denied access across different operations
-            expect(Gate::denies('viewList', User::class))->toBeTrue();
+            expect(Gate::denies('viewAny', User::class))->toBeTrue();
             expect(Gate::denies('create', User::class))->toBeTrue();
-            expect(Gate::denies('update', User::class))->toBeTrue();
-            expect(Gate::denies('delete', User::class))->toBeTrue();
-            expect(Gate::denies('restore', User::class))->toBeTrue();
+            expect(Gate::denies('update', $this->administrator))->toBeTrue();
+            expect(Gate::denies('delete', $this->administrator))->toBeTrue();
+            expect(Gate::denies('restore', $this->administrator))->toBeTrue();
 
             // Basic user should also be denied custom abilities
             expect(Gate::denies('manageUsers', User::class))->toBeTrue();
@@ -141,16 +141,16 @@ describe('User Role Integration Tests', function () {
             actingAs($this->administrator);
 
             // Administrator should have access to other entity management
-            expect(Gate::allows('viewList', Wrestler::class))->toBeTrue();
-            expect(Gate::allows('viewList', Manager::class))->toBeTrue();
-            expect(Gate::allows('viewList', Title::class))->toBeTrue();
+            expect(Gate::allows('viewAny', Wrestler::class))->toBeTrue();
+            expect(Gate::allows('viewAny', Manager::class))->toBeTrue();
+            expect(Gate::allows('viewAny', Title::class))->toBeTrue();
 
             actingAs($this->basicUser);
 
             // Basic user should be denied access to other entities
-            expect(Gate::denies('viewList', Wrestler::class))->toBeTrue();
-            expect(Gate::denies('viewList', Manager::class))->toBeTrue();
-            expect(Gate::denies('viewList', Title::class))->toBeTrue();
+            expect(Gate::denies('viewAny', Wrestler::class))->toBeTrue();
+            expect(Gate::denies('viewAny', Manager::class))->toBeTrue();
+            expect(Gate::denies('viewAny', Title::class))->toBeTrue();
         });
 
         test('authentication system respects user roles', function () {

--- a/tests/Unit/Policies/EventPolicyTest.php
+++ b/tests/Unit/Policies/EventPolicyTest.php
@@ -26,7 +26,7 @@ describe('EventPolicy Unit Tests', function () {
 
     describe('before hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -35,7 +35,7 @@ describe('EventPolicy Unit Tests', function () {
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -50,12 +50,12 @@ describe('EventPolicy Unit Tests', function () {
     });
 
     describe('basic CRUD permissions', function () {
-        test('viewList method denies basic users', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+        test('viewAny method denies basic users', function () {
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('view method denies basic users', function () {
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->event))->toBeFalse();
         });
 
         test('create method denies basic users', function () {
@@ -63,29 +63,29 @@ describe('EventPolicy Unit Tests', function () {
         });
 
         test('update method denies basic users', function () {
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->event))->toBeFalse();
         });
 
         test('delete method denies basic users', function () {
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->event))->toBeFalse();
         });
 
         test('restore method denies basic users', function () {
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->event))->toBeFalse();
         });
     });
 
     describe('policy integration with Laravel Gate', function () {
         test('policy integrates correctly with Gate facade', function () {
             // Test administrator permissions through Gate
-            expect(Gate::forUser($this->admin)->allows('viewList', Event::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('viewAny', Event::class))->toBeTrue();
             expect(Gate::forUser($this->admin)->allows('create', Event::class))->toBeTrue();
-            expect(Gate::forUser($this->admin)->allows('update', Event::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('update', $this->event))->toBeTrue();
 
             // Test basic user permissions through Gate
-            expect(Gate::forUser($this->basicUser)->denies('viewList', Event::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('viewAny', Event::class))->toBeTrue();
             expect(Gate::forUser($this->basicUser)->denies('create', Event::class))->toBeTrue();
-            expect(Gate::forUser($this->basicUser)->denies('update', Event::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('update', $this->event))->toBeTrue();
         });
 
         test('policy works with specific event instances', function () {
@@ -103,13 +103,14 @@ describe('EventPolicy Unit Tests', function () {
     describe('policy method consistency', function () {
         test('all policy methods follow consistent pattern', function () {
             $methods = [
-                'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($methods as $method) {
-                // All methods should return false for basic users
-                expect($this->policy->{$method}($this->basicUser))
-                    ->toBeFalse("Method {$method} should deny basic users");
+                $subject = in_array($method, ['viewAny', 'create'], true) ? Event::class : $this->event;
+
+                expect(Gate::forUser($this->basicUser)->denies($method, $subject))
+                    ->toBeTrue("Method {$method} should deny basic users");
 
                 // All methods should be bypassed for administrators via before hook
                 expect($this->policy->before($this->admin, $method))
@@ -119,7 +120,7 @@ describe('EventPolicy Unit Tests', function () {
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -135,7 +136,7 @@ describe('EventPolicy Unit Tests', function () {
             $policy2 = new EventPolicy();
 
             expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
-            expect($policy1->viewList($this->basicUser))->toBe($policy2->viewList($this->basicUser));
+            expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
     });
 });

--- a/tests/Unit/Policies/ManagerPolicyTest.php
+++ b/tests/Unit/Policies/ManagerPolicyTest.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Gate;
  *
  * UNIT TEST SCOPE:
  * - Before hook behavior for administrator bypass
- * - Individual permission method testing (viewList, view, create, update, delete, restore)
+ * - Individual permission method testing (viewAny, view, create, update, delete, restore)
  * - Business-specific authorization methods (employ, release, retire, unretire, suspend, reinstate, injure, clearFromInjury)
  * - Policy method consistency and return value verification
  * - Laravel Gate integration testing
@@ -35,7 +35,7 @@ describe('ManagerPolicy Unit Tests', function () {
 
     describe('before hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -44,7 +44,7 @@ describe('ManagerPolicy Unit Tests', function () {
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -79,12 +79,12 @@ describe('ManagerPolicy Unit Tests', function () {
     });
 
     describe('basic CRUD permissions', function () {
-        test('viewList method denies basic users', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+        test('viewAny method denies basic users', function () {
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('view method denies basic users', function () {
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->manager))->toBeFalse();
         });
 
         test('create method denies basic users', function () {
@@ -92,29 +92,29 @@ describe('ManagerPolicy Unit Tests', function () {
         });
 
         test('update method denies basic users', function () {
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->manager))->toBeFalse();
         });
 
         test('delete method denies basic users', function () {
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->manager))->toBeFalse();
         });
 
         test('restore method denies basic users', function () {
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->manager))->toBeFalse();
         });
     });
 
     describe('policy integration with Laravel Gate', function () {
         test('policy integrates correctly with Gate facade', function () {
             // Test administrator permissions through Gate
-            expect(Gate::forUser($this->admin)->allows('viewList', Manager::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('viewAny', Manager::class))->toBeTrue();
             expect(Gate::forUser($this->admin)->allows('create', Manager::class))->toBeTrue();
-            expect(Gate::forUser($this->admin)->allows('view', Manager::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('view', $this->manager))->toBeTrue();
 
             // Test basic user permissions through Gate
-            expect(Gate::forUser($this->basicUser)->denies('viewList', Manager::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('viewAny', Manager::class))->toBeTrue();
             expect(Gate::forUser($this->basicUser)->denies('create', Manager::class))->toBeTrue();
-            expect(Gate::forUser($this->basicUser)->denies('view', Manager::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('view', $this->manager))->toBeTrue();
         });
 
         test('policy works with specific manager instances', function () {
@@ -155,12 +155,13 @@ describe('ManagerPolicy Unit Tests', function () {
 
     describe('policy method consistency', function () {
         test('all policy methods follow consistent pattern', function () {
-            $methods = ['viewList', 'view', 'create', 'update', 'delete', 'restore'];
+            $methods = ['viewAny', 'view', 'create', 'update', 'delete', 'restore'];
 
             foreach ($methods as $method) {
-                // All methods should return false for basic users
-                expect($this->policy->{$method}($this->basicUser))
-                    ->toBeFalse("Method {$method} should deny basic users");
+                $subject = in_array($method, ['viewAny', 'create'], true) ? Manager::class : $this->manager;
+
+                expect(Gate::forUser($this->basicUser)->denies($method, $subject))
+                    ->toBeTrue("Method {$method} should deny basic users");
 
                 // All methods should be bypassed for administrators via before hook
                 expect($this->policy->before($this->admin, $method))
@@ -170,7 +171,7 @@ describe('ManagerPolicy Unit Tests', function () {
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -188,7 +189,7 @@ describe('ManagerPolicy Unit Tests', function () {
 
             // Should have the same basic structure
             expect(in_array('before', $managerMethods))->toBeTrue();
-            expect(in_array('viewList', $managerMethods))->toBeTrue();
+            expect(in_array('viewAny', $managerMethods))->toBeTrue();
             expect(in_array('create', $managerMethods))->toBeTrue();
             expect(in_array('update', $managerMethods))->toBeTrue();
             expect(in_array('delete', $managerMethods))->toBeTrue();
@@ -252,13 +253,13 @@ describe('ManagerPolicy Unit Tests', function () {
             $policy2 = new ManagerPolicy();
 
             expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
-            expect($policy1->viewList($this->basicUser))->toBe($policy2->viewList($this->basicUser));
+            expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
 
         test('policy is stateless', function () {
             // Multiple calls should return same results
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
 
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();

--- a/tests/Unit/Policies/MatchPolicyTest.php
+++ b/tests/Unit/Policies/MatchPolicyTest.php
@@ -26,7 +26,7 @@ describe('MatchPolicy Unit Tests', function () {
 
     describe('before hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -35,7 +35,7 @@ describe('MatchPolicy Unit Tests', function () {
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -50,12 +50,12 @@ describe('MatchPolicy Unit Tests', function () {
     });
 
     describe('basic CRUD permissions', function () {
-        test('viewList method denies basic users', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+        test('viewAny method denies basic users', function () {
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('view method denies basic users', function () {
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->eventMatch))->toBeFalse();
         });
 
         test('create method denies basic users', function () {
@@ -63,29 +63,29 @@ describe('MatchPolicy Unit Tests', function () {
         });
 
         test('update method denies basic users', function () {
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->eventMatch))->toBeFalse();
         });
 
         test('delete method denies basic users', function () {
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->eventMatch))->toBeFalse();
         });
 
         test('restore method denies basic users', function () {
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->eventMatch))->toBeFalse();
         });
     });
 
     describe('policy integration with Laravel Gate', function () {
         test('policy integrates correctly with Gate facade', function () {
             // Test administrator permissions through Gate
-            expect(Gate::forUser($this->admin)->allows('viewList', EventMatch::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('viewAny', EventMatch::class))->toBeTrue();
             expect(Gate::forUser($this->admin)->allows('create', EventMatch::class))->toBeTrue();
-            expect(Gate::forUser($this->admin)->allows('update', EventMatch::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('update', $this->eventMatch))->toBeTrue();
 
             // Test basic user permissions through Gate
-            expect(Gate::forUser($this->basicUser)->denies('viewList', EventMatch::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('viewAny', EventMatch::class))->toBeTrue();
             expect(Gate::forUser($this->basicUser)->denies('create', EventMatch::class))->toBeTrue();
-            expect(Gate::forUser($this->basicUser)->denies('update', EventMatch::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('update', $this->eventMatch))->toBeTrue();
         });
 
         test('policy works with specific event match instances', function () {
@@ -103,13 +103,14 @@ describe('MatchPolicy Unit Tests', function () {
     describe('policy method consistency', function () {
         test('all policy methods follow consistent pattern', function () {
             $methods = [
-                'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($methods as $method) {
-                // All methods should return false for basic users
-                expect($this->policy->{$method}($this->basicUser))
-                    ->toBeFalse("Method {$method} should deny basic users");
+                $subject = in_array($method, ['viewAny', 'create'], true) ? EventMatch::class : $this->eventMatch;
+
+                expect(Gate::forUser($this->basicUser)->denies($method, $subject))
+                    ->toBeTrue("Method {$method} should deny basic users");
 
                 // All methods should be bypassed for administrators via before hook
                 expect($this->policy->before($this->admin, $method))
@@ -119,7 +120,7 @@ describe('MatchPolicy Unit Tests', function () {
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -135,7 +136,7 @@ describe('MatchPolicy Unit Tests', function () {
             $policy2 = new MatchPolicy();
 
             expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
-            expect($policy1->viewList($this->basicUser))->toBe($policy2->viewList($this->basicUser));
+            expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
     });
 });

--- a/tests/Unit/Policies/RefereePolicyTest.php
+++ b/tests/Unit/Policies/RefereePolicyTest.php
@@ -28,7 +28,7 @@ describe('RefereePolicy Unit Tests', function () {
 
     describe('before hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -37,7 +37,7 @@ describe('RefereePolicy Unit Tests', function () {
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -76,12 +76,12 @@ describe('RefereePolicy Unit Tests', function () {
     });
 
     describe('basic CRUD permissions', function () {
-        test('viewList method denies basic users', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+        test('viewAny method denies basic users', function () {
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('view method denies basic users', function () {
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->referee))->toBeFalse();
         });
 
         test('create method denies basic users', function () {
@@ -89,29 +89,29 @@ describe('RefereePolicy Unit Tests', function () {
         });
 
         test('update method denies basic users', function () {
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->referee))->toBeFalse();
         });
 
         test('delete method denies basic users', function () {
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->referee))->toBeFalse();
         });
 
         test('restore method denies basic users', function () {
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->referee))->toBeFalse();
         });
     });
 
     describe('policy integration with Laravel Gate', function () {
         test('policy integrates correctly with Gate facade', function () {
             // Test administrator permissions through Gate
-            expect(Gate::forUser($this->admin)->allows('viewList', Referee::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('viewAny', Referee::class))->toBeTrue();
             expect(Gate::forUser($this->admin)->allows('create', Referee::class))->toBeTrue();
-            expect(Gate::forUser($this->admin)->allows('view', Referee::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('view', $this->referee))->toBeTrue();
 
             // Test basic user permissions through Gate
-            expect(Gate::forUser($this->basicUser)->denies('viewList', Referee::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('viewAny', Referee::class))->toBeTrue();
             expect(Gate::forUser($this->basicUser)->denies('create', Referee::class))->toBeTrue();
-            expect(Gate::forUser($this->basicUser)->denies('view', Referee::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('view', $this->referee))->toBeTrue();
         });
 
         test('policy works with specific referee instances', function () {
@@ -159,12 +159,13 @@ describe('RefereePolicy Unit Tests', function () {
 
     describe('policy method consistency', function () {
         test('all policy methods follow consistent pattern', function () {
-            $methods = ['viewList', 'view', 'create', 'update', 'delete', 'restore'];
+            $methods = ['viewAny', 'view', 'create', 'update', 'delete', 'restore'];
 
             foreach ($methods as $method) {
-                // All methods should return false for basic users
-                expect($this->policy->{$method}($this->basicUser))
-                    ->toBeFalse("Method {$method} should deny basic users");
+                $subject = in_array($method, ['viewAny', 'create'], true) ? Referee::class : $this->referee;
+
+                expect(Gate::forUser($this->basicUser)->denies($method, $subject))
+                    ->toBeTrue("Method {$method} should deny basic users");
 
                 // All methods should be bypassed for administrators via before hook
                 expect($this->policy->before($this->admin, $method))
@@ -174,7 +175,7 @@ describe('RefereePolicy Unit Tests', function () {
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -194,7 +195,7 @@ describe('RefereePolicy Unit Tests', function () {
 
             // Should have the same basic structure as other individual roster member policies
             expect(in_array('before', $refereeMethods))->toBeTrue();
-            expect(in_array('viewList', $refereeMethods))->toBeTrue();
+            expect(in_array('viewAny', $refereeMethods))->toBeTrue();
             expect(in_array('create', $refereeMethods))->toBeTrue();
             expect(in_array('update', $refereeMethods))->toBeTrue();
             expect(in_array('delete', $refereeMethods))->toBeTrue();
@@ -280,13 +281,13 @@ describe('RefereePolicy Unit Tests', function () {
             $policy2 = new RefereePolicy();
 
             expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
-            expect($policy1->viewList($this->basicUser))->toBe($policy2->viewList($this->basicUser));
+            expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
 
         test('policy is stateless', function () {
             // Multiple calls should return same results
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
 
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();

--- a/tests/Unit/Policies/StablePolicyTest.php
+++ b/tests/Unit/Policies/StablePolicyTest.php
@@ -33,7 +33,7 @@ describe('StablePolicy Unit Tests', function () {
 
     describe('before hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -46,7 +46,7 @@ describe('StablePolicy Unit Tests', function () {
         });
 
         test('basic users do not bypass authorization checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -66,7 +66,7 @@ describe('StablePolicy Unit Tests', function () {
 
     describe('view authorization', function () {
         test('basic users cannot view stable list', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('basic users cannot view individual stables', function () {
@@ -153,7 +153,7 @@ describe('StablePolicy Unit Tests', function () {
     //
     //     test('gate authorize calls work with policy methods', function () {
     //         // This belongs in Feature tests - requires authentication context
-    //         expect(fn() => Gate::authorize('viewList', Stable::class))
+    //         expect(fn() => Gate::authorize('viewAny', Stable::class))
     //             ->toThrow(AuthorizationException::class);
     //
     //         expect(fn() => Gate::authorize('view', $this->stable))
@@ -163,7 +163,7 @@ describe('StablePolicy Unit Tests', function () {
     //     test('gate allows calls work with policy methods', function () {
     //         // This belongs in Feature tests - requires authentication context
     //         Gate::forUser($this->basicUser);
-    //         expect(Gate::allows('viewList', Stable::class))->toBeFalse();
+    //         expect(Gate::allows('viewAny', Stable::class))->toBeFalse();
     //         expect(Gate::allows('view', $this->stable))->toBeFalse();
     //         expect(Gate::allows('create', Stable::class))->toBeFalse();
     //         expect(Gate::allows('update', $this->stable))->toBeFalse();
@@ -171,7 +171,7 @@ describe('StablePolicy Unit Tests', function () {
     //
     //         // Test admin permissions (should be allowed via before hook)
     //         Gate::forUser($this->admin);
-    //         expect(Gate::allows('viewList', Stable::class))->toBeTrue();
+    //         expect(Gate::allows('viewAny', Stable::class))->toBeTrue();
     //         expect(Gate::allows('view', $this->stable))->toBeTrue();
     //         expect(Gate::allows('create', Stable::class))->toBeTrue();
     //         expect(Gate::allows('update', $this->stable))->toBeTrue();
@@ -214,7 +214,7 @@ describe('StablePolicy Unit Tests', function () {
         test('all required policy methods exist', function () {
             $requiredMethods = [
                 'before',
-                'viewList',
+                'viewAny',
                 'view',
                 'create',
                 'update',
@@ -253,7 +253,7 @@ describe('StablePolicy Unit Tests', function () {
     describe('authorization consistency', function () {
         test('all authorization methods return boolean for basic users', function () {
             $methods = [
-                ['viewList', []],
+                ['viewAny', []],
                 ['view', [$this->stable]],
                 ['create', []],
                 ['update', [$this->stable]],
@@ -274,7 +274,7 @@ describe('StablePolicy Unit Tests', function () {
         });
 
         test('before hook returns boolean true for admin or null for others', function () {
-            $abilities = ['viewList', 'view', 'create', 'update', 'delete', 'restore', 'establish', 'disband', 'retire', 'unretire'];
+            $abilities = ['viewAny', 'view', 'create', 'update', 'delete', 'restore', 'establish', 'disband', 'retire', 'unretire'];
 
             foreach ($abilities as $ability) {
                 expect($this->policy->before($this->admin, $ability))->toBeTrue();

--- a/tests/Unit/Policies/TagTeamPolicyTest.php
+++ b/tests/Unit/Policies/TagTeamPolicyTest.php
@@ -32,7 +32,7 @@ describe('TagTeamPolicy Unit Tests', function () {
 
     describe('before hook authorization', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -47,7 +47,7 @@ describe('TagTeamPolicy Unit Tests', function () {
         });
 
         test('non-administrators do not bypass authorization checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -63,8 +63,8 @@ describe('TagTeamPolicy Unit Tests', function () {
     });
 
     describe('view permissions', function () {
-        test('viewList denies access for basic users', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+        test('viewAny denies access for basic users', function () {
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('view denies access for basic users', function () {
@@ -195,7 +195,7 @@ describe('TagTeamPolicy Unit Tests', function () {
         test('view permissions follow same restrictive pattern as management permissions', function () {
             // Only admins can view
             expect($this->policy->view($this->basicUser, $this->tagTeam))->toBeFalse();
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
 
             // Only admins can manage
             expect($this->policy->update($this->basicUser, $this->tagTeam))->toBeFalse();
@@ -286,7 +286,7 @@ describe('TagTeamPolicy Unit Tests', function () {
     describe('policy consistency and edge cases', function () {
         test('policy methods return correct types', function () {
             // All policy methods should return boolean values
-            expect($this->policy->viewList($this->basicUser))->toBeBool();
+            expect($this->policy->viewAny($this->basicUser))->toBeBool();
             expect($this->policy->view($this->basicUser, $this->tagTeam))->toBeBool();
             expect($this->policy->create($this->basicUser))->toBeBool();
             expect($this->policy->update($this->basicUser, $this->tagTeam))->toBeBool();

--- a/tests/Unit/Policies/TitlePolicyTest.php
+++ b/tests/Unit/Policies/TitlePolicyTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Gate;
  *
  * UNIT TEST SCOPE:
  * - Before hook behavior for administrator bypass
- * - Individual permission method testing (viewList, view, create, update, delete, restore)
+ * - Individual permission method testing (viewAny, view, create, update, delete, restore)
  * - Business-specific authorization methods (debut, pull, reinstate, retire, unretire, activate, deactivate)
  * - Policy method consistency and return value verification
  * - Laravel Gate integration testing
@@ -34,7 +34,7 @@ describe('TitlePolicy Unit Tests', function () {
 
     describe('before hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -43,7 +43,7 @@ describe('TitlePolicy Unit Tests', function () {
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -72,12 +72,12 @@ describe('TitlePolicy Unit Tests', function () {
     });
 
     describe('basic CRUD permissions', function () {
-        test('viewList method denies basic users', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+        test('viewAny method denies basic users', function () {
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('view method denies basic users', function () {
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->title))->toBeFalse();
         });
 
         test('create method denies basic users', function () {
@@ -85,29 +85,29 @@ describe('TitlePolicy Unit Tests', function () {
         });
 
         test('update method denies basic users', function () {
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->title))->toBeFalse();
         });
 
         test('delete method denies basic users', function () {
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->title))->toBeFalse();
         });
 
         test('restore method denies basic users', function () {
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->title))->toBeFalse();
         });
     });
 
     describe('policy integration with Laravel Gate', function () {
         test('policy integrates correctly with Gate facade', function () {
             // Test administrator permissions through Gate
-            expect(Gate::forUser($this->admin)->allows('viewList', Title::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('viewAny', Title::class))->toBeTrue();
             expect(Gate::forUser($this->admin)->allows('create', Title::class))->toBeTrue();
-            expect(Gate::forUser($this->admin)->allows('view', Title::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('view', $this->title))->toBeTrue();
 
             // Test basic user permissions through Gate
-            expect(Gate::forUser($this->basicUser)->denies('viewList', Title::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('viewAny', Title::class))->toBeTrue();
             expect(Gate::forUser($this->basicUser)->denies('create', Title::class))->toBeTrue();
-            expect(Gate::forUser($this->basicUser)->denies('view', Title::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('view', $this->title))->toBeTrue();
         });
 
         test('policy works with specific title instances', function () {
@@ -139,12 +139,13 @@ describe('TitlePolicy Unit Tests', function () {
 
     describe('policy method consistency', function () {
         test('all policy methods follow consistent pattern', function () {
-            $methods = ['viewList', 'view', 'create', 'update', 'delete', 'restore'];
+            $methods = ['viewAny', 'view', 'create', 'update', 'delete', 'restore'];
 
             foreach ($methods as $method) {
-                // All methods should return false for basic users
-                expect($this->policy->{$method}($this->basicUser))
-                    ->toBeFalse("Method {$method} should deny basic users");
+                $subject = in_array($method, ['viewAny', 'create'], true) ? Title::class : $this->title;
+
+                expect(Gate::forUser($this->basicUser)->denies($method, $subject))
+                    ->toBeTrue("Method {$method} should deny basic users");
 
                 // All methods should be bypassed for administrators via before hook
                 expect($this->policy->before($this->admin, $method))
@@ -154,7 +155,7 @@ describe('TitlePolicy Unit Tests', function () {
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -232,13 +233,13 @@ describe('TitlePolicy Unit Tests', function () {
             $policy2 = new TitlePolicy();
 
             expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
-            expect($policy1->viewList($this->basicUser))->toBe($policy2->viewList($this->basicUser));
+            expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
 
         test('policy is stateless', function () {
             // Multiple calls should return same results
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
 
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -25,19 +25,19 @@ describe('UserPolicy before hook', function () {
     });
 
     test('before hook allows administrators for any ability', function () {
-        $result = $this->policy->before($this->administrator, 'viewList');
+        $result = $this->policy->before($this->administrator, 'viewAny');
 
         expect($result)->toBeTrue();
     });
 
     test('before hook returns null for basic users', function () {
-        $result = $this->policy->before($this->basicUser, 'viewList');
+        $result = $this->policy->before($this->basicUser, 'viewAny');
 
         expect($result)->toBeNull();
     });
 
     test('before hook allows administrators for all abilities', function () {
-        $abilities = ['viewList', 'view', 'create', 'update', 'delete', 'restore'];
+        $abilities = ['viewAny', 'view', 'create', 'update', 'delete', 'restore'];
 
         foreach ($abilities as $ability) {
             $result = $this->policy->before($this->administrator, $ability);
@@ -46,7 +46,7 @@ describe('UserPolicy before hook', function () {
     });
 
     test('before hook returns null for basic users on all abilities', function () {
-        $abilities = ['viewList', 'view', 'create', 'update', 'delete', 'restore'];
+        $abilities = ['viewAny', 'view', 'create', 'update', 'delete', 'restore'];
 
         foreach ($abilities as $ability) {
             $result = $this->policy->before($this->basicUser, $ability);
@@ -73,14 +73,14 @@ describe('UserPolicy individual methods', function () {
         $this->basicUser = basicUser();
     });
 
-    test('viewList method returns false for basic users', function () {
-        $result = $this->policy->viewList($this->basicUser);
+    test('viewAny method returns false for basic users', function () {
+        $result = $this->policy->viewAny($this->basicUser);
 
         expect($result)->toBeFalse();
     });
 
     test('view method returns false for basic users', function () {
-        $result = $this->policy->view($this->basicUser);
+        $result = $this->policy->view($this->basicUser, $this->basicUser);
 
         expect($result)->toBeFalse();
     });
@@ -92,19 +92,19 @@ describe('UserPolicy individual methods', function () {
     });
 
     test('update method returns false for basic users', function () {
-        $result = $this->policy->update($this->basicUser);
+        $result = $this->policy->update($this->basicUser, $this->basicUser);
 
         expect($result)->toBeFalse();
     });
 
     test('delete method returns false for basic users', function () {
-        $result = $this->policy->delete($this->basicUser);
+        $result = $this->policy->delete($this->basicUser, $this->basicUser);
 
         expect($result)->toBeFalse();
     });
 
     test('restore method returns false for basic users', function () {
-        $result = $this->policy->restore($this->basicUser);
+        $result = $this->policy->restore($this->basicUser, $this->basicUser);
 
         expect($result)->toBeFalse();
     });
@@ -113,24 +113,26 @@ describe('UserPolicy individual methods', function () {
 describe('UserPolicy integration with Gate facade', function () {
     test('Gate allows administrators through before hook', function () {
         actingAs(administrator());
+        $targetUser = basicUser();
 
-        expect(Gate::allows('viewList', User::class))->toBeTrue();
-        expect(Gate::allows('view', User::class))->toBeTrue();
+        expect(Gate::allows('viewAny', User::class))->toBeTrue();
+        expect(Gate::allows('view', $targetUser))->toBeTrue();
         expect(Gate::allows('create', User::class))->toBeTrue();
-        expect(Gate::allows('update', User::class))->toBeTrue();
-        expect(Gate::allows('delete', User::class))->toBeTrue();
-        expect(Gate::allows('restore', User::class))->toBeTrue();
+        expect(Gate::allows('update', $targetUser))->toBeTrue();
+        expect(Gate::allows('delete', $targetUser))->toBeTrue();
+        expect(Gate::allows('restore', $targetUser))->toBeTrue();
     });
 
     test('Gate denies basic users after before hook returns null', function () {
         actingAs(basicUser());
+        $targetUser = administrator();
 
-        expect(Gate::denies('viewList', User::class))->toBeTrue();
-        expect(Gate::denies('view', User::class))->toBeTrue();
+        expect(Gate::denies('viewAny', User::class))->toBeTrue();
+        expect(Gate::denies('view', $targetUser))->toBeTrue();
         expect(Gate::denies('create', User::class))->toBeTrue();
-        expect(Gate::denies('update', User::class))->toBeTrue();
-        expect(Gate::denies('delete', User::class))->toBeTrue();
-        expect(Gate::denies('restore', User::class))->toBeTrue();
+        expect(Gate::denies('update', $targetUser))->toBeTrue();
+        expect(Gate::denies('delete', $targetUser))->toBeTrue();
+        expect(Gate::denies('restore', $targetUser))->toBeTrue();
     });
 
     test('Gate works with specific user instances', function () {
@@ -178,13 +180,18 @@ describe('UserPolicy method signatures', function () {
     });
 
     test('policy methods have correct signatures', function () {
-        $methods = ['viewList', 'view', 'create', 'update', 'delete', 'restore'];
+        $methods = ['viewAny', 'view', 'create', 'update', 'delete', 'restore'];
 
         foreach ($methods as $method) {
             $reflection = new ReflectionMethod(UserPolicy::class, $method);
 
-            expect($reflection->getParameters())->toHaveCount(1);
+            $expectedParameterCount = in_array($method, ['viewAny', 'create'], true) ? 1 : 2;
+
+            expect($reflection->getParameters())->toHaveCount($expectedParameterCount);
             expect(reflectionTypeName($reflection->getParameters()[0]))->toBe(User::class);
+            if ($expectedParameterCount === 2) {
+                expect(reflectionTypeName($reflection->getParameters()[1]))->toBe(User::class);
+            }
             expect(reflectionReturnTypeName($reflection))->toBe('bool');
         }
     });
@@ -262,13 +269,13 @@ describe('UserPolicy edge cases and security', function () {
         $policy2 = new UserPolicy();
 
         expect($policy1->before(administrator(), 'create'))->toBe($policy2->before(administrator(), 'create'));
-        expect($policy1->viewList(basicUser()))->toBe($policy2->viewList(basicUser()));
+        expect($policy1->viewAny(basicUser()))->toBe($policy2->viewAny(basicUser()));
     });
 
     test('policy is stateless', function () {
         // Multiple calls should return same results
-        expect($this->policy->viewList(basicUser()))->toBeFalse();
-        expect($this->policy->viewList(basicUser()))->toBeFalse();
+        expect($this->policy->viewAny(basicUser()))->toBeFalse();
+        expect($this->policy->viewAny(basicUser()))->toBeFalse();
 
         expect($this->policy->before(administrator(), 'create'))->toBeTrue();
         expect($this->policy->before(administrator(), 'create'))->toBeTrue();

--- a/tests/Unit/Policies/VenuePolicyTest.php
+++ b/tests/Unit/Policies/VenuePolicyTest.php
@@ -32,7 +32,7 @@ describe('VenuePolicy Unit Tests', function () {
 
     describe('before hook authorization', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -41,7 +41,7 @@ describe('VenuePolicy Unit Tests', function () {
         });
 
         test('non-administrators do not bypass authorization checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -51,12 +51,12 @@ describe('VenuePolicy Unit Tests', function () {
     });
 
     describe('view permissions', function () {
-        test('viewList denies access for basic users', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+        test('viewAny denies access for basic users', function () {
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('view denies access for basic users', function () {
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeFalse();
         });
     });
 
@@ -66,15 +66,15 @@ describe('VenuePolicy Unit Tests', function () {
         });
 
         test('update denies access for basic users', function () {
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
         });
 
         test('delete denies access for basic users', function () {
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
         });
 
         test('restore denies access for basic users', function () {
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->venue))->toBeFalse();
         });
     });
 
@@ -85,9 +85,9 @@ describe('VenuePolicy Unit Tests', function () {
             $outdoorVenue = Venue::factory()->make(['name' => 'Outdoor Stadium']);
 
             // All venue types should follow same authorization pattern
-            expect($this->policy->view($this->basicUser))->toBeFalse();
-            expect($this->policy->update($this->basicUser))->toBeFalse();
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
         });
 
         test('venue location management considers geographic factors', function () {
@@ -95,8 +95,8 @@ describe('VenuePolicy Unit Tests', function () {
             $remoteVenue = Venue::factory()->make(['city' => 'Remote City', 'state' => 'RS']);
 
             // Geographic location should not affect basic authorization
-            expect($this->policy->view($this->basicUser))->toBeFalse();
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
         });
 
         test('venue capacity and facilities do not affect base permissions', function () {
@@ -104,7 +104,7 @@ describe('VenuePolicy Unit Tests', function () {
             $smallVenue = Venue::factory()->make(['name' => 'Small Community Hall']);
 
             // Facility size should not affect authorization
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeFalse();
             expect($this->policy->create($this->basicUser))->toBeFalse();
         });
     });
@@ -125,9 +125,9 @@ describe('VenuePolicy Unit Tests', function () {
         test('basic users cannot perform management actions', function () {
             // All management actions should be denied for basic users
             expect($this->policy->create($this->basicUser))->toBeFalse();
-            expect($this->policy->update($this->basicUser))->toBeFalse();
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->venue))->toBeFalse();
         });
     });
 
@@ -140,14 +140,14 @@ describe('VenuePolicy Unit Tests', function () {
 
             // Basic user has no access
             expect($this->policy->create($this->basicUser))->toBeFalse();
-            expect($this->policy->update($this->basicUser))->toBeFalse();
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
         });
 
         test('view permissions are consistently restrictive', function () {
             // Both list and individual view permissions deny basic users
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeFalse();
         });
     });
 
@@ -161,7 +161,7 @@ describe('VenuePolicy Unit Tests', function () {
             ]);
 
             // Address complexity should not affect authorization
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
         });
 
@@ -174,8 +174,8 @@ describe('VenuePolicy Unit Tests', function () {
             ]);
 
             // Complex addresses should not change authorization
-            expect($this->policy->update($this->basicUser))->toBeFalse();
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
         });
     });
 
@@ -185,9 +185,9 @@ describe('VenuePolicy Unit Tests', function () {
             $quietVenue = Venue::factory()->make(['name' => 'Quiet Venue']);
 
             // Event history should not affect base authorization
-            expect($this->policy->view($this->basicUser))->toBeFalse();
-            expect($this->policy->update($this->basicUser))->toBeFalse();
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
         });
 
         test('venue booking management requires proper authorization', function () {
@@ -195,7 +195,7 @@ describe('VenuePolicy Unit Tests', function () {
             $newVenue = Venue::factory()->make(['name' => 'New Venue']);
 
             // Popularity should not affect authorization rules
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
         });
     });
@@ -204,7 +204,7 @@ describe('VenuePolicy Unit Tests', function () {
         test('restoration permissions are properly restricted', function () {
             $deletedVenue = Venue::factory()->make(['name' => 'Deleted Venue']);
 
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->venue))->toBeFalse();
             expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
         });
 
@@ -213,7 +213,7 @@ describe('VenuePolicy Unit Tests', function () {
             $unusedVenue = Venue::factory()->make(['name' => 'Unused Venue']);
 
             // Deletion should be restricted for basic users regardless of usage
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
             expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
         });
     });
@@ -221,12 +221,12 @@ describe('VenuePolicy Unit Tests', function () {
     describe('policy consistency and edge cases', function () {
         test('policy methods return correct types', function () {
             // All policy methods should return boolean values
-            expect($this->policy->viewList($this->basicUser))->toBeBool();
-            expect($this->policy->view($this->basicUser))->toBeBool();
+            expect($this->policy->viewAny($this->basicUser))->toBeBool();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeBool();
             expect($this->policy->create($this->basicUser))->toBeBool();
-            expect($this->policy->update($this->basicUser))->toBeBool();
-            expect($this->policy->delete($this->basicUser))->toBeBool();
-            expect($this->policy->restore($this->basicUser))->toBeBool();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeBool();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeBool();
+            expect($this->policy->restore($this->basicUser, $this->venue))->toBeBool();
         });
 
         test('before hook returns correct types', function () {
@@ -244,8 +244,8 @@ describe('VenuePolicy Unit Tests', function () {
 
             // Facility type should not change authorization pattern
             expect($this->policy->create($this->basicUser))->toBeFalse();
-            expect($this->policy->update($this->basicUser))->toBeFalse();
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
         });
 
         test('venue capacity planning requires admin access', function () {
@@ -253,7 +253,7 @@ describe('VenuePolicy Unit Tests', function () {
             $largeVenue = Venue::factory()->make(['name' => 'Large Stadium']);
 
             // Capacity planning should require administrative privileges
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
         });
     });
@@ -270,8 +270,8 @@ describe('VenuePolicy Unit Tests', function () {
             ]);
 
             // Geographic location should not change authorization
-            expect($this->policy->view($this->basicUser))->toBeFalse();
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
         });
 
         test('multi-state venue management follows standard rules', function () {
@@ -292,7 +292,7 @@ describe('VenuePolicy Unit Tests', function () {
             $operationalVenue = Venue::factory()->make(['name' => 'Operational Venue']);
 
             // Operational status should not affect basic authorization
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
         });
 
@@ -301,8 +301,8 @@ describe('VenuePolicy Unit Tests', function () {
             $bookedVenue = Venue::factory()->make(['name' => 'Fully Booked Venue']);
 
             // Availability should not change authorization requirements
-            expect($this->policy->view($this->basicUser))->toBeFalse();
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->venue))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
         });
     });
 });

--- a/tests/Unit/Policies/WrestlerPolicyTest.php
+++ b/tests/Unit/Policies/WrestlerPolicyTest.php
@@ -12,7 +12,7 @@ use Illuminate\Support\Facades\Gate;
  *
  * UNIT TEST SCOPE:
  * - Before hook behavior for administrator bypass
- * - Individual permission method testing (viewList, view, create, update, delete, restore)
+ * - Individual permission method testing (viewAny, view, create, update, delete, restore)
  * - Business-specific authorization methods (employ, release, retire, unretire, suspend, reinstate, injure, clearFromInjury)
  * - Policy method consistency and return value verification
  * - Laravel Gate integration testing
@@ -34,7 +34,7 @@ describe('WrestlerPolicy Unit Tests', function () {
 
     describe('before hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewList'))->toBeTrue();
+            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
             expect($this->policy->before($this->admin, 'view'))->toBeTrue();
             expect($this->policy->before($this->admin, 'create'))->toBeTrue();
             expect($this->policy->before($this->admin, 'update'))->toBeTrue();
@@ -51,7 +51,7 @@ describe('WrestlerPolicy Unit Tests', function () {
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewList'))->toBeNull();
+            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
             expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
@@ -74,12 +74,12 @@ describe('WrestlerPolicy Unit Tests', function () {
     });
 
     describe('basic CRUD permissions', function () {
-        test('viewList method denies basic users', function () {
-            expect($this->policy->viewList($this->basicUser))->toBeFalse();
+        test('viewAny method denies basic users', function () {
+            expect($this->policy->viewAny($this->basicUser))->toBeFalse();
         });
 
         test('view method denies basic users', function () {
-            expect($this->policy->view($this->basicUser))->toBeFalse();
+            expect($this->policy->view($this->basicUser, $this->wrestler))->toBeFalse();
         });
 
         test('create method denies basic users', function () {
@@ -87,69 +87,69 @@ describe('WrestlerPolicy Unit Tests', function () {
         });
 
         test('update method denies basic users', function () {
-            expect($this->policy->update($this->basicUser))->toBeFalse();
+            expect($this->policy->update($this->basicUser, $this->wrestler))->toBeFalse();
         });
 
         test('delete method denies basic users', function () {
-            expect($this->policy->delete($this->basicUser))->toBeFalse();
+            expect($this->policy->delete($this->basicUser, $this->wrestler))->toBeFalse();
         });
 
         test('restore method denies basic users', function () {
-            expect($this->policy->restore($this->basicUser))->toBeFalse();
+            expect($this->policy->restore($this->basicUser, $this->wrestler))->toBeFalse();
         });
     });
 
     describe('employment management permissions', function () {
         test('employ method denies basic users', function () {
-            expect($this->policy->employ($this->basicUser))->toBeFalse();
+            expect($this->policy->employ($this->basicUser, $this->wrestler))->toBeFalse();
         });
 
         test('release method denies basic users', function () {
-            expect($this->policy->release($this->basicUser))->toBeFalse();
+            expect($this->policy->release($this->basicUser, $this->wrestler))->toBeFalse();
         });
     });
 
     describe('retirement management permissions', function () {
         test('retire method denies basic users', function () {
-            expect($this->policy->retire($this->basicUser))->toBeFalse();
+            expect($this->policy->retire($this->basicUser, $this->wrestler))->toBeFalse();
         });
 
         test('unretire method denies basic users', function () {
-            expect($this->policy->unretire($this->basicUser))->toBeFalse();
+            expect($this->policy->unretire($this->basicUser, $this->wrestler))->toBeFalse();
         });
     });
 
     describe('suspension management permissions', function () {
         test('suspend method denies basic users', function () {
-            expect($this->policy->suspend($this->basicUser))->toBeFalse();
+            expect($this->policy->suspend($this->basicUser, $this->wrestler))->toBeFalse();
         });
 
         test('reinstate method denies basic users', function () {
-            expect($this->policy->reinstate($this->basicUser))->toBeFalse();
+            expect($this->policy->reinstate($this->basicUser, $this->wrestler))->toBeFalse();
         });
     });
 
     describe('injury management permissions', function () {
         test('injure method denies basic users', function () {
-            expect($this->policy->injure($this->basicUser))->toBeFalse();
+            expect($this->policy->injure($this->basicUser, $this->wrestler))->toBeFalse();
         });
 
         test('clearFromInjury method denies basic users', function () {
-            expect($this->policy->clearFromInjury($this->basicUser))->toBeFalse();
+            expect($this->policy->clearFromInjury($this->basicUser, $this->wrestler))->toBeFalse();
         });
     });
 
     describe('policy integration with Laravel Gate', function () {
         test('policy integrates correctly with Gate facade', function () {
             // Test administrator permissions through Gate
-            expect(Gate::forUser($this->admin)->allows('viewList', Wrestler::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('viewAny', Wrestler::class))->toBeTrue();
             expect(Gate::forUser($this->admin)->allows('create', Wrestler::class))->toBeTrue();
-            expect(Gate::forUser($this->admin)->allows('employ', Wrestler::class))->toBeTrue();
+            expect(Gate::forUser($this->admin)->allows('employ', $this->wrestler))->toBeTrue();
 
             // Test basic user permissions through Gate
-            expect(Gate::forUser($this->basicUser)->denies('viewList', Wrestler::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('viewAny', Wrestler::class))->toBeTrue();
             expect(Gate::forUser($this->basicUser)->denies('create', Wrestler::class))->toBeTrue();
-            expect(Gate::forUser($this->basicUser)->denies('employ', Wrestler::class))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->denies('employ', $this->wrestler))->toBeTrue();
         });
 
         test('policy works with specific wrestler instances', function () {
@@ -167,15 +167,16 @@ describe('WrestlerPolicy Unit Tests', function () {
     describe('policy method consistency', function () {
         test('all policy methods follow consistent pattern', function () {
             $methods = [
-                'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
                 'employ', 'release', 'retire', 'unretire', 'suspend',
                 'reinstate', 'injure', 'clearFromInjury',
             ];
 
             foreach ($methods as $method) {
-                // All methods should return false for basic users
-                expect($this->policy->{$method}($this->basicUser))
-                    ->toBeFalse("Method {$method} should deny basic users");
+                $subject = in_array($method, ['viewAny', 'create'], true) ? Wrestler::class : $this->wrestler;
+
+                expect(Gate::forUser($this->basicUser)->denies($method, $subject))
+                    ->toBeTrue("Method {$method} should deny basic users");
 
                 // All methods should be bypassed for administrators via before hook
                 expect($this->policy->before($this->admin, $method))
@@ -185,7 +186,7 @@ describe('WrestlerPolicy Unit Tests', function () {
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewList', 'view', 'create', 'update', 'delete', 'restore',
+                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
                 'employ', 'release', 'retire', 'unretire', 'suspend',
                 'reinstate', 'injure', 'clearFromInjury',
             ];
@@ -203,7 +204,7 @@ describe('WrestlerPolicy Unit Tests', function () {
             $policy2 = new WrestlerPolicy();
 
             expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
-            expect($policy1->viewList($this->basicUser))->toBe($policy2->viewList($this->basicUser));
+            expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
     });
 });


### PR DESCRIPTION
## Summary
- adopt Laravel's conventional viewAny policy ability
- require concrete model instances for instance-level policy methods
- correct Livewire and route authorization callers and record the convention

## Verification
- 1,193 focused authorization and Livewire tests passed (3,712 assertions)
- 3,388 application tests passed (10,951 assertions)
- application PHPStan passed
- Pest PHPStan passed
- Rector passed
- Pint and Blade formatting passed

The local browser phase produced no output for two minutes and was stopped per the repository's bounded-command rule; CI will run browser tests independently.