### PR TITLE
fix: validate title match competitor types

### DIFF
--- a/app/Actions/Matches/AddTitlesToMatchAction.php
+++ b/app/Actions/Matches/AddTitlesToMatchAction.php
@@ -60,12 +60,30 @@ class AddTitlesToMatchAction
 
         DB::transaction(function () use ($eventMatch, $requestedTitles): void {
             $this->conflictService->ensureTitlesCanBeAssigned($eventMatch, $requestedTitles);
+            $this->ensureTitleTypesMatchCompetitors($eventMatch, $requestedTitles);
             $this->ensureCurrentChampionsCompete($eventMatch, $requestedTitles);
 
             $requestedTitles->each(function (Title $title) use ($eventMatch): void {
                 $eventMatch->titles()->attach($title->id);
             });
         });
+    }
+
+    /** @param Collection<int, Title> $titles */
+    private function ensureTitleTypesMatchCompetitors(EventMatch $eventMatch, Collection $titles): void
+    {
+        $assignedCompetitorTypes = $eventMatch->competitors()
+            ->pluck('competitor_type')
+            ->unique();
+
+        foreach ($titles as $title) {
+            if ($assignedCompetitorTypes->count() === 1
+                && $assignedCompetitorTypes->contains($title->type->championMorphClass())) {
+                continue;
+            }
+
+            throw InvalidMatchConfigurationException::titleCompetitorTypeMismatch($title);
+        }
     }
 
     /** @param Collection<int, Title> $titles */

--- a/app/Actions/Matches/ApplyMatchTitleOutcomesAction.php
+++ b/app/Actions/Matches/ApplyMatchTitleOutcomesAction.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Actions\Matches;
 
 use App\Data\Matches\MatchResultData;
-use App\Enums\Titles\TitleType;
 use App\Exceptions\Matches\InvalidMatchOutcomeException;
 use App\Lifecycle\ChampionshipReignManager;
 use App\Models\Matches\EventMatch;
@@ -91,10 +90,7 @@ class ApplyMatchTitleOutcomesAction
     {
         $eligibleCompetitors = $winningCompetitors
             ->map(fn (MatchCompetitor $competitor): Wrestler|TagTeam => $competitor->competitor)
-            ->filter(fn (Wrestler|TagTeam $competitor): bool => match ($title->type) {
-                TitleType::Singles => $competitor instanceof Wrestler,
-                TitleType::TagTeam => $competitor instanceof TagTeam,
-            })
+            ->filter(fn (Wrestler|TagTeam $competitor): bool => $competitor instanceof ($title->type->championModelClass()))
             ->values();
 
         if ($eligibleCompetitors->count() !== 1) {

--- a/app/Enums/Titles/TitleType.php
+++ b/app/Enums/Titles/TitleType.php
@@ -4,8 +4,26 @@ declare(strict_types=1);
 
 namespace App\Enums\Titles;
 
+use App\Models\Roster\TagTeams\TagTeam;
+use App\Models\Roster\Wrestlers\Wrestler;
+use Illuminate\Database\Eloquent\Relations\Relation;
+
 enum TitleType: string
 {
     case Singles = 'singles';
     case TagTeam = 'tag-team';
+
+    /** @return class-string<Wrestler|TagTeam> */
+    public function championModelClass(): string
+    {
+        return match ($this) {
+            self::Singles => Wrestler::class,
+            self::TagTeam => TagTeam::class,
+        };
+    }
+
+    public function championMorphClass(): int|string
+    {
+        return Relation::getMorphAlias($this->championModelClass());
+    }
 }

--- a/app/Exceptions/Matches/InvalidMatchConfigurationException.php
+++ b/app/Exceptions/Matches/InvalidMatchConfigurationException.php
@@ -42,4 +42,9 @@ final class InvalidMatchConfigurationException extends BaseBusinessException
             "The current champion of [{$title->name}] must compete in the title match.",
         );
     }
+
+    public static function titleCompetitorTypeMismatch(Title $title): static
+    {
+        return new self("The [{$title->name}] cannot be contested by this match's competitor type.");
+    }
 }

--- a/app/Livewire/Matches/Forms/CreateEditForm.php
+++ b/app/Livewire/Matches/Forms/CreateEditForm.php
@@ -21,6 +21,7 @@ use App\Rules\Matches\CorrectNumberOfSides;
 use App\Rules\Referees\IsBookable as RefereeIsBookable;
 use App\Rules\Titles\CurrentChampionIsCompeting;
 use App\Rules\Titles\IsActive;
