### PR TITLE
refactor: remove stable action dispatcher

### DIFF
--- a/app/Livewire/Stables/Tables/Main.php
+++ b/app/Livewire/Stables/Tables/Main.php
@@ -11,7 +11,6 @@ use App\Actions\Stables\RestoreAction;
 use App\Actions\Stables\RetireAction;
 use App\Actions\Stables\UnretireAction;
 use App\Builders\Roster\StableBuilder;
-use App\Exceptions\BaseBusinessException;
 use App\Exceptions\Roster\Stables\CannotBeDisbandedException;
 use App\Exceptions\Roster\Stables\CannotBeEstablishedException;
 use App\Exceptions\Roster\Stables\CannotBeRestoredException;
@@ -182,26 +181,6 @@ class Main extends BaseTable
         } catch (CannotBeUnretiredException $e) {
             session()->flash('error', $e->getMessage());
             $this->redirect(request()->header('Referer') ?: route('stables.index'));
-        }
-    }
-
-    /**
-     * Handle stable actions through a unified interface.
-     */
-    public function handleStableAction(string $action, int $stableId): void
-    {
-        $stable = Stable::findOrFail($stableId);
-
-        try {
-            match ($action) {
-                'establish' => resolve(EstablishAction::class)->handle($stable),
-                'disband' => resolve(DisbandAction::class)->handle($stable),
-                'retire' => resolve(RetireAction::class)->handle($stable),
-                'unretire' => resolve(UnretireAction::class)->handle($stable),
-                default => null,
-            };
-        } catch (BaseBusinessException $e) {
-            session()->flash('error', $e->getMessage());
         }
     }
 }

--- a/tests/Feature/Workflows/RosterManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/RosterManagementWorkflowTest.php
@@ -132,7 +132,7 @@ describe('Stable Formation and Management Workflow', function () {
         actingAs($admin);
 
         \Pest\Livewire\livewire(StablesTable::class)
-            ->call('handleStableAction', 'establish', $stable->id)
+            ->call('establish', $stable)
             ->assertHasNoErrors();
 
         // Then: Stable should be active
@@ -142,7 +142,7 @@ describe('Stable Formation and Management Workflow', function () {
         actingAs($admin);
 
         \Pest\Livewire\livewire(StablesTable::class)
-            ->call('handleStableAction', 'retire', $stable->id)
+            ->call('retire', $stable)
             ->assertHasNoErrors();
 
         // Then: Stable should be retired
@@ -155,7 +155,7 @@ describe('Stable Formation and Management Workflow', function () {
         actingAs($admin);
 
         \Pest\Livewire\livewire(StablesTable::class)
-            ->call('handleStableAction', 'unretire', $retiredStable->id)
+            ->call('unretire', $retiredStable)
             ->assertHasNoErrors();
 
         // Then: Stable should no longer be retired


### PR DESCRIPTION
## Summary
- remove the redundant string-based Stable lifecycle dispatcher
- route workflow coverage through the same dedicated Livewire methods used by the UI
- preserve Stable lifecycle behavior while eliminating an alternate test-only entry point

## Verification
- php artisan test --compact tests/Feature/Workflows/RosterManagementWorkflowTest.php
- composer lint
- composer test:push
- 3,387 application tests / 10,903 assertions
- 19 browser tests / 65 assertions