### PR TITLE
fix: fail invalid rule selections safely

### DIFF
--- a/.ai/rules/rules.md
+++ b/.ai/rules/rules.md
@@ -7,3 +7,6 @@ paths:
 
 ## Separate shared and model-specific Stable eligibility
 Put employment, suspension, current-Stable exclusivity, and membership-date checks in App\Rules\Stables\CanJoinStable, parameterized by the eligible member model class. Keep constraints that apply only to one member type, such as wrestler injuries or duplicate representation through a selected tag team, in focused model-specific validation rules.
+
+## Fail invalid records through validation
+Custom validation rules must report missing or malformed selected records through the validation failure callback. Do not use findOrFail(), firstOrFail(), or sole() for user-supplied identifiers inside a rule; an exists rule may precede the custom rule, but the rule must remain safe when invoked independently.

--- a/app/Rules/Stables/CanJoinStable.php
+++ b/app/Rules/Stables/CanJoinStable.php
@@ -29,7 +29,19 @@ class CanJoinStable implements ValidationRule
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        $member = $this->memberClass::query()->findOrFail($value);
+        if (! is_int($value) && ! is_string($value)) {
+            $fail('The selected stable member is invalid.');
+
+            return;
+        }
+
+        $member = $this->memberClass::query()->find($value);
+
+        if (! $member instanceof Model) {
+            $fail('The selected stable member is invalid.');
+
+            return;
+        }
 
         if (! $member instanceof CanBeAStableMember ||
             ! $member instanceof Employable ||

--- a/app/Rules/Wrestlers/IsNotInjured.php
+++ b/app/Rules/Wrestlers/IsNotInjured.php
@@ -18,7 +18,13 @@ class IsNotInjured implements ValidationRule
             return;
         }
 
-        $wrestler = Wrestler::query()->whereKey($value)->firstOrFail();
+        $wrestler = Wrestler::query()->whereKey($value)->first();
+
+        if (! $wrestler instanceof Wrestler) {
+            $fail('The selected wrestler is invalid.');
+
+            return;
+        }
 
         if ($wrestler->isInjured()) {
             $fail("{$wrestler->name} is injured and cannot join the stable.");

--- a/app/Rules/Wrestlers/NotRepresentedBySelectedTagTeam.php
+++ b/app/Rules/Wrestlers/NotRepresentedBySelectedTagTeam.php
@@ -28,7 +28,14 @@ class NotRepresentedBySelectedTagTeam implements ValidationRule
             return;
         }
 
-        $wrestler = Wrestler::query()->whereKey($value)->firstOrFail();
+        $wrestler = Wrestler::query()->whereKey($value)->first();
+
+        if (! $wrestler instanceof Wrestler) {
+            $fail('The selected wrestler is invalid.');
+
+            return;
+        }
+
         $currentTagTeam = $wrestler->currentTagTeam()->first();
 
         if (! $currentTagTeam) {

--- a/tests/Unit/Rules/Stables/CanJoinStableUnitTest.php
+++ b/tests/Unit/Rules/Stables/CanJoinStableUnitTest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Roster\Wrestlers\Wrestler;
+use App\Rules\Stables\CanJoinStable;
+use Illuminate\Support\Facades\Validator;
+
+test('it reports an unknown stable member as a validation error', function () {
+    $validator = Validator::make(
+        ['member' => 999],
+        ['member' => [new CanJoinStable(Wrestler::class)]],
+    );
+
+    expect($validator->errors()->has('member'))->toBeTrue();
+});

--- a/tests/Unit/Rules/Wrestlers/IsNotInjuredUnitTest.php
+++ b/tests/Unit/Rules/Wrestlers/IsNotInjuredUnitTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Rules\Wrestlers\IsNotInjured;
+use Illuminate\Support\Facades\Validator;
+
+test('it reports an unknown wrestler as a validation error', function () {
+    $validator = Validator::make(
+        ['wrestler' => 999],
+        ['wrestler' => [new IsNotInjured()]],
+    );
+
+    expect($validator->errors()->has('wrestler'))->toBeTrue();
+});

--- a/tests/Unit/Rules/Wrestlers/NotRepresentedBySelectedTagTeamUnitTest.php
+++ b/tests/Unit/Rules/Wrestlers/NotRepresentedBySelectedTagTeamUnitTest.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Rules\Wrestlers\NotRepresentedBySelectedTagTeam;
+use Illuminate\Support\Facades\Validator;
+
+test('it reports an unknown wrestler as a validation error', function () {
+    $validator = Validator::make(
+        ['wrestler' => 999],
+        ['wrestler' => [new NotRepresentedBySelectedTagTeam(collect([1]))]],
+    );
+
+    expect($validator->errors()->has('wrestler'))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- return validation failures instead of throwing model-not-found exceptions from Stable membership rules
- make wrestler injury and tag-team representation rules safe when invoked independently
- add focused regression coverage for unknown selected records
- record the validation-rule convention for future rules

## Verification
- composer lint
- composer test:push
- 3,390 application tests / 10,907 assertions
- 19 browser tests / 65 assertions