### PR TITLE
refactor: type Livewire dummy data population

### DIFF
--- a/.ai/rules/livewire.md
+++ b/.ai/rules/livewire.md
@@ -22,3 +22,6 @@ Implement Livewire behavior in namespaced PHP classes using shared base classes 
 
 ## Translate only domain failures
 Catch and translate BaseBusinessException at Livewire user-interaction boundaries. Do not catch generic Exception or Throwable to produce business flash messages; let programmer, infrastructure, and framework failures propagate through Laravel's normal exception reporting.
+
+## Populate development data through typed forms
+Implement dummy-data population by assigning directly to the concrete Livewire form's typed properties. Do not return generic field-name arrays or dynamically assign arbitrary properties; dedicated collaborators such as match form population must accept the concrete form type.

--- a/app/Livewire/Concerns/GeneratesDummyData.php
+++ b/app/Livewire/Concerns/GeneratesDummyData.php
@@ -4,296 +4,32 @@ declare(strict_types=1);
 
 namespace App\Livewire\Concerns;
 
-use Closure;
-use DateTime;
-use LogicException;
-
-/**
- * Trait for generating dummy data in Livewire forms and modals.
- *
- * This trait provides a standardized approach to populating form fields with
- * realistic fake data for development and testing purposes. It automatically
- * detects the form structure and populates fields accordingly.
- *
- * The trait works with both direct property assignment and form object patterns,
- * making it flexible for different form architectures.
- *
- * @author Ringside
- *
- * @since 1.0.0
- */
 trait GeneratesDummyData
 {
-    /**
-     * Fill form fields with dummy data based on field definitions.
-     *
-     * This method automatically detects whether the form uses direct properties
-     * or a form object pattern and populates fields accordingly. It supports
-     * both callable generators and static values.
-     */
     public function fillDummyFields(): void
     {
         abort_unless(app()->environment(['local', 'testing']), 404);
 
-        $fields = $this->getDummyDataFields();
-
-        foreach ($fields as $field => $generator) {
-            $value = $generator;
-
-            if (is_callable($generator)) {
-                $value = $generator();
-            }
-
-            // Try to populate fields using available patterns
-            $this->populateField($field, $value);
-        }
+        $this->populateDummyData();
     }
 
-    /**
-     * Populate a single field with a value using available patterns.
-     *
-     * Attempts different field population strategies based on the class context.
-     *
-     * @param  string  $field  Field name to populate
-     * @param  mixed  $value  Value to set
-     */
-    private function populateField(string $field, mixed $value): void
-    {
-        if (isset($this->form) && property_exists($this->form, $field)) {
-            $this->form->{$field} = $value;
+    abstract protected function populateDummyData(): void;
 
-            return;
-        }
-
-        if (property_exists($this, $field)) {
-            $this->{$field} = $value;
-
-            return;
-        }
-
-        throw new LogicException("Dummy data field [{$field}] is not defined on the form or component.");
-    }
-
-    /**
-     * Get the dummy data field definitions for this form.
-     *
-     * This abstract method must be implemented by classes using this trait
-     * to define which fields should be populated and how they should be generated.
-     *
-     * @return array<string, callable|mixed> Array mapping field names to generators
-     */
-    abstract protected function getDummyDataFields(): array;
-
-    /**
-     * Generate a realistic wrestling-style name.
-     *
-     * Creates wrestling persona names using various patterns including
-     * real names, stage names with epithets, and single-word personas.
-     * Perfect for wrestler, manager, or character name generation.
-     *
-     * @return string A realistic wrestling name
-     */
-    protected function generateWrestlingName(): string
-    {
-        $patterns = [
-            fn (): string => fake()->firstName().' '.fake()->lastName(),
-            fn (): string => fake()->word().' '.fake()->lastName(),
-            fn (): string => 'The '.fake()->word(),
-            fn (): string => fake()->firstName().' "'.fake()->word().'" '.fake()->lastName(),
-        ];
-
-        $pattern = $this->randomGenerator($patterns);
-
-        return ucwords($pattern());
-    }
-
-    /**
-     * Generate a realistic wrestling signature move name.
-     *
-     * Creates authentic-sounding wrestling move names by combining
-     * move types with optional modifiers, similar to real wrestling
-     * signature moves and finishers.
-     *
-     * @return string A realistic signature move name
-     */
-    protected function generateSignatureMove(): string
-    {
-        $moveTypes = [
-            'Stunner', 'Slam', 'Drop', 'Splash', 'Driver', 'Cutter', 'Bomb', 'Lock',
-            'Submission', 'Suplex', 'Clothesline', 'Elbow', 'Knee', 'Kick', 'Punch',
-        ];
-
-        $modifiers = [
-            'Stone Cold', 'Five Knuckle', 'Attitude', 'Rock Bottom', 'Sweet Chin',
-            'Razor\'s Edge', 'Tombstone', 'People\'s', 'Sharpshooter', 'Figure Four',
-        ];
-
-        $useModifier = fake()->boolean(60);
-
-        if ($useModifier) {
-            return $this->randomString($modifiers).' '.$this->randomString($moveTypes);
-        }
-
-        return $this->randomString($moveTypes);
-    }
-
-    /**
-     * Generate a realistic venue name with proper suffix.
-     *
-     * Creates venue names that sound like real wrestling arenas, combining
-     * either corporate sponsors with venue types or city names with
-     * appropriate venue suffixes.
-     *
-     * @return string A realistic venue name
-     */
-    protected function generateVenueName(): string
-    {
-        $suffixes = ['Arena', 'Center', 'Stadium', 'Coliseum', 'Garden', 'Dome', 'Auditorium'];
-        $prefixes = [
-            'American Airlines', 'Madison Square', 'Staples', 'Wells Fargo', 'TD Garden',
-            'United Center', 'Honda Center', 'Barclays', 'Target', 'Capital One',
-        ];
-
-        $usePrefix = fake()->boolean(70);
-
-        if ($usePrefix) {
-            return $this->randomString($prefixes).' '.$this->randomString($suffixes);
-        }
-
-        return fake()->city().' '.$this->randomString($suffixes);
-    }
-
-    /**
-     * Generate a realistic championship title name.
-     *
-     * Creates wrestling championship names that mirror real-world title
-     * structures, combining divisions/categories with appropriate title
-     * nomenclature used in professional wrestling.
-     *
-     * @return string A realistic championship title name
-     */
-    protected function generateChampionshipTitle(): string
-    {
-        $titleTypes = [
-            'Championship Title', 'Title', 'Titles', 'Championship Titles',
-        ];
-
-        $categories = [
-            'Intercontinental', 'United States', 'European', 'Hardcore', 'Cruiserweight',
-            'Women\'s', 'Tag Team', 'World Heavyweight', 'Universal', 'Raw Women\'s',
-        ];
-
-        return $this->randomString($categories).' '.$this->randomString($titleTypes);
-    }
-
-    /**
-     * Generate realistic address components for US venues.
-     *
-     * Creates complete US address information suitable for venue locations,
-     * including proper state abbreviations and valid ZIP code formats.
-     *
-     * @return array<string, mixed> Address components with proper typing
-     */
-    protected function generateUSAddress(): array
-    {
-        $stateAbbreviations = [
-            'AL', 'AK', 'AZ', 'AR', 'CA', 'CO', 'CT', 'DE', 'FL', 'GA',
-            'HI', 'ID', 'IL', 'IN', 'IA', 'KS', 'KY', 'LA', 'ME', 'MD',
-            'MA', 'MI', 'MN', 'MS', 'MO', 'MT', 'NE', 'NV', 'NH', 'NJ',
-            'NM', 'NY', 'NC', 'ND', 'OH', 'OK', 'OR', 'PA', 'RI', 'SC',
-            'SD', 'TN', 'TX', 'UT', 'VT', 'VA', 'WA', 'WV', 'WI', 'WY',
-        ];
-
-        return [
-            'street_address' => fake()->streetAddress(),
-            'city' => fake()->city(),
-            'state' => $this->randomString($stateAbbreviations),
-            'zipcode' => (int) fake()->numerify('#####'),
-        ];
-    }
-
-    /**
-     * Generate realistic future date for activations or employment.
-     *
-     * Creates future dates within a specified timeframe, useful for
-     * scheduling activations, contract start dates, or event dates.
-     * Uses probability to sometimes return null for optional dates.
-     *
-     * @param  float  $probability  Probability of generating a date (0.0 to 1.0)
-     * @param  string  $maxPeriod  Maximum future period (e.g., '+3 months', '+1 year')
-     * @return string|null Date string in Y-m-d format, or null
-     */
-    protected function generateFutureDate(float $probability = 0.8, string $maxPeriod = '+3 months'): ?string
-    {
-        if (! fake()->boolean($probability * 100)) {
-            return null;
-        }
-
-        $dateTime = fake()->dateTimeBetween('now', $maxPeriod);
-
-        return $dateTime->format('Y-m-d');
-    }
-
-    /**
-     * Generate an optional start date with proper DateTime handling.
-     *
-     * Returns a formatted date string with specified probability, handling
-     * PHPStan nullsafe operator issues with DateTime objects by properly
-     * checking for null values before calling format().
-     *
-     * @param  string  $format  The date format to use (default: 'Y-m-d H:i:s')
-     * @param  float  $probability  The probability of returning a date (default: 0.8)
-     * @param  string  $maxPeriod  Maximum future period (default: '+3 month')
-     * @return string|null The formatted date string or null
-     */
     protected function generateOptionalStartDate(
         string $format = 'Y-m-d H:i:s',
         float $probability = 0.8,
         string $minPeriod = 'now',
-        string $maxPeriod = '+3 month'
+        string $maxPeriod = '+3 month',
     ): ?string {
-        // Directly check probability to avoid PHPStan confusion with fake()->optional()
-        if (fake()->boolean((int) ($probability * 100))) {
-            return fake()->dateTimeBetween($minPeriod, $maxPeriod)->format($format);
+        if (! fake()->boolean((int) ($probability * 100))) {
+            return null;
         }
 
-        return null;
+        return fake()->dateTimeBetween($minPeriod, $maxPeriod)->format($format);
     }
 
-    /**
-     * Generate an optional date for an employment field.
-     */
     protected function generateOptionalEmploymentDate(float $probability = 0.8): ?string
     {
         return $this->generateOptionalStartDate('Y-m-d', $probability);
-    }
-
-    /**
-     * @param  non-empty-list<string>  $values
-     */
-    private function randomString(array $values): string
-    {
-        $value = fake()->randomElement($values);
-
-        if (! is_string($value)) {
-            throw new LogicException('Expected the random value to be a string.');
-        }
-
-        return $value;
-    }
-
-    /**
-     * @param  non-empty-list<Closure(): string>  $generators
-     * @return Closure(): string
-     */
-    private function randomGenerator(array $generators): Closure
-    {
-        $generator = fake()->randomElement($generators);
-
-        if (! $generator instanceof Closure) {
-            throw new LogicException('Expected the random value to be a generator.');
-        }
-
-        return $generator;
     }
 }

--- a/app/Livewire/Events/Modals/FormModal.php
+++ b/app/Livewire/Events/Modals/FormModal.php
@@ -38,14 +38,16 @@ class FormModal extends BaseFormModal
         return Event::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        return [
-            'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
-            'date' => fn (): string => fake()->dateTimeBetween('now', '+3 month')->format('Y-m-d H:i:s'),
-            'venue_id' => fn () => Venue::query()->inRandomOrder()->value('id'),
-            'preview' => fn () => Str::of(fake()->text())->value(),
-        ];
+        $this->form->name = Str::of(fake()->sentence(2))->title()->value();
+        $this->form->date = fake()->dateTimeBetween('now', '+3 month')->format('Y-m-d H:i:s');
+        $venue = Venue::query()->inRandomOrder()->first();
+
+        if ($venue !== null) {
+            $this->form->venue_id = $venue->id;
+        }
+        $this->form->preview = Str::of(fake()->text())->value();
     }
 
     public function getModalTitle(): string

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -41,13 +41,11 @@ class FormModal extends BaseFormModal
         return Manager::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        return [
-            'first_name' => fn () => fake()->firstName(),
-            'last_name' => fn () => fake()->lastName(),
-            'employment_date' => fn (): ?string => $this->generateOptionalEmploymentDate(),
-        ];
+        $this->form->first_name = fake()->firstName();
+        $this->form->last_name = fake()->lastName();
+        $this->form->employment_date = $this->generateOptionalEmploymentDate();
     }
 
     protected function storeForm(): bool

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -90,10 +90,9 @@ class FormModal extends BaseFormModal
             ->all();
     }
 
