### PR TITLE
fix: prevent venue double booking

### DIFF
--- a/.ai/rules/events.md
+++ b/.ai/rules/events.md
@@ -7,3 +7,6 @@ paths:
 
 ## Keep occurred event dates immutable
 Once an event has occurred, its persisted date cannot change, though other event details may be corrected. Enforce this through EventSchedulingEligibility in both Livewire validation and the locked Events UpdateAction so non-UI callers cannot bypass it.
+
+## Lock venues before scheduling events
+A venue may host only one event at a given date and time. Event CreateAction and UpdateAction must lock the selected venue inside their transaction before VenueSchedulingEligibility checks for an existing booking; unscheduled events do not reserve a venue time.

--- a/app/Actions/Events/CreateAction.php
+++ b/app/Actions/Events/CreateAction.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Actions\Events;
 
 use App\Data\Events\EventData;
+use App\Lifecycle\VenueSchedulingEligibility;
 use App\Models\Events\Event;
+use App\Models\Events\Venue;
 use Illuminate\Support\Facades\DB;
 
 class CreateAction
@@ -24,15 +26,32 @@ class CreateAction
     public function handle(EventData $eventData): Event
     {
         return DB::transaction(function () use ($eventData): Event {
-            // Create the base event record
+            $venue = $this->lockScheduledVenue($eventData);
+
+            if ($venue !== null && $eventData->date !== null) {
+                VenueSchedulingEligibility::ensureAvailable($venue, $eventData->date);
+            }
+
             $event = Event::query()->create([
                 'name' => $eventData->name,
                 'date' => $eventData->date,
-                'venue_id' => $eventData->venue->id ?? null,
+                'venue_id' => $eventData->venue?->id,
                 'preview' => $eventData->preview,
             ]);
 
             return $event;
-        });
+        }, attempts: 3);
+    }
+
+    private function lockScheduledVenue(EventData $eventData): ?Venue
+    {
+        if ($eventData->date === null || $eventData->venue === null) {
+            return null;
+        }
+
+        return Venue::query()
+            ->whereKey($eventData->venue->id)
+            ->lockForUpdate()
+            ->firstOrFail();
     }
 }

--- a/app/Actions/Events/UpdateAction.php
+++ b/app/Actions/Events/UpdateAction.php
@@ -6,7 +6,9 @@ namespace App\Actions\Events;
 
 use App\Data\Events\EventData;
 use App\Lifecycle\EventSchedulingEligibility;
+use App\Lifecycle\VenueSchedulingEligibility;
 use App\Models\Events\Event;
+use App\Models\Events\Venue;
 use App\Services\MatchAssignmentConflictService;
 use Illuminate\Support\Facades\DB;
 
@@ -33,6 +35,11 @@ class UpdateAction
             $lockedEvent = Event::query()->whereKey($event->id)->lockForUpdate()->firstOrFail();
 
             EventSchedulingEligibility::ensureDateCanChange($lockedEvent, $eventData->date);
+            $venue = $this->lockScheduledVenue($eventData);
+
+            if ($venue !== null && $eventData->date !== null) {
+                VenueSchedulingEligibility::ensureAvailable($venue, $eventData->date, $lockedEvent);
+            }
 
             if (EventSchedulingEligibility::isDateChanging($lockedEvent, $eventData->date)) {
                 $this->assignmentConflicts->ensureEventCanBeRescheduled($lockedEvent, $eventData->date);
@@ -41,11 +48,23 @@ class UpdateAction
             $lockedEvent->update([
                 'name' => $eventData->name,
                 'date' => $eventData->date,
-                'venue_id' => $eventData->venue->id ?? null,
+                'venue_id' => $eventData->venue?->id,
                 'preview' => $eventData->preview,
             ]);
 
             return $lockedEvent;
         }, attempts: 3);
+    }
+
+    private function lockScheduledVenue(EventData $eventData): ?Venue
+    {
+        if ($eventData->date === null || $eventData->venue === null) {
+            return null;
+        }
+
+        return Venue::query()
+            ->whereKey($eventData->venue->id)
+            ->lockForUpdate()
+            ->firstOrFail();
     }
 }

--- a/app/Exceptions/Scheduling/SchedulingConflictException.php
+++ b/app/Exceptions/Scheduling/SchedulingConflictException.php
@@ -22,4 +22,9 @@ final class SchedulingConflictException extends BaseBusinessException
     {
         return new self("Title [{$titleName}] is already assigned at this event time.");
     }
+
+    public static function venueAlreadyBooked(string $venueName): static
+    {
+        return new self("Venue [{$venueName}] is already booked at this event time.");
+    }
 }

