### PR TITLE
refactor: trim Livewire documentation

### DIFF
--- a/app/Livewire/Events/Forms/CreateEditForm.php
+++ b/app/Livewire/Events/Forms/CreateEditForm.php
@@ -109,12 +109,10 @@ class CreateEditForm extends BaseForm
      */
     public function loadExtraData(): void
     {
-        // Map venue_id from model to venue_id form field
         if (isset($this->formModel->venue_id)) {
             $this->venue_id = $this->formModel->venue_id;
         }
 
-        // Venue list is cached automatically via PresentsVenuesList trait
     }
 
     /**

--- a/app/Livewire/Managers/Forms/CreateEditForm.php
+++ b/app/Livewire/Managers/Forms/CreateEditForm.php
@@ -91,12 +91,10 @@ class CreateEditForm extends BaseForm
      */
     public function loadExtraData(): void
     {
-        // Only process if we have a manager model
         if (! $this->formModel instanceof Manager) {
             return;
         }
 
-        // Load employment start date from relationship
         $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
     }
 

--- a/app/Livewire/Managers/Modals/FormModal.php
+++ b/app/Livewire/Managers/Modals/FormModal.php
@@ -20,7 +20,6 @@ class FormModal extends BaseFormModal
     {
         parent::mount($modelId);
 
-        // Override title field to use full_name for managers
         $this->modelTitleField = 'full_name';
     }
 

--- a/app/Livewire/Referees/Forms/CreateEditForm.php
+++ b/app/Livewire/Referees/Forms/CreateEditForm.php
@@ -90,12 +90,10 @@ class CreateEditForm extends BaseForm
      */
     public function loadExtraData(): void
     {
-        // Only process if we have a referee model
         if (! $this->formModel instanceof Referee) {
             return;
         }
 
-        // Load employment start date from relationship
         $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
     }
 

--- a/app/Livewire/Referees/Modals/FormModal.php
+++ b/app/Livewire/Referees/Modals/FormModal.php
@@ -66,7 +66,6 @@ class FormModal extends BaseFormModal
     {
         parent::mount($modelId);
 
-        // Set the title field to use full_name instead of name
         $this->modelTitleField = 'full_name';
     }
 