-    /** @return array<string, mixed> */
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        return $this->dummyData->generate();
+        $this->dummyData->fill($this->form);
     }
 
     public function openModal(int|string|null $modelId = null): void

--- a/app/Livewire/Matches/Support/MatchFormDummyData.php
+++ b/app/Livewire/Matches/Support/MatchFormDummyData.php
@@ -6,22 +6,14 @@ namespace App\Livewire\Matches\Support;
 
 use App\Enums\MatchType;
 use App\Lifecycle\RosterBookingEligibility;
+use App\Livewire\Matches\Forms\CreateEditForm;
 use App\Models\Roster\Referees\Referee;
 use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Titles\Title;
 
 final class MatchFormDummyData
 {
-    /**
-     * @return array{
-     *     matchType: MatchType,
-     *     competitors: array<int, array{wrestlers: array<int>, tag_teams: array<int>}>,
-     *     referees: array<int>,
-     *     titles: array<int>,
-     *     preview: string
-     * }
-     */
-    public function generate(): array
+    public function fill(CreateEditForm $form): void
     {
         $wrestlerIds = Wrestler::query()
             ->employed()
@@ -41,19 +33,17 @@ final class MatchFormDummyData
             ->map(fn (Referee $referee): int => $referee->id)
             ->all();
 
-        return [
-            'matchType' => MatchType::Singles,
-            'competitors' => [
-                ['wrestlers' => array_slice($wrestlerIds, 0, 1), 'tag_teams' => []],
-                ['wrestlers' => array_slice($wrestlerIds, 1, 1), 'tag_teams' => []],
-            ],
-            'referees' => $refereeIds,
-            'titles' => fake()->boolean(30)
-                ? Title::query()->active()->inRandomOrder()->limit(1)->get(['id'])
-                    ->map(fn (Title $title): int => $title->id)
-                    ->all()
-                : [],
-            'preview' => fake()->paragraph(2),
+        $form->matchType = MatchType::Singles;
+        $form->competitors = [
+            ['wrestlers' => array_slice($wrestlerIds, 0, 1), 'tag_teams' => []],
+            ['wrestlers' => array_slice($wrestlerIds, 1, 1), 'tag_teams' => []],
         ];
+        $form->referees = $refereeIds;
+        $form->titles = fake()->boolean(30)
+            ? Title::query()->active()->inRandomOrder()->limit(1)->get(['id'])
+                ->map(fn (Title $title): int => $title->id)
+                ->all()
+            : [];
+        $form->preview = fake()->paragraph(2);
     }
 }

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -40,13 +40,11 @@ class FormModal extends BaseFormModal
         return Referee::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        return [
-            'first_name' => fn () => fake()->firstName(),
-            'last_name' => fn () => fake()->lastName(),
-            'employment_date' => fn (): ?string => $this->generateOptionalEmploymentDate(),
-        ];
+        $this->form->first_name = fake()->firstName();
+        $this->form->last_name = fake()->lastName();
+        $this->form->employment_date = $this->generateOptionalEmploymentDate();
     }
 
     protected function storeForm(): bool