--- a/app/Lifecycle/VenueSchedulingEligibility.php
+++ b/app/Lifecycle/VenueSchedulingEligibility.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Exceptions\Scheduling\SchedulingConflictException;
+use App\Models\Events\Event;
+use App\Models\Events\Venue;
+use Illuminate\Support\Carbon;
+
+final class VenueSchedulingEligibility
+{
+    public static function ensureAvailable(Venue $venue, Carbon $date, ?Event $except = null): void
+    {
+        $events = $venue->events()->where('date', $date);
+
+        if ($except !== null) {
+            $events->whereKeyNot($except->getKey());
+        }
+
+        if ($events->exists()) {
+            throw SchedulingConflictException::venueAlreadyBooked($venue->name);
+        }
+    }
+}

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -246,6 +246,8 @@ An event's nullable `date` remains the authoritative scheduling value. `EventSta
 
 Event dates become immutable once the event has occurred. `EventSchedulingEligibility` owns that rule, while both Livewire validation and `Events\UpdateAction` enforce it so non-UI callers cannot bypass the invariant. Other event details may still be corrected without changing the historical date.
 
+A venue may host only one event at a given date and time. Event creation and updates lock the selected venue row before `VenueSchedulingEligibility` checks its event relationship, serializing competing bookings and rolling back the complete event write when a conflict exists. Unscheduled events do not reserve a venue time.
+
 ### Roster Management
 
 Dynamic competitor assignment from available talent:

--- a/tests/Integration/Actions/Events/VenueSchedulingTest.php
+++ b/tests/Integration/Actions/Events/VenueSchedulingTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Events\CreateAction;
+use App\Actions\Events\UpdateAction;
+use App\Data\Events\EventData;
+use App\Exceptions\Scheduling\SchedulingConflictException;
+use App\Models\Events\Event;
+use App\Models\Events\Venue;
+
+test('it rejects creating events at the same venue and time', function () {
+    $date = now()->addWeek();
+    $venue = Venue::factory()->create();
+    Event::factory()->for($venue)->create(['date' => $date]);
+    $data = new EventData('Conflicting Event', $date, $venue, null);
+
+    expect(fn () => resolve(CreateAction::class)->handle($data))
+        ->toThrow(
+            SchedulingConflictException::class,
+            "Venue [{$venue->name}] is already booked at this event time.",
+        );
+
+    expect(Event::query()->where('name', 'Conflicting Event')->exists())->toBeFalse();
+});
+
+test('it permits using the same venue at a different time', function () {
+    $venue = Venue::factory()->create();
+    Event::factory()->for($venue)->create(['date' => now()->addWeek()]);
+    $data = new EventData('Later Event', now()->addWeeks(2), $venue, null);
+
+    $event = resolve(CreateAction::class)->handle($data);
+
+    expect($event)
+        ->name->toBe('Later Event')
+        ->venue_id->toBe($venue->id);
+});
+
+test('it rejects moving an event into a venue scheduling conflict', function () {
+    $date = now()->addWeek();
+    $originalVenue = Venue::factory()->create();
+    $conflictingVenue = Venue::factory()->create();
+    $event = Event::factory()->for($originalVenue)->create(['date' => $date]);
+    Event::factory()->for($conflictingVenue)->create(['date' => $date]);
+    $data = new EventData('Updated Event', $date, $conflictingVenue, null);
+
+    expect(fn () => resolve(UpdateAction::class)->handle($event, $data))
+        ->toThrow(SchedulingConflictException::class);
+
+    expect($event->refresh())
+        ->name->not->toBe('Updated Event')
+        ->venue_id->toBe($originalVenue->id);
+});
+
+test('it rejects rescheduling an event into a conflict at its current venue', function () {
+    $originalDate = now()->addWeek();
+    $conflictingDate = now()->addWeeks(2);
+    $venue = Venue::factory()->create();
+    $event = Event::factory()->for($venue)->create(['date' => $originalDate]);
+    Event::factory()->for($venue)->create(['date' => $conflictingDate]);
+    $data = new EventData('Rescheduled Event', $conflictingDate, $venue, null);
+
+    expect(fn () => resolve(UpdateAction::class)->handle($event, $data))
+        ->toThrow(SchedulingConflictException::class);
+
+    expect($event->refresh())
+        ->name->not->toBe('Rescheduled Event')
+        ->and($event->date?->toDateTimeString())->toBe($originalDate->toDateTimeString());
+});
+
+test('it permits updating an event without changing its venue schedule', function () {
+    $date = now()->addWeek();
+    $venue = Venue::factory()->create();
+    $event = Event::factory()->for($venue)->create(['date' => $date]);
+    $data = new EventData('Updated Event', $date, $venue, 'Updated preview');
+
+    $updatedEvent = resolve(UpdateAction::class)->handle($event, $data);
+
+    expect($updatedEvent)
+        ->name->toBe('Updated Event')
+        ->preview->toBe('Updated preview')
+        ->venue_id->toBe($venue->id);
+});


### PR DESCRIPTION
## Summary
- lock scheduled venues during event creation and updates
- reject events that collide at the same venue and timestamp
- preserve unscheduled event behavior and allow unchanged schedules
- document and test the venue scheduling invariant

## Verification
- composer test:push