### PR TITLE
fix: use safe stable redirects

### DIFF
--- a/.ai/rules/livewire.md
+++ b/.ai/rules/livewire.md
@@ -25,3 +25,6 @@ Catch and translate BaseBusinessException at Livewire user-interaction boundarie
 
 ## Populate development data through typed forms
 Implement dummy-data population by assigning directly to the concrete Livewire form's typed properties. Do not return generic field-name arrays or dynamically assign arbitrary properties; dedicated collaborators such as match form population must accept the concrete form type.
+
+## Use deterministic internal redirects
+Redirect Livewire actions with redirectRoute() to a named internal route. Do not derive redirect destinations from Referer or other request headers because clients control those values.

--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -112,11 +112,11 @@ class Main extends BaseTable
 
         try {
             resolve(EstablishAction::class)->handle($stable);
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
-        } catch (CannotBeEstablishedException $e) {
-            session()->flash('error', $e->getMessage());
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
+        } catch (CannotBeEstablishedException $exception) {
+            session()->flash('error', $exception->getMessage());
         }
+
+        $this->redirectRoute('stables.index');
     }
 
     /**
@@ -128,11 +128,11 @@ class Main extends BaseTable
 
         try {
             resolve(DisbandAction::class)->handle($stable);
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
-        } catch (CannotBeDisbandedException $e) {
-            session()->flash('error', $e->getMessage());
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
+        } catch (CannotBeDisbandedException $exception) {
+            session()->flash('error', $exception->getMessage());
         }
+
+        $this->redirectRoute('stables.index');
     }
 
     /**
@@ -146,11 +146,11 @@ class Main extends BaseTable
 
         try {
             resolve(RestoreAction::class)->handle($stable);
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
-        } catch (CannotBeRestoredException $e) {
-            session()->flash('error', $e->getMessage());
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
+        } catch (CannotBeRestoredException $exception) {
+            session()->flash('error', $exception->getMessage());
         }
+
+        $this->redirectRoute('stables.index');
     }
 
     /**
@@ -162,11 +162,11 @@ class Main extends BaseTable
 
         try {
             resolve(RetireAction::class)->handle($stable);
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
-        } catch (CannotBeRetiredException $e) {
-            session()->flash('error', $e->getMessage());
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
+        } catch (CannotBeRetiredException $exception) {
+            session()->flash('error', $exception->getMessage());
         }
+
+        $this->redirectRoute('stables.index');
     }
 
     /**
@@ -178,11 +178,11 @@ class Main extends BaseTable
 
         try {
             resolve(UnretireAction::class)->handle($stable);
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
-        } catch (CannotBeUnretiredException $e) {
-            session()->flash('error', $e->getMessage());
-            $this->redirect(request()->header('Referer') ?: route('stables.index'));
+        } catch (CannotBeUnretiredException $exception) {
+            session()->flash('error', $exception->getMessage());
         }
+
+        $this->redirectRoute('stables.index');
     }
 
     /**

--- a/tests/Integration/Livewire/Stables/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Stables/Tables/MainTest.php
@@ -9,7 +9,6 @@ use App\Models\Roster\Stables\Stable;
 use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Users\User;
-use Livewire\Livewire;
 
 use function Pest\Laravel\actingAs;
 use function Pest\Livewire\livewire;
@@ -225,6 +224,18 @@ describe('StablesTable Component', function () {
 
             // Verify stable is established
             expect(freshModel($unformedStable)->isCurrentlyActive())->toBeTrue();
+        });
+
+        test('lifecycle actions ignore an external referrer when redirecting', function () {
+            $unformedStable = Stable::factory()->unactivated()->create(['name' => 'Unformed Stable']);
+
+            actingAs($this->admin);
+
+            request()->headers->set('Referer', 'https://attacker.example');
+
+            livewire(Main::class)
+                ->call('establish', $unformedStable)
+                ->assertRedirect(route('stables.index'));
         });
 
         test('restore action integration works correctly', function () {


### PR DESCRIPTION
## Summary
- replace client-controlled Referer redirects with Livewire named-route redirects
- consistently redirect after successful and rejected Stable lifecycle operations
- add a regression test proving external referrer headers are ignored
- record the deterministic redirect convention for Livewire components

## Verification
- composer lint
- composer test:push
- 3,388 application tests / 10,905 assertions
- 19 browser tests / 65 assertions