--- a/app/Livewire/Stables/Modals/FormModal.php
+++ b/app/Livewire/Stables/Modals/FormModal.php
@@ -41,12 +41,10 @@ class FormModal extends BaseFormModal
         return Stable::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        return [
-            'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
-            'start_date' => fn (): ?string => $this->generateOptionalStartDate(),
-        ];
+        $this->form->name = Str::of(fake()->sentence(2))->title()->value();
+        $this->form->started_at = $this->generateOptionalStartDate();
     }
 
     public function getModalTitle(): string

--- a/app/Livewire/TagTeams/Modals/FormModal.php
+++ b/app/Livewire/TagTeams/Modals/FormModal.php
@@ -40,20 +40,18 @@ class FormModal extends BaseFormModal
         return TagTeam::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        $wrestlerIds = Wrestler::query()
+        $wrestlers = Wrestler::query()
             ->inRandomOrder()
             ->limit(2)
-            ->pluck('id');
+            ->get(['id']);
 
-        return [
-            'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
-            'signature_move' => fn () => Str::of(fake()->optional(0.8)->sentence(3))->title()->value(),
-            'employment_date' => fn (): ?string => $this->generateOptionalEmploymentDate(),
-            'wrestlerA' => fn () => $wrestlerIds->first(),
-            'wrestlerB' => fn () => $wrestlerIds->get(1),
-        ];
+        $this->form->name = Str::of(fake()->sentence(2))->title()->value();
+        $this->form->signature_move = Str::of(fake()->optional(0.8)->sentence(3))->title()->value();
+        $this->form->employment_date = $this->generateOptionalEmploymentDate();
+        $this->form->wrestlerA = $wrestlers->get(0)?->id;
+        $this->form->wrestlerB = $wrestlers->get(1)?->id;
     }
 
     protected function storeForm(): bool

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -6,6 +6,7 @@ namespace App\Livewire\Titles\Modals;
 
 use App\Actions\Titles\CreateAction;
 use App\Actions\Titles\UpdateAction;
