### PR TITLE
fix: lock individual restorations

### DIFF
--- a/app/Actions/Managers/RestoreAction.php
+++ b/app/Actions/Managers/RestoreAction.php
@@ -32,14 +32,19 @@ class RestoreAction
      */
     public function handle(Manager $manager): void
     {
-        $this->eligibility->ensureCanRestore($manager);
-
         DB::transaction(function () use ($manager): void {
-            $restorationDate = now();
-            $this->deletionState->restore($manager, $restorationDate);
+            $lockedManager = Manager::query()
+                ->withTrashed()
+                ->whereKey($manager->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
 
-            $manager->employments()->whereNull('ended_at')->update(['ended_at' => $restorationDate]);
-            $this->managerAssignments->endCurrentAssignments($manager, $restorationDate);
+            $this->eligibility->ensureCanRestore($lockedManager);
+            $restorationDate = now();
+            $this->deletionState->restore($lockedManager, $restorationDate);
+
+            $lockedManager->employments()->whereNull('ended_at')->update(['ended_at' => $restorationDate]);
+            $this->managerAssignments->endCurrentAssignments($lockedManager, $restorationDate);
         });
     }
 }

--- a/app/Actions/Referees/RestoreAction.php
+++ b/app/Actions/Referees/RestoreAction.php
@@ -30,10 +30,15 @@ class RestoreAction
      */
     public function handle(Referee $referee): void
     {
-        $this->eligibility->ensureCanRestore($referee);
-
         DB::transaction(function () use ($referee): void {
-            $this->deletionState->restore($referee, now());
+            $lockedReferee = Referee::query()
+                ->withTrashed()
+                ->whereKey($referee->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->eligibility->ensureCanRestore($lockedReferee);
+            $this->deletionState->restore($lockedReferee, now());
 
             // Note: No automatic relationship restoration to avoid conflicts.
             // All employment relationships must be re-established explicitly using separate actions.

--- a/app/Actions/Wrestlers/RestoreAction.php
+++ b/app/Actions/Wrestlers/RestoreAction.php
@@ -32,12 +32,17 @@ class RestoreAction
      */
     public function handle(Wrestler $wrestler, ?Carbon $restoreDate = null): void
     {
-        $this->eligibility->ensureCanRestore($wrestler);
-
         $restoreDate = $restoreDate ?? now();
 
         DB::transaction(function () use ($wrestler, $restoreDate): void {
-            $this->deletionState->restore($wrestler, $restoreDate);
+            $lockedWrestler = Wrestler::query()
+                ->withTrashed()
+                ->whereKey($wrestler->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->eligibility->ensureCanRestore($lockedWrestler);
+            $this->deletionState->restore($lockedWrestler, $restoreDate);
 
             // Note: No automatic relationship restoration to avoid conflicts.
             // All employment, tag team, stable, and manager relationships

--- a/tests/Integration/Actions/Managers/RestoreActionTest.php
+++ b/tests/Integration/Actions/Managers/RestoreActionTest.php
@@ -35,6 +35,17 @@ test('it restores a soft-deleted manager', function () {
     expect($restoredManager->deleted_at)->toBeNull();
 });
 
+test('it reloads a stale manager before restoring', function () {
+    $manager = Manager::factory()->create();
+    $staleManager = clone $manager;
+
+    $manager->delete();
+
+    resolve(RestoreAction::class)->handle($staleManager);
+
+    expect(Manager::query()->find($manager->getKey()))->not->toBeNull();
+});
+
 test('it handles database transactions correctly', function () {
     $manager = Manager::factory()->employed()->create();
     $managerId = $manager->id;

--- a/tests/Integration/Actions/Referees/RestoreActionTest.php
+++ b/tests/Integration/Actions/Referees/RestoreActionTest.php
@@ -33,6 +33,17 @@ test('it restores a soft-deleted referee', function () {
     ]);
 });
 
+test('it reloads a stale referee before restoring', function () {
+    $referee = Referee::factory()->create();
+    $staleReferee = clone $referee;
+
+    $referee->delete();
+
+    resolve(RestoreAction::class)->handle($staleReferee);
+
+    expect(Referee::query()->find($referee->getKey()))->not->toBeNull();
+});
+
 test('it validates referee can be restored', function () {
     $referee = Referee::factory()->create();
     $referee->delete(); // Soft delete

--- a/tests/Integration/Actions/Wrestlers/RestoreActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/RestoreActionTest.php
@@ -31,6 +31,17 @@ test('it restores a soft-deleted wrestler', function () {
     ]);
 });
 
+test('it reloads a stale wrestler before restoring', function () {
+    $wrestler = Wrestler::factory()->create();
+    $staleWrestler = clone $wrestler;
+
+    $wrestler->delete();
+
+    resolve(RestoreAction::class)->handle($staleWrestler);
+
+    expect(Wrestler::query()->find($wrestler->getKey()))->not->toBeNull();
+});
+
 test('it restores wrestler with specific restore date', function () {
     $wrestler = Wrestler::factory()->create();
     $wrestler->delete(); // Soft delete


### PR DESCRIPTION
## Summary
- reload and lock Wrestler, Manager, and Referee records inside restoration transactions
- run eligibility and relationship cleanup against the locked records
- add stale-instance restoration regression coverage for each roster type

## Verification
- focused Pest: 30 tests, 98 assertions
- targeted PHPStan: passed
- Pint with Blade: passed
- composer test:push: application tests, Rector, and PHPStan passed; repository gate remains blocked by pre-existing unrelated Blade formatting findings