### PR TITLE
refactor: share match configuration requirements

### DIFF
--- a/app/Actions/Matches/AddMatchForEventAction.php
+++ b/app/Actions/Matches/AddMatchForEventAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\Matches;
 use App\Data\Matches\EventMatchData;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
 use App\Exceptions\Scheduling\EntityNotAvailableException;
+use App\Lifecycle\MatchConfigurationRequirements;
 use App\Models\Events\Event;
 use App\Models\Matches\EventMatch;
 use Illuminate\Support\Facades\DB;
@@ -14,15 +15,16 @@ use Illuminate\Support\Facades\DB;
 class AddMatchForEventAction
 {
     public function __construct(
-        protected AddRefereesToMatchAction $addRefereesToMatchAction,
-        protected AddTitlesToMatchAction $addTitlesToMatchAction,
-        protected AddCompetitorsToMatchAction $addCompetitorsToMatchAction
+        private readonly AddRefereesToMatchAction $addRefereesToMatchAction,
+        private readonly AddTitlesToMatchAction $addTitlesToMatchAction,
+        private readonly AddCompetitorsToMatchAction $addCompetitorsToMatchAction,
+        private readonly MatchConfigurationRequirements $requirements,
     ) {}
 
     /** @throws EntityNotAvailableException|InvalidMatchConfigurationException */
     public function handle(Event $event, EventMatchData $eventMatchData): EventMatch
     {
-        $this->validateMatchData($eventMatchData);
+        $this->requirements->ensureComplete($eventMatchData);
 
         return DB::transaction(function () use ($event, $eventMatchData): EventMatch {
             $lockedEvent = Event::query()
@@ -52,22 +54,5 @@ class AddMatchForEventAction
 
             return $createdMatch;
         });
-    }
-
-    /**
-     * Validate match data for completeness and business rules.
-     *
-     * @param  EventMatchData  $eventMatchData  The match data to validate
-     * @throws InvalidMatchConfigurationException When validation fails
-     */
-    private function validateMatchData(EventMatchData $eventMatchData): void
-    {
-        if ($eventMatchData->sides->isEmpty()) {
-            throw InvalidMatchConfigurationException::missingCompetitors();
-        }
-
-        if ($eventMatchData->referees->isEmpty()) {
-            throw InvalidMatchConfigurationException::missingReferees();
-        }
     }
 }

--- a/app/Actions/Matches/UpdateMatchAction.php
+++ b/app/Actions/Matches/UpdateMatchAction.php
@@ -6,6 +6,7 @@ namespace App\Actions\Matches;
 
 use App\Data\Matches\EventMatchData;
 use App\Exceptions\Matches\InvalidMatchConfigurationException;
+use App\Lifecycle\MatchConfigurationRequirements;
 use App\Models\Matches\EventMatch;
 use Illuminate\Support\Facades\DB;
 
@@ -15,11 +16,12 @@ class UpdateMatchAction
         private AddRefereesToMatchAction $addRefereesToMatchAction,
         private AddTitlesToMatchAction $addTitlesToMatchAction,
         private AddCompetitorsToMatchAction $addCompetitorsToMatchAction,
+        private MatchConfigurationRequirements $requirements,
     ) {}
 
     public function handle(EventMatch $match, EventMatchData $data): EventMatch
     {
-        $this->ensureComplete($data);
+        $this->requirements->ensureComplete($data);
 
         return DB::transaction(function () use ($match, $data): EventMatch {
             $lockedMatch = EventMatch::query()
@@ -52,16 +54,5 @@ class UpdateMatchAction
 
             return $lockedMatch->refresh();
         });
-    }
-
-    private function ensureComplete(EventMatchData $data): void
-    {
-        if ($data->sides->isEmpty()) {
-            throw InvalidMatchConfigurationException::missingCompetitors();
-        }
-
-        if ($data->referees->isEmpty()) {
-            throw InvalidMatchConfigurationException::missingReferees();
-        }
     }
 }

--- a/app/Lifecycle/MatchConfigurationRequirements.php
+++ b/app/Lifecycle/MatchConfigurationRequirements.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Lifecycle;
+
+use App\Data\Matches\EventMatchData;
+use App\Exceptions\Matches\InvalidMatchConfigurationException;
+
+final class MatchConfigurationRequirements
+{
+    public function ensureComplete(EventMatchData $data): void
+    {
+        if ($data->sides->isEmpty()) {
+            throw InvalidMatchConfigurationException::missingCompetitors();
+        }
+
+        if ($data->referees->isEmpty()) {
+            throw InvalidMatchConfigurationException::missingReferees();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- extract the shared competitor/referee completeness invariant
- use the same `MatchConfigurationRequirements` in match creation and update
- remove duplicated validation methods from both Actions

## Verification
- focused Pest: 11 tests, 35 assertions
- targeted PHPStan: passed
- targeted Pint with Blade: passed
- composer test:push: application tests, Rector, and PHPStan passed; repository gate remains blocked by pre-existing unrelated Blade formatting findings