### PR TITLE
fix: lock venue updates

### DIFF
--- a/app/Actions/Venues/UpdateAction.php
+++ b/app/Actions/Venues/UpdateAction.php
@@ -6,6 +6,7 @@ namespace App\Actions\Venues;
 
 use App\Data\Events\VenueData;
 use App\Models\Events\Venue;
+use Illuminate\Support\Facades\DB;
 
 class UpdateAction
 {
@@ -23,11 +24,18 @@ class UpdateAction
      */
     public function handle(Venue $venue, VenueData $venueData): Venue
     {
-        $venue->update([
-            'name' => $venueData->name,
-            'address' => $venueData->address,
-        ]);
+        return DB::transaction(function () use ($venue, $venueData): Venue {
+            $lockedVenue = Venue::query()
+                ->whereKey($venue->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        return $venue;
+            $lockedVenue->update([
+                'name' => $venueData->name,
+                'address' => $venueData->address,
+            ]);
+
+            return $lockedVenue;
+        });
     }
 }

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -152,6 +152,25 @@ describe('Venue Action Integration Tests', function () {
             expect($retrievedVenue->state)->toBe('Utah');
         });
 
+        test('update action uses the current persisted venue state', function () {
+            $venue = Venue::factory()->create(['name' => 'Original Arena']);
+            $staleVenue = $venue->replicate(['id']);
+            $staleVenue->id = $venue->id;
+            $staleVenue->exists = true;
+            $venueData = new VenueData(
+                name: 'Updated Arena',
+                street_address: $venue->street_address,
+                city: $venue->city,
+                state: $venue->state,
+                zipcode: $venue->zipcode
+            );
+
+            $updatedVenue = resolve(UpdateAction::class)->handle($staleVenue, $venueData);
+
+            expect($updatedVenue->getKey())->toBe($venue->getKey())
+                ->and(Venue::findOrFail($venue->getKey())->name)->toBe('Updated Arena');
+        });
+
         test('update action handles address changes', function () {
             $venue = Venue::factory()->create([
                 'street_address' => '123 Old Street',

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -166,9 +166,12 @@ describe('Venue Action Integration Tests', function () {
             );
 
             $updatedVenue = resolve(UpdateAction::class)->handle($staleVenue, $venueData);
+            $persistedVenue = Venue::query()
+                ->whereKey($venue->getKey())
+                ->firstOrFail();
 
             expect($updatedVenue->getKey())->toBe($venue->getKey())
-                ->and(Venue::findOrFail($venue->getKey())->name)->toBe('Updated Arena');
+                ->and($persistedVenue->name)->toBe('Updated Arena');
         });
 
         test('update action handles address changes', function () {


### PR DESCRIPTION
## Summary
- reload and lock the persisted venue before updating
- keep the update inside a database transaction
- cover updates through a stale venue instance

## Verification
- focused Pest: 25 tests, 73 assertions
- targeted PHPStan: passed
- Pint with Blade: passed