### PR TITLE
refactor: enforce match competitor composition

### DIFF
--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -21,6 +21,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/{Livewire,Actions,Lifecycle}/Matches/** | .ai/rules/livewire-actions-lifecycle-matches.md |
 | app/{Livewire,Actions}/Matches/** | .ai/rules/livewire-actions-matches.md |
 | app/Livewire/** | .ai/rules/livewire.md |
+| app/{Enums/MatchType.php,Livewire/Matches/**,Actions/Matches/**,Lifecycle/MatchCompetitorRequirements.php} | .ai/rules/matches-matches.md |
 | app/Exceptions/{Matches,Scheduling}/** | .ai/rules/matches-scheduling.md |
 | app/{Actions/Matches,Services}/** | .ai/rules/matches-services.md |
 | app/{Actions,Models}/Matches/** | .ai/rules/matches.md |

--- a/.ai/rules/matches-matches.md
+++ b/.ai/rules/matches-matches.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Enums/MatchType.php,Livewire/Matches/**,Actions/Matches/**,Lifecycle/MatchCompetitorRequirements.php}'
+---
+
+# Matches Matches
+
+## Distinguish competitor entries from represented roster members
+Enforce match formats with both concepts explicitly. A selected TagTeam is one competitor entry but represents all current wrestlers for named team and handicap side sizes; reject selecting one of those wrestlers directly in the same match. MatchCompetitorRequirements remains the authoritative persistence boundary.

--- a/app/Enums/MatchType.php
+++ b/app/Enums/MatchType.php
@@ -68,9 +68,35 @@ enum MatchType: string
     {
         return match ($this) {
             self::TagTeam, self::TornadoTagTeam, self::SixManTagTeam,
-            self::EightManTagTeam, self::TenManTagTeam => ['wrestler', 'tag_team'],
-            self::TripleThreat, self::Fatal4Way => ['wrestler', 'tag_team'],
-            default => ['wrestler'], // Singles and other types default to wrestler-only
+            self::EightManTagTeam, self::TenManTagTeam, self::TripleThreat,
+            self::Fatal4Way, self::TwoOnOneHandicap, self::ThreeOnTwoHandicap,
+            self::Gauntlet => ['wrestler', 'tag_team'],
+            default => ['wrestler'],
+        };
+    }
+
+    /** @return list<int>|null */
+    public function requiredRosterMembersPerSide(): ?array
+    {
+        return match ($this) {
+            self::TagTeam, self::TornadoTagTeam => [2, 2],
+            self::SixManTagTeam => [3, 3],
+            self::EightManTagTeam => [4, 4],
+            self::TenManTagTeam => [5, 5],
+            self::TwoOnOneHandicap => [1, 2],
+            self::ThreeOnTwoHandicap => [2, 3],
+            default => null,
+        };
+    }
+
+    /** @return list<int>|null */
+    public function requiredCompetitorEntriesPerSide(): ?array
+    {
+        return match ($this) {
+            self::Singles => [1, 1],
+            self::TripleThreat, self::Triangle => [1, 1, 1],
+            self::Fatal4Way => [1, 1, 1, 1],
+            default => null,
         };
     }
 

--- a/app/Exceptions/Matches/InvalidMatchConfigurationException.php
+++ b/app/Exceptions/Matches/InvalidMatchConfigurationException.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Exceptions\Matches;
 
 use App\Enums\BusinessRuleReason;
+use App\Enums\MatchType;
 use App\Exceptions\BaseBusinessException;
 use App\Models\Titles\Title;
 
