### PR TITLE
refactor: centralize Livewire modal authorization

### DIFF
--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -21,7 +21,6 @@ use App\Livewire\Matches\Support\MatchFormDummyData;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchStipulation;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\View\View;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\Locked;
@@ -105,17 +104,6 @@ class FormModal extends BaseFormModal
     protected function populateDummyData(): void
     {
         $this->dummyData->fill($this->form);
-    }
-
-    public function openModal(int|string|null $modelId = null): void
-    {
-        if ($modelId === null) {
-            Gate::authorize('create', EventMatch::class);
-        } else {
-            Gate::authorize('update', EventMatch::query()->findOrFail($modelId));
-        }
-
-        parent::openModal($modelId);
     }
 
     public function getModalTitle(): string

--- a/app/Livewire/Titles/Modals/FormModal.php
+++ b/app/Livewire/Titles/Modals/FormModal.php
@@ -10,7 +10,6 @@ use App\Enums\Titles\TitleType;
 use App\Livewire\Base\BaseFormModal;
 use App\Livewire\Titles\Forms\CreateEditForm;
 use App\Models\Titles\Title;
-use Illuminate\Support\Facades\Gate;
 use Illuminate\Support\Str;
 use Illuminate\View\View;
 
@@ -52,19 +51,6 @@ class FormModal extends BaseFormModal
         }
 
         return 'Create Title';
-    }
-
-    public function openModal(int|string|null $modelId = null): void
-    {
-        // Authorization check - only administrators can access title management
-        if ($modelId) {
-            $title = Title::findOrFail($modelId);
-            Gate::authorize('update', $title);
-        } else {
-            Gate::authorize('create', Title::class);
-        }
-
-        parent::openModal($modelId);
     }
 
     protected function storeForm(): bool


### PR DESCRIPTION
Summary:
- remove duplicate authorization overrides from title and match form modals
- rely on BaseFormModal for create and update authorization at open and submit boundaries
- preserve existing authorization behavior and tests

Verification:
- focused modal tests: 62 tests, 129 assertions
- pre-push passed type coverage, Rector, Pint, both PHPStan configurations, and 3,399 application tests with 10,928 assertions
- local browser stage produced no output and was stopped after a bounded wait; CI will run it