### PR TITLE
refactor: extract match title requirements

### DIFF
--- a/app/Actions/Matches/AddTitlesToMatchAction.php
+++ b/app/Actions/Matches/AddTitlesToMatchAction.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace App\Actions\Matches;
 
-use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Lifecycle\MatchTitleRequirements;
 use App\Models\Matches\EventMatch;
-use App\Models\Matches\MatchCompetitor;
 use App\Models\Titles\Title;
-use App\Models\Titles\TitleChampionship;
 use App\Services\MatchAssignmentConflictService;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
@@ -17,7 +15,8 @@ use Illuminate\Support\Facades\DB;
 class AddTitlesToMatchAction
 {
     public function __construct(
-        protected MatchAssignmentConflictService $conflictService,
+        private readonly MatchAssignmentConflictService $conflictService,
+        private readonly MatchTitleRequirements $requirements,
     ) {}
 
     /**
@@ -72,59 +71,11 @@ class AddTitlesToMatchAction
             }
 
             $this->conflictService->ensureTitlesCanBeAssigned($conflictingEventIds, $lockedTitles);
-            $this->ensureTitleTypesMatchCompetitors($lockedMatch, $lockedTitles);
-            $this->ensureCurrentChampionsCompete($lockedMatch, $lockedTitles);
+            $this->requirements->ensureSatisfied($lockedMatch, $lockedTitles);
 
             $lockedTitles->each(function (Title $title) use ($lockedMatch): void {
                 $lockedMatch->titles()->attach($title->id);
             });
         });
-    }
-
-    /** @param Collection<int, Title> $titles */
-    private function ensureTitleTypesMatchCompetitors(EventMatch $eventMatch, Collection $titles): void
-    {
-        $assignedCompetitorTypes = $eventMatch->competitors()
-            ->pluck('competitor_type')
-            ->unique();
-
-        foreach ($titles as $title) {
-            if ($assignedCompetitorTypes->count() === 1
-                && $assignedCompetitorTypes->contains($title->type->championMorphClass())) {
-                continue;
-            }
-
-            throw InvalidMatchConfigurationException::titleCompetitorTypeMismatch($title);
-        }
-    }
-
-    /** @param Collection<int, Title> $titles */
-    private function ensureCurrentChampionsCompete(EventMatch $eventMatch, Collection $titles): void
-    {
-        $assignedCompetitors = $eventMatch->competitors()
-            ->get(['competitor_type', 'competitor_id']);
-        $currentChampionships = TitleChampionship::query()
-            ->whereIn('title_id', $titles->pluck('id'))
-            ->current()
-            ->orderBy('id')
-            ->lockForUpdate()
-            ->get(['id', 'title_id', 'champion_type', 'champion_id']);
-
-        foreach ($currentChampionships as $championship) {
-            $championCompetes = $assignedCompetitors->contains(
-                fn (MatchCompetitor $competitor): bool => $competitor->competitor_type === $championship->champion_type
-                    && $competitor->competitor_id === $championship->champion_id,
-            );
-
-            if ($championCompetes) {
-                continue;
-            }
-
-            $title = $titles->firstWhere('id', $championship->title_id);
-
-            if ($title instanceof Title) {
-                throw InvalidMatchConfigurationException::currentChampionMissing($title);
-            }
-        }
     }
 }

--- a/app/Lifecycle/MatchTitleRequirements.php
+++ b/app/Lifecycle/MatchTitleRequirements.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Models\Matches\EventMatch;
+use App\Models\Matches\MatchCompetitor;
+use App\Models\Titles\Title;
+use App\Models\Titles\TitleChampionship;
+use Illuminate\Support\Collection;
+
+final class MatchTitleRequirements
+{
+    /** @param Collection<int, Title> $titles */
+    public function ensureSatisfied(EventMatch $match, Collection $titles): void
+    {
+        $this->ensureTitleTypesMatchCompetitors($match, $titles);
+        $this->ensureCurrentChampionsCompete($match, $titles);
+    }
+
+    /** @param Collection<int, Title> $titles */
+    private function ensureTitleTypesMatchCompetitors(EventMatch $match, Collection $titles): void
+    {
+        $assignedCompetitorTypes = $match->competitors()
+            ->pluck('competitor_type')
+            ->unique();
+
+        foreach ($titles as $title) {
+            if ($assignedCompetitorTypes->count() === 1
+                && $assignedCompetitorTypes->contains($title->type->championMorphClass())) {
+                continue;
+            }
+
+            throw InvalidMatchConfigurationException::titleCompetitorTypeMismatch($title);
+        }
+    }
+
+    /** @param Collection<int, Title> $titles */
+    private function ensureCurrentChampionsCompete(EventMatch $match, Collection $titles): void
+    {
+        $assignedCompetitors = $match->competitors()
+            ->get(['competitor_type', 'competitor_id']);
+        $currentChampionships = TitleChampionship::query()
+            ->whereIn('title_id', $titles->pluck('id'))
+            ->current()
+            ->orderBy('id')
+            ->lockForUpdate()
+            ->get(['id', 'title_id', 'champion_type', 'champion_id']);
+
+        foreach ($currentChampionships as $championship) {
+            $championCompetes = $assignedCompetitors->contains(
+                fn (MatchCompetitor $competitor): bool => $competitor->competitor_type === $championship->champion_type
+                    && $competitor->competitor_id === $championship->champion_id,
+            );
+
+            if ($championCompetes) {
+                continue;
+            }
+
+            $title = $titles->firstWhere('id', $championship->title_id);
+
+            if ($title instanceof Title) {
+                throw InvalidMatchConfigurationException::currentChampionMissing($title);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract title competitor-type and current-champion invariants into `MatchTitleRequirements`
- keep `AddTitlesToMatchAction` responsible for transaction, locking, availability, scheduling, and persistence
- preserve authoritative server-side validation for title assignments

## Verification
- focused Pest: 15 tests, 37 assertions
- targeted PHPStan: passed
- targeted Pint with Blade: passed
- composer test:push: application tests, Rector, and PHPStan passed; repository gate remains blocked by pre-existing unrelated Blade formatting findings