### PR TITLE
fix: lock wrestler updates

### DIFF
--- a/app/Actions/Wrestlers/UpdateAction.php
+++ b/app/Actions/Wrestlers/UpdateAction.php
@@ -42,8 +42,12 @@ class UpdateAction
     public function handle(Wrestler $wrestler, WrestlerData $wrestlerData): Wrestler
     {
         return DB::transaction(function () use ($wrestler, $wrestlerData): Wrestler {
-            // Update the wrestler's basic information
-            $wrestler->update([
+            $lockedWrestler = Wrestler::query()
+                ->whereKey($wrestler->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $lockedWrestler->update([
                 'name' => $wrestlerData->name,
                 'height' => $wrestlerData->height->toInches(),
                 'weight' => $wrestlerData->weight->toPounds(),
@@ -52,11 +56,11 @@ class UpdateAction
             ]);
 
             // Employ wrestler if employment_date is provided and they're not already employed
-            if (! is_null($wrestlerData->employment_date) && ! $wrestler->isEmployed()) {
-                $this->employAction->handle($wrestler, $wrestlerData->employment_date);
+            if (! is_null($wrestlerData->employment_date) && ! $lockedWrestler->isEmployed()) {
+                $this->employAction->handle($lockedWrestler, $wrestlerData->employment_date);
             }
 
-            return $wrestler;
+            return $lockedWrestler;
         });
     }
 }

--- a/tests/Integration/Actions/Wrestlers/UpdateActionTest.php
+++ b/tests/Integration/Actions/Wrestlers/UpdateActionTest.php
@@ -51,6 +51,36 @@ test('it updates wrestler basic information', function () {
     ]);
 });
 
+test('it updates using the current persisted wrestler state', function () {
+    $wrestler = Wrestler::factory()->create([
+        'name' => 'Original Name',
+        'height' => 70,
+        'weight' => 200,
+    ]);
+    $staleWrestler = $wrestler->replicate(['id']);
+    $staleWrestler->id = $wrestler->id;
+    $staleWrestler->exists = true;
+
+    $updatedWrestler = resolve(UpdateAction::class)->handle(
+        $staleWrestler,
+        new WrestlerData(
+            name: 'Updated From Stale State',
+            height: 75,
+            weight: 250,
+            hometown: $wrestler->hometown,
+            signature_move: $wrestler->signature_move,
+            employment_date: null,
+            managers: null,
+        ),
+    );
+    $persistedWrestler = Wrestler::query()
+        ->whereKey($wrestler->getKey())
+        ->firstOrFail();
+
+    expect($updatedWrestler->getKey())->toBe($wrestler->getKey())
+        ->and($persistedWrestler->name)->toBe('Updated From Stale State');
+});
+
 test('it updates wrestler and employs them when employment date provided', function () {
     $wrestler = Wrestler::factory()->create();
     $employmentDate = now();


### PR DESCRIPTION
## Summary
- reload and lock the persisted wrestler before updating
- evaluate employment on the locked model
- coordinate employment through the locked wrestler
- cover updates submitted with a stale wrestler instance

## Verification
- focused Pest: 12 tests, 48 assertions
- targeted PHPStan: passed
- Pint with Blade: passed
- git diff --check: passed