+use App\Enums\Titles\TitleType;
 use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Titles\Forms\CreateEditForm;
 use App\Models\Titles\Title;
@@ -35,13 +36,13 @@ class FormModal extends BaseFormModal
         return Title::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        return [
-            'name' => fn () => Str::of(fake()->word().' '.fake()->word())->title()->append(' Title')->value(),
-            'type' => fn () => fake()->randomElement(['singles', 'tag-team']),
-            'start_date' => fn (): ?string => $this->generateOptionalStartDate('Y-m-d', 0.6, '-1 year', 'now'),
-        ];
+        $this->form->name = Str::of(fake()->word().' '.fake()->word())->title()->append(' Title')->value();
+        $this->form->type = fake()->boolean()
+            ? TitleType::Singles->value
+            : TitleType::TagTeam->value;
+        $this->form->start_date = $this->generateOptionalStartDate('Y-m-d', 0.6, '-1 year', 'now');
     }
 
     public function getModalTitle(): string

--- a/app/Livewire/Users/Modals/FormModal.php
+++ b/app/Livewire/Users/Modals/FormModal.php
@@ -33,16 +33,14 @@ class FormModal extends BaseFormModal
         return User::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        return [
-            'first_name' => fn () => fake()->firstName(),
-            'last_name' => fn () => fake()->lastName(),
-            'email' => fn () => fake()->unique()->safeEmail(),
-            'password' => fn (): string => 'password123',
-            'password_confirmation' => fn (): string => 'password123',
-            'role' => fn (): string => 'basic',
-        ];
+        $this->form->first_name = fake()->firstName();
+        $this->form->last_name = fake()->lastName();
+        $this->form->email = fake()->unique()->safeEmail();
+        $this->form->password = 'password123';
+        $this->form->password_confirmation = 'password123';
+        $this->form->role = 'basic';
     }
 
     public function getModalTitle(): string

