### PR TITLE
fix: align event venue validation

### DIFF
--- a/app/Livewire/Events/Forms/CreateEditForm.php
+++ b/app/Livewire/Events/Forms/CreateEditForm.php
@@ -158,7 +158,7 @@ class CreateEditForm extends BaseForm
      * Validation Requirements:
      * - Name: Required, unique across events, max 255 characters
      * - Date: Optional, valid date format, custom business rule validation
-     * - Venue: Required when date is provided, must exist in venues table
+     * - Venue: Optional, when provided must exist in venues table
      * - Preview: Required promotional content, string format
      *
      * @return array<string, array<int, mixed>> Laravel validation rules array
@@ -173,7 +173,7 @@ class CreateEditForm extends BaseForm
         return [
             'name' => ['required', 'string', 'max:255', Rule::unique('events', 'name')->ignore($this->modelId)],
             'date' => ['bail', 'nullable', 'date', new DateCanBeChanged($this->isEditing() ? $this->event() : null)],
-            'venue_id' => ['nullable', 'required_with:date', 'integer', Rule::exists('venues', 'id')],
+            'venue_id' => ['nullable', 'integer', Rule::exists('venues', 'id')],
             'preview' => ['nullable', 'string'],
         ];
     }

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -244,6 +244,8 @@ Matches integrate seamlessly with event scheduling:
 
 An event's nullable `date` remains the authoritative scheduling value. `EventStatus::fromDate()` translates that persisted value into `Unscheduled`, `Scheduled`, or `Past`; the `Event` model exposes the result through its computed `status` attribute instead of carrying separate scheduling predicates.
 
+Events may have a date without a venue while planning or preserving historical records. A venue is optional event metadata; when one is selected for a dated event, it is reserved exclusively at that date and time.
+
 Event dates become immutable once the event has occurred. `EventSchedulingEligibility` owns that rule, while both Livewire validation and `Events\UpdateAction` enforce it so non-UI callers cannot bypass the invariant. Other event details may still be corrected without changing the historical date.
 
 A venue may host only one event at a given date and time. Event creation and updates lock the selected venue row before `VenueSchedulingEligibility` checks its event relationship, serializing competing bookings and rolling back the complete event write when a conflict exists. Unscheduled events do not reserve a venue time.

--- a/docs/guides/livewire/testing-forms.md
+++ b/docs/guides/livewire/testing-forms.md
@@ -115,20 +115,20 @@ describe('CreateEditForm Validation', function () {
         
         expect($form->getErrorBag()->has('name'))->toBeTrue();
         expect($form->getErrorBag()->has('date'))->toBeFalse(); // nullable
-        expect($form->getErrorBag()->has('venue_id'))->toBeFalse(); // required_with:date
+        expect($form->getErrorBag()->has('venue_id'))->toBeFalse(); // venue is optional
     });
     
-    test('validates required fields with dependencies', function () {
+    test('allows a date without a venue', function () {
         $form = new CreateEditForm();
-        
+
         $form->name = 'Test Event';
         $form->date = '2024-01-01';
-        $form->venue_id = 0; // Required when date is provided
-        
+        $form->venue_id = null;
+
         $form->validate();
-        
+
         expect($form->getErrorBag()->has('name'))->toBeFalse();
-        expect($form->getErrorBag()->has('venue_id'))->toBeTrue();
+        expect($form->getErrorBag()->has('venue_id'))->toBeFalse();
     });
 });
 ```

--- a/tests/Integration/Livewire/Events/Modals/FormModalTest.php
+++ b/tests/Integration/Livewire/Events/Modals/FormModalTest.php
@@ -97,6 +97,24 @@ describe('FormModal Create Operations', function () {
         ]);
     });
 
+    it('can create a dated event without a venue', function () {
+        $component = livewire(FormModal::class)
+            ->call('openModal')
+            ->set('form.name', 'Unassigned Event')
+            ->set('form.date', '2024-04-06')
+            ->set('form.venue_id', null)
+            ->call('save');
+
+        $component->assertHasNoErrors();
+        $component->assertDispatched('form-submitted');
+
+        $this->assertDatabaseHas('events', [
+            'name' => 'Unassigned Event',
+            'date' => '2024-04-06 00:00:00',
+            'venue_id' => null,
+        ]);
+    });
+
     it('validates required fields when creating', function () {
         $component = livewire(FormModal::class)
             ->call('openModal')


### PR DESCRIPTION
## Summary
- align Livewire event venue validation with the established date-only event behavior
- add coverage for creating dated events without venues
- document optional venue metadata and scheduling semantics

## Verification
- focused Pest: 52 tests, 155 assertions
- targeted Pint with Blade passed
- application tests, PHPStan, and Rector passed
- full lint remains blocked by unrelated pre-existing Blade formatting failures