### PR TITLE
fix: prevent event rescheduling conflicts

### DIFF
--- a/app/Actions/Events/UpdateAction.php
+++ b/app/Actions/Events/UpdateAction.php
@@ -6,10 +6,13 @@ namespace App\Actions\Events;
 
 use App\Data\Events\EventData;
 use App\Models\Events\Event;
+use App\Services\MatchAssignmentConflictService;
 use Illuminate\Support\Facades\DB;
 
 class UpdateAction
 {
+    public function __construct(private readonly MatchAssignmentConflictService $assignmentConflicts) {}
+
     /**
      * Update an event.
      *
@@ -26,15 +29,29 @@ class UpdateAction
     public function handle(Event $event, EventData $eventData): Event
     {
         return DB::transaction(function () use ($event, $eventData): Event {
-            // Update the event's information
-            $event->update([
+            $lockedEvent = Event::query()->whereKey($event->id)->lockForUpdate()->firstOrFail();
+
+            if ($this->dateIsChanging($lockedEvent, $eventData)) {
+                $this->assignmentConflicts->ensureEventCanBeRescheduled($lockedEvent, $eventData->date);
+            }
+
+            $lockedEvent->update([
                 'name' => $eventData->name,
                 'date' => $eventData->date,
                 'venue_id' => $eventData->venue->id ?? null,
                 'preview' => $eventData->preview,
             ]);
 
-            return $event;
-        });
+            return $lockedEvent;
+        }, attempts: 3);
+    }
+
+    private function dateIsChanging(Event $event, EventData $data): bool
+    {
+        if ($event->date === null) {
+            return $data->date !== null;
+        }
+
+        return $data->date === null || ! $event->date->equalTo($data->date);
     }
 }

--- a/app/Actions/Matches/AddRefereesToMatchAction.php
+++ b/app/Actions/Matches/AddRefereesToMatchAction.php
@@ -69,7 +69,7 @@ class AddRefereesToMatchAction
                 throw EntityNotAvailableException::forMatchAssignment('referees');
             }
 
-            $this->conflictService->ensureRefereesCanBeAssigned($lockedMatch, $conflictingEventIds, $lockedReferees);
+            $this->conflictService->ensureRefereesCanBeAssigned($lockedMatch->event_id, $conflictingEventIds, $lockedReferees);
 
             $lockedReferees->each(function (Referee $referee) use ($lockedMatch): void {
                 $lockedMatch->referees()->attach($referee->id);

--- a/app/Services/MatchAssignmentConflictService.php
+++ b/app/Services/MatchAssignmentConflictService.php
@@ -13,10 +13,56 @@ use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Titles\Title;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
 
 final class MatchAssignmentConflictService
 {
+    public function ensureEventCanBeRescheduled(Event $event, ?Carbon $date): void
+    {
+        if ($date === null) {
+            return;
+        }
+
+        $conflictingEventIds = Event::query()
+            ->where('date', $date)
+            ->whereKeyNot($event->id)
+            ->orderBy('id')
+            ->lockForUpdate()
+            ->get(['id'])
+            ->map(fn (Event $conflictingEvent): int => $conflictingEvent->id);
+
+        if ($conflictingEventIds->isEmpty()) {
+            return;
+        }
+
+        $matches = EventMatch::query()
+            ->where('event_id', $event->id)
+            ->with(['competitors.competitor', 'referees', 'titles'])
+            ->get();
+        $competitors = $matches->flatMap->competitors->pluck('competitor');
+        $wrestlers = $competitors->filter(fn (mixed $competitor): bool => $competitor instanceof Wrestler)->values();
+        $tagTeams = $competitors->filter(fn (mixed $competitor): bool => $competitor instanceof TagTeam)->values();
+        $referees = $matches->flatMap->referees->unique('id')->values();
+        $titles = $matches->flatMap->titles->unique('id')->values();
+
+        if ($wrestlers->isNotEmpty()) {
+            $this->ensureWrestlersCanBeAssigned($conflictingEventIds, $wrestlers);
+        }
+
+        if ($tagTeams->isNotEmpty()) {
+            $this->ensureTagTeamsCanBeAssigned($conflictingEventIds, $tagTeams);
+        }
+
+        if ($referees->isNotEmpty()) {
+            $this->ensureRefereesCanBeAssigned($event->id, $conflictingEventIds, $referees);
+        }
+
+        if ($titles->isNotEmpty()) {
+            $this->ensureTitlesCanBeAssigned($conflictingEventIds, $titles);
+        }
+    }
+
     /**
      * @param  Collection<int, int>  $conflictingEventIds
      * @param  Collection<int, Wrestler>  $wrestlers
@@ -75,10 +121,10 @@ final class MatchAssignmentConflictService
      * @param  Collection<int, int>  $conflictingEventIds
      * @param  Collection<int, Referee>  $referees
      */
-    public function ensureRefereesCanBeAssigned(EventMatch $eventMatch, Collection $conflictingEventIds, Collection $referees): void
+    public function ensureRefereesCanBeAssigned(int $eventId, Collection $conflictingEventIds, Collection $referees): void
     {
         $conflictingEventIds = $conflictingEventIds
-            ->reject(fn (int $eventId): bool => $eventId === $eventMatch->event_id);
+            ->reject(fn (int $conflictingEventId): bool => $conflictingEventId === $eventId);
 
         if ($conflictingEventIds->isEmpty()) {
             return;

--- a/docs/architecture/match-system.md
+++ b/docs/architecture/match-system.md
@@ -33,6 +33,8 @@ Match configuration and participant availability are separate failure boundaries
 
 Match assignment actions lock the match and every event that shares its scheduling window before reloading and locking selected wrestlers, tag teams, referees, or titles. Availability and conflict checks use those locked rows, so stale caller models cannot bypass current booking rules and concurrent assignments serialize across the same event window.
 
+Rescheduling an event reuses the same conflict boundary against every existing assignment on its card. The event update locks the source event and target scheduling window, rejects any wrestler, tag team, referee, or title collision, and changes the event date only when the complete card remains valid.
+
 Recorded outcomes are checked by `MatchOutcomeRequirements`, which explicitly composes focused winning-side, entry-order, and elimination-history requirements. Each requirement owns one cohesive rule family and raises `InvalidMatchOutcomeException`; the coordinator preserves their deterministic validation order without using a dynamic specification registry or mutation pipeline. `RecordResultAction` locks the match, its event date, the selected winning side, and the complete competitor collection before validation. Outcome requirements and championship reconciliation consume that shared snapshot rather than querying mutable match state independently.
 
 ## Event Card Scheduling

--- a/tests/Integration/Actions/Events/UpdateActionTest.php
+++ b/tests/Integration/Actions/Events/UpdateActionTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Events\UpdateAction;
+use App\Data\Events\EventData;
+use App\Exceptions\Scheduling\SchedulingConflictException;
+use App\Models\Events\Event;
+use App\Models\Matches\EventMatch;
+use App\Models\Roster\Referees\Referee;
+use App\Models\Roster\TagTeams\TagTeam;
+use App\Models\Roster\Wrestlers\Wrestler;
+use App\Models\Titles\Title;
+
+test('it rejects rescheduling when a wrestler is booked at the target time', function () {
+    $originalDate = now()->addWeek();
+    $targetDate = now()->addWeeks(2);
+    $event = Event::factory()->create(['date' => $originalDate]);
+    $conflictingEvent = Event::factory()->create(['date' => $targetDate]);
+    $wrestler = Wrestler::factory()->bookable()->create();
+    EventMatch::factory()->forEvent($event)->withCompetitors([$wrestler])->create();
+    EventMatch::factory()->forEvent($conflictingEvent)->withCompetitors([$wrestler])->create();
+    $data = new EventData('Rescheduled Event', $targetDate, null, null);
+
+    expect(fn () => resolve(UpdateAction::class)->handle($event, $data))
+        ->toThrow(SchedulingConflictException::class, "Wrestler [{$wrestler->name}] is already booked at this event time.");
+
+    expect($event->refresh()->date?->toDateTimeString())->toBe($originalDate->toDateTimeString());
+});
+
+test('it rejects rescheduling when a tag team is booked at the target time', function () {
+    $originalDate = now()->addWeek();
+    $targetDate = now()->addWeeks(2);
+    $event = Event::factory()->create(['date' => $originalDate]);
+    $conflictingEvent = Event::factory()->create(['date' => $targetDate]);
+    $tagTeam = TagTeam::factory()->bookable()->create();
+    EventMatch::factory()->forEvent($event)->withCompetitors([$tagTeam])->create();
+    EventMatch::factory()->forEvent($conflictingEvent)->withCompetitors([$tagTeam])->create();
+    $data = new EventData('Rescheduled Event', $targetDate, null, null);
+
+    expect(fn () => resolve(UpdateAction::class)->handle($event, $data))
+        ->toThrow(SchedulingConflictException::class, "Tag team [{$tagTeam->name}] is already booked at this event time.");
+
+    expect($event->refresh()->date?->toDateTimeString())->toBe($originalDate->toDateTimeString());
+});
+
+test('it rejects rescheduling when a referee is assigned at the target time', function () {
+    $originalDate = now()->addWeek();
+    $targetDate = now()->addWeeks(2);
+    $event = Event::factory()->create(['date' => $originalDate]);
+    $conflictingEvent = Event::factory()->create(['date' => $targetDate]);
+    $referee = Referee::factory()->bookable()->create();
+    $match = EventMatch::factory()->forEvent($event)->create();
+    $conflictingMatch = EventMatch::factory()->forEvent($conflictingEvent)->create();
+    $match->referees()->attach($referee);
+    $conflictingMatch->referees()->attach($referee);
+    $refereeName = $referee->refresh()->full_name;
+    $data = new EventData('Rescheduled Event', $targetDate, null, null);
+
+    expect(fn () => resolve(UpdateAction::class)->handle($event, $data))
+        ->toThrow(SchedulingConflictException::class, "Referee [{$refereeName}] is already assigned to another event at this time.");
+
+    expect($event->refresh()->date?->toDateTimeString())->toBe($originalDate->toDateTimeString());
+});
+
+test('it rejects rescheduling when a title is assigned at the target time', function () {
+    $originalDate = now()->addWeek();
+    $targetDate = now()->addWeeks(2);
+    $event = Event::factory()->create(['date' => $originalDate]);
+    $conflictingEvent = Event::factory()->create(['date' => $targetDate]);
+    $title = Title::factory()->active()->create();
+    $match = EventMatch::factory()->forEvent($event)->create();
+    $conflictingMatch = EventMatch::factory()->forEvent($conflictingEvent)->create();
+    $match->titles()->attach($title);
+    $conflictingMatch->titles()->attach($title);
+    $data = new EventData('Rescheduled Event', $targetDate, null, null);
+
+    expect(fn () => resolve(UpdateAction::class)->handle($event, $data))
+        ->toThrow(SchedulingConflictException::class, "Title [{$title->name}] is already assigned at this event time.");
+
+    expect($event->refresh()->date?->toDateTimeString())->toBe($originalDate->toDateTimeString());
+});


### PR DESCRIPTION
## Summary
- lock events before changing their schedule
- validate every existing wrestler, tag team, referee, and title assignment against the target time
- reuse the match assignment conflict boundary and retry deadlocked transactions
- preserve the original event date when any card assignment conflicts
- document event-rescheduling concurrency behavior

## Verification
- composer test:push
- 3,466 application tests / 11,072 assertions
- 19 browser tests / 65 assertions
- PHPStan, Pest PHPStan, Rector, type coverage, and Pint passed