@@ -74,7 +73,6 @@ class FormModal extends BaseFormModal
     {
         parent::openModal($modelId);
 
-        // Store original model data if editing
         if (isset($this->model)) {
             $this->originalModelData = [
                 'first_name' => $this->model->first_name,
@@ -89,14 +87,12 @@ class FormModal extends BaseFormModal
     public function clear(): void
     {
         if ($this->originalModelData) {
-            // Reset to original model data when editing
             $this->form->first_name = $this->originalModelData['first_name'];
             $this->form->last_name = $this->originalModelData['last_name'];
             $this->form->employment_date = $this->originalModelData['employment_date'];
             $this->form->resetErrorBag();
             $this->form->resetValidation();
         } else {
-            // Reset to empty state when creating - explicitly set defaults
             $this->form->first_name = '';
             $this->form->last_name = '';
             $this->form->employment_date = '';

--- a/app/Livewire/Stables/Forms/CreateEditForm.php
+++ b/app/Livewire/Stables/Forms/CreateEditForm.php
@@ -111,12 +111,10 @@ class CreateEditForm extends BaseForm
      */
     public function loadExtraData(): void
     {
-        // Only process if we have a stable model
         if (! $this->formModel instanceof Stable) {
             return;
         }
 
-        // Load activation dates from first activity period relationship
         $this->started_at = $this->formModel->firstActivityPeriod?->started_at?->toDateString();
         $this->ended_at = $this->formModel->firstActivityPeriod?->ended_at?->toDateString();
         $this->wrestlers = $this->formModel->currentWrestlers->modelKeys();
@@ -208,7 +206,6 @@ class CreateEditForm extends BaseForm
             ],
         ];
 
-        // Add validation that ended_at is after started_at if both are provided
         if (! in_array($this->started_at, [null, '', '0'], true) && ! in_array($this->ended_at, [null, '', '0'], true)) {
             $rules['ended_at'][] = 'after:started_at';
         }

--- a/app/Livewire/TagTeams/Forms/CreateEditForm.php
+++ b/app/Livewire/TagTeams/Forms/CreateEditForm.php
@@ -122,22 +122,18 @@ class CreateEditForm extends BaseForm
      */
     public function loadExtraData(): void
     {
-        // Only process if we have a tag team model
         if (! $this->formModel instanceof TagTeam) {
             return;
         }
 
-        // Load employment start date from relationship (with type safety)
         if ($this->formModel->hasEmploymentHistory()) {
             $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
         }
 
-        // Load current wrestler assignments
         $currentWrestlers = $this->formModel->currentWrestlers;
         $this->wrestlerA = $currentWrestlers->first()?->id;
         $this->wrestlerB = $currentWrestlers->skip(1)->first()?->id;
 
-        // Load current manager assignments
         $this->managers = $this->formModel->currentManagers
             ->map(fn (Manager $manager): int => $manager->id)
             ->all();

--- a/app/Livewire/Titles/Forms/CreateEditForm.php
+++ b/app/Livewire/Titles/Forms/CreateEditForm.php
@@ -89,12 +89,10 @@ class CreateEditForm extends BaseForm
      */
     public function loadExtraData(): void
     {
-        // Only process if we have a title model
         if (! $this->formModel instanceof Title) {
             return;
         }
 
-        // Load activation start date from first activity period relationship
         $this->start_date = $this->formModel->firstActivityPeriod?->started_at?->toDateString();
     }
 

--- a/app/Livewire/Titles/Tables/Main.php
+++ b/app/Livewire/Titles/Tables/Main.php
@@ -28,56 +28,18 @@ use App\Queries\Titles\TitleChampionshipQuery;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Facades\Gate;
 
-/**
- * Livewire table component for managing championship titles.
- *
- * This table displays all championship titles in the system with their current
- * status, activation dates, and provides actions for title lifecycle management.
- * It supports filtering by activation status and date ranges, along with search
- * functionality for title names.
- *
- * The table integrates with various title management actions including activation,
- * deactivation, retirement, restoration, and deletion through a comprehensive
- * action system with proper authorization and error handling.
- */
 /** @extends BaseTable<Title> */
 class Main extends BaseTable
 {
-    /**
-     * Enable action column for this table.
-     */
     protected bool $showActionColumn = true;
 
-    /**
-     * The database table name for the main query.
-     *
-     * @var string The name of the titles table
-     */
     protected string $databaseTableName = 'titles';
 
-    /**
-     * The base route path for title-related actions.
-     *
-     * @var string The route prefix for title management
-     */
     protected string $routeBasePath = 'titles';
 
-    /**
-     * The resource name for authorization and routing.
-     *
-     * @var string The resource identifier for titles
-     */
     protected string $resourceName = 'titles';
 
-    /**
-     * Build the query for retrieving titles with their relationships.
-     *
-     * Creates a query that fetches all titles with their current activity period
-     * information, ordered alphabetically by name. The current activity period
-     * relationship provides access to activation status and dates.
-     *
-     * @return TitleBuilder<Title> Query builder for titles with eager loaded relationships
-     */
+    /** @return TitleBuilder<Title> */
     public function builder(): TitleBuilder
     {
         return Title::query()
@@ -86,26 +48,12 @@ class Main extends BaseTable
             ->oldest('name');
     }
 
-    /**
-     * Configure additional table settings and behavior.
-     *
-     * Includes authorization check to ensure only authorized users can access
-     * the titles table, plus any additional table-specific configuration.
-     */
     public function configure(): void
     {
         Gate::authorize('viewAny', Title::class);
     }
 
-    /**
-     * Define the table columns for title display.
-     *
-     * Configures the columns shown in the titles table including the title name,
-     * current status, and first activation date. The status column shows whether
-     * a title is currently active, inactive, or retired.
-     *
-     * @return array<int, Column> Array of column definitions for the table
-     */
+    /** @return array<int, Column> */
     public function columns(): array
     {
         return [
@@ -120,15 +68,7 @@ class Main extends BaseTable
         ];
     }
 
-    /**
-     * Define the available filters for the titles table.
-     *
-     * Provides filtering options including activity status filter (Undebuted,
-     * Active, Inactive, Pending Debut) and first activation date range filter for finding
-     * titles activated within specific time periods.
-     *
-     * @return array<int, Filter> Array of filter definitions for the table
-     */
+    /** @return array<int, Filter> */
     public function filters(): array
     {
         return [
@@ -154,15 +94,6 @@ class Main extends BaseTable
         ];
     }
 
-    /**
-     * Delete a title from the system.
-     *
-     * Performs soft deletion of the specified title using the base table's
-     * delete functionality. The title will be moved to trash and can be
-     * restored later if needed.
-     *
-     * @param  Title  $title  The title to delete
-     */
     public function delete(Title $title): void
     {
         Gate::authorize('delete', $title);
@@ -171,11 +102,6 @@ class Main extends BaseTable
         session()->flash('status', 'Title successfully deleted.');
     }
 
-    /**
-     * Debut a title for competition.
-     *
-     * @param  Title  $title  The title to debut
-     */
     public function debut(Title $title): void
     {
         Gate::authorize('debut', $title);
@@ -189,11 +115,6 @@ class Main extends BaseTable
         $this->redirectRoute('titles.index');
     }
 
-    /**
-     * Put a title on hold (remove from active competition).
-     *
-     * @param  Title  $title  The title to put on hold
-     */
     public function putOnHold(Title $title): void
     {
         Gate::authorize('pull', $title);
@@ -207,11 +128,6 @@ class Main extends BaseTable
         $this->redirectRoute('titles.index');
     }
 
-    /**
-     * Restore a previously deleted title.
-     *
-     * @param  int  $titleId  The ID of the deleted title to restore
-     */
     public function restore(int $titleId): void
     {
         $title = Title::onlyTrashed()->findOrFail($titleId);
@@ -223,11 +139,6 @@ class Main extends BaseTable
         $this->redirectRoute('titles.index');
     }
 
-    /**
-     * Retire a title permanently.
-     *
-     * @param  Title  $title  The title to retire
-     */
     public function retire(Title $title): void
     {
         Gate::authorize('retire', $title);
@@ -241,11 +152,6 @@ class Main extends BaseTable
         $this->redirectRoute('titles.index');
     }
 
-    /**
-     * Unretire a previously retired title.
-     *
-     * @param  Title  $title  The title to unretire
-     */
     public function unretire(Title $title): void
     {
         Gate::authorize('unretire', $title);

--- a/app/Livewire/Users/Forms/CreateEditForm.php
+++ b/app/Livewire/Users/Forms/CreateEditForm.php
@@ -103,12 +103,8 @@ class CreateEditForm extends BaseForm
      */
     public function loadExtraData(): void
     {
-        // Clear password fields for security when editing existing users
         $this->password = '';
         $this->password_confirmation = '';
-
-        // Additional user data can be loaded here as needed:
-        // $this->roles = $this->formModel?->roles->pluck('name')->toArray() ?? [];
     }
 
     /**
@@ -180,12 +176,10 @@ class CreateEditForm extends BaseForm
             'role' => ['required', 'string', 'in:administrator,basic'],
         ];
 
-        // Password rules - required for creation, optional for updates
         if ($this->isCreating()) {
             $rules['password'] = ['required', 'string', 'min:8', 'confirmed'];
             $rules['password_confirmation'] = ['required'];
         } elseif (! empty($this->password)) {
-            // Only validate password during updates if user is actually trying to change it
             $rules['password'] = ['required', 'string', 'min:8', 'confirmed'];
             $rules['password_confirmation'] = ['required'];
         }

--- a/app/Livewire/Venues/Forms/CreateEditForm.php
+++ b/app/Livewire/Venues/Forms/CreateEditForm.php
@@ -94,18 +94,7 @@ class CreateEditForm extends BaseForm
      */
     public int|string|null $zipcode = '';
 
-    /**
-     * Load additional data when editing existing venue records.
-     *
-     * Handles data loading for venue-specific fields when editing
-     * existing venues. Called automatically during form initialization
-     * for edit operations. No special data transformation needed for venues.
-     */
-    public function loadExtraData(): void
-    {
-        // No additional data loading required for venues
-        // All venue data is loaded via standard form fill mechanism
-    }
+    public function loadExtraData(): void {}
 
     /**
      * Prepare venue data for model storage.

--- a/app/Livewire/Venues/Modals/FormModal.php
+++ b/app/Livewire/Venues/Modals/FormModal.php
@@ -88,7 +88,6 @@ class FormModal extends BaseFormModal
     public function closeModal(): void
     {
         parent::closeModal();
-        // Reset the form when modal is closed
         $this->form->reset();
     }
 }

--- a/app/Livewire/Wrestlers/Forms/CreateEditForm.php
+++ b/app/Livewire/Wrestlers/Forms/CreateEditForm.php
@@ -135,15 +135,12 @@ class CreateEditForm extends BaseForm
      */
     public function loadExtraData(): void
     {
-        // Early return if no model
         if (! $this->formModel) {
             return;
         }
 
-        // Load employment start date from relationship
         $this->employment_date = $this->formModel->firstEmployment?->started_at?->toDateString();
 
-        // Convert Height value object to separate feet/inches fields
         $height = $this->formModel->height;
         $this->height_feet = (int) floor($height->toInches() / 12);
         $this->height_inches = $height->toInches() % 12;


### PR DESCRIPTION
Summary:
- remove narrative comments that repeat Livewire form operations
- trim verbose Title table docblocks to static-analysis annotations
- preserve generics, array shapes, and other PHPStan-required documentation

Verification:
- pre-push passed type coverage, Rector, Pint, both PHPStan configurations, and 3,399 application tests with 10,945 assertions
- local browser stage produced no output and was stopped after a bounded wait; CI will run it