### PR TITLE
fix: enforce match booking eligibility

### DIFF
--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -18,6 +18,7 @@ use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Titles\Title;
 use App\Rules\Matches\CompetitorsNotDuplicated;
 use App\Rules\Matches\CorrectNumberOfSides;
+use App\Rules\Referees\CanRefereeMatch;
 use App\Rules\Titles\CurrentChampionIsCompeting;
 use App\Rules\Titles\IsActive;
 use Illuminate\Validation\Rule;
@@ -145,7 +146,7 @@ class CreateEditForm extends BaseForm
             ],
             'preview' => ['sometimes', 'string'],
             'referees' => ['required', 'array', 'min:1'],
-            'referees.*' => ['integer', 'exists:referees,id'],
+            'referees.*' => ['integer', 'exists:referees,id', new CanRefereeMatch()],
             'titles' => ['sometimes', 'array'],
             'titles.*' => [
                 'bail',

--- a/app/Livewire/Matches/Support/MatchCompetitorRuleSet.php
+++ b/app/Livewire/Matches/Support/MatchCompetitorRuleSet.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace App\Livewire\Matches\Support;
 
 use App\Enums\MatchType;
+use App\Rules\TagTeams\IsBookable as TagTeamIsBookable;
+use App\Rules\Wrestlers\IsBookable as WrestlerIsBookable;
 
 final readonly class MatchCompetitorRuleSet
 {
@@ -41,9 +43,9 @@ final readonly class MatchCompetitorRuleSet
         return [
             'competitors' => ['sometimes', 'array'],
             'competitors.*.wrestlers' => ['sometimes', 'array'],
-            'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
+            'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id', new WrestlerIsBookable()],
             'competitors.*.tag_teams' => ['sometimes', 'array'],
-            'competitors.*.tag_teams.*' => ['integer', 'exists:tag_teams,id'],
+            'competitors.*.tag_teams.*' => ['integer', 'exists:tag_teams,id', new TagTeamIsBookable()],
         ];
     }
 
@@ -54,7 +56,7 @@ final readonly class MatchCompetitorRuleSet
 
         foreach (range(0, $sideCount - 1) as $sideIndex) {
             $rules["competitors.{$sideIndex}.wrestlers"] = ['required', 'array', 'size:1'];
-            $rules["competitors.{$sideIndex}.wrestlers.*"] = ['integer', 'exists:wrestlers,id'];
+            $rules["competitors.{$sideIndex}.wrestlers.*"] = ['integer', 'exists:wrestlers,id', new WrestlerIsBookable()];
         }
 
         return $rules;
@@ -68,9 +70,9 @@ final readonly class MatchCompetitorRuleSet
         foreach (range(0, 1) as $sideIndex) {
             $rules["competitors.{$sideIndex}"] = ['required', 'array'];
             $rules["competitors.{$sideIndex}.wrestlers"] = ['sometimes', 'array', 'min:2'];
-            $rules["competitors.{$sideIndex}.wrestlers.*"] = ['integer', 'exists:wrestlers,id'];
+            $rules["competitors.{$sideIndex}.wrestlers.*"] = ['integer', 'exists:wrestlers,id', new WrestlerIsBookable()];
             $rules["competitors.{$sideIndex}.tag_teams"] = ['sometimes', 'array', 'min:1'];
-            $rules["competitors.{$sideIndex}.tag_teams.*"] = ['integer', 'exists:tag_teams,id'];
+            $rules["competitors.{$sideIndex}.tag_teams.*"] = ['integer', 'exists:tag_teams,id', new TagTeamIsBookable()];
         }
 
         return $rules;
@@ -89,7 +91,7 @@ final readonly class MatchCompetitorRuleSet
         return [
             'competitors' => ['required', 'array', 'size:1'],
             'competitors.0.wrestlers' => $wrestlerRules,
-            'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
+            'competitors.0.wrestlers.*' => ['integer', 'exists:wrestlers,id', new WrestlerIsBookable()],
         ];
     }
 
@@ -99,9 +101,9 @@ final readonly class MatchCompetitorRuleSet
         return [
             'competitors' => ['required', 'array', 'min:2'],
             'competitors.*.wrestlers' => ['sometimes', 'array'],
-            'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id'],
+            'competitors.*.wrestlers.*' => ['integer', 'exists:wrestlers,id', new WrestlerIsBookable()],
             'competitors.*.tag_teams' => ['sometimes', 'array'],
-            'competitors.*.tag_teams.*' => ['integer', 'exists:tag_teams,id'],
+            'competitors.*.tag_teams.*' => ['integer', 'exists:tag_teams,id', new TagTeamIsBookable()],
         ];
     }
 }

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -276,6 +276,23 @@ describe('FormModal Create Operations', function () {
         $component->assertHasErrors(['form.competitors.0.wrestlers.0', 'form.competitors.1.wrestlers.0']);
     });
 
+    it('rejects an unavailable competitor', function () {
+        $unavailableWrestler = Wrestler::factory()->unemployed()->create();
+        $bookableWrestler = Wrestler::factory()->bookable()->create();
+        $referee = Referee::factory()->bookable()->create();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->set('form.matchType', MatchType::Singles)
+            ->set('form.competitors', [
+                0 => ['wrestlers' => [$unavailableWrestler->id]],
+                1 => ['wrestlers' => [$bookableWrestler->id]],
+            ])
+            ->set('form.referees', [$referee->id])
+            ->call('save')
+            ->assertHasErrors(['form.competitors.0.wrestlers.0']);
+    });
+
     it('validates referees exist and are bookable', function () {
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
@@ -291,6 +308,23 @@ describe('FormModal Create Operations', function () {
             ->call('save');
 
         $component->assertHasErrors(['form.referees.0']);
+    });
+
+    it('rejects an unavailable referee', function () {
+        $firstWrestler = Wrestler::factory()->bookable()->create();
+        $secondWrestler = Wrestler::factory()->bookable()->create();
+        $unavailableReferee = Referee::factory()->suspended()->create();
+
+        livewire(FormModal::class, ['eventId' => $this->event->id])
+            ->call('openModal')
+            ->set('form.matchType', MatchType::Singles)
+            ->set('form.competitors', [
+                0 => ['wrestlers' => [$firstWrestler->id]],
+                1 => ['wrestlers' => [$secondWrestler->id]],
+            ])
+            ->set('form.referees', [$unavailableReferee->id])
+            ->call('save')
+            ->assertHasErrors(['form.referees.0']);
     });
 
     it('persists each battle royal entrant on an individual side', function () {


### PR DESCRIPTION
## Summary
- apply the existing wrestler and tag team booking rules to every match competitor shape
- require selected referees to satisfy the shared roster booking policy
- cover unavailable competitors and referees at the Livewire form boundary

## Verification
- php artisan test --compact tests/Integration/Livewire/Matches/Modals/FormModalTest.php
- composer lint
- composer test:types
- composer test:types:pest
- composer test:push through all non-browser stages (3,401 tests, 10,951 assertions); local browser stage was stopped after producing no output and GitHub CI will run it independently