### PR TITLE
fix: lock event and venue deletion

### DIFF
--- a/app/Actions/Events/DeleteAction.php
+++ b/app/Actions/Events/DeleteAction.php
@@ -41,6 +41,7 @@ class DeleteAction
     {
         DB::transaction(function () use ($event, $deletionDate): void {
             $lockedEvent = Event::query()
+                ->withTrashed()
                 ->whereKey($event->getKey())
                 ->lockForUpdate()
                 ->firstOrFail();

--- a/app/Actions/Events/DeleteAction.php
+++ b/app/Actions/Events/DeleteAction.php
@@ -7,6 +7,7 @@ namespace App\Actions\Events;
 use App\Lifecycle\DeletionStateManager;
 use App\Models\Events\Event;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class DeleteAction
 {
@@ -38,6 +39,13 @@ class DeleteAction
      */
     public function handle(Event $event, ?Carbon $deletionDate = null): void
     {
-        $this->deletionState->delete($event, $deletionDate ?? now());
+        DB::transaction(function () use ($event, $deletionDate): void {
+            $lockedEvent = Event::query()
+                ->whereKey($event->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->deletionState->delete($lockedEvent, $deletionDate ?? now());
+        });
     }
 }

--- a/app/Actions/Venues/DeleteAction.php
+++ b/app/Actions/Venues/DeleteAction.php
@@ -6,6 +6,7 @@ namespace App\Actions\Venues;
 
 use App\Lifecycle\DeletionStateManager;
 use App\Models\Events\Venue;
+use Illuminate\Support\Facades\DB;
 
 class DeleteAction
 {
@@ -24,6 +25,13 @@ class DeleteAction
      */
     public function handle(Venue $venue): void
     {
-        $this->deletionState->delete($venue, now());
+        DB::transaction(function () use ($venue): void {
+            $lockedVenue = Venue::query()
+                ->whereKey($venue->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->deletionState->delete($lockedVenue, now());
+        });
     }
 }

--- a/app/Actions/Venues/DeleteAction.php
+++ b/app/Actions/Venues/DeleteAction.php
@@ -27,6 +27,7 @@ class DeleteAction
     {
         DB::transaction(function () use ($venue): void {
             $lockedVenue = Venue::query()
+                ->withTrashed()
                 ->whereKey($venue->getKey())
                 ->lockForUpdate()
                 ->firstOrFail();

--- a/tests/Integration/Actions/Events/DeleteActionTest.php
+++ b/tests/Integration/Actions/Events/DeleteActionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Events\DeleteAction;
+use App\Models\Events\Event;
+
+test('it soft deletes an event through a locked record', function () {
+    $event = Event::factory()->create();
+    $staleEvent = clone $event;
+
+    $event->refresh();
+    resolve(DeleteAction::class)->handle($staleEvent);
+
+    expect(Event::query()->find($event->getKey()))->toBeNull()
+        ->and(Event::withTrashed()->find($event->getKey()))->not->toBeNull();
+});

--- a/tests/Integration/Actions/Venues/DeleteActionTest.php
+++ b/tests/Integration/Actions/Venues/DeleteActionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Actions\Venues\DeleteAction;
+use App\Models\Events\Venue;
+
+test('it soft deletes a venue through a locked record', function () {
+    $venue = Venue::factory()->create();
+    $staleVenue = clone $venue;
+
+    $venue->refresh();
+    resolve(DeleteAction::class)->handle($staleVenue);
+
+    expect(Venue::query()->find($venue->getKey()))->toBeNull()
+        ->and(Venue::withTrashed()->find($venue->getKey()))->not->toBeNull();
+});


### PR DESCRIPTION
## Summary
- reload and lock Event and Venue records inside deletion transactions
- preserve the existing DeletionStateManager lifecycle audit behavior
- add regression coverage for both deletion Actions

## Verification
- focused Pest: 2 tests, 4 assertions
- targeted PHPStan: passed
- targeted Pint with Blade: passed
- composer test:push: application tests, Rector, and PHPStan passed; repository gate remains blocked by pre-existing unrelated Blade formatting findings