### PR TITLE
fix: protect venue restoration names

### DIFF
--- a/.ai/rules/events-lifecycle.md
+++ b/.ai/rules/events-lifecycle.md
@@ -1,0 +1,9 @@
+---
+paths:
+  - 'app/{Actions/Venues,Exceptions/Events,Lifecycle}/**'
+---
+
+# Events Lifecycle
+
+## Validate venue restoration name conflicts
+Venue restoration must lock the soft-deleted venue inside its transaction and reject active venue name conflicts before restoring. Preserve historical event relationships without bypassing active venue identity uniqueness.

--- a/.ai/rules/index.md
+++ b/.ai/rules/index.md
@@ -5,6 +5,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | Applies to | Rule file |
 | --- | --- |
 | app/{Actions,Collections,Lifecycle,Models,Rules}/** | .ai/rules/actions-collections-lifecycle-models-rules.md |
+| app/{Actions,Lifecycle,Exceptions}/Titles/** | .ai/rules/actions-lifecycle-exceptions-titles.md |
 | app/{Actions,Lifecycle,Models}/** | .ai/rules/actions-lifecycle-models.md |
 | app/{Actions,Lifecycle}/** | .ai/rules/actions-lifecycle.md |
 | app/Actions/Matches/** | .ai/rules/actions-matches.md |
@@ -15,6 +16,7 @@ Before planning or editing, find the row whose globs match the file's path and r
 | app/Http/Controllers/** | .ai/rules/controllers.md |
 | app/Data/** | .ai/rules/data.md |
 | app/Enums/** | .ai/rules/enums.md |
+| app/{Actions/Venues,Exceptions/Events,Lifecycle}/** | .ai/rules/events-lifecycle.md |
 | app/{Actions,Exceptions,Lifecycle,Rules,Livewire}/Events/** | .ai/rules/events.md |
 | app/Exceptions/** | .ai/rules/exceptions.md |
 | tests/Feature/** | .ai/rules/feature.md |

--- a/app/Actions/Venues/RestoreAction.php
+++ b/app/Actions/Venues/RestoreAction.php
@@ -5,11 +5,16 @@ declare(strict_types=1);
 namespace App\Actions\Venues;
 
 use App\Lifecycle\DeletionStateManager;
+use App\Lifecycle\VenueDeletionEligibility;
 use App\Models\Events\Venue;
+use Illuminate\Support\Facades\DB;
 
 class RestoreAction
 {
-    public function __construct(private readonly DeletionStateManager $deletionState) {}
+    public function __construct(
+        private readonly DeletionStateManager $deletionState,
+        private readonly VenueDeletionEligibility $eligibility,
+    ) {}
 
     /**
      * Restore a soft-deleted venue.
@@ -24,6 +29,15 @@ class RestoreAction
      */
     public function handle(Venue $venue): void
     {
-        $this->deletionState->restore($venue, now());
+        DB::transaction(function () use ($venue): void {
+            $lockedVenue = Venue::query()
+                ->withTrashed()
+                ->whereKey($venue->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->eligibility->ensureCanRestore($lockedVenue);
+            $this->deletionState->restore($lockedVenue, now());
+        });
     }
 }

--- a/app/Exceptions/Events/CannotBeRestoredException.php
+++ b/app/Exceptions/Events/CannotBeRestoredException.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Events;
+
+use App\Enums\BusinessRuleReason;
+use App\Exceptions\BaseBusinessException;
+use App\Models\Events\Venue;
+
+final class CannotBeRestoredException extends BaseBusinessException
+{
+    public static function notDeleted(Venue $venue): static
+    {
+        $context = self::formatModelContext($venue);
+
+        return self::forReason(BusinessRuleReason::NotDeleted, "{$context} cannot be restored because it is not deleted.");
+    }
+
+    public static function nameConflict(Venue $venue, string $conflictingName): static
+    {
+        $context = self::formatModelContext($venue);
+
+        return new static("{$context} cannot be restored because the name conflicts with existing venue '{$conflictingName}'. Resolve the conflict before restoration.");
+    }
+}

--- a/app/Lifecycle/VenueDeletionEligibility.php
+++ b/app/Lifecycle/VenueDeletionEligibility.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Exceptions\Events\CannotBeRestoredException;
+use App\Models\Events\Venue;
+
+final class VenueDeletionEligibility
+{
+    public function canRestore(Venue $venue): bool
+    {
+        try {
+            $this->ensureCanRestore($venue);
+
+            return true;
+        } catch (CannotBeRestoredException) {
+            return false;
+        }
+    }
+
+    public function ensureCanRestore(Venue $venue): void
+    {
+        if (! $venue->trashed()) {
+            throw CannotBeRestoredException::notDeleted($venue);
+        }
+
+        $conflictingVenue = Venue::query()
+            ->where('name', $venue->name)
+            ->whereKeyNot($venue->getKey())
+            ->first();
+
+        if ($conflictingVenue !== null) {
+            throw CannotBeRestoredException::nameConflict($venue, $conflictingVenue->name);
+        }
+    }
+}

--- a/docs/architecture/system-overview.md
+++ b/docs/architecture/system-overview.md
@@ -252,6 +252,8 @@ A venue may host only one event at a given date and time. Event creation and upd
 
 Restoring a soft-deleted event applies the same venue lock and availability check before reactivating its booking, so a later event cannot be displaced or share the same venue slot.
 
+Restoring a soft-deleted venue locks the venue row and verifies that no active venue has claimed its name, preserving venue identity without bypassing active-name uniqueness.
+
 ### Roster Management
 
 Dynamic competitor assignment from available talent:

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -7,6 +7,7 @@ use App\Actions\Venues\DeleteAction;
 use App\Actions\Venues\RestoreAction;
 use App\Actions\Venues\UpdateAction;
 use App\Data\Events\VenueData;
+use App\Exceptions\Events\CannotBeRestoredException;
 use App\Models\Events\Event;
 use App\Models\Events\Venue;
 use App\Models\Users\User;
@@ -249,6 +250,18 @@ describe('Venue Action Integration Tests', function () {
 
             $restoredVenue = Venue::findOrFail($venueId);
             expect($restoredVenue->name)->toBe('Restoration Test Arena');
+        });
+
+        test('restore action rejects an active venue name conflict', function () {
+            $venue = Venue::factory()->create(['name' => 'Restoration Test Arena']);
+
+            resolve(DeleteAction::class)->handle($venue);
+            Venue::factory()->create(['name' => 'Restoration Test Arena']);
+
+            expect(fn () => resolve(RestoreAction::class)->handle($venue))
+                ->toThrow(CannotBeRestoredException::class);
+
+            expect(Venue::onlyTrashed()->whereKey($venue->getKey())->exists())->toBeTrue();
         });
 
         test('restore action maintains event relationships', function () {


### PR DESCRIPTION
## Summary
- lock venues before restoration
- reject restoration when an active venue already uses the name
- add typed eligibility and exception boundaries
- add regression coverage and architecture rules

## Verification
- targeted Pint with Blade passed
- narrow application and Pest PHPStan passed
- focused worktree tests were blocked by the isolated worktree Laravel bootstrap/browser environment; CI will run the authoritative suite