### PR TITLE
refactor: normalize Livewire redirects

### DIFF
--- a/app/Livewire/Events/Tables/Main.php
+++ b/app/Livewire/Events/Tables/Main.php
@@ -143,6 +143,6 @@ class Main extends BaseTable
 
         resolve(RestoreAction::class)->handle($event);
         session()->flash('status', 'Event successfully restored.');
-        $this->redirect(route('events.index'));
+        $this->redirectRoute('events.index');
     }
 }

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -26,7 +26,6 @@ use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Titles\Title;
 use App\Queries\Titles\TitleChampionshipQuery;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
 /**
@@ -176,47 +175,44 @@ class Main extends BaseTable
      * Debut a title for competition.
      *
      * @param  Title  $title  The title to debut
-     * @return RedirectResponse Redirect response with success or error message
      */
-    public function debut(Title $title): RedirectResponse
+    public function debut(Title $title): void
     {
         Gate::authorize('debut', $title);
 
         try {
             resolve(DebutAction::class)->handle($title);
         } catch (CannotBeDebutedException $e) {
-            return redirect()->back()->with('error', $e->getMessage());
+            session()->flash('error', $e->getMessage());
         }
 
-        return back();
+        $this->redirectRoute('titles.index');
     }
 
     /**
      * Put a title on hold (remove from active competition).
      *
      * @param  Title  $title  The title to put on hold
-     * @return RedirectResponse Redirect response with success or error message
      */
-    public function putOnHold(Title $title): RedirectResponse
+    public function putOnHold(Title $title): void
     {
         Gate::authorize('pull', $title);
 
         try {
             resolve(PullAction::class)->handle($title);
         } catch (CannotBePulledException $e) {
-            return redirect()->back()->with('error', $e->getMessage());
+            session()->flash('error', $e->getMessage());
         }
 
-        return back();
+        $this->redirectRoute('titles.index');
     }
 
     /**
      * Restore a previously deleted title.
      *
      * @param  int  $titleId  The ID of the deleted title to restore
-     * @return RedirectResponse Redirect response with success or error message
      */
-    public function restore(int $titleId): RedirectResponse
+    public function restore(int $titleId): void
     {
         $title = Title::onlyTrashed()->findOrFail($titleId);
 
@@ -224,57 +220,55 @@ class Main extends BaseTable
 
         resolve(RestoreAction::class)->handle($title);
 
-        return back();
+        $this->redirectRoute('titles.index');
     }
 
     /**
      * Retire a title permanently.
      *
      * @param  Title  $title  The title to retire
-     * @return RedirectResponse Redirect response with success or error message
      */
-    public function retire(Title $title): RedirectResponse
+    public function retire(Title $title): void
     {
         Gate::authorize('retire', $title);
 
         try {
             resolve(RetireAction::class)->handle($title);
         } catch (CannotBeRetiredException $e) {
-            return redirect()->back()->with('error', $e->getMessage());
+            session()->flash('error', $e->getMessage());
         }
 
-        return back();
+        $this->redirectRoute('titles.index');
     }
 
     /**
      * Unretire a previously retired title.
      *
      * @param  Title  $title  The title to unretire
-     * @return RedirectResponse Redirect response with success or error message
      */
-    public function unretire(Title $title): RedirectResponse
+    public function unretire(Title $title): void
     {
         Gate::authorize('unretire', $title);
 
         try {
             resolve(UnretireAction::class)->handle($title);
         } catch (CannotBeUnretiredException $e) {
-            return redirect()->back()->with('error', $e->getMessage());
+            session()->flash('error', $e->getMessage());
         }
 
-        return back();
+        $this->redirectRoute('titles.index');
     }
 
-    public function reinstate(Title $title): RedirectResponse
+    public function reinstate(Title $title): void
     {
         Gate::authorize('reinstate', $title);
 
         try {
             resolve(ReinstateAction::class)->handle($title);
         } catch (CannotBeReinstatedException $exception) {
-            return redirect()->back()->with('error', $exception->getMessage());
+            session()->flash('error', $exception->getMessage());
         }
 
-        return back();
+        $this->redirectRoute('titles.index');
     }
 }

--- a/app/Livewire/Venues/Tables/Main.php
+++ b/app/Livewire/Venues/Tables/Main.php
@@ -10,7 +10,6 @@ use App\Livewire\Base\Tables\BaseTable;
 use App\Livewire\Table\Column;
 use App\Models\Events\Venue;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
 /** @extends BaseTable<Venue> */
@@ -67,7 +66,7 @@ class Main extends BaseTable
     /**
      * Restore a deleted venue.
      */
-    public function restore(int $venueId): RedirectResponse
+    public function restore(int $venueId): void
     {
         $venue = Venue::onlyTrashed()->findOrFail($venueId);
 
@@ -75,6 +74,6 @@ class Main extends BaseTable
 
         resolve(RestoreAction::class)->handle($venue);
 
-        return back();
+        $this->redirectRoute('venues.index');
     }
 }

--- a/app/Livewire/Wrestlers/Tables/Main.php
+++ b/app/Livewire/Wrestlers/Tables/Main.php
@@ -25,7 +25,6 @@ use App\Livewire\Table\Column;
 use App\Livewire\Table\Filter;
 use App\Livewire\Table\Filters\SelectFilter;
 use App\Models\Roster\Wrestlers\Wrestler;
-use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Gate;
 
 /** @extends BaseTable<Wrestler> */
