### PR TITLE
fix: lock referee updates

### DIFF
--- a/app/Actions/Referees/UpdateAction.php
+++ b/app/Actions/Referees/UpdateAction.php
@@ -32,23 +32,22 @@ class UpdateAction
      */
     public function handle(Referee $referee, RefereeData $refereeData): Referee
     {
-        if (method_exists($referee, 'ensureCanBeUpdated')) {
-            $referee->ensureCanBeUpdated();
-        }
-
         return DB::transaction(function () use ($referee, $refereeData): Referee {
-            // Update the referee's basic information
-            $referee->update([
+            $lockedReferee = Referee::query()
+                ->whereKey($referee->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $lockedReferee->update([
                 'first_name' => $refereeData->first_name,
                 'last_name' => $refereeData->last_name,
             ]);
 
-            // Handle employment using EmployAction for consistency
-            if (! is_null($refereeData->employment_date) && ! $referee->isEmployed()) {
-                $this->employAction->handle($referee, $refereeData->employment_date);
+            if ($refereeData->employment_date !== null && ! $lockedReferee->isEmployed()) {
+                $this->employAction->handle($lockedReferee, $refereeData->employment_date);
             }
 
-            return $referee;
+            return $lockedReferee;
         });
     }
 }

--- a/app/Actions/Venues/UpdateAction.php
+++ b/app/Actions/Venues/UpdateAction.php
@@ -6,6 +6,7 @@ namespace App\Actions\Venues;
 
 use App\Data\Events\VenueData;
 use App\Models\Events\Venue;
+use Illuminate\Support\Facades\DB;
 
 class UpdateAction
 {
@@ -23,11 +24,18 @@ class UpdateAction
      */
     public function handle(Venue $venue, VenueData $venueData): Venue
     {
-        $venue->update([
-            'name' => $venueData->name,
-            'address' => $venueData->address,
-        ]);
+        return DB::transaction(function () use ($venue, $venueData): Venue {
+            $lockedVenue = Venue::query()
+                ->whereKey($venue->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        return $venue;
+            $lockedVenue->update([
+                'name' => $venueData->name,
+                'address' => $venueData->address,
+            ]);
+
+            return $lockedVenue;
+        });
     }
 }

--- a/tests/Integration/Actions/Referees/UpdateActionTest.php
+++ b/tests/Integration/Actions/Referees/UpdateActionTest.php
@@ -80,9 +80,12 @@ test('it updates using the current persisted referee state', function () {
     );
 
     $updatedReferee = resolve(UpdateAction::class)->handle($staleReferee, $updateData);
+    $persistedReferee = Referee::query()
+        ->whereKey($referee->getKey())
+        ->firstOrFail();
 
     expect($updatedReferee->getKey())->toBe($referee->getKey())
-        ->and(Referee::findOrFail($referee->getKey())->first_name)->toBe('Updated');
+        ->and($persistedReferee->first_name)->toBe('Updated');
 });
 
 test('it updates referee without employing when no employment date', function () {

--- a/tests/Integration/Actions/Referees/UpdateActionTest.php
+++ b/tests/Integration/Actions/Referees/UpdateActionTest.php
@@ -64,6 +64,27 @@ test('it updates referee and employs them when employment date provided', functi
     ]);
 });
 
+test('it updates using the current persisted referee state', function () {
+    $referee = Referee::factory()->create([
+        'first_name' => 'Original',
+        'last_name' => 'Name',
+    ]);
+    $staleReferee = $referee->replicate(['id']);
+    $staleReferee->id = $referee->id;
+    $staleReferee->exists = true;
+
+    $updateData = new RefereeData(
+        first_name: 'Updated',
+        last_name: 'Referee',
+        employment_date: null
+    );
+
+    $updatedReferee = resolve(UpdateAction::class)->handle($staleReferee, $updateData);
+
+    expect($updatedReferee->getKey())->toBe($referee->getKey())
+        ->and(Referee::findOrFail($referee->getKey())->first_name)->toBe('Updated');
+});
+
 test('it updates referee without employing when no employment date', function () {
     $referee = Referee::factory()->create();
 

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -152,6 +152,25 @@ describe('Venue Action Integration Tests', function () {
             expect($retrievedVenue->state)->toBe('Utah');
         });
 
+        test('update action uses the current persisted venue state', function () {
+            $venue = Venue::factory()->create(['name' => 'Original Arena']);
+            $staleVenue = $venue->replicate(['id']);
+            $staleVenue->id = $venue->id;
+            $staleVenue->exists = true;
+            $venueData = new VenueData(
+                name: 'Updated Arena',
+                street_address: $venue->street_address,
+                city: $venue->city,
+                state: $venue->state,
+                zipcode: $venue->zipcode
+            );
+
+            $updatedVenue = resolve(UpdateAction::class)->handle($staleVenue, $venueData);
+
+            expect($updatedVenue->getKey())->toBe($venue->getKey())
+                ->and(Venue::findOrFail($venue->getKey())->name)->toBe('Updated Arena');
+        });
+
         test('update action handles address changes', function () {
             $venue = Venue::factory()->create([
                 'street_address' => '123 Old Street',

--- a/tests/Integration/Actions/Venues/LifecycleTest.php
+++ b/tests/Integration/Actions/Venues/LifecycleTest.php
@@ -166,9 +166,12 @@ describe('Venue Action Integration Tests', function () {
             );
 
             $updatedVenue = resolve(UpdateAction::class)->handle($staleVenue, $venueData);
+            $persistedVenue = Venue::query()
+                ->whereKey($venue->getKey())
+                ->firstOrFail();
 
             expect($updatedVenue->getKey())->toBe($venue->getKey())
-                ->and(Venue::findOrFail($venue->getKey())->name)->toBe('Updated Arena');
+                ->and($persistedVenue->name)->toBe('Updated Arena');
         });
 
         test('update action handles address changes', function () {


### PR DESCRIPTION
## Summary
- reload and lock the persisted referee before updating
- remove the dead dynamic update guard
- use the locked referee for employment coordination
- cover updates through a stale referee instance

This branch is based on the venue update-locking slice and will narrow automatically once PR #1001 is merged.

## Verification
- focused Pest: 11 tests, 40 assertions
- targeted PHPStan: passed
- Pint with Blade: passed
- git diff --check: passed