### PR TITLE
refactor: lock match assignments

### DIFF
--- a/app/Actions/Matches/AddCompetitorsToMatchAction.php
+++ b/app/Actions/Matches/AddCompetitorsToMatchAction.php
@@ -41,12 +41,13 @@ class AddCompetitorsToMatchAction
      */
     public function handle(EventMatch $eventMatch, Collection $competitors): void
     {
-        $this->requirements->ensureSatisfied($eventMatch, $competitors);
-
         DB::transaction(function () use ($eventMatch, $competitors): void {
+            $lockedMatch = EventMatch::query()->whereKey($eventMatch->id)->lockForUpdate()->firstOrFail();
+            $this->requirements->ensureSatisfied($lockedMatch, $competitors);
+
             // Process each side and add competitors
             foreach ($competitors as $sideNumber => $sideCompetitors) {
-                $this->addSideCompetitors($eventMatch, (int) $sideNumber, $sideCompetitors);
+                $this->addSideCompetitors($lockedMatch, (int) $sideNumber, $sideCompetitors);
             }
         });
     }

--- a/app/Actions/Matches/AddRefereesToMatchAction.php
+++ b/app/Actions/Matches/AddRefereesToMatchAction.php
@@ -50,17 +50,29 @@ class AddRefereesToMatchAction
     {
         $requestedReferees = $referees->unique('id')->values();
 
-        if ($requestedReferees->isEmpty() || $requestedReferees->contains(
-            fn (Referee $referee): bool => ! RosterBookingEligibility::allows($referee)
-        )) {
+        if ($requestedReferees->isEmpty()) {
             throw EntityNotAvailableException::forMatchAssignment('referees');
         }
 
         DB::transaction(function () use ($eventMatch, $requestedReferees): void {
-            $this->conflictService->ensureRefereesCanBeAssigned($eventMatch, $requestedReferees);
+            $lockedMatch = EventMatch::query()->whereKey($eventMatch->id)->lockForUpdate()->firstOrFail();
+            $conflictingEventIds = $this->conflictService->lockConflictingEventIds($lockedMatch);
+            $lockedReferees = Referee::query()
+                ->whereKey($requestedReferees->pluck('id'))
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
 
-            $requestedReferees->each(function (Referee $referee) use ($eventMatch): void {
-                $eventMatch->referees()->attach($referee->id);
+            if ($lockedReferees->count() !== $requestedReferees->count() || $lockedReferees->contains(
+                fn (Referee $referee): bool => ! RosterBookingEligibility::allows($referee)
+            )) {
+                throw EntityNotAvailableException::forMatchAssignment('referees');
+            }
+
+            $this->conflictService->ensureRefereesCanBeAssigned($lockedMatch, $conflictingEventIds, $lockedReferees);
+
+            $lockedReferees->each(function (Referee $referee) use ($lockedMatch): void {
+                $lockedMatch->referees()->attach($referee->id);
             });
         });
     }

--- a/app/Actions/Matches/AddTagTeamsToMatchAction.php
+++ b/app/Actions/Matches/AddTagTeamsToMatchAction.php
@@ -52,9 +52,7 @@ class AddTagTeamsToMatchAction
     {
         $requestedTagTeams = $tagTeams->unique('id')->values();
 
-        if ($requestedTagTeams->isEmpty() || $requestedTagTeams->contains(
-            fn (TagTeam $tagTeam): bool => ! RosterBookingEligibility::allows($tagTeam)
-        )) {
+        if ($requestedTagTeams->isEmpty()) {
             throw EntityNotAvailableException::forMatchAssignment('tag teams');
         }
 
@@ -64,11 +62,25 @@ class AddTagTeamsToMatchAction
         }
 
         DB::transaction(function () use ($eventMatch, $requestedTagTeams, $sideNumber): void {
-            $this->conflictService->ensureTagTeamsCanBeAssigned($eventMatch, $requestedTagTeams);
-            $side = $eventMatch->sides()->firstOrCreate(['position' => $sideNumber]);
+            $lockedMatch = EventMatch::query()->whereKey($eventMatch->id)->lockForUpdate()->firstOrFail();
+            $conflictingEventIds = $this->conflictService->lockConflictingEventIds($lockedMatch);
+            $lockedTagTeams = TagTeam::query()
+                ->whereKey($requestedTagTeams->pluck('id'))
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
 
-            $requestedTagTeams->each(function (TagTeam $tagTeam) use ($eventMatch, $side): void {
-                $eventMatch->competitors()->create([
+            if ($lockedTagTeams->count() !== $requestedTagTeams->count() || $lockedTagTeams->contains(
+                fn (TagTeam $tagTeam): bool => ! RosterBookingEligibility::allows($tagTeam)
+            )) {
+                throw EntityNotAvailableException::forMatchAssignment('tag teams');
+            }
+
+            $this->conflictService->ensureTagTeamsCanBeAssigned($conflictingEventIds, $lockedTagTeams);
+            $side = $lockedMatch->sides()->firstOrCreate(['position' => $sideNumber]);
+
+            $lockedTagTeams->each(function (TagTeam $tagTeam) use ($lockedMatch, $side): void {
+                $lockedMatch->competitors()->create([
                     'competitor_id' => $tagTeam->id,
                     'competitor_type' => $tagTeam->getMorphClass(),
                     'match_side_id' => $side->id,

--- a/app/Actions/Matches/AddTitlesToMatchAction.php
+++ b/app/Actions/Matches/AddTitlesToMatchAction.php
@@ -52,19 +52,31 @@ class AddTitlesToMatchAction
     {
         $requestedTitles = $titles->unique('id')->values();
 
-        if ($requestedTitles->isEmpty() || $requestedTitles->contains(
-            fn (Title $title): bool => ! $title->isCurrentlyActive()
-        )) {
+        if ($requestedTitles->isEmpty()) {
             throw EntityNotAvailableException::forMatchAssignment('titles');
         }
 
         DB::transaction(function () use ($eventMatch, $requestedTitles): void {
-            $this->conflictService->ensureTitlesCanBeAssigned($eventMatch, $requestedTitles);
-            $this->ensureTitleTypesMatchCompetitors($eventMatch, $requestedTitles);
-            $this->ensureCurrentChampionsCompete($eventMatch, $requestedTitles);
+            $lockedMatch = EventMatch::query()->whereKey($eventMatch->id)->lockForUpdate()->firstOrFail();
+            $conflictingEventIds = $this->conflictService->lockConflictingEventIds($lockedMatch);
+            $lockedTitles = Title::query()
+                ->whereKey($requestedTitles->pluck('id'))
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
 
-            $requestedTitles->each(function (Title $title) use ($eventMatch): void {
-                $eventMatch->titles()->attach($title->id);
+            if ($lockedTitles->count() !== $requestedTitles->count() || $lockedTitles->contains(
+                fn (Title $title): bool => ! $title->isCurrentlyActive()
+            )) {
+                throw EntityNotAvailableException::forMatchAssignment('titles');
+            }
+
+            $this->conflictService->ensureTitlesCanBeAssigned($conflictingEventIds, $lockedTitles);
+            $this->ensureTitleTypesMatchCompetitors($lockedMatch, $lockedTitles);
+            $this->ensureCurrentChampionsCompete($lockedMatch, $lockedTitles);
+
+            $lockedTitles->each(function (Title $title) use ($lockedMatch): void {
+                $lockedMatch->titles()->attach($title->id);
             });
         });
     }

--- a/app/Actions/Matches/AddWrestlersToMatchAction.php
+++ b/app/Actions/Matches/AddWrestlersToMatchAction.php
@@ -51,9 +51,7 @@ class AddWrestlersToMatchAction
     {
         $requestedWrestlers = $wrestlers->unique('id')->values();
 
-        if ($requestedWrestlers->isEmpty() || $requestedWrestlers->contains(
-            fn (Wrestler $wrestler): bool => ! RosterBookingEligibility::allows($wrestler)
-        )) {
+        if ($requestedWrestlers->isEmpty()) {
             throw EntityNotAvailableException::forMatchAssignment('wrestlers');
         }
 
@@ -63,17 +61,31 @@ class AddWrestlersToMatchAction
         }
 
         DB::transaction(function () use ($eventMatch, $requestedWrestlers, $sideNumber): void {
-            $this->conflictService->ensureWrestlersCanBeAssigned($eventMatch, $requestedWrestlers);
-            $side = $eventMatch->sides()->firstOrCreate(['position' => $sideNumber]);
+            $lockedMatch = EventMatch::query()->whereKey($eventMatch->id)->lockForUpdate()->firstOrFail();
+            $conflictingEventIds = $this->conflictService->lockConflictingEventIds($lockedMatch);
+            $lockedWrestlers = Wrestler::query()
+                ->whereKey($requestedWrestlers->pluck('id'))
+                ->orderBy('id')
+                ->lockForUpdate()
+                ->get();
 
-            $requestedWrestlers->each(function (Wrestler $wrestler) use ($eventMatch, $side): void {
-                $competitor = $eventMatch->competitors()->create([
+            if ($lockedWrestlers->count() !== $requestedWrestlers->count() || $lockedWrestlers->contains(
+                fn (Wrestler $wrestler): bool => ! RosterBookingEligibility::allows($wrestler)
+            )) {
+                throw EntityNotAvailableException::forMatchAssignment('wrestlers');
+            }
+
+            $this->conflictService->ensureWrestlersCanBeAssigned($conflictingEventIds, $lockedWrestlers);
+            $side = $lockedMatch->sides()->firstOrCreate(['position' => $sideNumber]);
+
+            $lockedWrestlers->each(function (Wrestler $wrestler) use ($lockedMatch, $side): void {
+                $competitor = $lockedMatch->competitors()->create([
                     'competitor_id' => $wrestler->id,
                     'competitor_type' => $wrestler->getMorphClass(),
                     'match_side_id' => $side->id,
                 ]);
 
-                if ($eventMatch->match_type === MatchType::RoyalRumble) {
+                if ($lockedMatch->match_type === MatchType::RoyalRumble) {
                     $competitor->forceFill(['entry_order' => $side->position])->save();
                 }
             });

--- a/app/Services/MatchAssignmentConflictService.php
+++ b/app/Services/MatchAssignmentConflictService.php
@@ -18,11 +18,11 @@ use Illuminate\Support\Collection;
 final class MatchAssignmentConflictService
 {
     /**
+     * @param  Collection<int, int>  $conflictingEventIds
      * @param  Collection<int, Wrestler>  $wrestlers
      */
-    public function ensureWrestlersCanBeAssigned(EventMatch $eventMatch, Collection $wrestlers): void
+    public function ensureWrestlersCanBeAssigned(Collection $conflictingEventIds, Collection $wrestlers): void
     {
-        $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
         $conflictingCompetitor = MatchCompetitor::query()
             ->forCompetitorIds(
                 Wrestler::class,
@@ -45,11 +45,11 @@ final class MatchAssignmentConflictService
     }
 
     /**
+     * @param  Collection<int, int>  $conflictingEventIds
      * @param  Collection<int, TagTeam>  $tagTeams
      */
-    public function ensureTagTeamsCanBeAssigned(EventMatch $eventMatch, Collection $tagTeams): void
+    public function ensureTagTeamsCanBeAssigned(Collection $conflictingEventIds, Collection $tagTeams): void
     {
-        $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
         $conflictingCompetitor = MatchCompetitor::query()
             ->forCompetitorIds(
                 TagTeam::class,
@@ -72,11 +72,12 @@ final class MatchAssignmentConflictService
     }
 
     /**
+     * @param  Collection<int, int>  $conflictingEventIds
      * @param  Collection<int, Referee>  $referees
      */
-    public function ensureRefereesCanBeAssigned(EventMatch $eventMatch, Collection $referees): void
+    public function ensureRefereesCanBeAssigned(EventMatch $eventMatch, Collection $conflictingEventIds, Collection $referees): void
     {
-        $conflictingEventIds = $this->lockConflictingEvents($eventMatch)
+        $conflictingEventIds = $conflictingEventIds
             ->reject(fn (int $eventId): bool => $eventId === $eventMatch->event_id);
 
         if ($conflictingEventIds->isEmpty()) {
@@ -99,11 +100,11 @@ final class MatchAssignmentConflictService
     }
 
     /**
+     * @param  Collection<int, int>  $conflictingEventIds
      * @param  Collection<int, Title>  $titles
      */
-    public function ensureTitlesCanBeAssigned(EventMatch $eventMatch, Collection $titles): void
+    public function ensureTitlesCanBeAssigned(Collection $conflictingEventIds, Collection $titles): void
     {
-        $conflictingEventIds = $this->lockConflictingEvents($eventMatch);
         $conflictingTitleId = EventMatch::query()
             ->forEventIds($conflictingEventIds)
             ->withAnyTitleIds($titles->map(fn (Title $title): int => $title->id))
@@ -125,7 +126,7 @@ final class MatchAssignmentConflictService
     /**
      * @return Collection<int, int>
      */
-    private function lockConflictingEvents(EventMatch $eventMatch): Collection
+    public function lockConflictingEventIds(EventMatch $eventMatch): Collection
     {
         $event = $eventMatch->event()->firstOrFail();
 

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -31,6 +31,8 @@ The match system handles complex wrestling match scenarios with flexible competi
 
 Match configuration and participant availability are separate failure boundaries. `InvalidMatchConfigurationException` describes an incomplete or structurally invalid match, such as missing referees, missing competitors, insufficient populated sides, or an invalid side number. `EntityNotAvailableException` describes a wrestler, tag team, referee, or title whose current state prevents assignment. `SchedulingConflictException` is reserved for an actual collision between bookings, times, or resources and must not substitute for either boundary.
 
+Match assignment actions lock the match and every event that shares its scheduling window before reloading and locking selected wrestlers, tag teams, referees, or titles. Availability and conflict checks use those locked rows, so stale caller models cannot bypass current booking rules and concurrent assignments serialize across the same event window.
+
 Recorded outcomes are checked by `MatchOutcomeRequirements`, which explicitly composes focused winning-side, entry-order, and elimination-history requirements. Each requirement owns one cohesive rule family and raises `InvalidMatchOutcomeException`; the coordinator preserves their deterministic validation order without using a dynamic specification registry or mutation pipeline. `RecordResultAction` locks the match, its event date, the selected winning side, and the complete competitor collection before validation. Outcome requirements and championship reconciliation consume that shared snapshot rather than querying mutable match state independently.
 
 ## Event Card Scheduling

--- a/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
@@ -30,6 +30,19 @@ test('it rejects the entire assignment when any referee is unavailable', functio
     expect($match->referees()->count())->toBe(0);
 });
 
+test('it reloads referees before checking assignment eligibility', function () {
+    $match = EventMatch::factory()->create();
+    $referee = Referee::factory()->bookable()->create();
+    $staleReferee = Referee::query()->findOrFail($referee->id);
+
+    $referee->delete();
+
+    expect(fn () => resolve(AddRefereesToMatchAction::class)->handle($match, collect([$staleReferee])))
+        ->toThrow(EntityNotAvailableException::class);
+
+    expect($match->referees()->exists())->toBeFalse();
+});
+
 test('it allows a referee to officiate multiple matches on one event card', function () {
     $event = Event::factory()->scheduled()->create();
     $existingMatch = EventMatch::factory()->forEvent($event)->create();

--- a/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTagTeamsToMatchActionTest.php
@@ -52,6 +52,19 @@ test('it rejects the entire assignment when any tag team is unavailable', functi
         ->and($match->sides()->count())->toBe(0);
 });
 
+test('it reloads tag teams before checking assignment eligibility', function () {
+    $match = EventMatch::factory()->create();
+    $tagTeam = TagTeam::factory()->bookable()->create();
+    $staleTagTeam = TagTeam::query()->findOrFail($tagTeam->id);
+
+    $tagTeam->delete();
+
+    expect(fn () => resolve(AddTagTeamsToMatchAction::class)->handle($match, collect([$staleTagTeam]), 1))
+        ->toThrow(EntityNotAvailableException::class);
+
+    expect($match->competitors()->exists())->toBeFalse();
+});
+
 test('it rejects a tag team already booked on the event card', function () {
     $event = Event::factory()->scheduled()->create();
     $existingMatch = EventMatch::factory()->forEvent($event)->create();

--- a/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddTitlesToMatchActionTest.php
@@ -102,6 +102,19 @@ test('it throws exception when no eligible titles provided', function () {
         ->toThrow(EntityNotAvailableException::class, 'Selected titles must all be eligible for match assignment.');
 });
 
+test('it reloads titles before checking assignment eligibility', function () {
+    $match = createSinglesMatchWithCompetitors();
+    $title = Title::factory()->active()->create(['type' => TitleType::Singles]);
+    $staleTitle = Title::query()->findOrFail($title->id);
+
+    $title->delete();
+
+    expect(fn () => resolve(AddTitlesToMatchAction::class)->handle($match, collect([$staleTitle])))
+        ->toThrow(EntityNotAvailableException::class);
+
+    expect($match->titles()->exists())->toBeFalse();
+});
+
 test('it handles empty collection', function () {
     $match = EventMatch::factory()->create();
     $titles = Title::query()->whereKey([])->get();

--- a/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddWrestlersToMatchActionTest.php
@@ -128,6 +128,19 @@ test('it throws exception when no eligible wrestlers provided', function () {
         ->toThrow(EntityNotAvailableException::class, 'Selected wrestlers must all be eligible for match assignment.');
 });
 
+test('it reloads wrestlers before checking assignment eligibility', function () {
+    $match = EventMatch::factory()->create();
+    $wrestler = Wrestler::factory()->employed()->create();
+    $staleWrestler = Wrestler::query()->findOrFail($wrestler->id);
+
+    $wrestler->delete();
+
+    expect(fn () => resolve(AddWrestlersToMatchAction::class)->handle($match, collect([$staleWrestler]), 1))
+        ->toThrow(EntityNotAvailableException::class);
+
+    expect($match->competitors()->exists())->toBeFalse();
+});
+
 test('it throws exception when side number is invalid', function () {
     $match = EventMatch::factory()->create();
     $wrestler = Wrestler::factory()->employed()->create();

--- a/tests/Unit/Actions/Matches/AddCompetitorsToMatchActionTest.php
+++ b/tests/Unit/Actions/Matches/AddCompetitorsToMatchActionTest.php
@@ -31,8 +31,8 @@ test('it adds wrestler competitors to a match', function () {
     app()->instance(AddWrestlersToMatchAction::class, $addWrestlersToMatchAction);
     app()->instance(AddTagTeamsToMatchAction::class, $addTagTeamsToMatchAction);
 
-    $addWrestlersToMatchAction->expects('handle')->with($eventMatch, Argument::type('Illuminate\Support\Collection'), 0);
-    $addWrestlersToMatchAction->expects('handle')->with($eventMatch, Argument::type('Illuminate\Support\Collection'), 1);
+    $addWrestlersToMatchAction->expects('handle')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 0);
+    $addWrestlersToMatchAction->expects('handle')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 1);
 
     resolve(AddCompetitorsToMatchAction::class)->handle($eventMatch, $competitors);
 
@@ -59,8 +59,8 @@ test('it adds tag team competitors to a match', function () {
     app()->instance(AddWrestlersToMatchAction::class, $addWrestlersToMatchAction);
     app()->instance(AddTagTeamsToMatchAction::class, $addTagTeamsToMatchAction);
 
-    $addTagTeamsToMatchAction->expects('handle')->with($eventMatch, Argument::type('Illuminate\Support\Collection'), 0);
-    $addTagTeamsToMatchAction->expects('handle')->with($eventMatch, Argument::type('Illuminate\Support\Collection'), 1);
+    $addTagTeamsToMatchAction->expects('handle')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 0);
+    $addTagTeamsToMatchAction->expects('handle')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 1);
 
     resolve(AddCompetitorsToMatchAction::class)->handle($eventMatch, $competitors);
 


### PR DESCRIPTION
## Summary
- lock each match and its conflicting event window before assigning participants or titles
- reload and lock selected wrestlers, tag teams, referees, and titles before eligibility checks
- keep availability and scheduling-conflict failures inside one transaction
- add stale-model regression coverage and document the locking boundary

## Verification
- composer test:push
- 3,462 application tests / 11,060 assertions
- 19 browser tests / 65 assertions
- PHPStan, Pest PHPStan, Rector, type coverage, and Pint passed