### PR TITLE
fix: make referee match assignment idempotent

### DIFF
--- a/app/Actions/Matches/AddRefereesToMatchAction.php
+++ b/app/Actions/Matches/AddRefereesToMatchAction.php
@@ -15,7 +15,7 @@ use Illuminate\Support\Facades\DB;
 class AddRefereesToMatchAction
 {
     public function __construct(
-        protected MatchAssignmentConflictService $conflictService,
+        private readonly MatchAssignmentConflictService $conflictService,
     ) {}
 
     /**
@@ -71,9 +71,7 @@ class AddRefereesToMatchAction
 
             $this->conflictService->ensureRefereesCanBeAssigned($lockedMatch->event_id, $conflictingEventIds, $lockedReferees);
 
-            $lockedReferees->each(function (Referee $referee) use ($lockedMatch): void {
-                $lockedMatch->referees()->attach($referee->id);
-            });
+            $lockedMatch->referees()->syncWithoutDetaching($lockedReferees->modelKeys());
         });
     }
 }

--- a/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
+++ b/tests/Integration/Actions/Matches/AddRefereesToMatchActionTest.php
@@ -81,3 +81,13 @@ test('it assigns a repeated referee only once', function () {
 
     expect($match->referees()->count())->toBe(1);
 });
+
+test('it does not duplicate an existing referee assignment', function () {
+    $match = EventMatch::factory()->create();
+    $referee = Referee::factory()->bookable()->create();
+
+    resolve(AddRefereesToMatchAction::class)->handle($match, collect([$referee]));
+    resolve(AddRefereesToMatchAction::class)->handle($match, collect([$referee]));
+
+    expect($match->referees()->whereKey($referee)->count())->toBe(1);
+});


### PR DESCRIPTION
## Summary
- use `syncWithoutDetaching()` for referee match pivots
- prevent repeated assignment calls from creating duplicate rows
- add regression coverage for repeated Action calls

## Verification
- focused Pest: 7 tests, 12 assertions
- targeted PHPStan: passed
- targeted Pint with Blade: passed
- composer test:push: application tests, Rector, and PHPStan passed; repository gate remains blocked by pre-existing unrelated Blade formatting findings