### PR TITLE
fix: lock individual deletion workflows

### DIFF
--- a/app/Actions/Managers/DeleteAction.php
+++ b/app/Actions/Managers/DeleteAction.php
@@ -44,16 +44,21 @@ class DeleteAction
      */
     public function handle(Manager $manager, ?Carbon $deletionDate = null): void
     {
-        $this->eligibility->ensureCanDelete($manager);
-
         $deletionDate = $deletionDate ?? now();
 
         DB::transaction(function () use ($manager, $deletionDate): void {
-            $this->periods->close($manager, $deletionDate);
-            $this->endCurrentRelationships->handle($manager, $deletionDate);
+            $lockedManager = Manager::query()
+                ->withTrashed()
+                ->whereKey($manager->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->eligibility->ensureCanDelete($lockedManager);
+            $this->periods->close($lockedManager, $deletionDate);
+            $this->endCurrentRelationships->handle($lockedManager, $deletionDate);
 
             // Soft delete the manager record
-            $this->deletionState->delete($manager, $deletionDate);
+            $this->deletionState->delete($lockedManager, $deletionDate);
         });
     }
 }

--- a/app/Actions/Wrestlers/DeleteAction.php
+++ b/app/Actions/Wrestlers/DeleteAction.php
@@ -42,16 +42,21 @@ class DeleteAction
      */
     public function handle(Wrestler $wrestler, ?Carbon $deletionDate = null): void
     {
-        $this->eligibility->ensureCanDelete($wrestler);
-
         $deletionDate = $deletionDate ?? now();
 
         DB::transaction(function () use ($wrestler, $deletionDate): void {
-            $this->periods->close($wrestler, $deletionDate);
-            $this->endCurrentRelationships->handle($wrestler, $deletionDate);
+            $lockedWrestler = Wrestler::query()
+                ->withTrashed()
+                ->whereKey($wrestler->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->eligibility->ensureCanDelete($lockedWrestler);
+            $this->periods->close($lockedWrestler, $deletionDate);
+            $this->endCurrentRelationships->handle($lockedWrestler, $deletionDate);
 
             // Soft delete the wrestler record
-            $this->deletionState->delete($wrestler, $deletionDate);
+            $this->deletionState->delete($lockedWrestler, $deletionDate);
         });
     }
 }

--- a/tests/Integration/Actions/Managers/DeleteActionTest.php
+++ b/tests/Integration/Actions/Managers/DeleteActionTest.php
@@ -33,6 +33,18 @@ test('it soft deletes an unemployed manager', function () {
     expect($trashedManager->deleted_at)->not->toBeNull();
 });
 
+test('it deletes using the current persisted manager state', function () {
+    $manager = Manager::factory()->create();
+    $staleManager = $manager->replicate(['id']);
+    $staleManager->id = $manager->id;
+    $staleManager->exists = true;
+
+    resolve(DeleteAction::class)->handle($staleManager);
+
+    expect(Manager::find($manager->id))->toBeNull();
+    expect(Manager::withTrashed()->findOrFail($manager->id)->trashed())->toBeTrue();
+});
+
 test('it rejects deleting an already deleted manager', function () {
     $manager = Manager::factory()->create();
     $manager->delete();

--- a/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/DeleteActionTest.php
@@ -31,6 +31,18 @@ test('it soft deletes an unemployed wrestler', function () {
     ]);
 });
 
+test('it deletes using the current persisted wrestler state', function () {
+    $wrestler = Wrestler::factory()->create();
+    $staleWrestler = $wrestler->replicate(['id']);
+    $staleWrestler->id = $wrestler->id;
+    $staleWrestler->exists = true;
+
+    resolve(DeleteAction::class)->handle($staleWrestler);
+
+    expect(Wrestler::find($wrestler->id))->toBeNull();
+    expect(Wrestler::withTrashed()->findOrFail($wrestler->id)->trashed())->toBeTrue();
+});
+
 test('it soft deletes wrestler with specific deletion date', function () {
     $wrestler = Wrestler::factory()->create();
     $deletionDate = now()->subDays(2);


### PR DESCRIPTION
## Summary
- reload and lock wrestler and manager rows before deletion validation
- keep relationship cleanup and soft deletion inside the same transaction
- cover deletion through stale model instances

## Verification
- focused Pest: 19 tests, 56 assertions
- targeted PHPStan: passed
- Pint with Blade: passed for changed files
- repository push hook reaches the known unrelated Blade baseline failure; GitHub CI will validate the branch