### PR TITLE
refactor: keep competitor assignment atomic

### DIFF
--- a/app/Actions/Matches/AddCompetitorsToMatchAction.php
+++ b/app/Actions/Matches/AddCompetitorsToMatchAction.php
@@ -65,7 +65,7 @@ class AddCompetitorsToMatchAction
         $wrestlers = $sideCompetitors['wrestlers'] ?? [];
 
         if ($wrestlers !== []) {
-            $this->addWrestlersToMatchAction->handle(
+            $this->addWrestlersToMatchAction->handleWithinTransaction(
                 $eventMatch,
                 collect($wrestlers),
                 $sideNumber
@@ -76,7 +76,7 @@ class AddCompetitorsToMatchAction
         $tagTeams = $sideCompetitors['tag_teams'] ?? [];
 
         if ($tagTeams !== []) {
-            $this->addTagTeamsToMatchAction->handle(
+            $this->addTagTeamsToMatchAction->handleWithinTransaction(
                 $eventMatch,
                 collect($tagTeams),
                 $sideNumber

--- a/app/Actions/Matches/AddTagTeamsToMatchAction.php
+++ b/app/Actions/Matches/AddTagTeamsToMatchAction.php
@@ -63,34 +63,45 @@ class AddTagTeamsToMatchAction
 
         DB::transaction(function () use ($eventMatch, $requestedTagTeams, $sideNumber): void {
             $lockedMatch = EventMatch::query()->whereKey($eventMatch->id)->lockForUpdate()->firstOrFail();
-            $conflictingEventIds = $this->conflictService->lockConflictingEventIds($lockedMatch);
-            $lockedTagTeams = TagTeam::query()
-                ->whereKey($requestedTagTeams->pluck('id'))
-                ->orderBy('id')
-                ->lockForUpdate()
-                ->get();
+            $this->handleWithinTransaction($lockedMatch, $requestedTagTeams, $sideNumber);
+        });
+    }
 
-            if ($lockedTagTeams->count() !== $requestedTagTeams->count() || $lockedTagTeams->contains(
-                fn (TagTeam $tagTeam): bool => ! RosterBookingEligibility::allows($tagTeam)
-            )) {
-                throw EntityNotAvailableException::forMatchAssignment('tag teams');
-            }
+    /**
+     * Assign tag teams while the caller owns the match transaction and lock.
+     *
+     * @param  Collection<int, TagTeam>  $tagTeams
+     */
+    public function handleWithinTransaction(EventMatch $lockedMatch, Collection $tagTeams, int $sideNumber): void
+    {
+        $requestedTagTeams = $tagTeams->unique('id')->values();
+        $conflictingEventIds = $this->conflictService->lockConflictingEventIds($lockedMatch);
+        $lockedTagTeams = TagTeam::query()
+            ->whereKey($requestedTagTeams->pluck('id'))
+            ->orderBy('id')
+            ->lockForUpdate()
+            ->get();
 
-            $this->conflictService->ensureCompetitorsCanBeAssigned(
-                $conflictingEventIds,
-                $lockedTagTeams,
-                TagTeam::class,
-                'Tag team',
-            );
-            $side = $lockedMatch->sides()->firstOrCreate(['position' => $sideNumber]);
+        if ($lockedTagTeams->count() !== $requestedTagTeams->count() || $lockedTagTeams->contains(
+            fn (TagTeam $tagTeam): bool => ! RosterBookingEligibility::allows($tagTeam)
+        )) {
+            throw EntityNotAvailableException::forMatchAssignment('tag teams');
+        }
 
-            $lockedTagTeams->each(function (TagTeam $tagTeam) use ($lockedMatch, $side): void {
-                $lockedMatch->competitors()->create([
-                    'competitor_id' => $tagTeam->id,
-                    'competitor_type' => $tagTeam->getMorphClass(),
-                    'match_side_id' => $side->id,
-                ]);
-            });
+        $this->conflictService->ensureCompetitorsCanBeAssigned(
+            $conflictingEventIds,
+            $lockedTagTeams,
+            TagTeam::class,
+            'Tag team',
+        );
+        $side = $lockedMatch->sides()->firstOrCreate(['position' => $sideNumber]);
+
+        $lockedTagTeams->each(function (TagTeam $tagTeam) use ($lockedMatch, $side): void {
+            $lockedMatch->competitors()->create([
+                'competitor_id' => $tagTeam->id,
+                'competitor_type' => $tagTeam->getMorphClass(),
+                'match_side_id' => $side->id,
+            ]);
         });
     }
 }

--- a/app/Actions/Matches/AddWrestlersToMatchAction.php
+++ b/app/Actions/Matches/AddWrestlersToMatchAction.php
@@ -62,38 +62,49 @@ class AddWrestlersToMatchAction
 
         DB::transaction(function () use ($eventMatch, $requestedWrestlers, $sideNumber): void {
             $lockedMatch = EventMatch::query()->whereKey($eventMatch->id)->lockForUpdate()->firstOrFail();
-            $conflictingEventIds = $this->conflictService->lockConflictingEventIds($lockedMatch);
-            $lockedWrestlers = Wrestler::query()
-                ->whereKey($requestedWrestlers->pluck('id'))
-                ->orderBy('id')
-                ->lockForUpdate()
-                ->get();
+            $this->handleWithinTransaction($lockedMatch, $requestedWrestlers, $sideNumber);
+        });
+    }
 
-            if ($lockedWrestlers->count() !== $requestedWrestlers->count() || $lockedWrestlers->contains(
-                fn (Wrestler $wrestler): bool => ! RosterBookingEligibility::allows($wrestler)
-            )) {
-                throw EntityNotAvailableException::forMatchAssignment('wrestlers');
+    /**
+     * Assign wrestlers while the caller owns the match transaction and lock.
+     *
+     * @param  Collection<int, Wrestler>  $wrestlers
+     */
+    public function handleWithinTransaction(EventMatch $lockedMatch, Collection $wrestlers, int $sideNumber): void
+    {
+        $requestedWrestlers = $wrestlers->unique('id')->values();
+        $conflictingEventIds = $this->conflictService->lockConflictingEventIds($lockedMatch);
+        $lockedWrestlers = Wrestler::query()
+            ->whereKey($requestedWrestlers->pluck('id'))
+            ->orderBy('id')
+            ->lockForUpdate()
+            ->get();
+
+        if ($lockedWrestlers->count() !== $requestedWrestlers->count() || $lockedWrestlers->contains(
+            fn (Wrestler $wrestler): bool => ! RosterBookingEligibility::allows($wrestler)
+        )) {
+            throw EntityNotAvailableException::forMatchAssignment('wrestlers');
+        }
+
+        $this->conflictService->ensureCompetitorsCanBeAssigned(
+            $conflictingEventIds,
+            $lockedWrestlers,
+            Wrestler::class,
+            'Wrestler',
+        );
+        $side = $lockedMatch->sides()->firstOrCreate(['position' => $sideNumber]);
+
+        $lockedWrestlers->each(function (Wrestler $wrestler) use ($lockedMatch, $side): void {
+            $competitor = $lockedMatch->competitors()->create([
+                'competitor_id' => $wrestler->id,
+                'competitor_type' => $wrestler->getMorphClass(),
+                'match_side_id' => $side->id,
+            ]);
+
+            if ($lockedMatch->match_type === MatchType::RoyalRumble) {
+                $competitor->forceFill(['entry_order' => $side->position])->save();
             }
-
-            $this->conflictService->ensureCompetitorsCanBeAssigned(
-                $conflictingEventIds,
-                $lockedWrestlers,
-                Wrestler::class,
-                'Wrestler',
-            );
-            $side = $lockedMatch->sides()->firstOrCreate(['position' => $sideNumber]);
-
-            $lockedWrestlers->each(function (Wrestler $wrestler) use ($lockedMatch, $side): void {
-                $competitor = $lockedMatch->competitors()->create([
-                    'competitor_id' => $wrestler->id,
-                    'competitor_type' => $wrestler->getMorphClass(),
-                    'match_side_id' => $side->id,
-                ]);
-
-                if ($lockedMatch->match_type === MatchType::RoyalRumble) {
-                    $competitor->forceFill(['entry_order' => $side->position])->save();
-                }
-            });
         });
     }
 }

--- a/tests/Integration/Actions/Matches/AddCompetitorsToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddCompetitorsToMatchActionTest.php
@@ -27,7 +27,7 @@ test('it adds wrestler competitors to a match', function () {
 
     $addWrestlersAction = Double::for(AddWrestlersToMatchAction::class);
     $addTagTeamsAction = Double::for(AddTagTeamsToMatchAction::class);
-    $addWrestlersAction->expects('handle')->times(2);
+    $addWrestlersAction->expects('handleWithinTransaction')->times(2);
 
     $this->app->instance(AddWrestlersToMatchAction::class, $addWrestlersAction);
     $this->app->instance(AddTagTeamsToMatchAction::class, $addTagTeamsAction);
@@ -53,7 +53,7 @@ test('it adds tag team competitors to a match', function () {
 
     $addWrestlersAction = Double::for(AddWrestlersToMatchAction::class);
     $addTagTeamsAction = Double::for(AddTagTeamsToMatchAction::class);
-    $addTagTeamsAction->expects('handle')->times(2);
+    $addTagTeamsAction->expects('handleWithinTransaction')->times(2);
 
     $this->app->instance(AddWrestlersToMatchAction::class, $addWrestlersAction);
     $this->app->instance(AddTagTeamsToMatchAction::class, $addTagTeamsAction);

--- a/tests/Unit/Actions/Matches/AddCompetitorsToMatchActionTest.php
+++ b/tests/Unit/Actions/Matches/AddCompetitorsToMatchActionTest.php
@@ -31,8 +31,8 @@ test('it adds wrestler competitors to a match', function () {
     app()->instance(AddWrestlersToMatchAction::class, $addWrestlersToMatchAction);
     app()->instance(AddTagTeamsToMatchAction::class, $addTagTeamsToMatchAction);
 
-    $addWrestlersToMatchAction->expects('handle')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 0);
-    $addWrestlersToMatchAction->expects('handle')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 1);
+    $addWrestlersToMatchAction->expects('handleWithinTransaction')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 0);
+    $addWrestlersToMatchAction->expects('handleWithinTransaction')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 1);
 
     resolve(AddCompetitorsToMatchAction::class)->handle($eventMatch, $competitors);
 
@@ -59,8 +59,8 @@ test('it adds tag team competitors to a match', function () {
     app()->instance(AddWrestlersToMatchAction::class, $addWrestlersToMatchAction);
     app()->instance(AddTagTeamsToMatchAction::class, $addTagTeamsToMatchAction);
 
-    $addTagTeamsToMatchAction->expects('handle')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 0);
-    $addTagTeamsToMatchAction->expects('handle')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 1);
+    $addTagTeamsToMatchAction->expects('handleWithinTransaction')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 0);
+    $addTagTeamsToMatchAction->expects('handleWithinTransaction')->with(Argument::type(EventMatch::class), Argument::type('Illuminate\Support\Collection'), 1);
 
     resolve(AddCompetitorsToMatchAction::class)->handle($eventMatch, $competitors);
 


### PR DESCRIPTION
## Summary
- add explicit within-transaction assignment paths for wrestler and tag-team Actions
- let AddCompetitorsToMatchAction retain one outer transaction and match lock
- preserve direct public handles for standalone assignments

## Verification
- focused Pest: 22 tests, 48 assertions
- targeted PHPStan: passed
- targeted Pint with Blade: passed
- composer test:push: application tests, Rector, and PHPStan passed; repository gate remains blocked by pre-existing unrelated Blade formatting findings