### PR TITLE
fix: protect event restoration scheduling

### DIFF
--- a/.ai/rules/events.md
+++ b/.ai/rules/events.md
@@ -10,3 +10,6 @@ Once an event has occurred, its persisted date cannot change, though other event
 
 ## Lock venues before scheduling events
 A venue may host only one event at a given date and time. Event CreateAction and UpdateAction must lock the selected venue inside their transaction before VenueSchedulingEligibility checks for an existing booking; unscheduled events do not reserve a venue time.
+
+## Validate venue conflicts during event restoration
+Restoring a soft-deleted event must lock its event and selected venue inside a transaction, then run VenueSchedulingEligibility before restoring. Restoration must not recreate a venue/date conflict created after deletion.

--- a/app/Actions/Events/RestoreAction.php
+++ b/app/Actions/Events/RestoreAction.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace App\Actions\Events;
 
 use App\Lifecycle\DeletionStateManager;
+use App\Lifecycle\VenueSchedulingEligibility;
 use App\Models\Events\Event;
+use App\Models\Events\Venue;
+use Illuminate\Support\Facades\DB;
 
 class RestoreAction
 {
@@ -26,6 +29,23 @@ class RestoreAction
      */
     public function handle(Event $event): void
     {
-        $this->deletionState->restore($event, now());
+        DB::transaction(function () use ($event): void {
+            $lockedEvent = Event::query()
+                ->withTrashed()
+                ->whereKey($event->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            if ($lockedEvent->date !== null && $lockedEvent->venue_id !== null) {
+                $venue = Venue::query()
+                    ->whereKey($lockedEvent->venue_id)
+                    ->lockForUpdate()
+                    ->firstOrFail();
+
+                VenueSchedulingEligibility::ensureAvailable($venue, $lockedEvent->date, $lockedEvent);
+            }
+
+            $this->deletionState->restore($lockedEvent, now());
+        });
     }
 }

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -250,6 +250,8 @@ Event dates become immutable once the event has occurred. `EventSchedulingEligib
 
 A venue may host only one event at a given date and time. Event creation and updates lock the selected venue row before `VenueSchedulingEligibility` checks its event relationship, serializing competing bookings and rolling back the complete event write when a conflict exists. Unscheduled events do not reserve a venue time.
 
+Restoring a soft-deleted event applies the same venue lock and availability check before reactivating its booking, so a later event cannot be displaced or share the same venue slot.
+
 ### Roster Management
 
 Dynamic competitor assignment from available talent:

--- a/tests/Integration/Actions/Events/VenueSchedulingTest.php
+++ b/tests/Integration/Actions/Events/VenueSchedulingTest.php
@@ -3,6 +3,8 @@
 declare(strict_types=1);
 
 use App\Actions\Events\CreateAction;
+use App\Actions\Events\DeleteAction;
+use App\Actions\Events\RestoreAction;
 use App\Actions\Events\UpdateAction;
 use App\Data\Events\EventData;
 use App\Exceptions\Scheduling\SchedulingConflictException;
@@ -80,4 +82,21 @@ test('it permits updating an event without changing its venue schedule', functio
         ->name->toBe('Updated Event')
         ->preview->toBe('Updated preview')
         ->venue_id->toBe($venue->id);
+});
+
+test('it rejects restoring an event into a venue scheduling conflict', function () {
+    $date = now()->addWeek();
+    $venue = Venue::factory()->create();
+    $deletedEvent = Event::factory()->for($venue)->create(['date' => $date]);
+
+    resolve(DeleteAction::class)->handle($deletedEvent);
+    Event::factory()->for($venue)->create(['date' => $date]);
+
+    expect(fn () => resolve(RestoreAction::class)->handle($deletedEvent))
+        ->toThrow(
+            SchedulingConflictException::class,
+            "Venue [{$venue->name}] is already booked at this event time.",
+        );
+
+    expect(Event::onlyTrashed()->whereKey($deletedEvent->getKey())->exists())->toBeTrue();
 });


### PR DESCRIPTION
## Summary
- lock soft-deleted events and venues before restoration
- reject restores that would recreate a venue/date conflict
- add rollback coverage and document the invariant

## Verification
- focused Pest: 29 tests, 112 assertions
- targeted Pint with Blade passed
- application tests, PHPStan, and Rector passed
- full lint remains blocked by unrelated pre-existing Blade formatting failures