### PR TITLE
fix: lock manager updates

### DIFF
--- a/app/Actions/Managers/UpdateAction.php
+++ b/app/Actions/Managers/UpdateAction.php
@@ -33,18 +33,22 @@ class UpdateAction
     public function handle(Manager $manager, ManagerData $managerData): Manager
     {
         return DB::transaction(function () use ($manager, $managerData): Manager {
-            // Update the manager's basic information
-            $manager->update([
+            $lockedManager = Manager::query()
+                ->whereKey($manager->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $lockedManager->update([
                 'first_name' => $managerData->first_name,
                 'last_name' => $managerData->last_name,
             ]);
 
             // Handle employment using EmployAction for consistency
-            if (! is_null($managerData->employment_date) && ! $manager->isEmployed()) {
-                $this->employAction->handle($manager, $managerData->employment_date);
+            if (! is_null($managerData->employment_date) && ! $lockedManager->isEmployed()) {
+                $this->employAction->handle($lockedManager, $managerData->employment_date);
             }
 
-            return $manager;
+            return $lockedManager;
         });
     }
 }

--- a/tests/Integration/Actions/Managers/UpdateActionTest.php
+++ b/tests/Integration/Actions/Managers/UpdateActionTest.php
@@ -34,6 +34,24 @@ test('it updates a manager with new information', function () {
     ]);
 });
 
+test('it updates using the current persisted manager state', function () {
+    $manager = Manager::factory()->create([
+        'first_name' => 'Original',
+        'last_name' => 'Name',
+    ]);
+    $staleManager = $manager->replicate(['id']);
+    $staleManager->id = $manager->id;
+    $staleManager->exists = true;
+
+    $updatedManager = resolve(UpdateAction::class)->handle(
+        $staleManager,
+        new ManagerData('Updated', 'From Stale State', null),
+    );
+
+    expect($updatedManager->first_name)->toBe('Updated')
+        ->and(Manager::query()->findOrFail($manager->id)->last_name)->toBe('From Stale State');
+});
+
 test('it updates manager and creates employment when employment date is provided', function () {
     $manager = Manager::factory()->create([
         'first_name' => 'John',


### PR DESCRIPTION
## Summary
- reload and lock the persisted manager before updating
- coordinate employment through the locked model
- cover updates submitted with a stale manager instance

## Verification
- focused Pest: 4 tests, 16 assertions
- targeted PHPStan: passed
- Pint with Blade: passed
- git diff --check: passed