### PR TITLE
refactor: share Livewire submission events

### DIFF
--- a/app/Livewire/Base/BaseFormModal.php
+++ b/app/Livewire/Base/BaseFormModal.php
@@ -25,6 +25,12 @@ abstract class BaseFormModal extends BaseModal
 
     public bool $isModalOpen = false;
 
+    protected ?string $createdEventName = null;
+
+    protected ?string $updatedEventName = null;
+
+    protected bool $resetFormAfterSubmission = false;
+
     public function openModal(int|string|null $modelId = null): void
     {
         $this->mount($modelId);
@@ -44,6 +50,8 @@ abstract class BaseFormModal extends BaseModal
 
     public function submitForm(): bool
     {
+        $wasCreating = $this->form->isCreating();
+
         if ($this->model !== null) {
             $this->form->setModel($this->model);
         }
@@ -58,6 +66,18 @@ abstract class BaseFormModal extends BaseModal
         $this->closeModal();
         $this->dispatch('closeModal');
         $this->dispatch('form-submitted');
+
+        $eventName = $wasCreating
+            ? $this->createdEventName
+            : $this->updatedEventName;
+
+        if ($eventName !== null) {
+            $this->dispatch($eventName);
+        }
+
+        if ($this->resetFormAfterSubmission) {
+            $this->form->reset();
+        }
 
         return true;
     }

--- a/app/Livewire/Matches/Modals/FormModal.php
+++ b/app/Livewire/Matches/Modals/FormModal.php
@@ -34,6 +34,12 @@ class FormModal extends BaseFormModal
     use PresentsTitlesList;
     use PresentsWrestlersList;
 
+    protected ?string $createdEventName = 'matchCreated';
+
+    protected ?string $updatedEventName = 'matchUpdated';
+
+    protected bool $resetFormAfterSubmission = true;
+
     #[Locked]
     public int $eventId = 0;
 
@@ -109,21 +115,6 @@ class FormModal extends BaseFormModal
     public function getModalTitle(): string
     {
         return isset($this->model) ? 'Edit Match' : 'Create Match';
-    }
-
-    public function submitForm(): bool
-    {
-        $isCreating = $this->form->isCreating();
-        $wasStored = parent::submitForm();
-
-        if (! $wasStored) {
-            return false;
-        }
-
-        $this->dispatch($isCreating ? 'matchCreated' : 'matchUpdated');
-        $this->form->reset();
-
-        return true;
     }
 
     public function updatedFormMatchType(mixed $value): void

--- a/app/Livewire/Users/Modals/FormModal.php
+++ b/app/Livewire/Users/Modals/FormModal.php
@@ -16,6 +16,12 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
+    protected ?string $createdEventName = 'userCreated';
+
+    protected ?string $updatedEventName = 'userUpdated';
+
+    protected bool $resetFormAfterSubmission = true;
+
     public CreateEditForm $form;
 
     private CreateAction $createAction;
@@ -65,25 +71,6 @@ class FormModal extends BaseFormModal
         $this->createAction->handle($this->form->toData());
 
         return true;
-    }
-
-    public function submitForm(): bool
-    {
-        $isCreating = $this->form->isCreating();
-
-        $result = parent::submitForm();
-
-        if ($result) {
-            if ($isCreating) {
-                $this->dispatch('userCreated');
-            } else {
-                $this->dispatch('userUpdated');
-            }
-
-            $this->form->reset();
-        }
-
-        return $result;
     }
 
     public function closeModal(): void

--- a/app/Livewire/Venues/Modals/FormModal.php
+++ b/app/Livewire/Venues/Modals/FormModal.php
@@ -17,6 +17,12 @@ use Illuminate\View\View;
  */
 class FormModal extends BaseFormModal
 {
+    protected ?string $createdEventName = 'venueCreated';
+
+    protected ?string $updatedEventName = 'venueUpdated';
+
+    protected bool $resetFormAfterSubmission = true;
+
     public CreateEditForm $form;
 
     private CreateAction $createAction;
@@ -77,28 +83,6 @@ class FormModal extends BaseFormModal
         $this->createAction->handle($this->form->toData());
 
         return true;
-    }
-
-    public function submitForm(): bool
-    {
-        // Store whether we're creating or updating before the form submission
-        $isCreating = $this->form->isCreating();
-
-        $result = parent::submitForm();
-
-        if ($result) {
-            // Dispatch the appropriate event based on whether we created or updated
-            if ($isCreating) {
-                $this->dispatch('venueCreated');
-            } else {
-                $this->dispatch('venueUpdated');
-            }
-
-            // Reset the form after successful submission
-            $this->form->reset();
-        }
-
-        return $result;
     }
 
     public function closeModal(): void


### PR DESCRIPTION
Summary:
- centralize successful form event dispatch and optional reset behavior in BaseFormModal
- configure user, venue, and match modals with their created and updated event names
- remove duplicated submitForm overrides while preserving failed-submission behavior

Verification:
- focused modal tests: 90 tests, 233 assertions
- pre-push passed type coverage, Rector, Pint, both PHPStan configurations, and 3,399 application tests with 10,946 assertions
- local browser stage produced no output and was stopped after a bounded wait; CI will run it