--- a/app/Livewire/Venues/Modals/FormModal.php
+++ b/app/Livewire/Venues/Modals/FormModal.php
@@ -34,7 +34,7 @@ class FormModal extends BaseFormModal
         return Venue::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
         /**
          * @var string $state
@@ -43,13 +43,11 @@ class FormModal extends BaseFormModal
          */
         $state = fake('en_US')->state();
 
-        return [
-            'name' => fn () => Str::of(fake()->sentence(2))->title()->append(' Arena')->value(),
-            'street_address' => fn () => fake()->streetAddress(),
-            'city' => fn () => fake()->city(),
-            'state' => fn () => $state,
-            'zipcode' => fn () => fake('en_US')->numerify('#####'),
-        ];
+        $this->form->name = Str::of(fake()->sentence(2))->title()->append(' Arena')->value();
+        $this->form->street_address = fake()->streetAddress();
+        $this->form->city = fake()->city();
+        $this->form->state = $state;
+        $this->form->zipcode = fake('en_US')->numerify('#####');
     }
 
     public function getModalTitle(): string

--- a/app/Livewire/Wrestlers/Modals/FormModal.php
+++ b/app/Livewire/Wrestlers/Modals/FormModal.php
@@ -34,17 +34,15 @@ class FormModal extends BaseFormModal
         return Wrestler::class;
     }
 
-    protected function getDummyDataFields(): array
+    protected function populateDummyData(): void
     {
-        return [
-            'name' => fn () => Str::of(fake()->sentence(2))->title()->value(),
-            'hometown' => fn (): string => fake()->city().', '.fake()->stateAbbr(), // @phpstan-ignore-line
-            'height_feet' => fn (): int => fake()->numberBetween(5, 7),
-            'height_inches' => fn (): int => fake()->numberBetween(0, 11),
-            'weight' => fn (): int => fake()->numberBetween(180, 350),
-            'signature_move' => fn () => Str::of(fake()->optional(0.8)->sentence(3))->title()->value(),
-            'employment_date' => fn (): ?string => $this->generateOptionalEmploymentDate(),
-        ];
+        $this->form->name = Str::of(fake()->sentence(2))->title()->value();
+        $this->form->hometown = fake()->city().', '.fake()->stateAbbr(); // @phpstan-ignore-line
+        $this->form->height_feet = fake()->numberBetween(5, 7);
+        $this->form->height_inches = fake()->numberBetween(0, 11);
+        $this->form->weight = fake()->numberBetween(180, 350);
+        $this->form->signature_move = Str::of(fake()->optional(0.8)->sentence(3))->title()->value();
+        $this->form->employment_date = $this->generateOptionalEmploymentDate();
     }
 
     protected function storeForm(): bool

