### PR TITLE
fix: lock title updates

### DIFF
--- a/app/Actions/Titles/UpdateAction.php
+++ b/app/Actions/Titles/UpdateAction.php
@@ -29,19 +29,23 @@ class UpdateAction
     public function handle(Title $title, TitleData $titleData): Title
     {
         return DB::transaction(function () use ($title, $titleData): Title {
-            // Update the title's basic information
-            $title->update([
+            $lockedTitle = Title::query()
+                ->whereKey($title->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $lockedTitle->update([
                 'name' => $titleData->name,
                 'type' => $titleData->type,
             ]);
 
             // Handle conditional debut creation - only debut titles that have never debuted before
             // Note: This will not reactivate pulled titles - use ReinstateAction for that
-            if (! is_null($titleData->debut_date) && ! $title->hasActivityPeriods()) {
-                $this->startActivityPeriod->handle($title, $titleData->debut_date);
+            if (! is_null($titleData->debut_date) && ! $lockedTitle->hasActivityPeriods()) {
+                $this->startActivityPeriod->handle($lockedTitle, $titleData->debut_date);
             }
 
-            return $title;
+            return $lockedTitle;
         });
     }
 }

--- a/tests/Integration/Actions/Titles/UpdateActionTest.php
+++ b/tests/Integration/Actions/Titles/UpdateActionTest.php
@@ -24,6 +24,24 @@ test('it updates a title', function () {
     expect($title->type)->toBe(TitleType::Singles);
 });
 
+test('it updates using the current persisted title state', function () {
+    $title = Title::factory()->unactivated()->create(['name' => 'Original Title']);
+    $staleTitle = $title->replicate(['id']);
+    $staleTitle->id = $title->id;
+    $staleTitle->exists = true;
+
+    $updatedTitle = resolve(UpdateAction::class)->handle(
+        $staleTitle,
+        new TitleData('Updated From Stale State', TitleType::Singles, null),
+    );
+    $persistedTitle = Title::query()
+        ->whereKey($title->getKey())
+        ->firstOrFail();
+
+    expect($updatedTitle->name)->toBe('Updated From Stale State')
+        ->and($persistedTitle->name)->toBe('Updated From Stale State');
+});
+
 test('it activates an unactivated title if activation date is filled in request', function () {
     $datetime = now();
     $data = new TitleData('New Example Title', TitleType::Singles, $datetime);


### PR DESCRIPTION
## Summary
- reload and lock the persisted title before updating
- evaluate activity history on the locked title
- coordinate new activity periods through the locked model
- cover updates submitted with a stale title instance

## Verification
- focused Pest: 4 tests, 11 assertions
- targeted PHPStan: passed
- Pint with Blade: passed
- git diff --check: passed