### PR TITLE
refactor: make value objects castable

### DIFF
--- a/app/Models/Events/Venue.php
+++ b/app/Models/Events/Venue.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Models\Events;
 
 use App\Builders\Events\VenueBuilder;
-use App\Casts\AddressCast;
 use App\Models\Concerns\HasLifecycleTransitions;
 use App\Models\Contracts\SoftDeletable;
 use App\ValueObjects\Address;
@@ -66,7 +65,7 @@ class Venue extends Model implements SoftDeletable
     protected function casts(): array
     {
         return [
-            'address' => AddressCast::class,
+            'address' => Address::class,
         ];
     }
 }

--- a/app/Models/Roster/Wrestlers/Wrestler.php
+++ b/app/Models/Roster/Wrestlers/Wrestler.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Models\Roster\Wrestlers;
 
 use App\Builders\Roster\WrestlerBuilder;
-use App\Casts\HeightCast;
-use App\Casts\WeightCast;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\HasChampionshipReigns;
 use App\Models\Concerns\HasComputedEmploymentStatus;
@@ -246,8 +244,8 @@ class Wrestler extends Model implements CanBeAStableMember, CanBeChampion, Emplo
     protected function casts(): array
     {
         return [
-            'height' => HeightCast::class,
-            'weight' => WeightCast::class,
+            'height' => Height::class,
+            'weight' => Weight::class,
         ];
     }
 }

--- a/app/Models/Users/User.php
+++ b/app/Models/Users/User.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Models\Users;
 
 use App\Builders\Users\UserBuilder;
-use App\Casts\PhoneNumberCast;
 use App\Enums\Users\Role;
 use App\Enums\Users\UserStatus;
 use App\ValueObjects\PhoneNumber;
@@ -77,7 +76,7 @@ class User extends Authenticatable
         return [
             'role' => Role::class,
             'status' => UserStatus::class,
-            'phone_number' => PhoneNumberCast::class,
+            'phone_number' => PhoneNumber::class,
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];

--- a/app/ValueObjects/Address.php
+++ b/app/ValueObjects/Address.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\ValueObjects;
 
+use App\Casts\AddressCast;
 use App\Enums\Shared\UnitedStatesState;
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use InvalidArgumentException;
 
-readonly class Address
+readonly class Address implements Castable
 {
     public function __construct(
         public string $streetAddress,
@@ -27,6 +29,15 @@ readonly class Address
     public function formatted(): string
     {
         return "{$this->streetAddress}, {$this->city}, {$this->state->value} {$this->zipcode}";
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return class-string<AddressCast>
+     */
+    public static function castUsing(array $arguments): string
+    {
+        return AddressCast::class;
     }
 
     /** @return array{street_address: string, city: string, state: string, zipcode: string} */

--- a/app/ValueObjects/Height.php
+++ b/app/ValueObjects/Height.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace App\ValueObjects;
 
+use App\Casts\HeightCast;
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use InvalidArgumentException;
 
 /**
@@ -14,7 +16,7 @@ use InvalidArgumentException;
  * Height is stored as feet and inches since this is the standard format
  * used in professional wrestling.
  */
-readonly class Height
+readonly class Height implements Castable
 {
     /**
      * Create a new Height instance.
@@ -46,6 +48,15 @@ readonly class Height
         }
 
         return new self(intdiv($inches, 12), $inches % 12);
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return class-string<HeightCast>
+     */
+    public static function castUsing(array $arguments): string
+    {
+        return HeightCast::class;
     }
 
     /**

--- a/app/ValueObjects/PhoneNumber.php
+++ b/app/ValueObjects/PhoneNumber.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\ValueObjects;
 
+use App\Casts\PhoneNumberCast;
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use InvalidArgumentException;
 
-readonly class PhoneNumber
+readonly class PhoneNumber implements Castable
 {
     private string $digits;
 
@@ -24,6 +26,15 @@ readonly class PhoneNumber
     public function __toString(): string
     {
         return $this->digits;
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return class-string<PhoneNumberCast>
+     */
+    public static function castUsing(array $arguments): string
+    {
+        return PhoneNumberCast::class;
     }
 
     public function formatted(): string

--- a/app/ValueObjects/Weight.php
+++ b/app/ValueObjects/Weight.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App\ValueObjects;
 
+use App\Casts\WeightCast;
+use Illuminate\Contracts\Database\Eloquent\Castable;
 use InvalidArgumentException;
 
-readonly class Weight
+readonly class Weight implements Castable
 {
     public function __construct(public int $pounds)
     {
@@ -18,6 +20,15 @@ readonly class Weight
     public function __toString(): string
     {
         return "{$this->pounds} lbs";
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return class-string<WeightCast>
+     */
+    public static function castUsing(array $arguments): string
+    {
+        return WeightCast::class;
     }
 
     public function toPounds(): int

--- a/tests/Unit/Models/Events/VenueTest.php
+++ b/tests/Unit/Models/Events/VenueTest.php
@@ -3,9 +3,9 @@
 declare(strict_types=1);
 
 use App\Builders\Events\VenueBuilder;
-use App\Casts\AddressCast;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
+use App\ValueObjects\Address;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -47,7 +47,7 @@ describe('Venue Model Unit Tests', function () {
             $casts = $venue->getCasts();
 
             expect($casts)->toMatchArray([
-                'address' => AddressCast::class,
+                'address' => Address::class,
             ]);
         });
 

--- a/tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php
+++ b/tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use App\Builders\Roster\WrestlerBuilder;
-use App\Casts\HeightCast;
 use App\Enums\Shared\EmploymentStatus;
 use App\Models\Concerns\HasChampionshipReigns;
 use App\Models\Concerns\HasMatchParticipations;
@@ -19,6 +18,8 @@ use App\Models\Contracts\Manageable;
 use App\Models\Contracts\Retirable;
 use App\Models\Contracts\Suspendable;
 use App\Models\Roster\Wrestlers\Wrestler;
+use App\ValueObjects\Height;
+use App\ValueObjects\Weight;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
@@ -60,7 +61,8 @@ describe('Wrestler Model Unit Tests', function () {
             $wrestler = new Wrestler();
             $casts = $wrestler->getCasts();
 
-            expect($casts['height'])->toBe(HeightCast::class);
+            expect($casts['height'])->toBe(Height::class)
+                ->and($casts['weight'])->toBe(Weight::class);
             // Status is computed attribute, no cast needed
             expect($casts)->not->toHaveKey('status');
         });


### PR DESCRIPTION
## Summary
- make address, height, phone number, and weight implement Laravel's native Castable contract
- configure Eloquent models with the domain value-object classes instead of caster implementation classes
- preserve the existing dedicated caster behavior and update model configuration coverage

## Verification
- composer lint
- php artisan test --compact tests/Unit/Casts tests/Unit/ValueObjects tests/Unit/Models/Events/VenueTest.php tests/Unit/Models/Roster/Wrestlers/WrestlerTest.php (51 tests, 82 assertions)
- composer test:push through formatting, Rector, PHPStan, type coverage, and application tests (3,387 tests, 10,905 assertions)
- browser stage stopped after producing no output in the sandbox; GitHub Actions will run it authoritatively
- git diff --check