### PR TITLE
fix: enforce stable establishment size

### DIFF
--- a/app/Actions/Stables/UpdateAction.php
+++ b/app/Actions/Stables/UpdateAction.php
@@ -53,6 +53,8 @@ class UpdateAction
                 'name' => $stableData->getTrimmedName(),
             ]);
 
+            $this->membershipService->updateMembership($lockedStable, $stableData->members, now());
+
             if ($stableData->hasStartDate()) {
                 $activityPeriod = $lockedStable->firstActivityPeriod()->lockForUpdate()->first();
 
@@ -69,9 +71,6 @@ class UpdateAction
                     );
                 }
             }
-
-            // Update stable membership using service
-            $this->membershipService->updateMembership($lockedStable, $stableData->members, now());
 
             return $lockedStable;
         });

--- a/app/Exceptions/Roster/Stables/CannotBeEstablishedException.php
+++ b/app/Exceptions/Roster/Stables/CannotBeEstablishedException.php
@@ -29,4 +29,11 @@ final class CannotBeEstablishedException extends BaseBusinessException
 
         return new static("{$context} is retired and cannot be established.");
     }
+
+    public static function insufficientMembers(Stable $stable, int $currentMembers, int $minimumMembers): static
+    {
+        $context = self::formatModelContext($stable);
+
+        return new static("{$context} has {$currentMembers} members but requires at least {$minimumMembers} members to be established.");
+    }
 }

--- a/app/Lifecycle/StableActivityEligibility.php
+++ b/app/Lifecycle/StableActivityEligibility.php
@@ -13,10 +13,14 @@ use App\Exceptions\Roster\Stables\CannotBeReunitedException;
 use App\Models\Roster\Stables\Stable;
 use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
+use App\Services\StableMembershipService;
 
 final class StableActivityEligibility
 {
-    public function __construct(private readonly StableFormerMemberEligibility $formerMemberEligibility) {}
+    public function __construct(
+        private readonly StableFormerMemberEligibility $formerMemberEligibility,
+        private readonly StableMembershipService $membershipService,
+    ) {}
 
     public function allows(Stable $stable, StableActivityTransition $transition): bool
     {
@@ -50,6 +54,16 @@ final class StableActivityEligibility
 
         if ($stable->isRetired()) {
             throw CannotBeEstablishedException::retired($stable);
+        }
+
+        $members = $this->membershipService->currentMembers($stable);
+
+        if (! $members->hasMinimumMembers()) {
+            throw CannotBeEstablishedException::insufficientMembers(
+                $stable,
+                $members->getTotalMemberCount(),
+                StableMembershipData::MINIMUM_MEMBER_COUNT,
+            );
         }
     }
 

--- a/app/Livewire/Stables/Forms/CreateEditForm.php
+++ b/app/Livewire/Stables/Forms/CreateEditForm.php
@@ -12,6 +12,7 @@ use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
 use App\Rules\Shared\CanChangeDebutDate;
 use App\Rules\Stables\CanJoinStable;
+use App\Rules\Stables\HasMinimumMembers;
 use App\Rules\Wrestlers\IsNotInjured;
 use App\Rules\Wrestlers\NotRepresentedBySelectedTagTeam;
 use Illuminate\Support\Carbon;
@@ -186,7 +187,15 @@ class CreateEditForm extends BaseForm
                 'max:255',
                 Rule::unique('stables', 'name')->ignore($this->modelId)->withoutTrashed(),
             ],
