### PR TITLE
refactor: validate match outcomes from locked state

### DIFF
--- a/app/Lifecycle/MatchOutcomeRequirements.php
+++ b/app/Lifecycle/MatchOutcomeRequirements.php
@@ -9,7 +9,7 @@ use App\Models\Matches\EventMatch;
 use App\Models\Matches\MatchCompetitor;
 use Illuminate\Database\Eloquent\Collection;
 
-class MatchOutcomeRequirements
+final class MatchOutcomeRequirements
 {
     public function __construct(
         private readonly MatchWinningSideRequirement $winningSide,
@@ -22,7 +22,7 @@ class MatchOutcomeRequirements
      */
     public function ensureSatisfied(EventMatch $match, MatchResultData $result, Collection $competitors): void
     {
-        $this->winningSide->ensureSatisfied($match, $result);
+        $this->winningSide->ensureSatisfied($match, $result, $competitors);
         $this->entryOrder->ensureSatisfied($match, $competitors);
         $this->eliminations->ensureSatisfied($match, $result, $competitors);
     }

--- a/app/Lifecycle/MatchWinningSideRequirement.php
+++ b/app/Lifecycle/MatchWinningSideRequirement.php
@@ -7,10 +7,15 @@ namespace App\Lifecycle;
 use App\Data\Matches\MatchResultData;
 use App\Exceptions\Matches\InvalidMatchOutcomeException;
 use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use Illuminate\Database\Eloquent\Collection;
 
 final class MatchWinningSideRequirement
 {
-    public function ensureSatisfied(EventMatch $match, MatchResultData $result): void
+    /**
+     * @param  Collection<int, MatchCompetitor>  $competitors
+     */
+    public function ensureSatisfied(EventMatch $match, MatchResultData $result, Collection $competitors): void
     {
         if ($result->finish->requiresWinningSide() && $result->winningSide === null) {
             throw InvalidMatchOutcomeException::missingWinningSide();
@@ -28,7 +33,7 @@ final class MatchWinningSideRequirement
             throw InvalidMatchOutcomeException::winningSideFromAnotherMatch();
         }
 
-        if (! $result->winningSide->competitors()->exists()) {
+        if ($competitors->where('match_side_id', $result->winningSide->id)->isEmpty()) {
             throw InvalidMatchOutcomeException::winningSideWithoutCompetitors();
         }
     }

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -31,7 +31,7 @@ The match system handles complex wrestling match scenarios with flexible competi
 
 Match configuration and participant availability are separate failure boundaries. `InvalidMatchConfigurationException` describes an incomplete or structurally invalid match, such as missing referees, missing competitors, insufficient populated sides, or an invalid side number. `EntityNotAvailableException` describes a wrestler, tag team, referee, or title whose current state prevents assignment. `SchedulingConflictException` is reserved for an actual collision between bookings, times, or resources and must not substitute for either boundary.
 
-Recorded outcomes are checked by `MatchOutcomeRequirements`, which explicitly composes focused winning-side, entry-order, and elimination-history requirements. Each requirement owns one cohesive rule family and raises `InvalidMatchOutcomeException`; the coordinator preserves their deterministic validation order without using a dynamic specification registry or mutation pipeline.
+Recorded outcomes are checked by `MatchOutcomeRequirements`, which explicitly composes focused winning-side, entry-order, and elimination-history requirements. Each requirement owns one cohesive rule family and raises `InvalidMatchOutcomeException`; the coordinator preserves their deterministic validation order without using a dynamic specification registry or mutation pipeline. `RecordResultAction` locks the match, selected winning side, and complete competitor collection before validation, and every requirement evaluates that shared snapshot rather than querying mutable relationship state independently.
 
 ## Event Card Scheduling
 

--- a/tests/Integration/Lifecycle/MatchOutcomeRequirementsTest.php
+++ b/tests/Integration/Lifecycle/MatchOutcomeRequirementsTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Data\Matches\MatchEliminationData;
+use App\Data\Matches\MatchResultData;
+use App\Enums\MatchFinish;
+use App\Enums\MatchType;
+use App\Exceptions\Matches\InvalidMatchOutcomeException;
+use App\Lifecycle\MatchOutcomeRequirements;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Matches\MatchSide;
+
+/**
+ * @return array{MatchSide, MatchCompetitor}
+ */
+function createOutcomeCompetitor(EventMatch $match, int $position, ?int $entryOrder = null): array
+{
+    $side = MatchSide::factory()->for($match, 'match')->create([
+        'position' => $position,
+    ]);
+    $competitor = MatchCompetitor::factory()->create([
+        'match_id' => $match->id,
+        'match_side_id' => $side->id,
+    ]);
+    $competitor->forceFill(['entry_order' => $entryOrder])->save();
+
+    return [$side, $competitor];
+}
+
+/**
+ * @param  list<MatchEliminationData>  $eliminations
+ */
+function ensureOutcomeRequirements(
+    EventMatch $match,
+    MatchFinish $finish,
+    ?MatchSide $winningSide,
+    array $eliminations = [],
+): void {
+    resolve(MatchOutcomeRequirements::class)->ensureSatisfied(
+        $match,
+        new MatchResultData($finish, $winningSide, collect($eliminations)),
+        $match->competitors()->get(),
+    );
+}
+
+it('accepts a decisive outcome with a populated winning side', function () {
+    $match = EventMatch::factory()->create();
+    [$winningSide] = createOutcomeCompetitor($match, 1);
+
+    ensureOutcomeRequirements($match, MatchFinish::Pinfall, $winningSide);
+})->throwsNoExceptions();
+
+it('accepts a no-outcome finish without a winning side', function () {
+    $match = EventMatch::factory()->create();
+
+    ensureOutcomeRequirements($match, MatchFinish::NoDecision, null);
+})->throwsNoExceptions();
+
+it('requires a winning side for a decisive finish', function () {
+    $match = EventMatch::factory()->create();
+
+    ensureOutcomeRequirements($match, MatchFinish::Submission, null);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('rejects a winning side for a no-outcome finish', function () {
+    $match = EventMatch::factory()->create();
+    [$winningSide] = createOutcomeCompetitor($match, 1);
+
+    ensureOutcomeRequirements($match, MatchFinish::NoDecision, $winningSide);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('requires the winning side to belong to the resulted match', function () {
+    $match = EventMatch::factory()->create();
+    $otherMatch = EventMatch::factory()->create();
+    [$otherSide] = createOutcomeCompetitor($otherMatch, 1);
+
+    ensureOutcomeRequirements($match, MatchFinish::Pinfall, $otherSide);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('requires the winning side to contain a competitor from the locked snapshot', function () {
+    $match = EventMatch::factory()->create();
+    $emptySide = MatchSide::factory()->for($match, 'match')->create(['position' => 1]);
+
+    ensureOutcomeRequirements($match, MatchFinish::Pinfall, $emptySide);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('accepts complete elimination history', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $firstEliminated] = createOutcomeCompetitor($match, 1);
+    [, $secondEliminated] = createOutcomeCompetitor($match, 2);
+    [$winningSide, $winner] = createOutcomeCompetitor($match, 3);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($firstEliminated, 1, $winner),
+        new MatchEliminationData($secondEliminated, 2, $winner),
+    ]);
+})->throwsNoExceptions();
+
+it('accepts partial elimination history for a no-outcome finish', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $eliminated] = createOutcomeCompetitor($match, 1);
+    [, $eliminator] = createOutcomeCompetitor($match, 2);
+
+    ensureOutcomeRequirements($match, MatchFinish::NoDecision, null, [
+        new MatchEliminationData($eliminated, 1, $eliminator),
+    ]);
+})->throwsNoExceptions();
+
+it('rejects elimination metadata for a match type that does not record it', function () {
+    $match = EventMatch::factory()->create();
+    [$winningSide, $competitor] = createOutcomeCompetitor($match, 1);
+
+    ensureOutcomeRequirements($match, MatchFinish::Pinfall, $winningSide, [
+        new MatchEliminationData($competitor, 1),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('rejects a duplicate eliminated competitor', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $eliminated] = createOutcomeCompetitor($match, 1);
+    [$winningSide, $winner] = createOutcomeCompetitor($match, 2);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($eliminated, 1, $winner),
+        new MatchEliminationData($eliminated, 2, $winner),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('rejects nonconsecutive elimination order', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $eliminated] = createOutcomeCompetitor($match, 1);
+    [$winningSide, $winner] = createOutcomeCompetitor($match, 2);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($eliminated, 2, $winner),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('rejects an eliminated competitor from another match', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [$winningSide, $winner] = createOutcomeCompetitor($match, 1);
+    $otherMatch = EventMatch::factory()->create();
+    [, $otherCompetitor] = createOutcomeCompetitor($otherMatch, 1);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($otherCompetitor, 1, $winner),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('rejects an eliminating competitor from another match', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $eliminated] = createOutcomeCompetitor($match, 1);
+    [$winningSide] = createOutcomeCompetitor($match, 2);
+    $otherMatch = EventMatch::factory()->create();
+    [, $otherCompetitor] = createOutcomeCompetitor($otherMatch, 1);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($eliminated, 1, $otherCompetitor),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('rejects self elimination', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $eliminated] = createOutcomeCompetitor($match, 1);
+    [$winningSide] = createOutcomeCompetitor($match, 2);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($eliminated, 1, $eliminated),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('rejects an eliminated winner', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $loser] = createOutcomeCompetitor($match, 1);
+    [$winningSide, $winner] = createOutcomeCompetitor($match, 2);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($winner, 1, $loser),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('requires every losing competitor in a decisive elimination match', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $firstLoser] = createOutcomeCompetitor($match, 1);
+    createOutcomeCompetitor($match, 2);
+    [$winningSide, $winner] = createOutcomeCompetitor($match, 3);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($firstLoser, 1, $winner),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('rejects an elimination credited after the eliminator exited', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::BattleRoyal]);
+    [, $firstCompetitor] = createOutcomeCompetitor($match, 1);
+    [, $secondCompetitor] = createOutcomeCompetitor($match, 2);
+    [$winningSide] = createOutcomeCompetitor($match, 3);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($firstCompetitor, 1, $secondCompetitor),
+        new MatchEliminationData($secondCompetitor, 2, $firstCompetitor),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);
+
+it('requires consecutive Royal Rumble entry order', function () {
+    $match = EventMatch::factory()->create(['match_type' => MatchType::RoyalRumble]);
+    [, $firstCompetitor] = createOutcomeCompetitor($match, 1, 1);
+    [$winningSide, $winner] = createOutcomeCompetitor($match, 2, 3);
+
+    ensureOutcomeRequirements($match, MatchFinish::Stipulation, $winningSide, [
+        new MatchEliminationData($firstCompetitor, 1, $winner),
+    ]);
+})->throws(InvalidMatchOutcomeException::class);


### PR DESCRIPTION
## Summary
- keep the focused winning-side, entry-order, and elimination requirement boundaries
- validate winning-side population from RecordResultAction's locked competitor snapshot instead of querying the relationship independently
- make the outcome coordinator final and document the shared snapshot boundary
- add direct integration coverage for every outcome rule family, including duplicate elimination, invalid ordering, foreign participants, chronology, and Royal Rumble entry order

## Verification
- focused outcome and RecordResultAction suite: 46 tests, 77 assertions
- full non-browser suite: 3,457 tests, 11,046 assertions
- Rector, Pint with Blade, application PHPStan, Pest PHPStan, and type coverage: passed
- local Pest Browser process exceeded Composer's 300-second connection timeout; CI is the authoritative browser check