+use App\Rules\Titles\MatchesCompetitorType;
 use Illuminate\Validation\Rule;
 use Illuminate\Validation\Rules\Enum;
 use LogicException;
@@ -153,6 +154,7 @@ class CreateEditForm extends BaseForm
                 'integer',
                 'exists:titles,id',
                 new IsActive(),
+                new MatchesCompetitorType(),
                 new CurrentChampionIsCompeting(),
             ],
         ];

--- a/app/Rules/Titles/MatchesCompetitorType.php
+++ b/app/Rules/Titles/MatchesCompetitorType.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Rules\Titles;
+
+use App\Enums\Titles\TitleType;
+use App\Models\Titles\Title;
+use Closure;
+use Illuminate\Contracts\Validation\DataAwareRule;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+class MatchesCompetitorType implements DataAwareRule, ValidationRule
+{
+    /** @var array<string, mixed> */
+    private array $data = [];
+
+    /** @param array<string, mixed> $data */
+    public function setData(array $data): self
+    {
+        $this->data = $data;
+
+        return $this;
+    }
+
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if (! is_int($value) && (! is_string($value) || ! ctype_digit($value))) {
+            $fail('The selected title is invalid.');
+
+            return;
+        }
+
+        $title = Title::query()->find((int) $value);
+
+        if (! $title instanceof Title) {
+            $fail('The selected title is invalid.');
+
+            return;
+        }
+
+        $expectedCompetitorKey = match ($title->type) {
+            TitleType::Singles => 'wrestlers',
+            TitleType::TagTeam => 'tag_teams',
+        };
+        $unexpectedCompetitorKey = match ($title->type) {
+            TitleType::Singles => 'tag_teams',
+            TitleType::TagTeam => 'wrestlers',
+        };
+
+        if ($this->hasCompetitors($expectedCompetitorKey) && ! $this->hasCompetitors($unexpectedCompetitorKey)) {
+            return;
+        }
+
+        $expectedCompetitor = match ($title->type) {
+            TitleType::Singles => 'wrestlers',
+            TitleType::TagTeam => 'tag teams',
+        };
+
+        $fail("The {$title->name} may only be contested by {$expectedCompetitor}.");
+    }
+
+    private function hasCompetitors(string $competitorKey): bool
+    {
+        $competitorSides = $this->data['competitors'] ?? null;
+
+        if (! is_array($competitorSides)) {
+            return false;
+        }
+
+        foreach ($competitorSides as $competitorSide) {
+            if (! is_array($competitorSide)) {
+                continue;
+            }
+
+            $competitors = $competitorSide[$competitorKey] ?? null;
+
+            if (is_array($competitors) && $competitors !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/tests/Feature/Architecture/ApplicationArchitectureTest.php
+++ b/tests/Feature/Architecture/ApplicationArchitectureTest.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use Illuminate\Contracts\Validation\ValidationRule;
+
 arch()->preset()->php();
 arch()->preset()->security();
 
@@ -36,3 +38,7 @@ arch('actions use the action suffix')
 arch('services use the service suffix')
     ->expect('App\\Services')
     ->toHaveSuffix('Service');
+
+arch('custom validation rules implement Laravel validation rules')
+    ->expect('App\\Rules')
+    ->toImplement(ValidationRule::class);

--- a/tests/Integration/Actions/Matches/AddMatchForEventActionTest.php
+++ b/tests/Integration/Actions/Matches/AddMatchForEventActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\Matches\AddMatchForEventAction;
 use App\Data\Matches\EventMatchData;
 use App\Enums\MatchType;
+use App\Enums\Titles\TitleType;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Events\Event;
@@ -50,7 +51,7 @@ test('it rejects a match without referees', function () {
 test('it creates a complete side-based match', function () {
     $event = Event::factory()->create();
     $referee = Referee::factory()->bookable()->create();
-    $title = Title::factory()->active()->create();
+    $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
     $firstWrestler = Wrestler::factory()->bookable()->create();
     $secondWrestler = Wrestler::factory()->bookable()->create();
     $matchData = new EventMatchData(
@@ -128,7 +129,7 @@ test('it creates a title match when the current champion is a competitor', funct
     $referee = Referee::factory()->bookable()->create();
     $champion = Wrestler::factory()->bookable()->create();
     $challenger = Wrestler::factory()->bookable()->create();
-    $title = Title::factory()->active()->create();
+    $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
     TitleChampionship::factory()->for($title)->forWrestler($champion)->current()->create();
     $matchData = new EventMatchData(
         MatchType::Singles,
@@ -152,7 +153,7 @@ test('it rolls back a title match when the current champion is absent', function
     $champion = Wrestler::factory()->bookable()->create();
     $firstChallenger = Wrestler::factory()->bookable()->create();
     $secondChallenger = Wrestler::factory()->bookable()->create();
-    $title = Title::factory()->active()->create();
+    $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
     TitleChampionship::factory()->for($title)->forWrestler($champion)->current()->create();
     $matchData = new EventMatchData(
         MatchType::Singles,

--- a/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
@@ -22,9 +22,16 @@ beforeEach(function () {
     testTime()->freeze();
 });
 
+function createSinglesMatchWithCompetitors(): EventMatch
+{
+    return EventMatch::factory()
+        ->withCompetitors(Wrestler::factory()->bookable()->count(2)->create()->all())
+        ->create();
+}
+
 test('it adds a single title to a match', function () {
-    $match = EventMatch::factory()->create();
-    $title = Title::factory()->active()->create();
+    $match = createSinglesMatchWithCompetitors();
+    $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
 
     $titles = collect([$title]);
 
@@ -42,9 +49,15 @@ test('it adds a single title to a match', function () {
 });
 
 test('it adds multiple titles to a match', function () {
-    $match = EventMatch::factory()->create();
-    $title1 = Title::factory()->active()->create(['name' => 'WWE Championship']);
-    $title2 = Title::factory()->active()->create(['name' => 'Universal Championship']);
+    $match = createSinglesMatchWithCompetitors();
+    $title1 = Title::factory()->active()->create([
+        'name' => 'WWE Championship',
+        'type' => TitleType::Singles,
+    ]);
+    $title2 = Title::factory()->active()->create([
+        'name' => 'Universal Championship',
+        'type' => TitleType::Singles,
+    ]);
 
     $titles = collect([$title1, $title2]);
 
@@ -98,12 +111,14 @@ test('it handles empty collection', function () {
 });
 
 test('it creates championship match correctly', function () {
-    $match = EventMatch::factory()->create();
+    $match = createSinglesMatchWithCompetitors();
     $wweChampionship = Title::factory()->active()->create([
         'name' => 'WWE Championship',
+        'type' => TitleType::Singles,
     ]);
     $intercontinentalTitle = Title::factory()->active()->create([
         'name' => 'Intercontinental Championship',
+        'type' => TitleType::Singles,
     ]);
 
     $titles = collect([$wweChampionship, $intercontinentalTitle]);
@@ -120,9 +135,9 @@ test('it creates championship match correctly', function () {
 });
 
 test('it handles transaction consistency', function () {
-    $match = EventMatch::factory()->create();
-    $title1 = Title::factory()->active()->create();
-    $title2 = Title::factory()->active()->create();
+    $match = createSinglesMatchWithCompetitors();
+    $title1 = Title::factory()->active()->create(['type' => TitleType::Singles]);
+    $title2 = Title::factory()->active()->create(['type' => TitleType::Singles]);
 
     $titles = collect([$title1, $title2]);
 
@@ -150,8 +165,8 @@ test('it rejects a title already assigned on the event card', function () {
 });
 
 test('it assigns a repeated title only once', function () {
-    $match = EventMatch::factory()->create();
-    $title = Title::factory()->active()->create();
+    $match = createSinglesMatchWithCompetitors();
+    $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
 
     resolve(AddTitlesToMatchAction::class)->handle($match, collect([$title, $title]));
 
@@ -209,4 +224,42 @@ test('it accepts a title match containing the current tag team champion', functi
     resolve(AddTitlesToMatchAction::class)->handle($match, collect([$title]));
 
     expect($match->titles()->whereKey($title)->exists())->toBeTrue();
+});
+
+test('it rejects a singles title assigned to tag team competitors', function () {
+    $match = EventMatch::factory()->create();
+    $side = MatchSide::factory()->for($match, 'match')->create();
+    $tagTeam = TagTeam::factory()->bookable()->create();
+    $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
+    MatchCompetitor::factory()->for($match, 'eventMatch')->for($side, 'side')->create([
+        'competitor_type' => $tagTeam->getMorphClass(),
+        'competitor_id' => $tagTeam->id,
+    ]);
+
+    expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($match, collect([$title])))
+        ->toThrow(
+            InvalidMatchConfigurationException::class,
+            "The [{$title->name}] cannot be contested by this match's competitor type.",
+        );
+
+    expect($match->titles()->exists())->toBeFalse();
+});
+
+test('it rejects a tag team title assigned to wrestler competitors', function () {
+    $match = EventMatch::factory()->create();
+    $side = MatchSide::factory()->for($match, 'match')->create();
+    $wrestler = Wrestler::factory()->bookable()->create();
+    $title = Title::factory()->active()->create(['type' => TitleType::TagTeam]);
+    MatchCompetitor::factory()->for($match, 'eventMatch')->for($side, 'side')->create([
+        'competitor_type' => $wrestler->getMorphClass(),
+        'competitor_id' => $wrestler->id,
+    ]);
+
+    expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($match, collect([$title])))
+        ->toThrow(
+            InvalidMatchConfigurationException::class,
+            "The [{$title->name}] cannot be contested by this match's competitor type.",
+        );
+
+    expect($match->titles()->exists())->toBeFalse();
 });

--- a/tests/Integration/Actions/Matches/UpdateMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/UpdateMatchActionTest.php
@@ -6,6 +6,7 @@ use App\Actions\Matches\UpdateMatchAction;
 use App\Data\Matches\EventMatchData;
 use App\Enums\MatchFinish;
 use App\Enums\MatchType;
+use App\Enums\Titles\TitleType;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
 use App\Models\Matches\EventMatch;
@@ -22,7 +23,7 @@ test('it atomically replaces a match configuration', function () {
         'preview' => 'Original preview',
     ]);
     $originalReferee = Referee::factory()->bookable()->create();
-    $originalTitle = Title::factory()->active()->create();
+    $originalTitle = Title::factory()->active()->create(['type' => TitleType::Singles]);
     $originalWrestler = Wrestler::factory()->bookable()->create();
     $originalSide = MatchSide::factory()->for($match, 'match')->create(['position' => 1]);
     MatchCompetitor::factory()->for($match, 'eventMatch')->for($originalSide, 'side')->create([
@@ -33,7 +34,7 @@ test('it atomically replaces a match configuration', function () {
     $match->titles()->attach($originalTitle);
 
     $newReferee = Referee::factory()->bookable()->create();
-    $newTitle = Title::factory()->active()->create();
+    $newTitle = Title::factory()->active()->create(['type' => TitleType::Singles]);
     $firstWrestler = Wrestler::factory()->bookable()->create();
     $secondWrestler = Wrestler::factory()->bookable()->create();
     $data = new EventMatchData(
@@ -99,7 +100,7 @@ test('it rolls back the original configuration when the current champion is not 
     $match = EventMatch::factory()->create(['preview' => 'Original preview']);
     $originalReferee = Referee::factory()->bookable()->create();
     $originalWrestler = Wrestler::factory()->bookable()->create();
-    $originalTitle = Title::factory()->active()->create();
+    $originalTitle = Title::factory()->active()->create(['type' => TitleType::Singles]);
     $originalSide = MatchSide::factory()->for($match, 'match')->create(['position' => 1]);
     MatchCompetitor::factory()->for($match, 'eventMatch')->for($originalSide, 'side')->create([
         'competitor_id' => $originalWrestler->id,
@@ -109,7 +110,7 @@ test('it rolls back the original configuration when the current champion is not 
     $match->titles()->attach($originalTitle);
 
     $newReferee = Referee::factory()->bookable()->create();
-    $title = Title::factory()->active()->create();
+    $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
     $champion = Wrestler::factory()->bookable()->create();
     $firstChallenger = Wrestler::factory()->bookable()->create();
     $secondChallenger = Wrestler::factory()->bookable()->create();

--- a/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Matches/Modals/FormModalTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Enums\MatchType;
+use App\Enums\Titles\TitleType;
 use App\Livewire\Matches\Forms\CreateEditForm;
 use App\Livewire\Matches\Modals\FormModal;
 use App\Models\Events\Event;
@@ -512,7 +513,7 @@ describe('FormModal Edit Operations', function () {
 
 describe('FormModal Title Championship Integration', function () {
     it('can create championship match with title stakes', function () {
-        $title = Title::factory()->active()->create();
+        $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
         $wrestler1 = Wrestler::factory()->bookable()->create();
         $wrestler2 = Wrestler::factory()->bookable()->create();
         $referee = Referee::factory()->bookable()->create();

--- a/tests/Unit/Rules/Titles/MatchesCompetitorTypeTest.php
+++ b/tests/Unit/Rules/Titles/MatchesCompetitorTypeTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\Titles\TitleType;
+use App\Models\Roster\TagTeams\TagTeam;
+use App\Models\Roster\Wrestlers\Wrestler;
+use App\Models\Titles\Title;
+use App\Rules\Titles\MatchesCompetitorType;
+use Illuminate\Support\Facades\Validator;
+
+test('it accepts a singles title contested only by wrestlers', function () {
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $wrestler = Wrestler::factory()->create();
+
+    $validator = Validator::make([
+        'competitors' => [['wrestlers' => [$wrestler->id], 'tag_teams' => []]],
+        'titles' => [$title->id],
+    ], [
+        'titles.*' => [new MatchesCompetitorType()],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+test('it accepts a tag team title contested only by tag teams', function () {
+    $title = Title::factory()->create(['type' => TitleType::TagTeam]);
+    $tagTeam = TagTeam::factory()->create();
+
+    $validator = Validator::make([
+        'competitors' => [['wrestlers' => [], 'tag_teams' => [$tagTeam->id]]],
+        'titles' => [$title->id],
+    ], [
+        'titles.*' => [new MatchesCompetitorType()],
+    ]);
+
+    expect($validator->passes())->toBeTrue();
+});
+
+test('it rejects a singles title contested by tag teams', function () {
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $tagTeam = TagTeam::factory()->create();
+
+    $validator = Validator::make([
+        'competitors' => [['wrestlers' => [], 'tag_teams' => [$tagTeam->id]]],
+        'titles' => [$title->id],
+    ], [
+        'titles.*' => [new MatchesCompetitorType()],
+    ]);
+
+    expect($validator->errors()->first('titles.0'))
+        ->toBe("The {$title->name} may only be contested by wrestlers.");
+});
+
+test('it rejects a tag team title contested by wrestlers', function () {
+    $title = Title::factory()->create(['type' => TitleType::TagTeam]);
+    $wrestler = Wrestler::factory()->create();
+
+    $validator = Validator::make([
+        'competitors' => [['wrestlers' => [$wrestler->id], 'tag_teams' => []]],
+        'titles' => [$title->id],
+    ], [
+        'titles.*' => [new MatchesCompetitorType()],
+    ]);
+
+    expect($validator->errors()->first('titles.0'))
+        ->toBe("The {$title->name} may only be contested by tag teams.");
+});
+
+test('it rejects mixed competitor types for one title', function () {
+    $title = Title::factory()->create(['type' => TitleType::Singles]);
+    $wrestler = Wrestler::factory()->create();
+    $tagTeam = TagTeam::factory()->create();
+
+    $validator = Validator::make([
+        'competitors' => [[
+            'wrestlers' => [$wrestler->id],
+            'tag_teams' => [$tagTeam->id],
+        ]],
+        'titles' => [$title->id],
+    ], [
+        'titles.*' => [new MatchesCompetitorType()],
+    ]);
+
+    expect($validator->errors()->has('titles.0'))->toBeTrue();
+});
+
+test('it safely rejects a missing title', function () {
+    $validator = Validator::make([
+        'competitors' => [['wrestlers' => [1], 'tag_teams' => []]],
+        'titles' => [PHP_INT_MAX],
+    ], [
+        'titles.*' => [new MatchesCompetitorType()],
+    ]);
+
+    expect($validator->errors()->first('titles.0'))->toBe('The selected title is invalid.');
+});


### PR DESCRIPTION
## Summary
- reject title matches whose competitor type does not match the title type
- enforce the invariant in both Livewire validation and the authoritative match action
- centralize champion model and morph mappings on TitleType
- add validation-rule architecture and regression coverage

## Verification
- 270 focused tests passed (605 assertions)
- application and Pest PHPStan passed
- Rector and Pint with Blade passed
- full application suite passed: 3,438 tests / 10,983 assertions
- local browser runner could not complete: sandbox port binding is prohibited, and the unrestricted runner was stopped after 90 seconds without output; CI will provide the browser result