--- a/tests/Integration/Livewire/Wrestlers/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Wrestlers/Modals/FormModalTest.php
@@ -126,18 +126,6 @@ describe('FormModal Form Integration', function () {
 });
 
 describe('FormModal Dummy Data', function () {
-    it('has dummy data fields configured', function () {
-        $modal = new FormModal();
-        $reflection = new ReflectionClass($modal);
-        $method = $reflection->getMethod('getDummyDataFields');
-        $method->setAccessible(true);
-
-        $dummyFields = $method->invoke($modal);
-
-        expect($dummyFields)->toBeArray();
-        expect($dummyFields)->toHaveKeys(['name', 'hometown', 'height_feet', 'height_inches', 'weight', 'signature_move', 'employment_date']);
-    });
-
     it('can fill dummy data', function () {
         $component = livewire(FormModal::class);
         $component->call('fillDummyFields');

--- a/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
+++ b/tests/Unit/Livewire/Concerns/GeneratesDummyDataTest.php
@@ -4,316 +4,48 @@ declare(strict_types=1);
 
 use App\Livewire\Concerns\GeneratesDummyData;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
-use Tests\Integration\Livewire\Concerns\GeneratesDummyDataTest;
 
-/**
- * Unit tests for GeneratesDummyData trait structure.
- *
- * UNIT TEST SCOPE:
- * - Trait structure verification
- * - Method signatures and return types
- * - Method visibility and documentation
- * - Abstract method requirements
- * - Trait naming and namespace
- *
- * @see GeneratesDummyData
- * @see GeneratesDummyDataTest
- */
-describe('GeneratesDummyData Unit Tests', function () {
-    describe('trait structure', function () {
-        test('is trait', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            expect($reflection->isTrait())->toBeTrue();
-        });
+describe('GeneratesDummyData', function () {
+    test('delegates population to the typed component implementation', function () {
+        $component = new class
+        {
+            use GeneratesDummyData;
 
-        test('is abstract due to abstract method', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            expect($reflection->isAbstract())->toBeTrue();
-        });
+            public string $name = '';
 
-    });
-
-    describe('public method signatures', function () {
-        test('has fillDummyFields method', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            expect($reflection->hasMethod('fillDummyFields'))->toBeTrue();
-
-            $method = $reflection->getMethod('fillDummyFields');
-            expect($method->isPublic())->toBeTrue();
-            expect(reflectionReturnTypeName($method))->toBe('void');
-            expect($method->getNumberOfParameters())->toBe(0);
-        });
-    });
-
-    describe('private helper method signatures', function () {
-        test('has populateField method', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            expect($reflection->hasMethod('populateField'))->toBeTrue();
-
-            $method = $reflection->getMethod('populateField');
-            expect($method->isPrivate())->toBeTrue();
-            expect(reflectionReturnTypeName($method))->toBe('void');
-            expect($method->getNumberOfParameters())->toBe(2);
-
-            $parameters = $method->getParameters();
-            expect($parameters[0]->getName())->toBe('field');
-            expect(reflectionTypeName($parameters[0]))->toBe('string');
-            expect($parameters[1]->getName())->toBe('value');
-            expect(reflectionTypeName($parameters[1]))->toBe('mixed');
-        });
-
-    });
-
-    describe('protected generator method signatures', function () {
-        test('has wrestling name generators', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            expect($reflection->hasMethod('generateWrestlingName'))->toBeTrue();
-            expect($reflection->hasMethod('generateSignatureMove'))->toBeTrue();
-
-            $nameMethod = $reflection->getMethod('generateWrestlingName');
-            expect($nameMethod->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($nameMethod))->toBe('string');
-            expect($nameMethod->getNumberOfParameters())->toBe(0);
-
-            $moveMethod = $reflection->getMethod('generateSignatureMove');
-            expect($moveMethod->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($moveMethod))->toBe('string');
-            expect($moveMethod->getNumberOfParameters())->toBe(0);
-        });
-
-        test('has venue and title generators', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            expect($reflection->hasMethod('generateVenueName'))->toBeTrue();
-            expect($reflection->hasMethod('generateChampionshipTitle'))->toBeTrue();
-
-            $venueMethod = $reflection->getMethod('generateVenueName');
-            expect($venueMethod->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($venueMethod))->toBe('string');
-            expect($venueMethod->getNumberOfParameters())->toBe(0);
-
-            $titleMethod = $reflection->getMethod('generateChampionshipTitle');
-            expect($titleMethod->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($titleMethod))->toBe('string');
-            expect($titleMethod->getNumberOfParameters())->toBe(0);
-        });
-
-        test('has address and date generators', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            expect($reflection->hasMethod('generateUSAddress'))->toBeTrue();
-            expect($reflection->hasMethod('generateFutureDate'))->toBeTrue();
-
-            $addressMethod = $reflection->getMethod('generateUSAddress');
-            expect($addressMethod->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($addressMethod))->toBe('array');
-            expect($addressMethod->getNumberOfParameters())->toBe(0);
-
-            $dateMethod = $reflection->getMethod('generateFutureDate');
-            expect($dateMethod->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($dateMethod))->toBe('string');
-            expect(requiredReflectionType($dateMethod->getReturnType())->allowsNull())->toBeTrue();
-            expect($dateMethod->getNumberOfParameters())->toBe(2);
-        });
-    });
-
-    describe('abstract method requirements', function () {
-        test('has getDummyDataFields abstract method', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-
-            expect($reflection->hasMethod('getDummyDataFields'))->toBeTrue();
-
-            $method = $reflection->getMethod('getDummyDataFields');
-            expect($method->isAbstract())->toBeTrue();
-            expect($method->isProtected())->toBeTrue();
-            expect(reflectionReturnTypeName($method))->toBe('array');
-            expect($method->getNumberOfParameters())->toBe(0);
-        });
-    });
-
-    describe('namespace and naming', function () {
-        test('uses correct namespace', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            expect($reflection->getNamespaceName())->toBe('App\\Livewire\\Concerns');
-        });
-
-        test('follows trait naming convention', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            expect($reflection->getShortName())->toBe('GeneratesDummyData');
-        });
-    });
-
-    describe('dependency imports', function () {
-        test('imports LogicException', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $source = reflectionSource($reflection);
-
-            expect($source)->toContain('use LogicException;');
-        });
-    });
-
-    describe('trait method organization', function () {
-        test('has correct method visibility distribution', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $methods = array_filter(
-                $reflection->getMethods(),
-                fn ($method) => $method->getDeclaringClass()->getName() === GeneratesDummyData::class
-            );
-
-            $publicMethods = array_filter($methods, fn ($method) => $method->isPublic());
-            $protectedMethods = array_filter($methods, fn ($method) => $method->isProtected());
-            $privateMethods = array_filter($methods, fn ($method) => $method->isPrivate());
-
-            expect($publicMethods)->toHaveCount(1); // fillDummyFields
-            expect(count($protectedMethods))->toBeGreaterThan(5); // generators + abstract
-            expect(array_values(array_map(
-                fn (ReflectionMethod $method): string => $method->getName(),
-                $privateMethods
-            )))->toEqualCanonicalizing(['populateField', 'randomString', 'randomGenerator']);
-        });
-
-        test('has no properties', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $properties = array_filter(
-                $reflection->getProperties(),
-                fn ($property) => $property->getDeclaringClass()->getName() === GeneratesDummyData::class
-            );
-
-            expect($properties)->toHaveCount(0);
-        });
-    });
-
-    describe('field population', function () {
-        test('rejects dummy data requests outside local and testing environments', function () {
-            $form = new class
+            protected function populateDummyData(): void
             {
-                use GeneratesDummyData;
-
-                public string $name = '';
-
-                protected function getDummyDataFields(): array
-                {
-                    return ['name' => 'Test Name'];
-                }
-            };
-
-            app()->detectEnvironment(fn () => 'production');
-
-            try {
-                expect(fn () => $form->fillDummyFields())->toThrow(NotFoundHttpException::class);
-            } finally {
-                app()->detectEnvironment(fn () => 'testing');
+                $this->name = 'Test Name';
             }
-        });
+        };
 
-        test('populates fields directly on a form', function () {
-            $form = new class
-            {
-                use GeneratesDummyData;
+        $component->fillDummyFields();
 
-                public string $name = '';
-
-                protected function getDummyDataFields(): array
-                {
-                    return ['name' => 'Test Name'];
-                }
-            };
-
-            $form->fillDummyFields();
-
-            expect($form->name)->toBe('Test Name');
-        });
-
-        test('populates fields on a nested form object', function () {
-            $nestedForm = new class
-            {
-                public string $name = '';
-            };
-            $component = new class($nestedForm)
-            {
-                use GeneratesDummyData;
-
-                public function __construct(public object $form) {}
-
-                protected function getDummyDataFields(): array
-                {
-                    return ['name' => 'Test Name'];
-                }
-            };
-
-            $component->fillDummyFields();
-
-            expect($nestedForm->name)->toBe('Test Name');
-        });
-
-        test('propagates invalid field configuration', function () {
-            $form = new class
-            {
-                use GeneratesDummyData;
-
-                protected function getDummyDataFields(): array
-                {
-                    return ['missing' => 'Test Name'];
-                }
-            };
-
-            expect(fn () => $form->fillDummyFields())
-                ->toThrow(LogicException::class, 'Dummy data field [missing] is not defined');
-        });
-
-        test('propagates invalid generated value types', function () {
-            $form = new class
-            {
-                use GeneratesDummyData;
-
-                public int $count = 0;
-
-                protected function getDummyDataFields(): array
-                {
-                    return ['count' => 'invalid'];
-                }
-            };
-
-            expect(fn () => $form->fillDummyFields())->toThrow(TypeError::class);
-        });
+        expect($component->name)->toBe('Test Name');
     });
 