@@ -27,6 +28,37 @@ final class InvalidMatchConfigurationException extends BaseBusinessException
     public static function duplicateCompetitors(): static
     {
         return new self('The same competitor cannot compete multiple times in a match.');
+    }
+
+    public static function duplicateCompetitorRepresentation(): static
+    {
+        return new self('A wrestler cannot compete directly and through a selected tag team in the same match.');
+    }
+
+    public static function unsupportedCompetitorType(MatchType $matchType): static
+    {
+        return new self("The [{$matchType->label()}] match does not support the selected competitor type.");
+    }
+
+    /** @param list<int> $requiredRosterMembersPerSide */
+    public static function invalidSideComposition(MatchType $matchType, array $requiredRosterMembersPerSide): static
+    {
+        $composition = implode('-on-', $requiredRosterMembersPerSide);
+
+        return new self("The [{$matchType->label()}] match requires a {$composition} roster-member composition.");
+    }
+
+    /** @param list<int> $requiredCompetitorEntriesPerSide */
+    public static function invalidCompetitorEntryComposition(MatchType $matchType, array $requiredCompetitorEntriesPerSide): static
+    {
+        $composition = implode('-on-', $requiredCompetitorEntriesPerSide);
+
+        return new self("The [{$matchType->label()}] match requires a {$composition} competitor-entry composition.");
+    }
+
+    public static function individualCompetitorSidesRequired(MatchType $matchType): static
+    {
+        return new self("Each [{$matchType->label()}] entrant must compete on an individual side.");
     }
 
     public static function invalidSideNumber(int $sideNumber): static

--- a/app/Lifecycle/MatchCompetitorRequirements.php
+++ b/app/Lifecycle/MatchCompetitorRequirements.php
@@ -44,9 +44,66 @@ final class MatchCompetitorRequirements
         $wrestlers = $competitors->filter(fn (Wrestler|TagTeam $competitor): bool => $competitor instanceof Wrestler);
         $tagTeams = $competitors->filter(fn (Wrestler|TagTeam $competitor): bool => $competitor instanceof TagTeam);
 
+        if (($wrestlers->isNotEmpty() && ! $match->match_type->allowsWrestlers())
+            || ($tagTeams->isNotEmpty() && ! $match->match_type->allowsTagTeams())) {
+            throw InvalidMatchConfigurationException::unsupportedCompetitorType($match->match_type);
+        }
+
         if ($wrestlers->count() !== $wrestlers->unique('id')->count()
             || $tagTeams->count() !== $tagTeams->unique('id')->count()) {
             throw InvalidMatchConfigurationException::duplicateCompetitors();
+        }
+
+        $actualCompetitorEntriesPerSide = $populatedSides
+            ->map(fn (array $side): int => count($side['wrestlers'] ?? []) + count($side['tag_teams'] ?? []))
+            ->sort()
+            ->values()
+            ->all();
+        $requiredCompetitorEntriesPerSide = $match->match_type->requiredCompetitorEntriesPerSide();
+
+        if ($requiredCompetitorEntriesPerSide !== null
+            && $actualCompetitorEntriesPerSide !== $requiredCompetitorEntriesPerSide) {
+            throw InvalidMatchConfigurationException::invalidCompetitorEntryComposition(
+                $match->match_type,
+                $requiredCompetitorEntriesPerSide,
+            );
+        }
+
+        if ($match->match_type->usesIndividualCompetitorSides()
+            && $actualCompetitorEntriesPerSide !== array_fill(0, $populatedSides->count(), 1)) {
+            throw InvalidMatchConfigurationException::individualCompetitorSidesRequired($match->match_type);
+        }
+
+        (new TagTeam())->newCollection($tagTeams->all())->loadMissing('currentWrestlers');
+        $representedWrestlerIds = $tagTeams
+            ->flatMap(fn (TagTeam $tagTeam): array => $tagTeam->currentWrestlers->modelKeys());
+
+        if ($wrestlers->pluck('id')->intersect($representedWrestlerIds)->isNotEmpty()) {
+            throw InvalidMatchConfigurationException::duplicateCompetitorRepresentation();
+        }
+
+        $requiredRosterMembersPerSide = $match->match_type->requiredRosterMembersPerSide();
+
+        if ($requiredRosterMembersPerSide === null) {
+            return;
+        }
+
+        $actualRosterMembersPerSide = $populatedSides
+            ->map(function (array $side): int {
+                $tagTeamMembers = collect($side['tag_teams'] ?? [])
+                    ->sum(fn (TagTeam $tagTeam): int => $tagTeam->currentWrestlers->count());
+
+                return count($side['wrestlers'] ?? []) + $tagTeamMembers;
+            })
+            ->sort()
+            ->values()
+            ->all();
+
+        if ($actualRosterMembersPerSide !== $requiredRosterMembersPerSide) {
+            throw InvalidMatchConfigurationException::invalidSideComposition(
+                $match->match_type,
+                $requiredRosterMembersPerSide,
+            );
         }
     }
 

