### PR TITLE
fix: prevent rescheduling past events

### DIFF
--- a/.ai/rules/events.md
+++ b/.ai/rules/events.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Actions,Exceptions,Lifecycle,Rules,Livewire}/Events/**'
+---
+
+# Events
+
+## Keep occurred event dates immutable
+Once an event has occurred, its persisted date cannot change, though other event details may be corrected. Enforce this through EventSchedulingEligibility in both Livewire validation and the locked Events UpdateAction so non-UI callers cannot bypass it.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -15,6 +15,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/Http/Controllers/** | .ai/rules/controllers.md |
 | app/Data/** | .ai/rules/data.md |
 | app/Enums/** | .ai/rules/enums.md |
+| app/{Actions,Exceptions,Lifecycle,Rules,Livewire}/Events/** | .ai/rules/events.md |
 | app/Exceptions/** | .ai/rules/exceptions.md |
 | tests/Feature/** | .ai/rules/feature.md |
 | tests/Integration/** | .ai/rules/integration.md |

--- a/app/Actions/Events/UpdateAction.php
+++ b/app/Actions/Events/UpdateAction.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Actions\Events;
 
 use App\Data\Events\EventData;
+use App\Lifecycle\EventSchedulingEligibility;
 use App\Models\Events\Event;
 use App\Services\MatchAssignmentConflictService;
 use Illuminate\Support\Facades\DB;
@@ -31,7 +32,9 @@ class UpdateAction
         return DB::transaction(function () use ($event, $eventData): Event {
             $lockedEvent = Event::query()->whereKey($event->id)->lockForUpdate()->firstOrFail();
 
-            if ($this->dateIsChanging($lockedEvent, $eventData)) {
+            EventSchedulingEligibility::ensureDateCanChange($lockedEvent, $eventData->date);
+
+            if (EventSchedulingEligibility::isDateChanging($lockedEvent, $eventData->date)) {
                 $this->assignmentConflicts->ensureEventCanBeRescheduled($lockedEvent, $eventData->date);
             }
 
@@ -44,14 +47,5 @@ class UpdateAction
 
             return $lockedEvent;
         }, attempts: 3);
-    }
-
-    private function dateIsChanging(Event $event, EventData $data): bool
-    {
-        if ($event->date === null) {
-            return $data->date !== null;
-        }
-
-        return $data->date === null || ! $event->date->equalTo($data->date);
     }
 }

--- a/app/Exceptions/Events/CannotBeRescheduledException.php
+++ b/app/Exceptions/Events/CannotBeRescheduledException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Events;
+
+use App\Exceptions\BaseBusinessException;
+use App\Models\Events\Event;
+
+final class CannotBeRescheduledException extends BaseBusinessException
+{
+    public static function alreadyOccurred(Event $event): self
+    {
+        return new self("Event [{$event->name}] cannot be rescheduled because it has already occurred.");
+    }
+}

--- a/app/Lifecycle/EventSchedulingEligibility.php
+++ b/app/Lifecycle/EventSchedulingEligibility.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Enums\EventStatus;
+use App\Exceptions\Events\CannotBeRescheduledException;
+use App\Models\Events\Event;
+use Illuminate\Support\Carbon;
+
+final class EventSchedulingEligibility
+{
+    public static function ensureDateCanChange(Event $event, ?Carbon $targetDate): void
+    {
+        if (! self::isDateChanging($event, $targetDate)) {
+            return;
+        }
+
+        if ($event->status === EventStatus::Past) {
+            throw CannotBeRescheduledException::alreadyOccurred($event);
+        }
+    }
+
+    public static function isDateChanging(Event $event, ?Carbon $targetDate): bool
+    {
+        if ($event->date === null) {
+            return $targetDate !== null;
+        }
+
+        return $targetDate === null || ! $event->date->isSameSecond($targetDate);
+    }
+}

--- a/app/Livewire/Events/Forms/CreateEditForm.php
+++ b/app/Livewire/Events/Forms/CreateEditForm.php
@@ -172,7 +172,7 @@ class CreateEditForm extends BaseForm
     {
         return [
             'name' => ['required', 'string', 'max:255', Rule::unique('events', 'name')->ignore($this->modelId)],
-            'date' => ['nullable', 'date', new DateCanBeChanged($this->formModel)],
+            'date' => ['bail', 'nullable', 'date', new DateCanBeChanged($this->isEditing() ? $this->event() : null)],
             'venue_id' => ['nullable', 'required_with:date', 'integer', Rule::exists('venues', 'id')],
             'preview' => ['nullable', 'string'],
         ];

--- a/app/Rules/Events/DateCanBeChanged.php
+++ b/app/Rules/Events/DateCanBeChanged.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace App\Rules\Events;
 
-use App\Enums\EventStatus;
+use App\Exceptions\Events\CannotBeRescheduledException;
+use App\Lifecycle\EventSchedulingEligibility;
 use App\Models\Events\Event;
 use Closure;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Support\Facades\Date;
 
 class DateCanBeChanged implements ValidationRule
 {
@@ -15,8 +17,21 @@ class DateCanBeChanged implements ValidationRule
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
-        if ($this->event?->status === EventStatus::Past) {
-            $fail('Cannot change the date of an event that has already occurred.');
+        if (! $this->event) {
+            return;
+        }
+
+        if ($value !== null && ! is_string($value)) {
+            return;
+        }
+
+        try {
+            EventSchedulingEligibility::ensureDateCanChange(
+                $this->event,
+                $value === null ? null : Date::parse($value),
+            );
+        } catch (CannotBeRescheduledException $exception) {
+            $fail($exception->getMessage());
         }
     }
 }

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -244,6 +244,8 @@ Matches integrate seamlessly with event scheduling:
 
 An event's nullable `date` remains the authoritative scheduling value. `EventStatus::fromDate()` translates that persisted value into `Unscheduled`, `Scheduled`, or `Past`; the `Event` model exposes the result through its computed `status` attribute instead of carrying separate scheduling predicates.
 
+Event dates become immutable once the event has occurred. `EventSchedulingEligibility` owns that rule, while both Livewire validation and `Events\UpdateAction` enforce it so non-UI callers cannot bypass the invariant. Other event details may still be corrected without changing the historical date.
+
 ### Roster Management
 
 Dynamic competitor assignment from available talent:

--- a/tests/Integration/Actions/Events/UpdateActionTest.php
+++ b/tests/Integration/Actions/Events/UpdateActionTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use App\Actions\Events\UpdateAction;
 use App\Data\Events\EventData;
+use App\Exceptions\Events\CannotBeRescheduledException;
 use App\Exceptions\Scheduling\SchedulingConflictException;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
@@ -11,6 +12,30 @@ use App\Models\Roster\Referees\Referee;
 use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Titles\Title;
+
+test('it rejects changing the date of an event that already occurred', function () {
+    $originalDate = now()->subWeek();
+    $event = Event::factory()->create(['date' => $originalDate]);
+    $data = new EventData($event->name, now()->addWeek(), $event->venue, $event->preview);
+
+    expect(fn () => resolve(UpdateAction::class)->handle($event, $data))
+        ->toThrow(CannotBeRescheduledException::class);
+
+    expect($event->refresh()->date?->toDateTimeString())->toBe($originalDate->toDateTimeString());
+});
+
+test('it permits updating a past event when its date is unchanged', function () {
+    $originalDate = now()->subWeek();
+    $event = Event::factory()->create(['date' => $originalDate]);
+    $data = new EventData('Updated Event Name', $originalDate->clone(), $event->venue, 'Updated preview');
+
+    $updatedEvent = resolve(UpdateAction::class)->handle($event, $data);
+
+    expect($updatedEvent)
+        ->name->toBe('Updated Event Name')
+        ->preview->toBe('Updated preview')
+        ->and($updatedEvent->date?->toDateTimeString())->toBe($originalDate->toDateTimeString());
+});
 
 test('it rejects rescheduling when a wrestler is booked at the target time', function () {
     $originalDate = now()->addWeek();

--- a/tests/Integration/Livewire/Events/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Events/Modals/FormModalTest.php
@@ -172,14 +172,16 @@ describe('FormModal Edit Operations', function () {
         $venue2 = Venue::factory()->create();
         $event = Event::factory()->create([
             'name' => 'Original Event',
-            'date' => '2024-04-06',
+            'date' => now()->addWeek(),
             'venue_id' => $venue1->id,
         ]);
+
+        $updatedDate = now()->addWeeks(2)->toDateString();
 
         $component = livewire(FormModal::class)
             ->call('openModal', $event->id)
             ->set('form.name', 'Updated Event')
-            ->set('form.date', '2024-04-07')
+            ->set('form.date', $updatedDate)
             ->set('form.venue_id', $venue2->id)
             ->call('save');
 
@@ -189,16 +191,17 @@ describe('FormModal Edit Operations', function () {
         $this->assertDatabaseHas('events', [
             'id' => $event->id,
             'name' => 'Updated Event',
-            'date' => '2024-04-07 00:00:00',
+            'date' => "{$updatedDate} 00:00:00",
             'venue_id' => $venue2->id,
         ]);
     });
 
     it('loads existing event data in edit mode', function () {
         $venue = Venue::factory()->create();
+        $eventDate = now()->addWeek()->startOfSecond();
         $event = Event::factory()->create([
             'name' => 'Test Event',
-            'date' => '2024-04-06',
+            'date' => $eventDate,
             'venue_id' => $venue->id,
         ]);
 
@@ -206,7 +209,7 @@ describe('FormModal Edit Operations', function () {
             ->call('openModal', $event->id);
 
         $component->assertSet('form.name', 'Test Event');
-        $component->assertSet('form.date', '2024-04-06 00:00:00');
+        $component->assertSet('form.date', $eventDate->toDateTimeString());
         $component->assertSet('form.venue_id', $venue->id);
     });
 
@@ -226,14 +229,15 @@ describe('FormModal Edit Operations', function () {
         $venue = Venue::factory()->create();
         $event = Event::factory()->create([
             'name' => 'Test Event',
-            'date' => '2024-04-06',
+            'date' => now()->addWeek(),
             'venue_id' => $venue->id,
         ]);
+        $updatedDate = now()->addWeeks(2)->toDateString();
 
         $component = livewire(FormModal::class)
             ->call('openModal', $event->id)
             ->set('form.name', 'Test Event')
-            ->set('form.date', '2024-04-07')
+            ->set('form.date', $updatedDate)
             ->call('save');
 
         $component->assertHasNoErrors();
@@ -243,6 +247,7 @@ describe('FormModal Edit Operations', function () {
     it('validates date change rules for existing events', function () {
         $venue = Venue::factory()->create();
         $event = Event::factory()->past()->create();
+        $originalDate = $event->date?->toDateTimeString();
 
         $component = livewire(FormModal::class)
             ->call('openModal', $event->id)
@@ -250,8 +255,9 @@ describe('FormModal Edit Operations', function () {
             ->set('form.venue_id', $venue->id)
             ->call('save');
 
-        // Should use DateCanBeChanged rule and allow future date changes
-        $component->assertHasNoErrors();
+        $component->assertHasErrors(['form.date']);
+
+        expect($event->refresh()->date?->toDateTimeString())->toBe($originalDate);
     });
 });
 

--- a/tests/Unit/Lifecycle/EventSchedulingEligibilityTest.php
+++ b/tests/Unit/Lifecycle/EventSchedulingEligibilityTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Exceptions\Events\CannotBeRescheduledException;
+use App\Lifecycle\EventSchedulingEligibility;
+use App\Models\Events\Event;
+
+test('it rejects changing the date of a past event', function () {
+    $event = Event::factory()->make([
+        'name' => 'Summer Spectacular',
+        'date' => now()->subWeek(),
+    ]);
+
+    expect(fn () => EventSchedulingEligibility::ensureDateCanChange($event, now()->addWeek()))
+        ->toThrow(
+            CannotBeRescheduledException::class,
+            'Event [Summer Spectacular] cannot be rescheduled because it has already occurred.',
+        );
+});
+
+test('it permits retaining the date of a past event', function () {
+    $date = now()->subWeek();
+    $event = Event::factory()->make(['date' => $date]);
+
+    EventSchedulingEligibility::ensureDateCanChange($event, $date->clone());
+
+    expect(true)->toBeTrue();
+});
+
+test('it permits changing the date of a future event', function () {
+    $event = Event::factory()->make(['date' => now()->addWeek()]);
+
+    EventSchedulingEligibility::ensureDateCanChange($event, now()->addWeeks(2));
+
+    expect(true)->toBeTrue();
+});

--- a/tests/Unit/Rules/Events/DateCanBeChangedUnitTest.php
+++ b/tests/Unit/Rules/Events/DateCanBeChangedUnitTest.php
@@ -19,7 +19,7 @@ describe('DateCanBeChanged Validation Rule Unit Tests', function () {
             };
 
             // Act
-            $rule->validate('date', now()->addWeek(), validationFailureCallback($failCallback));
+            $rule->validate('date', now()->addWeek()->toDateTimeString(), validationFailureCallback($failCallback));
 
             // Assert
             expect($failCalled)->toBeFalse();
@@ -38,11 +38,11 @@ describe('DateCanBeChanged Validation Rule Unit Tests', function () {
             };
 
             // Act
-            $rule->validate('date', now()->addWeek(), validationFailureCallback($failCallback));
+            $rule->validate('date', now()->addWeek()->toDateTimeString(), validationFailureCallback($failCallback));
 
             // Assert
             expect($failCalled)->toBeTrue();
-            expect($failMessage)->toBe('Cannot change the date of an event that has already occurred.');
+            expect($failMessage)->toBe("Event [{$pastEvent->name}] cannot be rescheduled because it has already occurred.");
         });
 
         test('validation passes when no event provided', function () {
@@ -57,6 +57,21 @@ describe('DateCanBeChanged Validation Rule Unit Tests', function () {
             $rule->validate('date', now()->addWeek(), validationFailureCallback($failCallback));
 
             // Assert
+            expect($failCalled)->toBeFalse();
+        });
+
+        test('validation passes when a past event keeps its existing date', function () {
+            $date = now()->subWeek();
+            $pastEvent = Event::factory()->make(['date' => $date]);
+            $rule = new DateCanBeChanged($pastEvent);
+            $failCalled = false;
+
+            $rule->validate('date', $date->toDateTimeString(), validationFailureCallback(
+                function () use (&$failCalled): void {
+                    $failCalled = true;
+                },
+            ));
+
             expect($failCalled)->toBeFalse();
         });
     });
@@ -81,7 +96,7 @@ describe('DateCanBeChanged Validation Rule Unit Tests', function () {
             expect($rule)->toBeInstanceOf(DateCanBeChanged::class);
         });
 
-        test('rule handles various date value types', function () {
+        test('rule handles a validated date string', function () {
             // Arrange
             $futureEvent = Event::factory()->make(['date' => now()->addWeek()]);
             $rule = new DateCanBeChanged($futureEvent);
@@ -91,12 +106,10 @@ describe('DateCanBeChanged Validation Rule Unit Tests', function () {
                 $failCalled = true;
             };
 
-            // Act & Assert - string date
+            // Act
             $rule->validate('date', '2024-12-25', validationFailureCallback($failCallback));
-            expect($failCalled)->toBeFalse();
 
-            // Act & Assert - Carbon instance
-            $rule->validate('date', now()->addWeek(), validationFailureCallback($failCallback));
+            // Assert
             expect($failCalled)->toBeFalse();
         });
     });
@@ -135,13 +148,13 @@ describe('DateCanBeChanged Validation Rule Unit Tests', function () {
             };
 
             // Act
-            $rule->validate('date', now()->addWeek(), validationFailureCallback($failCallback));
-            $rule->validate('different_field', now()->addMonth(), validationFailureCallback($failCallback));
+            $rule->validate('date', now()->addWeek()->toDateTimeString(), validationFailureCallback($failCallback));
+            $rule->validate('different_field', now()->addMonth()->toDateTimeString(), validationFailureCallback($failCallback));
 
             // Assert
             expect($messages)->toHaveCount(2);
             expect($messages[0])->toBe($messages[1]);
-            expect($messages[0])->toBe('Cannot change the date of an event that has already occurred.');
+            expect($messages[0])->toBe("Event [{$pastEvent->name}] cannot be rescheduled because it has already occurred.");
         });
 
         test('attribute name does not affect validation logic', function () {
@@ -155,9 +168,9 @@ describe('DateCanBeChanged Validation Rule Unit Tests', function () {
             };
 
             // Act
-            $rule->validate('date', now(), validationFailureCallback($failCallback));
-            $rule->validate('event_date', now(), validationFailureCallback($failCallback));
-            $rule->validate('scheduled_date', now(), validationFailureCallback($failCallback));
+            $rule->validate('date', now()->toDateTimeString(), validationFailureCallback($failCallback));
+            $rule->validate('event_date', now()->toDateTimeString(), validationFailureCallback($failCallback));
+            $rule->validate('scheduled_date', now()->toDateTimeString(), validationFailureCallback($failCallback));
 
             // Assert
             expect($failCallCount)->toBe(3);


### PR DESCRIPTION
## Summary
- centralize event date-change eligibility outside Livewire
- prevent past-event rescheduling in the locked update action while permitting other corrections
- use Laravel validation and Date facade behavior at the Livewire boundary
- document and test the invariant

## Verification
- composer test:push