-    describe('generator method parameters', function () {
-        test('generateFutureDate has proper parameters', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $method = $reflection->getMethod('generateFutureDate');
-            $parameters = $method->getParameters();
+    test('rejects dummy data requests outside local and testing environments', function () {
+        $component = new class
+        {
+            use GeneratesDummyData;
 
-            expect($parameters[0]->getName())->toBe('probability');
-            expect(reflectionTypeName($parameters[0]))->toBe('float');
-            expect($parameters[0]->isOptional())->toBeTrue();
-            expect($parameters[0]->getDefaultValue())->toBe(0.8);
+            protected function populateDummyData(): void {}
+        };
 
-            expect($parameters[1]->getName())->toBe('maxPeriod');
-            expect(reflectionTypeName($parameters[1]))->toBe('string');
-            expect($parameters[1]->isOptional())->toBeTrue();
-            expect($parameters[1]->getDefaultValue())->toBe('+3 months');
-        });
+        app()->detectEnvironment(fn (): string => 'production');
+
+        try {
+            expect(fn () => $component->fillDummyFields())->toThrow(NotFoundHttpException::class);
+        } finally {
+            app()->detectEnvironment(fn (): string => 'testing');
+        }
     });
 
-    describe('return type annotations', function () {
-        test('getDummyDataFields has proper return type annotation', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $method = $reflection->getMethod('getDummyDataFields');
-            $docComment = $method->getDocComment();
+    test('requires a typed population hook', function () {
+        $method = new ReflectionMethod(GeneratesDummyData::class, 'populateDummyData');
 
-            expect($docComment)->toContain('@return array<string, callable|mixed>');
-        });
-
-        test('generateUSAddress has proper return type annotation', function () {
-            $reflection = new ReflectionClass(GeneratesDummyData::class);
-            $method = $reflection->getMethod('generateUSAddress');
-            $docComment = $method->getDocComment();
-
-            expect($docComment)->toContain('@return array<string, mixed>');
-        });
+        expect($method->isAbstract())->toBeTrue()
+            ->and($method->isProtected())->toBeTrue()
+            ->and(reflectionReturnTypeName($method))->toBe('void');
     });
 });


### PR DESCRIPTION
## Summary
- replace generic field-name arrays and dynamic property assignment with typed Livewire form population
- make match dummy data fill the concrete match form directly
- remove unused generic dummy-data generators and record the typed-form convention

## Verification
- focused Livewire and workflow suite: 207 tests, 669 assertions
- application PHPStan: passed
- Pest PHPStan: passed
- Rector: passed
- Pint with Blade: passed
- application suite: 3,369 tests, 10,881 assertions

The local browser phase produced no output and was stopped after the rest of the pre-push pipeline passed; GitHub Actions will run the browser suite.