### PR TITLE
refactor: centralize administrator authorization

### DIFF
--- a/app/Policies/EventMatchPolicy.php
+++ b/app/Policies/EventMatchPolicy.php
@@ -8,73 +8,40 @@ use App\Models\Matches\EventMatch;
 use App\Models\Users\User;
 
 /**
- * Simplified EventMatchPolicy using before hook pattern.
+ * Simplified EventMatchPolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class EventMatchPolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, EventMatch $eventMatch): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, EventMatch $eventMatch): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, EventMatch $eventMatch): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, EventMatch $eventMatch): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/EventPolicy.php
+++ b/app/Policies/EventPolicy.php
@@ -8,73 +8,40 @@ use App\Models\Events\Event;
 use App\Models\Users\User;
 
 /**
- * Simplified EventPolicy using before hook pattern.
+ * Simplified EventPolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class EventPolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, Event $event): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, Event $event): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, Event $event): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, Event $event): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/ManagerPolicy.php
+++ b/app/Policies/ManagerPolicy.php
@@ -8,137 +8,80 @@ use App\Models\Roster\Managers\Manager;
 use App\Models\Users\User;
 
 /**
- * Simplified ManagerPolicy using before hook pattern.
+ * Simplified ManagerPolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class ManagerPolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can employ managers (handled by before hook).
-     */
     public function employ(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can release managers (handled by before hook).
-     */
     public function release(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can retire managers (handled by before hook).
-     */
     public function retire(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can unretire managers (handled by before hook).
-     */
     public function unretire(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can suspend managers (handled by before hook).
-     */
     public function suspend(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can reinstate managers (handled by before hook).
-     */
     public function reinstate(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can injure managers (handled by before hook).
-     */
     public function injure(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can clear managers from injury (handled by before hook).
-     */
     public function clearFromInjury(User $user, Manager $manager): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/MatchPolicy.php
+++ b/app/Policies/MatchPolicy.php
@@ -8,73 +8,40 @@ use App\Models\Matches\EventMatch;
 use App\Models\Users\User;
 
 /**
- * Simplified MatchPolicy using before hook pattern.
+ * Simplified MatchPolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class MatchPolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, EventMatch $eventMatch): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, EventMatch $eventMatch): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, EventMatch $eventMatch): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, EventMatch $eventMatch): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/RefereePolicy.php
+++ b/app/Policies/RefereePolicy.php
@@ -8,137 +8,80 @@ use App\Models\Roster\Referees\Referee;
 use App\Models\Users\User;
 
 /**
- * Simplified RefereePolicy using before hook pattern.
+ * Simplified RefereePolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class RefereePolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can employ referees (handled by before hook).
-     */
     public function employ(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can release referees (handled by before hook).
-     */
     public function release(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can retire referees (handled by before hook).
-     */
     public function retire(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can unretire referees (handled by before hook).
-     */
     public function unretire(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can suspend referees (handled by before hook).
-     */
     public function suspend(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can reinstate referees (handled by before hook).
-     */
     public function reinstate(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can injure referees (handled by before hook).
-     */
     public function injure(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can clear referees from injury (handled by before hook).
-     */
     public function clearFromInjury(User $user, Referee $referee): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/StablePolicy.php
+++ b/app/Policies/StablePolicy.php
@@ -8,105 +8,60 @@ use App\Models\Roster\Stables\Stable;
 use App\Models\Users\User;
 
 /**
- * Simplified StablePolicy using before hook pattern.
+ * Simplified StablePolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class StablePolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, Stable $stable): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, Stable $stable): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, Stable $stable): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, Stable $stable): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can establish stables (handled by before hook).
-     */
     public function establish(User $user, Stable $stable): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can disband stables (handled by before hook).
-     */
     public function disband(User $user, Stable $stable): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can retire stables (handled by before hook).
-     */
     public function retire(User $user, Stable $stable): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can unretire stables (handled by before hook).
-     */
     public function unretire(User $user, Stable $stable): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/TagTeamPolicy.php
+++ b/app/Policies/TagTeamPolicy.php
@@ -8,121 +8,70 @@ use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Users\User;
 
 /**
- * Simplified TagTeamPolicy using before hook pattern.
+ * Simplified TagTeamPolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class TagTeamPolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can employ tag teams (handled by before hook).
-     */
     public function employ(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can release tag teams (handled by before hook).
-     */
     public function release(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can suspend tag teams (handled by before hook).
-     */
     public function suspend(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can reinstate tag teams (handled by before hook).
-     */
     public function reinstate(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can retire tag teams (handled by before hook).
-     */
     public function retire(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can unretire tag teams (handled by before hook).
-     */
     public function unretire(User $user, TagTeam $tagTeam): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/TitlePolicy.php
+++ b/app/Policies/TitlePolicy.php
@@ -8,129 +8,75 @@ use App\Models\Titles\Title;
 use App\Models\Users\User;
 
 /**
- * Simplified TitlePolicy using before hook pattern.
+ * Simplified TitlePolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class TitlePolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can debut titles (handled by before hook).
-     */
     public function debut(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can pull titles (handled by before hook).
-     */
     public function pull(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can reinstate titles (handled by before hook).
-     */
     public function reinstate(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can retire titles (handled by before hook).
-     */
     public function retire(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can unretire titles (handled by before hook).
-     */
     public function unretire(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can activate titles (handled by before hook).
-     */
     public function activate(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can deactivate titles (handled by before hook).
-     */
     public function deactivate(User $user, Title $title): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/UserPolicy.php
+++ b/app/Policies/UserPolicy.php
@@ -7,97 +7,55 @@ namespace App\Policies;
 use App\Models\Users\User;
 
 /**
- * Simplified UserPolicy using before hook pattern.
+ * Simplified UserPolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class UserPolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, User $targetUser): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, User $targetUser): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, User $targetUser): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, User $targetUser): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can manage users (handled by before hook).
-     */
     public function manageUsers(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can change user roles (handled by before hook).
-     */
     public function changeUserRoles(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view audit logs (handled by before hook).
-     */
     public function viewAuditLogs(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/VenuePolicy.php
+++ b/app/Policies/VenuePolicy.php
@@ -8,73 +8,40 @@ use App\Models\Events\Venue;
 use App\Models\Users\User;
 
 /**
- * Simplified VenuePolicy using before hook pattern.
+ * Simplified VenuePolicy using global Gate hook.
  *
- * All repetitive administrator checks are handled by the before hook.
+ * All repetitive administrator checks are handled by the global Gate hook.
  * Business validation is handled in Actions using custom exceptions.
  */
 class VenuePolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, Venue $venue): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, Venue $venue): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, Venue $venue): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, Venue $venue): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Policies/WrestlerPolicy.php
+++ b/app/Policies/WrestlerPolicy.php
@@ -16,130 +16,73 @@ use App\Models\Users\User;
  */
 class WrestlerPolicy
 {
-    /**
-     * Administrator bypass for all actions.
-     *
-     * This before hook allows administrators to perform any action without
-     * further permission checks, dramatically simplifying policy logic.
-     */
-    public function before(User $user, string $ability): ?bool
-    {
-        if ($user->role->isAdministrator()) {
-            return true;
-        }
-
-        return null; // Continue to individual method checks
-    }
-
-    /**
-     * Only administrators can view entity lists (handled by before hook).
-     */
     public function viewAny(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can view individual entities (handled by before hook).
-     */
     public function view(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can create entities (handled by before hook).
-     */
     public function create(User $user): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can update entities (handled by before hook).
-     */
     public function update(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can delete entities (handled by before hook).
-     */
     public function delete(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can restore entities (handled by before hook).
-     */
     public function restore(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can employ wrestlers (handled by before hook).
-     */
     public function employ(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can release wrestlers (handled by before hook).
-     */
     public function release(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can retire wrestlers (handled by before hook).
-     */
     public function retire(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can unretire wrestlers (handled by before hook).
-     */
     public function unretire(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can suspend wrestlers (handled by before hook).
-     */
     public function suspend(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can reinstate wrestlers (handled by before hook).
-     */
     public function reinstate(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can injure wrestlers (handled by before hook).
-     */
     public function injure(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 
-    /**
-     * Only administrators can clear wrestlers from injury (handled by before hook).
-     */
     public function clearFromInjury(User $user, Wrestler $wrestler): bool
     {
-        return false; // Will be bypassed by before hook for administrators
+        return false;
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -17,6 +17,7 @@ use App\Models\Users\User;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Support\Facades\Vite;
@@ -62,6 +63,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        Gate::before(
+            fn (User $user): ?bool => $user->role->isAdministrator() ? true : null,
+        );
+
         /** @param array<string> $parameters */
         Validator::replacer('ends_with', static function (string $message, string $attribute, string $rule, array $parameters): string {
             /** @var string $values */

--- a/tests/Unit/Policies/EventPolicyTest.php
+++ b/tests/Unit/Policies/EventPolicyTest.php
@@ -24,28 +24,28 @@ describe('EventPolicy Unit Tests', function () {
         $this->event = Event::factory()->create();
     });
 
-    describe('before hook behavior', function () {
+    describe('global Gate hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
         });
 
-        test('before hook works for arbitrary abilities', function () {
-            expect($this->policy->before($this->admin, 'custom-ability'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'custom-ability'))->toBeNull();
+        test('global Gate hook works for arbitrary abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('custom-ability'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('custom-ability'))->toBeNull();
         });
     });
 
@@ -112,15 +112,15 @@ describe('EventPolicy Unit Tests', function () {
                 expect(Gate::forUser($this->basicUser)->denies($method, $subject))
                     ->toBeTrue("Method {$method} should deny basic users");
 
-                // All methods should be bypassed for administrators via before hook
-                expect($this->policy->before($this->admin, $method))
+                // All methods should be bypassed for administrators via the global Gate hook
+                expect(Gate::forUser($this->admin)->raw($method))
                     ->toBeTrue("Method {$method} should be bypassed for administrators");
             }
         });
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -135,7 +135,6 @@ describe('EventPolicy Unit Tests', function () {
             $policy1 = new EventPolicy();
             $policy2 = new EventPolicy();
 
-            expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
             expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
     });

--- a/tests/Unit/Policies/ManagerPolicyTest.php
+++ b/tests/Unit/Policies/ManagerPolicyTest.php
@@ -12,14 +12,14 @@ use Illuminate\Support\Facades\Gate;
  * Unit tests for ManagerPolicy authorization logic.
  *
  * UNIT TEST SCOPE:
- * - Before hook behavior for administrator bypass
+ * - global Gate hook behavior for administrator bypass
  * - Individual permission method testing (viewAny, view, create, update, delete, restore)
  * - Business-specific authorization methods (employ, release, retire, unretire, suspend, reinstate, injure, clearFromInjury)
  * - Policy method consistency and return value verification
  * - Laravel Gate integration testing
  *
  * These tests verify that the ManagerPolicy correctly implements
- * the before hook pattern and authorization logic in isolation.
+ * the global Gate hook and authorization logic in isolation.
  * Business logic validation is handled in Actions, not policies.
  *
  * @see ManagerPolicy
@@ -33,48 +33,48 @@ describe('ManagerPolicy Unit Tests', function () {
         $this->manager = Manager::factory()->create();
     });
 
-    describe('before hook behavior', function () {
+    describe('global Gate hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
         });
 
-        test('before hook works for arbitrary abilities', function () {
-            expect($this->policy->before($this->admin, 'custom-ability'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'custom-ability'))->toBeNull();
+        test('global Gate hook works for arbitrary abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('custom-ability'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('custom-ability'))->toBeNull();
         });
 
-        test('before hook works for manager-specific abilities', function () {
-            expect($this->policy->before($this->admin, 'employ'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'release'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'retire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'unretire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'injure'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'clearFromInjury'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'suspend'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'reinstate'))->toBeTrue();
+        test('global Gate hook works for manager-specific abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('employ'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('release'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('retire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('unretire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('injure'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('clearFromInjury'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('suspend'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('reinstate'))->toBeTrue();
 
-            expect($this->policy->before($this->basicUser, 'employ'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'release'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'retire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'unretire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'injure'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'clearFromInjury'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'suspend'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'reinstate'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('employ'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('release'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('retire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('unretire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('injure'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('clearFromInjury'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('suspend'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('reinstate'))->toBeNull();
         });
     });
 
@@ -163,15 +163,15 @@ describe('ManagerPolicy Unit Tests', function () {
                 expect(Gate::forUser($this->basicUser)->denies($method, $subject))
                     ->toBeTrue("Method {$method} should deny basic users");
 
-                // All methods should be bypassed for administrators via before hook
-                expect($this->policy->before($this->admin, $method))
+                // All methods should be bypassed for administrators via the global Gate hook
+                expect(Gate::forUser($this->admin)->raw($method))
                     ->toBeTrue("Method {$method} should be bypassed for administrators");
             }
         });
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -188,7 +188,7 @@ describe('ManagerPolicy Unit Tests', function () {
             $wrestlerMethods = get_class_methods($wrestlerPolicy);
 
             // Should have the same basic structure
-            expect(in_array('before', $managerMethods))->toBeTrue();
+            expect($managerMethods)->not->toContain('before');
             expect(in_array('viewAny', $managerMethods))->toBeTrue();
             expect(in_array('create', $managerMethods))->toBeTrue();
             expect(in_array('update', $managerMethods))->toBeTrue();
@@ -198,9 +198,9 @@ describe('ManagerPolicy Unit Tests', function () {
     });
 
     describe('manager-specific business context', function () {
-        test('policy supports manager lifecycle operations via before hook', function () {
+        test('policy supports manager lifecycle operations via the global Gate hook', function () {
             // These operations aren't explicitly defined in the policy
-            // but should be allowed for administrators via before hook
+            // but should be allowed for administrators via the global Gate hook
             $managerOperations = [
                 'employ', 'release', 'retire', 'unretire',
                 'injure', 'clearFromInjury', 'suspend', 'reinstate',
@@ -208,10 +208,10 @@ describe('ManagerPolicy Unit Tests', function () {
             ];
 
             foreach ($managerOperations as $operation) {
-                expect($this->policy->before($this->admin, $operation))
+                expect(Gate::forUser($this->admin)->raw($operation))
                     ->toBeTrue("Administrator should be able to {$operation} managers");
 
-                expect($this->policy->before($this->basicUser, $operation))
+                expect(Gate::forUser($this->basicUser)->raw($operation))
                     ->toBeNull("Basic user should continue to individual checks for {$operation}");
             }
         });
@@ -252,7 +252,6 @@ describe('ManagerPolicy Unit Tests', function () {
             $policy1 = new ManagerPolicy();
             $policy2 = new ManagerPolicy();
 
-            expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
             expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
 
@@ -261,8 +260,8 @@ describe('ManagerPolicy Unit Tests', function () {
             expect($this->policy->viewAny($this->basicUser))->toBeFalse();
             expect($this->policy->viewAny($this->basicUser))->toBeFalse();
 
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
         });
 
         test('policy handles complex manager states consistently', function () {

--- a/tests/Unit/Policies/MatchPolicyTest.php
+++ b/tests/Unit/Policies/MatchPolicyTest.php
@@ -24,28 +24,28 @@ describe('MatchPolicy Unit Tests', function () {
         $this->eventMatch = EventMatch::factory()->create();
     });
 
-    describe('before hook behavior', function () {
+    describe('global Gate hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
         });
 
-        test('before hook works for arbitrary abilities', function () {
-            expect($this->policy->before($this->admin, 'custom-ability'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'custom-ability'))->toBeNull();
+        test('global Gate hook works for arbitrary abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('custom-ability'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('custom-ability'))->toBeNull();
         });
     });
 
@@ -112,15 +112,15 @@ describe('MatchPolicy Unit Tests', function () {
                 expect(Gate::forUser($this->basicUser)->denies($method, $subject))
                     ->toBeTrue("Method {$method} should deny basic users");
 
-                // All methods should be bypassed for administrators via before hook
-                expect($this->policy->before($this->admin, $method))
+                // All methods should be bypassed for administrators via the global Gate hook
+                expect(Gate::forUser($this->admin)->raw($method))
                     ->toBeTrue("Method {$method} should be bypassed for administrators");
             }
         });
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -135,7 +135,6 @@ describe('MatchPolicy Unit Tests', function () {
             $policy1 = new MatchPolicy();
             $policy2 = new MatchPolicy();
 
-            expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
             expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
     });

--- a/tests/Unit/Policies/PolicyBeforeHookTest.php
+++ b/tests/Unit/Policies/PolicyBeforeHookTest.php
@@ -12,15 +12,16 @@ use App\Policies\TitlePolicy;
 use App\Policies\UserPolicy;
 use App\Policies\VenuePolicy;
 use App\Policies\WrestlerPolicy;
+use Illuminate\Support\Facades\Gate;
 
 /**
- * Shared tests for policy before hook pattern.
+ * Shared tests for global Gate hook.
  *
- * This test ensures all policies follow the consistent before hook pattern
+ * This test ensures all policies follow the consistent global Gate hook
  * where administrators bypass all authorization checks and basic users
  * continue to individual method checks.
  */
-describe('Policy Before Hook Pattern', function () {
+describe('Global Gate Hook Pattern', function () {
 
     beforeEach(function () {
         $this->policies = [
@@ -42,13 +43,13 @@ describe('Policy Before Hook Pattern', function () {
 
     test('administrators bypass all authorization methods', function () {
         foreach ($this->policies as $policy) {
-            // Test arbitrary ability (proves before hook works for non-method abilities)
-            expect($policy->before($this->admin, 'any-ability'))->toBeTrue();
+            // Test arbitrary ability (proves global Gate hook works for non-method abilities)
+            expect(Gate::forUser($this->admin)->raw('any-ability'))->toBeTrue();
 
             // Test all actual policy methods
             $methods = getPublicPolicyMethods($policy);
             foreach ($methods as $methodName) {
-                expect($policy->before($this->admin, $methodName))
+                expect(Gate::forUser($this->admin)->raw($methodName))
                     ->toBeTrue("Admin should bypass {$methodName} in ".get_class($policy));
             }
         }
@@ -56,13 +57,13 @@ describe('Policy Before Hook Pattern', function () {
 
     test('basic users continue to individual method checks', function () {
         foreach ($this->policies as $policy) {
-            // Test arbitrary ability (proves before hook works for non-method abilities)
-            expect($policy->before($this->basicUser, 'any-ability'))->toBeNull();
+            // Test arbitrary ability (proves global Gate hook works for non-method abilities)
+            expect(Gate::forUser($this->basicUser)->raw('any-ability'))->toBeNull();
 
             // Test all actual policy methods
             $methods = getPublicPolicyMethods($policy);
             foreach ($methods as $methodName) {
-                expect($policy->before($this->basicUser, $methodName))
+                expect(Gate::forUser($this->basicUser)->raw($methodName))
                     ->toBeNull("Basic user should continue to {$methodName} check in ".get_class($policy));
             }
         }

--- a/tests/Unit/Policies/RefereePolicyTest.php
+++ b/tests/Unit/Policies/RefereePolicyTest.php
@@ -26,52 +26,52 @@ describe('RefereePolicy Unit Tests', function () {
         $this->referee = Referee::factory()->create();
     });
 
-    describe('before hook behavior', function () {
+    describe('global Gate hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
         });
 
-        test('before hook works for arbitrary abilities', function () {
-            expect($this->policy->before($this->admin, 'custom-ability'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'custom-ability'))->toBeNull();
+        test('global Gate hook works for arbitrary abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('custom-ability'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('custom-ability'))->toBeNull();
         });
 
-        test('before hook works for referee-specific abilities', function () {
-            expect($this->policy->before($this->admin, 'employ'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'release'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'retire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'unretire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'injure'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'clearFromInjury'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'suspend'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'reinstate'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'assignToMatch'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'removeFromMatch'))->toBeTrue();
+        test('global Gate hook works for referee-specific abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('employ'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('release'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('retire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('unretire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('injure'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('clearFromInjury'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('suspend'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('reinstate'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('assignToMatch'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('removeFromMatch'))->toBeTrue();
 
-            expect($this->policy->before($this->basicUser, 'employ'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'release'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'retire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'unretire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'injure'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'clearFromInjury'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'suspend'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'reinstate'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'assignToMatch'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'removeFromMatch'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('employ'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('release'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('retire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('unretire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('injure'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('clearFromInjury'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('suspend'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('reinstate'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('assignToMatch'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('removeFromMatch'))->toBeNull();
         });
     });
 
@@ -167,15 +167,15 @@ describe('RefereePolicy Unit Tests', function () {
                 expect(Gate::forUser($this->basicUser)->denies($method, $subject))
                     ->toBeTrue("Method {$method} should deny basic users");
 
-                // All methods should be bypassed for administrators via before hook
-                expect($this->policy->before($this->admin, $method))
+                // All methods should be bypassed for administrators via the global Gate hook
+                expect(Gate::forUser($this->admin)->raw($method))
                     ->toBeTrue("Method {$method} should be bypassed for administrators");
             }
         });
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -194,7 +194,7 @@ describe('RefereePolicy Unit Tests', function () {
             $managerMethods = get_class_methods($managerPolicy);
 
             // Should have the same basic structure as other individual roster member policies
-            expect(in_array('before', $refereeMethods))->toBeTrue();
+            expect($refereeMethods)->not->toContain('before');
             expect(in_array('viewAny', $refereeMethods))->toBeTrue();
             expect(in_array('create', $refereeMethods))->toBeTrue();
             expect(in_array('update', $refereeMethods))->toBeTrue();
@@ -204,9 +204,9 @@ describe('RefereePolicy Unit Tests', function () {
     });
 
     describe('referee-specific business context', function () {
-        test('policy supports referee lifecycle operations via before hook', function () {
+        test('policy supports referee lifecycle operations via the global Gate hook', function () {
             // These operations aren't explicitly defined in the policy
-            // but should be allowed for administrators via before hook
+            // but should be allowed for administrators via the global Gate hook
             $refereeOperations = [
                 'employ', 'release', 'retire', 'unretire',
                 'injure', 'clearFromInjury', 'suspend', 'reinstate',
@@ -214,10 +214,10 @@ describe('RefereePolicy Unit Tests', function () {
             ];
 
             foreach ($refereeOperations as $operation) {
-                expect($this->policy->before($this->admin, $operation))
+                expect(Gate::forUser($this->admin)->raw($operation))
                     ->toBeTrue("Administrator should be able to {$operation} referees");
 
-                expect($this->policy->before($this->basicUser, $operation))
+                expect(Gate::forUser($this->basicUser)->raw($operation))
                     ->toBeNull("Basic user should continue to individual checks for {$operation}");
             }
         });
@@ -280,7 +280,6 @@ describe('RefereePolicy Unit Tests', function () {
             $policy1 = new RefereePolicy();
             $policy2 = new RefereePolicy();
 
-            expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
             expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
 
@@ -289,8 +288,8 @@ describe('RefereePolicy Unit Tests', function () {
             expect($this->policy->viewAny($this->basicUser))->toBeFalse();
             expect($this->policy->viewAny($this->basicUser))->toBeFalse();
 
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
         });
 
         test('policy handles complex referee states consistently', function () {

--- a/tests/Unit/Policies/StablePolicyTest.php
+++ b/tests/Unit/Policies/StablePolicyTest.php
@@ -13,7 +13,7 @@ use Illuminate\Support\Facades\Gate;
  * UNIT TEST SCOPE:
  * - Policy method logic in isolation
  * - User role and permission checking
- * - Before hook behavior and bypass logic
+ * - global Gate hook behavior and bypass logic
  * - Individual authorization rules
  * - Policy registration and Gate integration
  *
@@ -31,36 +31,36 @@ describe('StablePolicy Unit Tests', function () {
         $this->stable = Stable::factory()->active()->create();
     });
 
-    describe('before hook behavior', function () {
+    describe('global Gate hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'establish'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'disband'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'retire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'unretire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('establish'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('disband'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('retire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('unretire'))->toBeTrue();
         });
 
         test('basic users do not bypass authorization checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'establish'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'disband'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'retire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'unretire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('establish'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('disband'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('retire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('unretire'))->toBeNull();
         });
 
-        test('before hook handles unknown abilities correctly', function () {
-            expect($this->policy->before($this->admin, 'nonexistentAbility'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'nonexistentAbility'))->toBeNull();
+        test('global Gate hook handles unknown abilities correctly', function () {
+            expect(Gate::forUser($this->admin)->raw('nonexistentAbility'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('nonexistentAbility'))->toBeNull();
         });
     });
 
@@ -169,7 +169,7 @@ describe('StablePolicy Unit Tests', function () {
     //         expect(Gate::allows('update', $this->stable))->toBeFalse();
     //         expect(Gate::allows('delete', $this->stable))->toBeFalse();
     //
-    //         // Test admin permissions (should be allowed via before hook)
+    //         // Test admin permissions (should be allowed via the global Gate hook)
     //         Gate::forUser($this->admin);
     //         expect(Gate::allows('viewAny', Stable::class))->toBeTrue();
     //         expect(Gate::allows('view', $this->stable))->toBeTrue();
@@ -213,7 +213,6 @@ describe('StablePolicy Unit Tests', function () {
     describe('policy method completeness', function () {
         test('all required policy methods exist', function () {
             $requiredMethods = [
-                'before',
                 'viewAny',
                 'view',
                 'create',
@@ -235,10 +234,6 @@ describe('StablePolicy Unit Tests', function () {
 
         test('policy methods have correct signatures', function () {
             $reflection = new ReflectionClass($this->policy);
-
-            // Before hook should accept user and ability
-            $beforeMethod = $reflection->getMethod('before');
-            expect($beforeMethod->getNumberOfParameters())->toBe(2);
 
             // View methods should accept user and optionally model
             $viewMethod = $reflection->getMethod('view');
@@ -273,12 +268,12 @@ describe('StablePolicy Unit Tests', function () {
             }
         });
 
-        test('before hook returns boolean true for admin or null for others', function () {
+        test('global Gate hook returns boolean true for admin or null for others', function () {
             $abilities = ['viewAny', 'view', 'create', 'update', 'delete', 'restore', 'establish', 'disband', 'retire', 'unretire'];
 
             foreach ($abilities as $ability) {
-                expect($this->policy->before($this->admin, $ability))->toBeTrue();
-                expect($this->policy->before($this->basicUser, $ability))->toBeNull();
+                expect(Gate::forUser($this->admin)->raw($ability))->toBeTrue();
+                expect(Gate::forUser($this->basicUser)->raw($ability))->toBeNull();
             }
         });
     });

--- a/tests/Unit/Policies/TagTeamPolicyTest.php
+++ b/tests/Unit/Policies/TagTeamPolicyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Users\User;
 use App\Policies\TagTeamPolicy;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * Unit tests for TagTeamPolicy authorization logic.
@@ -12,7 +13,7 @@ use App\Policies\TagTeamPolicy;
  * UNIT TEST SCOPE:
  * - Policy method logic in isolation
  * - User role checking and authorization rules
- * - Before hook behavior for administrators
+ * - global Gate hook behavior for administrators
  * - Individual authorization rules for tag team operations
  * - Employment status-based authorization decisions
  *
@@ -30,35 +31,35 @@ describe('TagTeamPolicy Unit Tests', function () {
         $this->tagTeam = TagTeam::factory()->make(['id' => 1]);
     });
 
-    describe('before hook authorization', function () {
+    describe('global Gate hook authorization', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'employ'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'release'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'suspend'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'reinstate'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'retire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'unretire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('employ'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('release'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('suspend'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('reinstate'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('retire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('unretire'))->toBeTrue();
         });
 
         test('non-administrators do not bypass authorization checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'employ'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'release'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'suspend'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'reinstate'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'retire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'unretire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('employ'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('release'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('suspend'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('reinstate'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('retire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('unretire'))->toBeNull();
         });
     });
 
@@ -160,12 +161,12 @@ describe('TagTeamPolicy Unit Tests', function () {
             $releasedTagTeam = TagTeam::factory()->released()->make();
 
             // Admin should be able to manage any tag team regardless of status
-            expect($this->policy->before($this->admin, 'employ'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'release'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'suspend'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'reinstate'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'retire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'unretire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('employ'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('release'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('suspend'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('reinstate'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('retire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('unretire'))->toBeTrue();
         });
 
         test('basic users cannot perform management actions', function () {
@@ -182,9 +183,9 @@ describe('TagTeamPolicy Unit Tests', function () {
     describe('role-based authorization patterns', function () {
         test('role hierarchy is respected for tag team operations', function () {
             // Administrator has full access
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
 
             // Basic user has restricted access
             expect($this->policy->create($this->basicUser))->toBeFalse();
@@ -270,7 +271,7 @@ describe('TagTeamPolicy Unit Tests', function () {
             $deletedTagTeam = TagTeam::factory()->trashed()->make();
 
             expect($this->policy->restore($this->basicUser, $deletedTagTeam))->toBeFalse();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('deletion permissions consider tag team status', function () {
@@ -299,10 +300,10 @@ describe('TagTeamPolicy Unit Tests', function () {
             expect($this->policy->unretire($this->basicUser, $this->tagTeam))->toBeBool();
         });
 
-        test('before hook returns correct types', function () {
-            // Before hook should return true for admin, null for others
-            expect($this->policy->before($this->admin, 'any_ability'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'any_ability'))->toBeNull();
+        test('global Gate hook returns correct types', function () {
+            // global Gate hook should return true for admin, null for others
+            expect(Gate::forUser($this->admin)->raw('any_ability'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('any_ability'))->toBeNull();
         });
     });
 });

--- a/tests/Unit/Policies/TitlePolicyTest.php
+++ b/tests/Unit/Policies/TitlePolicyTest.php
@@ -11,14 +11,14 @@ use Illuminate\Support\Facades\Gate;
  * Unit tests for TitlePolicy authorization logic.
  *
  * UNIT TEST SCOPE:
- * - Before hook behavior for administrator bypass
+ * - global Gate hook behavior for administrator bypass
  * - Individual permission method testing (viewAny, view, create, update, delete, restore)
  * - Business-specific authorization methods (debut, pull, reinstate, retire, unretire, activate, deactivate)
  * - Policy method consistency and return value verification
  * - Laravel Gate integration testing
  *
  * These tests verify that the TitlePolicy correctly implements
- * the before hook pattern and authorization logic in isolation.
+ * the global Gate hook and authorization logic in isolation.
  * Business logic validation is handled in Actions, not policies.
  *
  * @see TitlePolicy
@@ -32,42 +32,42 @@ describe('TitlePolicy Unit Tests', function () {
         $this->title = Title::factory()->create();
     });
 
-    describe('before hook behavior', function () {
+    describe('global Gate hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
         });
 
-        test('before hook works for arbitrary abilities', function () {
-            expect($this->policy->before($this->admin, 'custom-ability'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'custom-ability'))->toBeNull();
+        test('global Gate hook works for arbitrary abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('custom-ability'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('custom-ability'))->toBeNull();
         });
 
-        test('before hook works for title-specific abilities', function () {
-            expect($this->policy->before($this->admin, 'debut'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'pull'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'reinstate'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'retire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'unretire'))->toBeTrue();
+        test('global Gate hook works for title-specific abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('debut'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('pull'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('reinstate'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('retire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('unretire'))->toBeTrue();
 
-            expect($this->policy->before($this->basicUser, 'debut'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'pull'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'reinstate'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'retire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'unretire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('debut'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('pull'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('reinstate'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('retire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('unretire'))->toBeNull();
         });
     });
 
@@ -147,15 +147,15 @@ describe('TitlePolicy Unit Tests', function () {
                 expect(Gate::forUser($this->basicUser)->denies($method, $subject))
                     ->toBeTrue("Method {$method} should deny basic users");
 
-                // All methods should be bypassed for administrators via before hook
-                expect($this->policy->before($this->admin, $method))
+                // All methods should be bypassed for administrators via the global Gate hook
+                expect(Gate::forUser($this->admin)->raw($method))
                     ->toBeTrue("Method {$method} should be bypassed for administrators");
             }
         });
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
             ];
 
             foreach ($expectedMethods as $method) {
@@ -182,19 +182,19 @@ describe('TitlePolicy Unit Tests', function () {
     });
 
     describe('title-specific business context', function () {
-        test('policy supports title lifecycle operations via before hook', function () {
+        test('policy supports title lifecycle operations via the global Gate hook', function () {
             // These operations aren't explicitly defined in the policy
-            // but should be allowed for administrators via before hook
+            // but should be allowed for administrators via the global Gate hook
             $titleOperations = [
                 'debut', 'pull', 'reinstate', 'retire', 'unretire',
                 'assignChampion', 'vacate', 'defendTitle',
             ];
 
             foreach ($titleOperations as $operation) {
-                expect($this->policy->before($this->admin, $operation))
+                expect(Gate::forUser($this->admin)->raw($operation))
                     ->toBeTrue("Administrator should be able to {$operation} titles");
 
-                expect($this->policy->before($this->basicUser, $operation))
+                expect(Gate::forUser($this->basicUser)->raw($operation))
                     ->toBeNull("Basic user should continue to individual checks for {$operation}");
             }
         });
@@ -232,7 +232,6 @@ describe('TitlePolicy Unit Tests', function () {
             $policy1 = new TitlePolicy();
             $policy2 = new TitlePolicy();
 
-            expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
             expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
 
@@ -241,8 +240,8 @@ describe('TitlePolicy Unit Tests', function () {
             expect($this->policy->viewAny($this->basicUser))->toBeFalse();
             expect($this->policy->viewAny($this->basicUser))->toBeFalse();
 
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
         });
     });
 });

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -12,58 +12,58 @@ use function Pest\Laravel\actingAs;
 /**
  * Unit tests for UserPolicy authorization logic.
  *
- * Tests the before hook pattern used for administrator bypass
+ * Tests the global Gate hook used for administrator bypass
  * and validates that basic users are properly restricted.
  *
  * @see UserPolicy
  */
-describe('UserPolicy before hook', function () {
+describe('UserPolicy global Gate hook', function () {
     beforeEach(function () {
         $this->policy = new UserPolicy();
         $this->administrator = administrator();
         $this->basicUser = basicUser();
     });
 
-    test('before hook allows administrators for any ability', function () {
-        $result = $this->policy->before($this->administrator, 'viewAny');
+    test('global Gate hook allows administrators for any ability', function () {
+        $result = Gate::forUser($this->administrator)->raw('viewAny');
 
         expect($result)->toBeTrue();
     });
 
-    test('before hook returns null for basic users', function () {
-        $result = $this->policy->before($this->basicUser, 'viewAny');
+    test('global Gate hook returns null for basic users', function () {
+        $result = Gate::forUser($this->basicUser)->raw('viewAny');
 
         expect($result)->toBeNull();
     });
 
-    test('before hook allows administrators for all abilities', function () {
+    test('global Gate hook allows administrators for all abilities', function () {
         $abilities = ['viewAny', 'view', 'create', 'update', 'delete', 'restore'];
 
         foreach ($abilities as $ability) {
-            $result = $this->policy->before($this->administrator, $ability);
+            $result = Gate::forUser($this->administrator)->raw($ability);
             expect($result)->toBeTrue("Administrator should be allowed for {$ability}");
         }
     });
 
-    test('before hook returns null for basic users on all abilities', function () {
+    test('global Gate hook returns null for basic users on all abilities', function () {
         $abilities = ['viewAny', 'view', 'create', 'update', 'delete', 'restore'];
 
         foreach ($abilities as $ability) {
-            $result = $this->policy->before($this->basicUser, $ability);
+            $result = Gate::forUser($this->basicUser)->raw($ability);
             expect($result)->toBeNull("Basic user should get null for {$ability}");
         }
     });
 
-    test('before hook works for user-specific abilities', function () {
-        expect($this->policy->before($this->administrator, 'viewProfile'))->toBeTrue();
-        expect($this->policy->before($this->administrator, 'changePassword'))->toBeTrue();
-        expect($this->policy->before($this->administrator, 'manageRoles'))->toBeTrue();
-        expect($this->policy->before($this->administrator, 'deactivate'))->toBeTrue();
+    test('global Gate hook works for user-specific abilities', function () {
+        expect(Gate::forUser($this->administrator)->raw('viewProfile'))->toBeTrue();
+        expect(Gate::forUser($this->administrator)->raw('changePassword'))->toBeTrue();
+        expect(Gate::forUser($this->administrator)->raw('manageRoles'))->toBeTrue();
+        expect(Gate::forUser($this->administrator)->raw('deactivate'))->toBeTrue();
 
-        expect($this->policy->before($this->basicUser, 'viewProfile'))->toBeNull();
-        expect($this->policy->before($this->basicUser, 'changePassword'))->toBeNull();
-        expect($this->policy->before($this->basicUser, 'manageRoles'))->toBeNull();
-        expect($this->policy->before($this->basicUser, 'deactivate'))->toBeNull();
+        expect(Gate::forUser($this->basicUser)->raw('viewProfile'))->toBeNull();
+        expect(Gate::forUser($this->basicUser)->raw('changePassword'))->toBeNull();
+        expect(Gate::forUser($this->basicUser)->raw('manageRoles'))->toBeNull();
+        expect(Gate::forUser($this->basicUser)->raw('deactivate'))->toBeNull();
     });
 });
 
@@ -111,7 +111,7 @@ describe('UserPolicy individual methods', function () {
 });
 
 describe('UserPolicy integration with Gate facade', function () {
-    test('Gate allows administrators through before hook', function () {
+    test('Gate allows administrators through global Gate hook', function () {
         actingAs(administrator());
         $targetUser = basicUser();
 
@@ -123,7 +123,7 @@ describe('UserPolicy integration with Gate facade', function () {
         expect(Gate::allows('restore', $targetUser))->toBeTrue();
     });
 
-    test('Gate denies basic users after before hook returns null', function () {
+    test('Gate denies basic users after global Gate hook returns null', function () {
         actingAs(basicUser());
         $targetUser = administrator();
 
@@ -150,7 +150,7 @@ describe('UserPolicy integration with Gate facade', function () {
     });
 
     // NOTE: Gate integration testing moved to Feature tests for proper application context
-    // test('Gate supports user management operations through before hook', function () {
+    // test('Gate supports user management operations through global Gate hook', function () {
     //     actingAs(administrator());
     //
     //     // User management operations should be allowed for administrators
@@ -170,13 +170,8 @@ describe('UserPolicy integration with Gate facade', function () {
 });
 
 describe('UserPolicy method signatures', function () {
-    test('before method has correct signature', function () {
-        $reflection = new ReflectionMethod(UserPolicy::class, 'before');
-
-        expect($reflection->getParameters())->toHaveCount(2);
-        expect(reflectionTypeName($reflection->getParameters()[0]))->toBe(User::class);
-        expect(reflectionTypeName($reflection->getParameters()[1]))->toBe('string');
-        expect(reflectionReturnTypeName($reflection))->toBe('bool');
+    test('administrator bypass is not duplicated on the policy', function () {
+        expect(get_class_methods($this->policy))->not->toContain('before');
     });
 
     test('policy methods have correct signatures', function () {
@@ -202,19 +197,19 @@ describe('UserPolicy business context', function () {
         $this->policy = new UserPolicy();
     });
 
-    test('policy supports user management operations via before hook', function () {
+    test('policy supports user management operations via the global Gate hook', function () {
         // These operations aren't explicitly defined in the policy
-        // but should be allowed for administrators via before hook
+        // but should be allowed for administrators via the global Gate hook
         $userOperations = [
             'viewProfile', 'changePassword', 'manageRoles', 'deactivate',
             'activate', 'resetPassword', 'changeRole', 'viewAuditLog',
         ];
 
         foreach ($userOperations as $operation) {
-            expect($this->policy->before(administrator(), $operation))
+            expect(Gate::forUser(administrator())->raw($operation))
                 ->toBeTrue("Administrator should be able to {$operation} users");
 
-            expect($this->policy->before(basicUser(), $operation))
+            expect(Gate::forUser(basicUser())->raw($operation))
                 ->toBeNull("Basic user should continue to individual checks for {$operation}");
         }
     });
@@ -254,8 +249,8 @@ describe('UserPolicy business context', function () {
         expect($admin->role->isAdministrator())->toBeTrue();
         expect($basic->role->isAdministrator())->toBeFalse();
 
-        expect($this->policy->before($admin, 'any-operation'))->toBeTrue();
-        expect($this->policy->before($basic, 'any-operation'))->toBeNull();
+        expect(Gate::forUser($admin)->raw('any-operation'))->toBeTrue();
+        expect(Gate::forUser($basic)->raw('any-operation'))->toBeNull();
     });
 });
 
@@ -268,7 +263,6 @@ describe('UserPolicy edge cases and security', function () {
         $policy1 = new UserPolicy();
         $policy2 = new UserPolicy();
 
-        expect($policy1->before(administrator(), 'create'))->toBe($policy2->before(administrator(), 'create'));
         expect($policy1->viewAny(basicUser()))->toBe($policy2->viewAny(basicUser()));
     });
 
@@ -277,20 +271,20 @@ describe('UserPolicy edge cases and security', function () {
         expect($this->policy->viewAny(basicUser()))->toBeFalse();
         expect($this->policy->viewAny(basicUser()))->toBeFalse();
 
-        expect($this->policy->before(administrator(), 'create'))->toBeTrue();
-        expect($this->policy->before(administrator(), 'create'))->toBeTrue();
+        expect(Gate::forUser(administrator())->raw('create'))->toBeTrue();
+        expect(Gate::forUser(administrator())->raw('create'))->toBeTrue();
     });
 
     test('policy correctly identifies administrator privileges', function () {
         $admin = administrator();
         $basic = basicUser();
 
-        // Administrator should consistently pass the before hook
+        // Administrator should consistently pass the global Gate hook
         $abilities = ['create', 'read', 'update', 'delete', 'custom', 'manage', 'any'];
 
         foreach ($abilities as $ability) {
-            expect($this->policy->before($admin, $ability))->toBeTrue();
-            expect($this->policy->before($basic, $ability))->toBeNull();
+            expect(Gate::forUser($admin)->raw($ability))->toBeTrue();
+            expect(Gate::forUser($basic)->raw($ability))->toBeNull();
         }
     });
 });

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -171,7 +171,7 @@ describe('UserPolicy integration with Gate facade', function () {
 
 describe('UserPolicy method signatures', function () {
     test('administrator bypass is not duplicated on the policy', function () {
-        expect(get_class_methods($this->policy))->not->toContain('before');
+        expect(get_class_methods(UserPolicy::class))->not->toContain('before');
     });
 
     test('policy methods have correct signatures', function () {

--- a/tests/Unit/Policies/VenuePolicyTest.php
+++ b/tests/Unit/Policies/VenuePolicyTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Models\Events\Venue;
 use App\Models\Users\User;
 use App\Policies\VenuePolicy;
+use Illuminate\Support\Facades\Gate;
 
 /**
  * Unit tests for VenuePolicy authorization logic.
@@ -12,7 +13,7 @@ use App\Policies\VenuePolicy;
  * UNIT TEST SCOPE:
  * - Policy method logic in isolation
  * - User role checking and authorization rules
- * - Before hook behavior for administrators
+ * - global Gate hook behavior for administrators
  * - Individual authorization rules for venue operations
  * - Location and facility management authorization
  *
@@ -30,23 +31,23 @@ describe('VenuePolicy Unit Tests', function () {
         $this->venue = Venue::factory()->make(['id' => 1]);
     });
 
-    describe('before hook authorization', function () {
+    describe('global Gate hook authorization', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('non-administrators do not bypass authorization checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
         });
     });
 
@@ -116,10 +117,10 @@ describe('VenuePolicy Unit Tests', function () {
             $historicVenue = Venue::factory()->make(['name' => 'Historic Venue']);
 
             // Admin should be able to manage any venue regardless of characteristics
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('basic users cannot perform management actions', function () {
@@ -134,9 +135,9 @@ describe('VenuePolicy Unit Tests', function () {
     describe('role-based authorization patterns', function () {
         test('role hierarchy is respected for venue operations', function () {
             // Administrator has full access
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
 
             // Basic user has no access
             expect($this->policy->create($this->basicUser))->toBeFalse();
@@ -162,7 +163,7 @@ describe('VenuePolicy Unit Tests', function () {
 
             // Address complexity should not affect authorization
             expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
         });
 
         test('venue relocation authorization follows policy pattern', function () {
@@ -196,7 +197,7 @@ describe('VenuePolicy Unit Tests', function () {
 
             // Popularity should not affect authorization rules
             expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
         });
     });
 
@@ -205,7 +206,7 @@ describe('VenuePolicy Unit Tests', function () {
             $deletedVenue = Venue::factory()->make(['name' => 'Deleted Venue']);
 
             expect($this->policy->restore($this->basicUser, $this->venue))->toBeFalse();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
         });
 
         test('deletion permissions consider venue status', function () {
@@ -214,7 +215,7 @@ describe('VenuePolicy Unit Tests', function () {
 
             // Deletion should be restricted for basic users regardless of usage
             expect($this->policy->delete($this->basicUser, $this->venue))->toBeFalse();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
         });
     });
 
@@ -229,10 +230,10 @@ describe('VenuePolicy Unit Tests', function () {
             expect($this->policy->restore($this->basicUser, $this->venue))->toBeBool();
         });
 
-        test('before hook returns correct types', function () {
-            // Before hook should return true for admin, null for others
-            expect($this->policy->before($this->admin, 'any_ability'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'any_ability'))->toBeNull();
+        test('global Gate hook returns correct types', function () {
+            // global Gate hook should return true for admin, null for others
+            expect(Gate::forUser($this->admin)->raw('any_ability'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('any_ability'))->toBeNull();
         });
     });
 
@@ -254,7 +255,7 @@ describe('VenuePolicy Unit Tests', function () {
 
             // Capacity planning should require administrative privileges
             expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
         });
     });
 
@@ -282,7 +283,7 @@ describe('VenuePolicy Unit Tests', function () {
 
             // Complex venues should follow same authorization pattern
             expect($this->policy->create($this->basicUser))->toBeFalse();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
         });
     });
 
@@ -293,7 +294,7 @@ describe('VenuePolicy Unit Tests', function () {
 
             // Operational status should not affect basic authorization
             expect($this->policy->update($this->basicUser, $this->venue))->toBeFalse();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
         });
 
         test('venue availability management requires admin access', function () {

--- a/tests/Unit/Policies/WrestlerPolicyTest.php
+++ b/tests/Unit/Policies/WrestlerPolicyTest.php
@@ -11,14 +11,14 @@ use Illuminate\Support\Facades\Gate;
  * Unit tests for WrestlerPolicy authorization logic.
  *
  * UNIT TEST SCOPE:
- * - Before hook behavior for administrator bypass
+ * - global Gate hook behavior for administrator bypass
  * - Individual permission method testing (viewAny, view, create, update, delete, restore)
  * - Business-specific authorization methods (employ, release, retire, unretire, suspend, reinstate, injure, clearFromInjury)
  * - Policy method consistency and return value verification
  * - Laravel Gate integration testing
  *
  * These tests verify that the WrestlerPolicy correctly implements
- * the before hook pattern and authorization logic in isolation.
+ * the global Gate hook and authorization logic in isolation.
  * Business logic validation is handled in Actions, not policies.
  *
  * @see WrestlerPolicy
@@ -32,44 +32,44 @@ describe('WrestlerPolicy Unit Tests', function () {
         $this->wrestler = Wrestler::factory()->create();
     });
 
-    describe('before hook behavior', function () {
+    describe('global Gate hook behavior', function () {
         test('administrators bypass all authorization checks', function () {
-            expect($this->policy->before($this->admin, 'viewAny'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'view'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'create'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'update'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'delete'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'restore'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'employ'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'release'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'retire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'unretire'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'suspend'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'reinstate'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'injure'))->toBeTrue();
-            expect($this->policy->before($this->admin, 'clearFromInjury'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('viewAny'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('view'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('create'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('update'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('delete'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('restore'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('employ'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('release'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('retire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('unretire'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('suspend'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('reinstate'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('injure'))->toBeTrue();
+            expect(Gate::forUser($this->admin)->raw('clearFromInjury'))->toBeTrue();
         });
 
         test('basic users continue to individual method checks', function () {
-            expect($this->policy->before($this->basicUser, 'viewAny'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'view'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'create'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'update'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'delete'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'restore'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'employ'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'release'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'retire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'unretire'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'suspend'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'reinstate'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'injure'))->toBeNull();
-            expect($this->policy->before($this->basicUser, 'clearFromInjury'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('viewAny'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('view'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('create'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('update'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('delete'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('restore'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('employ'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('release'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('retire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('unretire'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('suspend'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('reinstate'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('injure'))->toBeNull();
+            expect(Gate::forUser($this->basicUser)->raw('clearFromInjury'))->toBeNull();
         });
 
-        test('before hook works for arbitrary abilities', function () {
-            expect($this->policy->before($this->admin, 'custom-ability'))->toBeTrue();
-            expect($this->policy->before($this->basicUser, 'custom-ability'))->toBeNull();
+        test('global Gate hook works for arbitrary abilities', function () {
+            expect(Gate::forUser($this->admin)->raw('custom-ability'))->toBeTrue();
+            expect(Gate::forUser($this->basicUser)->raw('custom-ability'))->toBeNull();
         });
     });
 
@@ -178,15 +178,15 @@ describe('WrestlerPolicy Unit Tests', function () {
                 expect(Gate::forUser($this->basicUser)->denies($method, $subject))
                     ->toBeTrue("Method {$method} should deny basic users");
 
-                // All methods should be bypassed for administrators via before hook
-                expect($this->policy->before($this->admin, $method))
+                // All methods should be bypassed for administrators via the global Gate hook
+                expect(Gate::forUser($this->admin)->raw($method))
                     ->toBeTrue("Method {$method} should be bypassed for administrators");
             }
         });
 
         test('policy has all expected methods', function () {
             $expectedMethods = [
-                'before', 'viewAny', 'view', 'create', 'update', 'delete', 'restore',
+                'viewAny', 'view', 'create', 'update', 'delete', 'restore',
                 'employ', 'release', 'retire', 'unretire', 'suspend',
                 'reinstate', 'injure', 'clearFromInjury',
             ];
@@ -203,7 +203,6 @@ describe('WrestlerPolicy Unit Tests', function () {
             $policy1 = new WrestlerPolicy();
             $policy2 = new WrestlerPolicy();
 
-            expect($policy1->before($this->admin, 'create'))->toBe($policy2->before($this->admin, 'create'));
             expect($policy1->viewAny($this->basicUser))->toBe($policy2->viewAny($this->basicUser));
         });
     });


### PR DESCRIPTION
## Summary
- move the application-wide administrator bypass to Laravel's native global Gate hook
- remove duplicated before methods from all resource policies
- update policy tests to exercise the global authorization boundary
- remove redundant policy comments that repeated the method bodies

## Verification
- focused policy and authorization suites: 353 tests, 1,561 assertions
- composer lint
- composer test:types
- composer test:rector
- composer test:application: 3,387 tests, 10,899 assertions
- composer test:type-coverage: 100%

## Local browser runner
The browser suite could not bind its local port in the sandbox (Operation not permitted). GitHub's browser workflow remains required.