@@ -113,7 +112,7 @@ class Main extends BaseTable
     /**
      * Restore a deleted wrestler.
      */
-    public function restore(int $wrestlerId): RedirectResponse
+    public function restore(int $wrestlerId): void
     {
         $wrestler = Wrestler::onlyTrashed()->findOrFail($wrestlerId);
 
@@ -121,7 +120,7 @@ class Main extends BaseTable
 
         resolve(RestoreAction::class)->handle($wrestler);
 
-        return back();
+        $this->redirectRoute('wrestlers.index');
     }
 
     /**

--- a/tests/Feature/Livewire/Wrestlers/Tables/WrestlersTableTest.php
+++ b/tests/Feature/Livewire/Wrestlers/Tables/WrestlersTableTest.php
@@ -92,7 +92,8 @@ describe('Main Component Feature Workflows', function () {
 
             // Restore workflow
             $component->call('restore', $wrestler->id)
-                ->assertHasNoErrors();
+                ->assertHasNoErrors()
+                ->assertRedirectToRoute('wrestlers.index');
 
             // Verify wrestler is restored
             expect(Wrestler::withTrashed()->findOrFail($wrestler->id)->deleted_at)->toBeNull();

--- a/tests/Feature/Workflows/TitleManagementWorkflowTest.php
+++ b/tests/Feature/Workflows/TitleManagementWorkflowTest.php
@@ -101,7 +101,8 @@ describe('Title Lifecycle Management Workflow', function () {
 
         livewire(Main::class)
             ->call('debut', $title)
-            ->assertHasNoErrors();
+            ->assertHasNoErrors()
+            ->assertRedirectToRoute('titles.index');
 
         // Then: Title should be active (check after component execution)
         expect(freshModel($title)->isCurrentlyActive())->toBeTrue();
@@ -111,7 +112,8 @@ describe('Title Lifecycle Management Workflow', function () {
 
         livewire(Main::class)
             ->call('putOnHold', $title)
-            ->assertHasNoErrors();
+            ->assertHasNoErrors()
+            ->assertRedirectToRoute('titles.index');
 
         // Then: Title should be inactive
         expect(freshModel($title)->isCurrentlyActive())->toBeFalse();
@@ -121,7 +123,8 @@ describe('Title Lifecycle Management Workflow', function () {
 
         livewire(Main::class)
             ->call('reinstate', $title)
-            ->assertHasNoErrors();
+            ->assertHasNoErrors()
+            ->assertRedirectToRoute('titles.index');
 
         // Then: Title should be active again
         expect(freshModel($title)->isCurrentlyActive())->toBeTrue();
@@ -131,7 +134,8 @@ describe('Title Lifecycle Management Workflow', function () {
 
         livewire(Main::class)
             ->call('retire', $title)
-            ->assertHasNoErrors();
+            ->assertHasNoErrors()
+            ->assertRedirectToRoute('titles.index');
 
         // Then: Title should be retired
         expect(freshModel($title)->isRetired())->toBeTrue();
@@ -141,7 +145,8 @@ describe('Title Lifecycle Management Workflow', function () {
 
         livewire(Main::class)
             ->call('unretire', $title)
-            ->assertHasNoErrors();
+            ->assertHasNoErrors()
+            ->assertRedirectToRoute('titles.index');
 
         // Then: Title should no longer be retired
         expect(freshModel($title)->isRetired())->toBeFalse();
@@ -299,7 +304,8 @@ describe('Title Deletion and Restoration Workflow', function () {
 
         livewire(Main::class)
             ->call('restore', $title->id)
-            ->assertHasNoErrors();
+            ->assertHasNoErrors()
+            ->assertRedirectToRoute('titles.index');
 
         // Then: Title should be restored
         expect($title->fresh())->not->toBeNull();

--- a/tests/Integration/Livewire/Events/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Events/Tables/MainTest.php
@@ -224,7 +224,7 @@ describe('EventsTable Component Integration', function () {
 
             $component->call('restore', $deletedEvent->id)
                 ->assertHasNoErrors()
-                ->assertRedirect();
+                ->assertRedirectToRoute('events.index');
 
             // Verify event is restored
             expect(Event::find($deletedEvent->id))->not()->toBeNull();
@@ -256,7 +256,7 @@ describe('EventsTable Component Integration', function () {
 
             $component->call('restore', $deletedEvent->id)
                 ->assertHasNoErrors()
-                ->assertRedirect();
+                ->assertRedirectToRoute('events.index');
 
             expect(Event::find($deletedEvent->id))->not()->toBeNull();
         });

--- a/tests/Integration/Livewire/Venues/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Venues/Tables/MainTest.php
@@ -256,7 +256,8 @@ describe('VenuesTable Integration Tests', function () {
             $component = livewire(Main::class);
 
             $component->call('restore', $this->deletedVenue->id)
-                ->assertHasNoErrors();
+                ->assertHasNoErrors()
+                ->assertRedirectToRoute('venues.index');
 
             expect(Venue::find($this->deletedVenue->id))->not()->toBeNull();
         });


### PR DESCRIPTION
Summary:
- use Livewire named-route redirects for table actions
- preserve title lifecycle error flash messages across deterministic redirects
- assert exact redirect destinations in Livewire tests

Verification:
- focused Livewire tests: 81 tests, 297 assertions
- pre-push passed type coverage, Rector, Pint, both PHPStan configurations, and 3,399 application tests with 10,946 assertions
- local browser stage produced no output and was stopped after a bounded wait; CI will run it