### PR TITLE
refactor: share roster component action handling

### DIFF
--- a/app/Livewire/Managers/Components/Actions.php
+++ b/app/Livewire/Managers/Components/Actions.php
@@ -14,10 +14,10 @@ use App\Actions\Managers\RetireAction;
 use App\Actions\Managers\SuspendAction;
 use App\Actions\Managers\UnretireAction;
 use App\Enums\Roster\RosterEntityType;
+use App\Enums\Roster\RosterLifecycleAction;
 use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Models\Roster\Managers\Manager;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class Actions extends Component
@@ -33,56 +33,47 @@ class Actions extends Component
 
     public function employ(): void
     {
-        Gate::authorize('employ', $this->manager);
-        $this->executeRosterAction('employed', RosterEntityType::Manager, fn () => resolve(EmployAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Employ, RosterEntityType::Manager, $this->manager, fn () => resolve(EmployAction::class)->handle($this->manager));
     }
 
     public function release(): void
     {
-        Gate::authorize('release', $this->manager);
-        $this->executeRosterAction('released', RosterEntityType::Manager, fn () => resolve(ReleaseAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Release, RosterEntityType::Manager, $this->manager, fn () => resolve(ReleaseAction::class)->handle($this->manager));
     }
 
     public function retire(): void
     {
-        Gate::authorize('retire', $this->manager);
-        $this->executeRosterAction('retired', RosterEntityType::Manager, fn () => resolve(RetireAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Retire, RosterEntityType::Manager, $this->manager, fn () => resolve(RetireAction::class)->handle($this->manager));
     }
 
     public function unretire(): void
     {
-        Gate::authorize('unretire', $this->manager);
-        $this->executeRosterAction('unretired', RosterEntityType::Manager, fn () => resolve(UnretireAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Unretire, RosterEntityType::Manager, $this->manager, fn () => resolve(UnretireAction::class)->handle($this->manager));
     }
 
     public function suspend(): void
     {
-        Gate::authorize('suspend', $this->manager);
-        $this->executeRosterAction('suspended', RosterEntityType::Manager, fn () => resolve(SuspendAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Suspend, RosterEntityType::Manager, $this->manager, fn () => resolve(SuspendAction::class)->handle($this->manager));
     }
 
     public function reinstate(): void
     {
-        Gate::authorize('reinstate', $this->manager);
-        $this->executeRosterAction('reinstated', RosterEntityType::Manager, fn () => resolve(ReinstateAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Reinstate, RosterEntityType::Manager, $this->manager, fn () => resolve(ReinstateAction::class)->handle($this->manager));
     }
 
     public function injure(): void
     {
-        Gate::authorize('injure', $this->manager);
-        $this->executeRosterAction('injured', RosterEntityType::Manager, fn () => resolve(InjureAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Injure, RosterEntityType::Manager, $this->manager, fn () => resolve(InjureAction::class)->handle($this->manager));
     }
 
     public function clearFromInjury(): void
     {
-        Gate::authorize('clearFromInjury', $this->manager);
-        $this->executeRosterAction('cleared_from_injury', RosterEntityType::Manager, fn () => resolve(ClearFromInjuryAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::ClearFromInjury, RosterEntityType::Manager, $this->manager, fn () => resolve(ClearFromInjuryAction::class)->handle($this->manager));
     }
 
     public function restore(): void
     {
-        Gate::authorize('restore', $this->manager);
-        $this->executeRosterAction('restored', RosterEntityType::Manager, fn () => resolve(RestoreAction::class)->handle($this->manager));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Restore, RosterEntityType::Manager, $this->manager, fn () => resolve(RestoreAction::class)->handle($this->manager));
     }
 
     public function render(): View

--- a/app/Livewire/Referees/Components/Actions.php
+++ b/app/Livewire/Referees/Components/Actions.php
@@ -14,10 +14,10 @@ use App\Actions\Referees\RetireAction;
 use App\Actions\Referees\SuspendAction;
 use App\Actions\Referees\UnretireAction;
 use App\Enums\Roster\RosterEntityType;
+use App\Enums\Roster\RosterLifecycleAction;
 use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Models\Roster\Referees\Referee;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class Actions extends Component
@@ -33,56 +33,47 @@ class Actions extends Component
 
     public function employ(): void
     {
-        Gate::authorize('employ', $this->referee);
-        $this->executeRosterAction('employed', RosterEntityType::Referee, fn () => resolve(EmployAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Employ, RosterEntityType::Referee, $this->referee, fn () => resolve(EmployAction::class)->handle($this->referee));
     }
 
     public function release(): void
     {
-        Gate::authorize('release', $this->referee);
-        $this->executeRosterAction('released', RosterEntityType::Referee, fn () => resolve(ReleaseAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Release, RosterEntityType::Referee, $this->referee, fn () => resolve(ReleaseAction::class)->handle($this->referee));
     }
 
     public function retire(): void
     {
-        Gate::authorize('retire', $this->referee);
-        $this->executeRosterAction('retired', RosterEntityType::Referee, fn () => resolve(RetireAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Retire, RosterEntityType::Referee, $this->referee, fn () => resolve(RetireAction::class)->handle($this->referee));
     }
 
     public function unretire(): void
     {
-        Gate::authorize('unretire', $this->referee);
-        $this->executeRosterAction('unretired', RosterEntityType::Referee, fn () => resolve(UnretireAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Unretire, RosterEntityType::Referee, $this->referee, fn () => resolve(UnretireAction::class)->handle($this->referee));
     }
 
     public function suspend(): void
     {
-        Gate::authorize('suspend', $this->referee);
-        $this->executeRosterAction('suspended', RosterEntityType::Referee, fn () => resolve(SuspendAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Suspend, RosterEntityType::Referee, $this->referee, fn () => resolve(SuspendAction::class)->handle($this->referee));
     }
 
     public function reinstate(): void
     {
-        Gate::authorize('reinstate', $this->referee);
-        $this->executeRosterAction('reinstated', RosterEntityType::Referee, fn () => resolve(ReinstateAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Reinstate, RosterEntityType::Referee, $this->referee, fn () => resolve(ReinstateAction::class)->handle($this->referee));
     }
 
     public function injure(): void
     {
-        Gate::authorize('injure', $this->referee);
-        $this->executeRosterAction('injured', RosterEntityType::Referee, fn () => resolve(InjureAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Injure, RosterEntityType::Referee, $this->referee, fn () => resolve(InjureAction::class)->handle($this->referee));
     }
 
     public function clearFromInjury(): void
     {
-        Gate::authorize('clearFromInjury', $this->referee);
-        $this->executeRosterAction('cleared_from_injury', RosterEntityType::Referee, fn () => resolve(ClearFromInjuryAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::ClearFromInjury, RosterEntityType::Referee, $this->referee, fn () => resolve(ClearFromInjuryAction::class)->handle($this->referee));
     }
 
     public function restore(): void
     {
-        Gate::authorize('restore', $this->referee);
-        $this->executeRosterAction('restored', RosterEntityType::Referee, fn () => resolve(RestoreAction::class)->handle($this->referee));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Restore, RosterEntityType::Referee, $this->referee, fn () => resolve(RestoreAction::class)->handle($this->referee));
     }
 
     public function render(): View

--- a/app/Livewire/TagTeams/Components/Actions.php
+++ b/app/Livewire/TagTeams/Components/Actions.php
@@ -13,6 +13,7 @@ use App\Actions\TagTeams\RetireAction;
 use App\Actions\TagTeams\SuspendAction;
 use App\Actions\TagTeams\UnretireAction;
 use App\Enums\Roster\RosterEntityType;
+use App\Enums\Roster\RosterLifecycleAction;
 use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Models\Roster\TagTeams\TagTeam;
 use Illuminate\Contracts\View\View;
@@ -32,38 +33,32 @@ class Actions extends Component
 
     public function employ(): void
     {
-        Gate::authorize('employ', $this->tagTeam);
-        $this->executeRosterAction('employed', RosterEntityType::TagTeam, fn () => resolve(EmployAction::class)->handle($this->tagTeam));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Employ, RosterEntityType::TagTeam, $this->tagTeam, fn () => resolve(EmployAction::class)->handle($this->tagTeam));
     }
 
     public function release(): void
     {
-        Gate::authorize('release', $this->tagTeam);
-        $this->executeRosterAction('released', RosterEntityType::TagTeam, fn () => resolve(ReleaseAction::class)->handle($this->tagTeam));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Release, RosterEntityType::TagTeam, $this->tagTeam, fn () => resolve(ReleaseAction::class)->handle($this->tagTeam));
     }
 
     public function retire(): void
     {
-        Gate::authorize('retire', $this->tagTeam);
-        $this->executeRosterAction('retired', RosterEntityType::TagTeam, fn () => resolve(RetireAction::class)->handle($this->tagTeam));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Retire, RosterEntityType::TagTeam, $this->tagTeam, fn () => resolve(RetireAction::class)->handle($this->tagTeam));
     }
 
     public function unretire(): void
     {
-        Gate::authorize('unretire', $this->tagTeam);
-        $this->executeRosterAction('unretired', RosterEntityType::TagTeam, fn () => resolve(UnretireAction::class)->handle($this->tagTeam));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Unretire, RosterEntityType::TagTeam, $this->tagTeam, fn () => resolve(UnretireAction::class)->handle($this->tagTeam));
     }
 
     public function suspend(): void
     {
-        Gate::authorize('suspend', $this->tagTeam);
-        $this->executeRosterAction('suspended', RosterEntityType::TagTeam, fn () => resolve(SuspendAction::class)->handle($this->tagTeam));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Suspend, RosterEntityType::TagTeam, $this->tagTeam, fn () => resolve(SuspendAction::class)->handle($this->tagTeam));
     }
 
     public function reinstate(): void
     {
-        Gate::authorize('reinstate', $this->tagTeam);
-        $this->executeRosterAction('reinstated', RosterEntityType::TagTeam, fn () => resolve(ReinstateAction::class)->handle($this->tagTeam));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Reinstate, RosterEntityType::TagTeam, $this->tagTeam, fn () => resolve(ReinstateAction::class)->handle($this->tagTeam));
     }
 
     public function delete(): void
@@ -74,8 +69,7 @@ class Actions extends Component
 
     public function restore(): void
     {
-        Gate::authorize('restore', $this->tagTeam);
-        $this->executeRosterAction('restored', RosterEntityType::TagTeam, fn () => resolve(RestoreAction::class)->handle($this->tagTeam));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Restore, RosterEntityType::TagTeam, $this->tagTeam, fn () => resolve(RestoreAction::class)->handle($this->tagTeam));
     }
 
     public function render(): View

--- a/app/Livewire/Wrestlers/Components/Actions.php
+++ b/app/Livewire/Wrestlers/Components/Actions.php
@@ -14,10 +14,10 @@ use App\Actions\Wrestlers\RetireAction;
 use App\Actions\Wrestlers\SuspendAction;
 use App\Actions\Wrestlers\UnretireAction;
 use App\Enums\Roster\RosterEntityType;
+use App\Enums\Roster\RosterLifecycleAction;
 use App\Livewire\Concerns\ExecutesRosterActions;
 use App\Models\Roster\Wrestlers\Wrestler;
 use Illuminate\Contracts\View\View;
-use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class Actions extends Component
@@ -33,56 +33,47 @@ class Actions extends Component
 
     public function employ(): void
     {
-        Gate::authorize('employ', $this->wrestler);
-        $this->executeRosterAction('employed', RosterEntityType::Wrestler, fn () => resolve(EmployAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Employ, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(EmployAction::class)->handle($this->wrestler));
     }
 
     public function release(): void
     {
-        Gate::authorize('release', $this->wrestler);
-        $this->executeRosterAction('released', RosterEntityType::Wrestler, fn () => resolve(ReleaseAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Release, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(ReleaseAction::class)->handle($this->wrestler));
     }
 
     public function retire(): void
     {
-        Gate::authorize('retire', $this->wrestler);
-        $this->executeRosterAction('retired', RosterEntityType::Wrestler, fn () => resolve(RetireAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Retire, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(RetireAction::class)->handle($this->wrestler));
     }
 
     public function unretire(): void
     {
-        Gate::authorize('unretire', $this->wrestler);
-        $this->executeRosterAction('unretired', RosterEntityType::Wrestler, fn () => resolve(UnretireAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Unretire, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(UnretireAction::class)->handle($this->wrestler));
     }
 
     public function suspend(): void
     {
-        Gate::authorize('suspend', $this->wrestler);
-        $this->executeRosterAction('suspended', RosterEntityType::Wrestler, fn () => resolve(SuspendAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Suspend, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(SuspendAction::class)->handle($this->wrestler));
     }
 
     public function reinstate(): void
     {
-        Gate::authorize('reinstate', $this->wrestler);
-        $this->executeRosterAction('reinstated', RosterEntityType::Wrestler, fn () => resolve(ReinstateAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Reinstate, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(ReinstateAction::class)->handle($this->wrestler));
     }
 
     public function injure(): void
     {
-        Gate::authorize('injure', $this->wrestler);
-        $this->executeRosterAction('injured', RosterEntityType::Wrestler, fn () => resolve(InjureAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Injure, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(InjureAction::class)->handle($this->wrestler));
     }
 
     public function clearFromInjury(): void
     {
-        Gate::authorize('clearFromInjury', $this->wrestler);
-        $this->executeRosterAction('cleared_from_injury', RosterEntityType::Wrestler, fn () => resolve(ClearFromInjuryAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::ClearFromInjury, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(ClearFromInjuryAction::class)->handle($this->wrestler));
     }
 
     public function restore(): void
     {
-        Gate::authorize('restore', $this->wrestler);
-        $this->executeRosterAction('restored', RosterEntityType::Wrestler, fn () => resolve(RestoreAction::class)->handle($this->wrestler));
+        $this->executeAuthorizedRosterAction(RosterLifecycleAction::Restore, RosterEntityType::Wrestler, $this->wrestler, fn () => resolve(RestoreAction::class)->handle($this->wrestler));
     }
 
     public function render(): View


### PR DESCRIPTION
## Summary
- route roster lifecycle component actions through the shared typed executor
- centralize lifecycle authorization abilities and success-message keys
- retain Tag Team deletion as an explicit non-lifecycle operation

## Verification
- composer lint
- focused Livewire suites: 95 tests, 284 assertions
- application and Pest PHPStan: 0 errors
- application and Pest Rector: no changes
- composer test:application: 3,387 tests, 10,904 assertions
- composer test:push passed through type coverage, Rector, lint, PHPStan, and application tests; local browser runner stalled without output and was stopped after a bounded wait (GitHub browser CI remains required)