-            'started_at' => ['nullable', 'date', new CanChangeDebutDate($this->formModel)],
+            'started_at' => [
+                'nullable',
+                'date',
+                new CanChangeDebutDate($this->formModel),
+                new HasMinimumMembers(
+                    Wrestler::query()->whereKey($this->wrestlers)->get(),
+                    TagTeam::query()->whereKey($this->tag_teams)->get(),
+                ),
+            ],
             'ended_at' => ['nullable', 'date'],
             'wrestlers' => ['nullable', 'array'],
             'wrestlers.*' => [

--- a/tests/Integration/Actions/Stables/LifecycleTest.php
+++ b/tests/Integration/Actions/Stables/LifecycleTest.php
@@ -32,7 +32,7 @@ use Illuminate\Support\Carbon;
  */
 describe('Stable Activation Action Integration', function () {
     beforeEach(function () {
-        $this->stable = Stable::factory()->create();
+        $this->stable = Stable::factory()->withEmployedDefaultMembers()->create();
     });
 
     describe('debut action workflow', function () {
@@ -71,6 +71,18 @@ describe('Stable Activation Action Integration', function () {
                 ->toThrow(InvalidDateRangeException::class);
 
             expect($this->stable->activityPeriods()->doesntExist())->toBeTrue();
+        });
+
+        test('debut action requires the minimum member headcount', function () {
+            $stable = Stable::factory()->withNoMembers()->create();
+
+            expect(fn () => resolve(EstablishAction::class)->handle($stable))
+                ->toThrow(
+                    CannotBeEstablishedException::class,
+                    CannotBeEstablishedException::insufficientMembers($stable, 0, 3)->getMessage(),
+                );
+
+            expect($stable->activityPeriods()->doesntExist())->toBeTrue();
         });
 
         test('establishment records its lifecycle transition', function () {

--- a/tests/Integration/Lifecycle/StableActivityEligibilityTest.php
+++ b/tests/Integration/Lifecycle/StableActivityEligibilityTest.php
@@ -27,7 +27,8 @@ test('establishment predicate stays aligned with its guard', function (string $f
 
     expect(fn () => $eligibility->ensureAllowed($stable, StableActivityTransition::Establish))->toThrow(CannotBeEstablishedException::class);
 })->with([
-    'unformed' => ['default', true],
+    'unformed with enough members' => ['withEmployedDefaultMembers', true],
+    'unformed without enough members' => ['default', false],
     'active' => ['active', false],
     'disbanded' => ['disbanded', false],
     'retired' => ['retired', false],

--- a/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Stables/Modals/FormModalTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Livewire\Stables\Forms\CreateEditForm;
 use App\Livewire\Stables\Modals\FormModal;
+use App\Models\Lifecycle\Employment;
 use App\Models\Roster\Managers\Manager;
 use App\Models\Roster\Stables\Stable;
 use App\Models\Roster\TagTeams\TagTeam;
@@ -16,6 +17,10 @@ use function Pest\Livewire\livewire;
 beforeEach(function () {
     $this->admin = User::factory()->administrator()->create();
     $this->actingAs($this->admin);
+    $this->minimumWrestlers = Wrestler::factory()
+        ->count(3)
+        ->has(Employment::factory()->started(Carbon::parse('2020-01-01')), 'employments')
+        ->create();
 });
 
 describe('FormModal Configuration', function () {
@@ -102,6 +107,7 @@ describe('FormModal Create Operations', function () {
             ->call('openModal')
             ->set('form.name', 'The New World Order')
             ->set('form.started_at', '2024-01-01')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -135,6 +141,7 @@ describe('FormModal Create Operations', function () {
             ->call('openModal')
             ->set('form.name', 'Existing Stable')
             ->set('form.started_at', '2024-01-01')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasErrors(['form.name']);
@@ -148,6 +155,7 @@ describe('FormModal Create Operations', function () {
             ->call('openModal')
             ->set('form.name', 'Existing Stable')
             ->set('form.started_at', '2024-01-01')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -162,6 +170,20 @@ describe('FormModal Create Operations', function () {
             ->call('save');
 
         $component->assertHasErrors(['form.started_at']);
+    });
+
+    it('requires the minimum member headcount when establishing a stable', function () {
+        $wrestler = Wrestler::factory()->bookable()->create();
+
+        livewire(FormModal::class)
+            ->call('openModal')
+            ->set('form.name', 'Undersized Stable')
+            ->set('form.started_at', now()->toDateString())
+            ->set('form.wrestlers', [$wrestler->id])
+            ->call('save')
+            ->assertHasErrors(['form.started_at']);
+
+        $this->assertDatabaseMissing('stables', ['name' => 'Undersized Stable']);
     });
 
     it('validates ended_at is after started_at', function () {
@@ -181,6 +203,7 @@ describe('FormModal Create Operations', function () {
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
             ->set('form.ended_at', '2024-12-31')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -206,6 +229,7 @@ describe('FormModal Create Operations', function () {
             ->set('form.name', 'Future Stable')
             ->set('form.started_at', $startDate->toDateString())
             ->set('form.ended_at', $endDate->toDateString())
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -229,6 +253,7 @@ describe('FormModal Edit Operations', function () {
             ->call('openModal', $stable->id)
             ->set('form.name', 'Updated Stable')
             ->set('form.started_at', '2024-01-02')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -252,6 +277,7 @@ describe('FormModal Edit Operations', function () {
             ->call('openModal', $stable->id)
             ->set('form.started_at', $startDate->toDateString())
             ->set('form.ended_at', $endDate->toDateString())
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -297,6 +323,7 @@ describe('FormModal Edit Operations', function () {
             ->call('openModal', $stable->id)
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-02')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -308,7 +335,12 @@ describe('FormModal Edit Operations', function () {
         // Create some wrestlers and associate them with the stable
         $wrestler1 = Wrestler::factory()->create();
         $wrestler2 = Wrestler::factory()->create();
-        $stable->wrestlers()->attach([$wrestler1->id => ['joined_at' => now()], $wrestler2->id => ['joined_at' => now()]]);
+        $wrestler3 = Wrestler::factory()->create();
+        $stable->wrestlers()->attach([
+            $wrestler1->id => ['joined_at' => now()],
+            $wrestler2->id => ['joined_at' => now()],
+            $wrestler3->id => ['joined_at' => now()],
+        ]);
 
         $component = livewire(FormModal::class)
             ->call('openModal', $stable->id)
@@ -326,6 +358,7 @@ describe('FormModal Activity Period Management', function () {
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -340,6 +373,7 @@ describe('FormModal Activity Period Management', function () {
             ->set('form.name', 'Disbanded Stable')
             ->set('form.started_at', '2024-01-01')
             ->set('form.ended_at', '2024-06-01')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -364,12 +398,13 @@ describe('FormModal Member Management', function () {
     it('can assign wrestlers to stable', function () {
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
+        $wrestler3 = Wrestler::factory()->bookable()->create();
 
         $component = livewire(FormModal::class)
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', now()->toDateString())
-            ->set('form.wrestlers', [$wrestler1->id, $wrestler2->id])
+            ->set('form.wrestlers', [$wrestler1->id, $wrestler2->id, $wrestler3->id])
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -378,6 +413,7 @@ describe('FormModal Member Management', function () {
         $stable->refresh();
         expect($stable->wrestlers->pluck('id'))->toContain($wrestler1->id);
         expect($stable->wrestlers->pluck('id'))->toContain($wrestler2->id);
+        expect($stable->wrestlers->pluck('id'))->toContain($wrestler3->id);
     });
 
     it('can assign tag teams to stable', function () {
@@ -517,6 +553,7 @@ describe('FormModal Member Management', function () {
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->set('form.tag_teams', [999])
             ->call('save');
 
@@ -542,6 +579,7 @@ describe('FormModal State Management', function () {
             ->call('openModal')
             ->set('form.name', 'Test Stable')
             ->set('form.started_at', '2024-01-01')
+            ->set('form.wrestlers', $this->minimumWrestlers->modelKeys())
             ->call('save');
 
         $component->assertDispatched('closeModal');

--- a/tests/Integration/Livewire/Stables/Tables/MainTest.php
+++ b/tests/Integration/Livewire/Stables/Tables/MainTest.php
@@ -212,7 +212,7 @@ describe('StablesTable Component', function () {
         });
 
         test('establish action integration works correctly', function () {
-            $unformedStable = Stable::factory()->unactivated()->create(['name' => 'Unformed Stable']);
+            $unformedStable = Stable::factory()->withEmployedDefaultMembers()->unactivated()->create(['name' => 'Unformed Stable']);
 
             actingAs($this->admin);
 
@@ -227,7 +227,7 @@ describe('StablesTable Component', function () {
         });
 
         test('lifecycle actions ignore an external referrer when redirecting', function () {
-            $unformedStable = Stable::factory()->unactivated()->create(['name' => 'Unformed Stable']);
+            $unformedStable = Stable::factory()->withEmployedDefaultMembers()->unactivated()->create(['name' => 'Unformed Stable']);
 
             actingAs($this->admin);
 


### PR DESCRIPTION
## Summary
- enforce the documented three-person weighted headcount before a stable can be established
- validate selected members at the Livewire form boundary for immediate feedback
- synchronize submitted members before establishment during transactional updates
- align lifecycle and Livewire fixtures with realistic eligible stable membership

## Verification
- composer lint
- php artisan test --compact tests/Integration/Actions/Stables tests/Integration/Livewire/Stables
- php artisan test --compact tests/Integration/Lifecycle/StableActivityEligibilityTest.php
- composer test:types
- composer test:types:pest
- composer test:application (3,402 tests, 10,956 assertions)