### PR TITLE
fix: lock tag team updates

### DIFF
--- a/app/Actions/TagTeams/UpdateAction.php
+++ b/app/Actions/TagTeams/UpdateAction.php
@@ -28,8 +28,12 @@ class UpdateAction
     public function handle(TagTeam $tagTeam, TagTeamData $tagTeamData): TagTeam
     {
         return DB::transaction(function () use ($tagTeam, $tagTeamData): TagTeam {
-            // Update the tag team's basic information
-            $tagTeam->update([
+            $lockedTagTeam = TagTeam::query()
+                ->whereKey($tagTeam->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $lockedTagTeam->update([
                 'name' => mb_trim($tagTeamData->name),
                 'signature_move' => $tagTeamData->signature_move,
             ]);
@@ -40,21 +44,21 @@ class UpdateAction
             $membershipData = $tagTeamData->getMembershipData();
 
             $this->membershipService->updateMembership(
-                $tagTeam,
+                $lockedTagTeam,
                 $membershipData,
                 $updateDate,
             );
 
             if ($tagTeamData->employment_date) {
-                if (! $tagTeam->isEmployed()) {
-                    $this->employAction->handle($tagTeam, $tagTeamData->employment_date);
+                if (! $lockedTagTeam->isEmployed()) {
+                    $this->employAction->handle($lockedTagTeam, $tagTeamData->employment_date);
                 } else {
-                    $this->employCurrentWrestlersAction->handle($tagTeam, $tagTeamData->employment_date);
-                    $this->employCurrentManagersAction->handle($tagTeam, $tagTeamData->employment_date);
+                    $this->employCurrentWrestlersAction->handle($lockedTagTeam, $tagTeamData->employment_date);
+                    $this->employCurrentManagersAction->handle($lockedTagTeam, $tagTeamData->employment_date);
                 }
             }
 
-            return $tagTeam;
+            return $lockedTagTeam;
         });
     }
 }

--- a/tests/Integration/Actions/TagTeams/UpdateActionTest.php
+++ b/tests/Integration/Actions/TagTeams/UpdateActionTest.php
@@ -42,6 +42,25 @@ test('it updates tag team basic information', function () {
     ]);
 });
 
+test('it updates using the current persisted tag team state', function () {
+    $staleTagTeam = $this->tagTeam->replicate(['id']);
+    $staleTagTeam->id = $this->tagTeam->id;
+    $staleTagTeam->exists = true;
+
+    $updateData = new TagTeamData(
+        name: 'Updated From Stale Team',
+        signature_move: $this->tagTeam->signature_move,
+        employment_date: null,
+        wrestlerA: $this->wrestlerA,
+        wrestlerB: $this->wrestlerB,
+    );
+
+    $updatedTagTeam = resolve(UpdateAction::class)->handle($staleTagTeam, $updateData);
+
+    expect($updatedTagTeam->name)->toBe('Updated From Stale Team')
+        ->and(TagTeam::query()->findOrFail($this->tagTeam->id)->name)->toBe('Updated From Stale Team');
+});
+
 test('it updates only the name when signature move is repeated', function () {
     $updateData = new TagTeamData(
         name: 'Updated Team Only',


### PR DESCRIPTION
## Summary
- reload and lock the persisted tag team before updating
- coordinate membership and employment changes through the locked model
- cover updates submitted with a stale tag team instance

## Verification
- focused Pest: 12 tests, 27 assertions
- targeted PHPStan: passed
- Pint with Blade: passed
- git diff --check: passed