--- a/app/Livewire/Matches/Support/MatchCompetitorRuleSet.php
+++ b/app/Livewire/Matches/Support/MatchCompetitorRuleSet.php
@@ -25,9 +25,9 @@ final readonly class MatchCompetitorRuleSet
 
         return match ($this->matchType) {
             MatchType::Singles => $this->individualSideRules(2),
-            MatchType::TripleThreat,
             MatchType::Triangle => $this->individualSideRules(3),
-            MatchType::Fatal4Way => $this->individualSideRules(4),
+            MatchType::TripleThreat => $this->mixedSingleCompetitorSideRules(3),
+            MatchType::Fatal4Way => $this->mixedSingleCompetitorSideRules(4),
             MatchType::TagTeam,
             MatchType::SixManTagTeam,
             MatchType::EightManTagTeam,
@@ -80,6 +80,28 @@ final readonly class MatchCompetitorRuleSet
             $rules["competitors.{$sideIndex}.wrestlers.*"] = ['bail', 'integer', 'exists:wrestlers,id', new WrestlerIsBookable()];
             $rules["competitors.{$sideIndex}.tag_teams"] = ['sometimes', 'array', 'min:1'];
             $rules["competitors.{$sideIndex}.tag_teams.*"] = ['bail', 'integer', 'exists:tag_teams,id', new TagTeamIsBookable()];
+        }
+
+        return $rules;
+    }
+
+    /** @return array<string, array<int, mixed>> */
+    private function mixedSingleCompetitorSideRules(int $sideCount): array
+    {
+        $rules = [
+            'competitors' => ['required', 'array', 'list', "size:{$sideCount}"],
+            'competitors.*.wrestlers.*' => ['distinct'],
+            'competitors.*.tag_teams.*' => ['distinct'],
+        ];
+
+        foreach (range(0, $sideCount - 1) as $sideIndex) {
+            $wrestlers = "competitors.{$sideIndex}.wrestlers";
+            $tagTeams = "competitors.{$sideIndex}.tag_teams";
+
+            $rules[$wrestlers] = ['required_without:'.$tagTeams, 'array', 'max:1', 'prohibits:'.$tagTeams];
+            $rules["{$wrestlers}.*"] = ['bail', 'integer', 'exists:wrestlers,id', new WrestlerIsBookable()];
+            $rules[$tagTeams] = ['required_without:'.$wrestlers, 'array', 'max:1', 'prohibits:'.$wrestlers];
+            $rules["{$tagTeams}.*"] = ['bail', 'integer', 'exists:tag_teams,id', new TagTeamIsBookable()];
         }
 
         return $rules;

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -50,6 +50,10 @@ The Livewire match form applies model-specific booking rules to every selected w
 
 Assignment Actions treat each requested collection as an atomic command. They reject the entire assignment when any selected wrestler, tag team, referee, or title is unavailable; they never silently discard unavailable selections and persist a partial request. Repeated selections of the same record are normalized before assignment.
 
+`MatchCompetitorRequirements` authoritatively validates competitor types and composition before assignments are persisted. Match formats whose names encode a roster-member count use the current wrestlers represented by each selected tag team: standard and tornado tag matches require 2-on-2, six/eight/ten-person tag matches require 3/4/5 per side, and handicap matches require 2-on-1 or 3-on-2 in either side order. A wrestler cannot also be selected directly when represented by a selected tag team.
+
+Competitor entries and represented roster members are separate concepts. Singles, Triple Threat, Triangle, and Fatal 4-Way matches require exactly one wrestler or tag-team entry on each side, subject to the match type's allowed competitor types. Battle Royal and Royal Rumble entrants each occupy an individual side.
+
 `MatchStipulation` is an optional match configuration selected from active definitions when a match is created or edited. The match retains that relationship as historical configuration even if the definition is later made inactive. Stipulation capabilities and match presentation must be implemented by the match domain when they are enforced; the model does not infer behavior from hard-coded slug lists.
 
 `AddMatchForEventAction` receives side-based `EventMatchData`, locks the owning event, allocates the next card position without reusing soft-deleted match numbers, and persists the match, officials, championship stakes, sides, and competitors in one transaction. Assignment Actions retain eligibility and scheduling-conflict enforcement for their respective relationships.

--- a/docs/architecture/match-type-system.md
+++ b/docs/architecture/match-type-system.md
@@ -56,13 +56,13 @@ MatchType::factory()->royalRumble()->create();  // Special rumble format
 'slug' => 'tagteam'
 'min_competitors' => 2
 'max_competitors' => 2
-'allowed_types' => ['tag_team']
+'allowed_types' => ['wrestler', 'tag_team']
 ```
 
 **Rules:**
-- Exactly 2 tag teams required
-- Only tag teams allowed (no individual wrestlers)
-- Team-based competition format
+- Exactly two represented roster members are required on each side
+- Wrestlers, tag teams, or mixed combinations are allowed
+- A selected tag team represents all of its current wrestlers
 
 ### Triple Threat Match
 
@@ -192,14 +192,14 @@ Each match type defines allowed competitor types:
 // Example MatchType method
 public function getAllowedCompetitorTypes(): array
 {
-    return match ($this->slug) {
-        'singles', 'royal-rumble', 'battle-royal' => ['wrestler'],
-        'tagteam' => ['tag_team'],
-        'triple-threat', 'fatal-4-way' => ['wrestler', 'tag_team'],
+    return match ($this) {
+        self::Singles, self::Triangle, self::BattleRoyal, self::RoyalRumble => ['wrestler'],
         default => ['wrestler', 'tag_team'],
     };
 }
 ```
+
+`MatchCompetitorRequirements` is the authoritative assignment boundary. It applies these type restrictions, prevents duplicate representation, and validates competitor-entry and represented-roster-member compositions before persistence.
 
 ## Match Type Validation
 

--- a/tests/Integration/Actions/Matches/AddCompetitorsToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddCompetitorsToMatchActionTest.php
@@ -39,7 +39,7 @@ test('it adds wrestler competitors to a match', function () {
 });
 
 test('it adds tag team competitors to a match', function () {
-    $eventMatch = EventMatch::factory()->create();
+    $eventMatch = EventMatch::factory()->withMatchType(MatchType::TagTeam)->create();
     $tagTeamA = TagTeam::factory()->bookable()->create();
     $tagTeamB = TagTeam::factory()->bookable()->create();
     $competitors = collect([

--- a/tests/Integration/Actions/Matches/UpdateMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/UpdateMatchActionTest.php
@@ -13,6 +13,7 @@ use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use App\Models\Matches\MatchSide;
 use App\Models\Roster\Referees\Referee;
+use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
@@ -34,16 +35,16 @@ test('it atomically replaces a match configuration', function () {
     $match->titles()->attach($originalTitle);
 
     $newReferee = Referee::factory()->bookable()->create();
-    $newTitle = Title::factory()->active()->create(['type' => TitleType::Singles]);
-    $firstWrestler = Wrestler::factory()->bookable()->create();
-    $secondWrestler = Wrestler::factory()->bookable()->create();
+    $newTitle = Title::factory()->active()->create(['type' => TitleType::TagTeam]);
+    $firstTagTeam = TagTeam::factory()->bookable()->create();
+    $secondTagTeam = TagTeam::factory()->bookable()->create();
     $data = new EventMatchData(
         MatchType::TagTeam,
         Referee::query()->whereKey($newReferee)->get(),
         Title::query()->whereKey($newTitle)->get(),
         collect([
-            1 => ['wrestlers' => [$firstWrestler]],
-            2 => ['wrestlers' => [$secondWrestler]],
+            1 => ['tag_teams' => [$firstTagTeam]],
+            2 => ['tag_teams' => [$secondTagTeam]],
         ]),
         'Updated preview',
     );
@@ -56,8 +57,8 @@ test('it atomically replaces a match configuration', function () {
         ->and($updatedMatch->referees->modelKeys())->toBe([$newReferee->id])
         ->and($updatedMatch->titles->modelKeys())->toBe([$newTitle->id])
         ->and($updatedMatch->competitors()->pluck('competitor_id')->all())->toEqualCanonicalizing([
-            $firstWrestler->id,
-            $secondWrestler->id,
+            $firstTagTeam->id,
+            $secondTagTeam->id,
         ]);
 });
 

--- a/tests/Integration/Lifecycle/MatchCompetitorRequirementsTest.php
+++ b/tests/Integration/Lifecycle/MatchCompetitorRequirementsTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MatchType;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Lifecycle\MatchCompetitorRequirements;
+use App\Models\Matches\EventMatch;
+use App\Models\Roster\TagTeams\TagTeam;
+use App\Models\Roster\Wrestlers\Wrestler;
+
+it('rejects competitor types unsupported by the match format', function () {
+    $match = EventMatch::factory()->withMatchType(MatchType::Singles)->create();
+    $tagTeam = TagTeam::factory()->bookable()->create();
+    $wrestler = Wrestler::factory()->bookable()->create();
+
+    expect(fn () => resolve(MatchCompetitorRequirements::class)->ensureSatisfied($match, collect([
+        ['tag_teams' => [$tagTeam]],
+        ['wrestlers' => [$wrestler]],
+    ])))->toThrow(
+        InvalidMatchConfigurationException::class,
+        'The [Singles] match does not support the selected competitor type.',
+    );
+});
+
+it('rejects a wrestler represented directly and by a selected tag team', function () {
+    $match = EventMatch::factory()->withMatchType(MatchType::TagTeam)->create();
+    $tagTeam = TagTeam::factory()->bookable()->create();
+    $representedWrestler = $tagTeam->currentWrestlers()->firstOrFail();
+
+    expect(fn () => resolve(MatchCompetitorRequirements::class)->ensureSatisfied($match, collect([
+        ['tag_teams' => [$tagTeam]],
+        ['wrestlers' => [$representedWrestler]],
+    ])))->toThrow(
+        InvalidMatchConfigurationException::class,
+        'A wrestler cannot compete directly and through a selected tag team in the same match.',
+    );
+});
+
+it('accepts mixed competitors that satisfy a multi-person tag composition', function () {
+    $match = EventMatch::factory()->withMatchType(MatchType::SixManTagTeam)->create();
+    $firstTagTeam = TagTeam::factory()->bookable()->create();
+    $secondTagTeam = TagTeam::factory()->bookable()->create();
+    $firstWrestler = Wrestler::factory()->bookable()->create();
+    $secondWrestler = Wrestler::factory()->bookable()->create();
+
+    resolve(MatchCompetitorRequirements::class)->ensureSatisfied($match, collect([
+        ['tag_teams' => [$firstTagTeam], 'wrestlers' => [$firstWrestler]],
+        ['tag_teams' => [$secondTagTeam], 'wrestlers' => [$secondWrestler]],
+    ]));
+
+    expect(true)->toBeTrue();
+});
+
+it('rejects an incorrect multi-person tag composition', function () {
+    $match = EventMatch::factory()->withMatchType(MatchType::SixManTagTeam)->create();
+    $firstTagTeam = TagTeam::factory()->bookable()->create();
+    $secondTagTeam = TagTeam::factory()->bookable()->create();
+
+    expect(fn () => resolve(MatchCompetitorRequirements::class)->ensureSatisfied($match, collect([
+        ['tag_teams' => [$firstTagTeam]],
+        ['tag_teams' => [$secondTagTeam]],
+    ])))->toThrow(
+        InvalidMatchConfigurationException::class,
+        'The [6 Man Tag Team] match requires a 3-on-3 roster-member composition.',
+    );
+});
+
+it('accepts a handicap composition in either side order', function () {
+    $match = EventMatch::factory()->withMatchType(MatchType::TwoOnOneHandicap)->create();
+    $tagTeam = TagTeam::factory()->bookable()->create();
+    $wrestler = Wrestler::factory()->bookable()->create();
+
+    resolve(MatchCompetitorRequirements::class)->ensureSatisfied($match, collect([
+        ['tag_teams' => [$tagTeam]],
+        ['wrestlers' => [$wrestler]],
+    ]));
+
+    expect(true)->toBeTrue();
+});
+
+it('rejects multiple competitor entries on an independently competing side', function () {
+    $match = EventMatch::factory()->withMatchType(MatchType::TripleThreat)->create();
+    $firstWrestler = Wrestler::factory()->bookable()->create();
+    $secondWrestler = Wrestler::factory()->bookable()->create();
+    $thirdWrestler = Wrestler::factory()->bookable()->create();
+    $fourthWrestler = Wrestler::factory()->bookable()->create();
+
+    expect(fn () => resolve(MatchCompetitorRequirements::class)->ensureSatisfied($match, collect([
+        ['wrestlers' => [$firstWrestler, $secondWrestler]],
+        ['wrestlers' => [$thirdWrestler]],
+        ['wrestlers' => [$fourthWrestler]],
+    ])))->toThrow(
+        InvalidMatchConfigurationException::class,
+        'The [Triple Threat] match requires a 1-on-1-on-1 competitor-entry composition.',
+    );
+});
+
+it('requires an individual side for every elimination-match entrant', function () {
+    $match = EventMatch::factory()->withMatchType(MatchType::BattleRoyal)->create();
+    $firstWrestler = Wrestler::factory()->bookable()->create();
+    $secondWrestler = Wrestler::factory()->bookable()->create();
+    $thirdWrestler = Wrestler::factory()->bookable()->create();
+
+    expect(fn () => resolve(MatchCompetitorRequirements::class)->ensureSatisfied($match, collect([
+        ['wrestlers' => [$firstWrestler, $secondWrestler]],
+        ['wrestlers' => [$thirdWrestler]],
+    ])))->toThrow(
+        InvalidMatchConfigurationException::class,
+        'Each [Battle Royal] entrant must compete on an individual side.',
+    );
+});

--- a/tests/Unit/Actions/Matches/AddCompetitorsToMatchActionTest.php
+++ b/tests/Unit/Actions/Matches/AddCompetitorsToMatchActionTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Actions\Matches\AddCompetitorsToMatchAction;
 use App\Actions\Matches\AddTagTeamsToMatchAction;
 use App\Actions\Matches\AddWrestlersToMatchAction;
+use App\Enums\MatchType;
 use App\Models\Matches\EventMatch;
 use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
@@ -40,7 +41,7 @@ test('it adds wrestler competitors to a match', function () {
 });
 
 test('it adds tag team competitors to a match', function () {
-    $eventMatch = EventMatch::factory()->create();
+    $eventMatch = EventMatch::factory()->withMatchType(MatchType::TagTeam)->create();
     $tagTeamA = TagTeam::factory()->bookable()->create();
     $tagTeamB = TagTeam::factory()->bookable()->create();
     $competitors = collect([

--- a/tests/Unit/Enums/MatchTypeTest.php
+++ b/tests/Unit/Enums/MatchTypeTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Enums\MatchType;
+
+it('defines roster-member compositions for formats that encode side sizes', function (
+    MatchType $matchType,
+    array $composition,
+) {
+    expect($matchType->requiredRosterMembersPerSide())->toBe($composition);
+})->with([
+    'tag team' => [MatchType::TagTeam, [2, 2]],
+    'six man tag team' => [MatchType::SixManTagTeam, [3, 3]],
+    'eight man tag team' => [MatchType::EightManTagTeam, [4, 4]],
+    'ten man tag team' => [MatchType::TenManTagTeam, [5, 5]],
+    'two on one handicap' => [MatchType::TwoOnOneHandicap, [1, 2]],
+    'three on two handicap' => [MatchType::ThreeOnTwoHandicap, [2, 3]],
+    'tornado tag team' => [MatchType::TornadoTagTeam, [2, 2]],
+]);
+
+it('allows mixed competitors for flexible match formats', function (MatchType $matchType) {
+    expect($matchType->allowsWrestlers())->toBeTrue()
+        ->and($matchType->allowsTagTeams())->toBeTrue();
+})->with([
+    MatchType::TagTeam,
+    MatchType::TripleThreat,
+    MatchType::Fatal4Way,
+    MatchType::SixManTagTeam,
+    MatchType::EightManTagTeam,
+    MatchType::TenManTagTeam,
+    MatchType::TwoOnOneHandicap,
+    MatchType::ThreeOnTwoHandicap,
+    MatchType::TornadoTagTeam,
+    MatchType::Gauntlet,
+]);
+
+it('defines one-entry sides for independently competing formats', function (MatchType $matchType, array $composition) {
+    expect($matchType->requiredCompetitorEntriesPerSide())->toBe($composition);
+})->with([
+    'singles' => [MatchType::Singles, [1, 1]],
+    'triple threat' => [MatchType::TripleThreat, [1, 1, 1]],
+    'triangle' => [MatchType::Triangle, [1, 1, 1]],
+    'fatal four way' => [MatchType::Fatal4Way, [1, 1, 1, 1]],
+]);
+
+it('restricts individual-only match formats to wrestlers', function (MatchType $matchType) {
+    expect($matchType->allowsWrestlers())->toBeTrue()
+        ->and($matchType->allowsTagTeams())->toBeFalse();
+})->with([
+    MatchType::Singles,
+    MatchType::Triangle,
+    MatchType::BattleRoyal,
+    MatchType::RoyalRumble,
+]);

--- a/tests/Unit/Livewire/Matches/Support/MatchCompetitorRuleSetTest.php
+++ b/tests/Unit/Livewire/Matches/Support/MatchCompetitorRuleSetTest.php
@@ -16,8 +16,22 @@ it('builds fixed individual-side rules', function (MatchType $matchType, int $si
     }
 })->with([
     'singles' => [MatchType::Singles, 2],
-    'triple threat' => [MatchType::TripleThreat, 3],
     'triangle' => [MatchType::Triangle, 3],
+]);
+
+it('builds mutually exclusive mixed-competitor side rules', function (MatchType $matchType, int $sideCount) {
+    $rules = (new MatchCompetitorRuleSet($matchType))->rules();
+
+    expect($rules['competitors'])->toContain("size:{$sideCount}")
+        ->and($rules['competitors.*.wrestlers.*'])->toContain('distinct')
+        ->and($rules['competitors.*.tag_teams.*'])->toContain('distinct');
+
+    foreach (range(0, $sideCount - 1) as $sideIndex) {
+        expect($rules["competitors.{$sideIndex}.wrestlers"])->toContain('max:1')
+            ->and($rules["competitors.{$sideIndex}.tag_teams"])->toContain('max:1');
+    }
+})->with([
+    'triple threat' => [MatchType::TripleThreat, 3],
     'fatal four way' => [MatchType::Fatal4Way, 4],
 ]);
 


### PR DESCRIPTION
## Summary
- distinguish match competitor entries from the roster members they represent
- enforce allowed competitor types, side composition, and duplicate representation at the action boundary
- align Livewire competitor rules, architecture documentation, and shared AI guidance

## Verification
- composer lint
- targeted application and Pest PHPStan: passed
- 102 focused tests, 271 assertions: passed
- full non-browser suite: 3,439 tests, 11,032 assertions: passed
- composer test:push browser phase exceeded Composer's 300-second timeout
- isolated MatchResult browser test hung during browser connection and reported a WebSocket abnormal close when stopped; CI will validate on the configured runner