### PR TITLE
fix: lock relationship closing actions

### DIFF
--- a/app/Actions/Managers/EndCurrentRelationshipsAction.php
+++ b/app/Actions/Managers/EndCurrentRelationshipsAction.php
@@ -8,19 +8,27 @@ use App\Models\Roster\Managers\Manager;
 use App\Models\Roster\TagTeams\TagTeamManager;
 use App\Models\Roster\Wrestlers\WrestlerManager;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class EndCurrentRelationshipsAction
 {
     public function handle(Manager $manager, Carbon $effectiveDate): void
     {
-        WrestlerManager::query()
-            ->forManagerId($manager->id)
-            ->current()
-            ->update(['fired_at' => $effectiveDate]);
+        DB::transaction(function () use ($manager, $effectiveDate): void {
+            $lockedManager = Manager::query()
+                ->whereKey($manager->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        TagTeamManager::query()
-            ->forManagerId($manager->id)
-            ->current()
-            ->update(['fired_at' => $effectiveDate]);
+            WrestlerManager::query()
+                ->forManagerId($lockedManager->id)
+                ->current()
+                ->update(['fired_at' => $effectiveDate]);
+
+            TagTeamManager::query()
+                ->forManagerId($lockedManager->id)
+                ->current()
+                ->update(['fired_at' => $effectiveDate]);
+        });
     }
 }

--- a/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
+++ b/app/Actions/TagTeams/EndCurrentRelationshipsAction.php
@@ -9,6 +9,7 @@ use App\Models\Roster\TagTeams\TagTeam;
 use App\Models\Roster\TagTeams\TagTeamManager;
 use App\Models\Roster\TagTeams\TagTeamWrestler;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class EndCurrentRelationshipsAction
 {
@@ -16,16 +17,23 @@ class EndCurrentRelationshipsAction
 
     public function handle(TagTeam $tagTeam, Carbon $effectiveDate): void
     {
-        TagTeamWrestler::query()
-            ->forTagTeamId($tagTeam->id)
-            ->current()
-            ->update(['left_at' => $effectiveDate]);
+        DB::transaction(function () use ($tagTeam, $effectiveDate): void {
+            $lockedTagTeam = TagTeam::query()
+                ->whereKey($tagTeam->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        TagTeamManager::query()
-            ->where('tag_team_id', $tagTeam->id)
-            ->current()
-            ->update(['fired_at' => $effectiveDate]);
+            TagTeamWrestler::query()
+                ->forTagTeamId($lockedTagTeam->id)
+                ->current()
+                ->update(['left_at' => $effectiveDate]);
 
-        $this->championshipReigns->endCurrentReignsForChampion($tagTeam, $effectiveDate);
+            TagTeamManager::query()
+                ->where('tag_team_id', $lockedTagTeam->id)
+                ->current()
+                ->update(['fired_at' => $effectiveDate]);
+
+            $this->championshipReigns->endCurrentReignsForChampion($lockedTagTeam, $effectiveDate);
+        });
     }
 }

--- a/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
+++ b/app/Actions/Wrestlers/EndCurrentRelationshipsAction.php
@@ -10,6 +10,7 @@ use App\Models\Roster\TagTeams\TagTeamWrestler;
 use App\Models\Roster\Wrestlers\Wrestler;
 use App\Models\Roster\Wrestlers\WrestlerManager;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 class EndCurrentRelationshipsAction
 {
@@ -17,21 +18,28 @@ class EndCurrentRelationshipsAction
 
     public function handle(Wrestler $wrestler, Carbon $effectiveDate): void
     {
-        TagTeamWrestler::query()
-            ->forWrestlerId($wrestler->id)
-            ->current()
-            ->update(['left_at' => $effectiveDate]);
+        DB::transaction(function () use ($wrestler, $effectiveDate): void {
+            $lockedWrestler = Wrestler::query()
+                ->whereKey($wrestler->getKey())
+                ->lockForUpdate()
+                ->firstOrFail();
 
-        StableWrestler::query()
-            ->where('wrestler_id', $wrestler->id)
-            ->current()
-            ->update(['left_at' => $effectiveDate]);
+            TagTeamWrestler::query()
+                ->forWrestlerId($lockedWrestler->id)
+                ->current()
+                ->update(['left_at' => $effectiveDate]);
 
-        WrestlerManager::query()
-            ->where('wrestler_id', $wrestler->id)
-            ->current()
-            ->update(['fired_at' => $effectiveDate]);
+            StableWrestler::query()
+                ->where('wrestler_id', $lockedWrestler->id)
+                ->current()
+                ->update(['left_at' => $effectiveDate]);
 
-        $this->championshipReigns->endCurrentReignsForChampion($wrestler, $effectiveDate);
+            WrestlerManager::query()
+                ->where('wrestler_id', $lockedWrestler->id)
+                ->current()
+                ->update(['fired_at' => $effectiveDate]);
+
+            $this->championshipReigns->endCurrentReignsForChampion($lockedWrestler, $effectiveDate);
+        });
     }
 }


### PR DESCRIPTION
## Summary
- wrap relationship-closing Actions in transactions
- lock the owning roster model before closing current relationships
- preserve atomic championship and pivot updates

## Verification
- focused Pest tests passed
- focused PHPStan passed
- focused Pint with Blade passed
- full test:push reached the existing repository-wide Blade formatting failure; no unrelated views were changed