### PR TITLE
fix: lock referee deletion workflow

### DIFF
--- a/app/Actions/Referees/DeleteAction.php
+++ b/app/Actions/Referees/DeleteAction.php
@@ -43,15 +43,20 @@ class DeleteAction
      */
     public function handle(Referee $referee, ?Carbon $deletionDate = null): void
     {
-        $this->eligibility->ensureCanDelete($referee);
-
         $deletionDate = $deletionDate ?? now();
 
         DB::transaction(function () use ($referee, $deletionDate): void {
-            $this->periods->close($referee, $deletionDate);
+            $lockedReferee = Referee::query()
+                ->withTrashed()
+                ->whereKey($referee->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $this->eligibility->ensureCanDelete($lockedReferee);
+            $this->periods->close($lockedReferee, $deletionDate);
 
             // Soft delete the referee record
-            $this->deletionState->delete($referee, $deletionDate);
+            $this->deletionState->delete($lockedReferee, $deletionDate);
         });
     }
 }

--- a/tests/Integration/Actions/Referees/DeleteActionTest.php
+++ b/tests/Integration/Actions/Referees/DeleteActionTest.php
@@ -31,6 +31,18 @@ test('it soft deletes an unemployed referee', function () {
     ]);
 });
 
+test('it deletes using the current persisted referee state', function () {
+    $referee = Referee::factory()->create();
+    $staleReferee = $referee->replicate(['id']);
+    $staleReferee->id = $referee->id;
+    $staleReferee->exists = true;
+
+    resolve(DeleteAction::class)->handle($staleReferee);
+
+    expect(Referee::find($referee->id))->toBeNull();
+    expect(Referee::withTrashed()->findOrFail($referee->id)->trashed())->toBeTrue();
+});
+
 test('it rejects deleting an already deleted referee', function () {
     $referee = Referee::factory()->create();
     $referee->delete();


### PR DESCRIPTION
## Summary
- reload and lock the persisted referee before deletion validation
- keep lifecycle closure and soft deletion in one transaction
- cover deletion through a stale referee instance

## Verification
- focused Pest: 12 tests, 37 assertions
- targeted PHPStan: passed
- Pint with Blade: passed