### PR TITLE
refactor: consolidate history query composition

### DIFF
--- a/app/Builders/Matches/EventMatchBuilder.php
+++ b/app/Builders/Matches/EventMatchBuilder.php
@@ -39,6 +39,19 @@ class EventMatchBuilder extends Builder
         return $this;
     }
 
+    public function forHistory(): static
+    {
+        return $this
+            ->forPastEvents()
+            ->with([
+                'titles',
+                'competitors.competitor',
+                'competitors.side',
+                'winningSide.competitors.competitor',
+            ])
+            ->latestEventFirst();
+    }
+
     /**
      * @template TRelatedModel of Model
      *

--- a/app/Livewire/Referees/Tables/PreviousMatches.php
+++ b/app/Livewire/Referees/Tables/PreviousMatches.php
@@ -35,9 +35,7 @@ class PreviousMatches extends BasePreviousMatchesTable
         $referee = Referee::query()->findOrFail($this->refereeId);
 
         return EventMatch::query()
-            ->forPastEvents()
-            ->with(['titles', 'competitors.competitor', 'competitors.side', 'winningSide.competitors.competitor'])
-            ->forReferee($referee)
-            ->latestEventFirst();
+            ->forHistory()
+            ->forReferee($referee);
     }
 }

--- a/app/Livewire/TagTeams/Tables/PreviousMatches.php
+++ b/app/Livewire/TagTeams/Tables/PreviousMatches.php
@@ -35,9 +35,7 @@ class PreviousMatches extends BasePreviousMatchesTable
         $tagTeam = TagTeam::query()->findOrFail($this->tagTeamId);
 
         return EventMatch::query()
-            ->forPastEvents()
-            ->with(['titles', 'competitors.competitor', 'competitors.side', 'winningSide.competitors.competitor'])
-            ->forCompetitor($tagTeam)
-            ->latestEventFirst();
+            ->forHistory()
+            ->forCompetitor($tagTeam);
     }
 }

--- a/app/Livewire/Wrestlers/Tables/PreviousMatches.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousMatches.php
@@ -33,9 +33,7 @@ class PreviousMatches extends BasePreviousMatchesTable
         $wrestler = Wrestler::query()->findOrFail($this->wrestlerId);
 
         return EventMatch::query()
-            ->forPastEvents()
-            ->with(['titles', 'competitors.competitor', 'competitors.side', 'winningSide.competitors.competitor'])
-            ->forCompetitor($wrestler)
-            ->latestEventFirst();
+            ->forHistory()
+            ->forCompetitor($wrestler);
     }
 }

--- a/app/Models/Matches/EventMatch.php
+++ b/app/Models/Matches/EventMatch.php
@@ -57,6 +57,7 @@ use Illuminate\Support\Carbon;
  *
  * @method static \Database\Factories\Matches\MatchFactory factory($count = null, $state = [])
  * @method static EventMatchBuilder<static>|EventMatch forPastEvents()
+ * @method static EventMatchBuilder<static>|EventMatch forHistory()
  * @method static EventMatchBuilder<static>|EventMatch forCompetitor(Wrestler|TagTeam $competitor)
  * @method static EventMatchBuilder<static>|EventMatch forEventIds(\Illuminate\Support\Collection<int, int> $eventIds)
  * @method static EventMatchBuilder<static>|EventMatch forReferee(Referee $referee)

--- a/app/Queries/Titles/TitleChampionshipQuery.php
+++ b/app/Queries/Titles/TitleChampionshipQuery.php
@@ -7,6 +7,7 @@ namespace App\Queries\Titles;
 use App\Models\Titles\Title;
 use App\Models\Titles\TitleChampionship;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
 
 final class TitleChampionshipQuery
 {
@@ -51,24 +52,24 @@ final class TitleChampionshipQuery
         return self::firstChampionship($title)?->champion;
     }
 
-    public static function longestChampionship(Title $title): ?TitleChampionship
+    public static function longestChampionship(Title $title, ?Carbon $asOf = null): ?TitleChampionship
     {
         return $title->championships()
             ->get()
-            ->sortByDesc(self::reignLengthInDays(...))
+            ->sortByDesc(fn (TitleChampionship $championship): int => self::reignLengthInDays($championship, $asOf))
             ->first();
     }
 
-    public static function reignLengthInDays(TitleChampionship $championship): int
+    public static function reignLengthInDays(TitleChampionship $championship, ?Carbon $asOf = null): int
     {
-        $reignEnd = $championship->lost_at ?? now();
+        $reignEnd = $championship->lost_at ?? ($asOf ?? now());
 
         return (int) $championship->won_at->diffInDays($reignEnd);
     }
 
-    public static function longestChampion(Title $title): ?Model
+    public static function longestChampion(Title $title, ?Carbon $asOf = null): ?Model
     {
-        return self::longestChampionship($title)?->champion;
+        return self::longestChampionship($title, $asOf)?->champion;
     }
 
     public static function reignCount(Title $title): int

--- a/tests/Unit/Builders/Matches/EventMatchBuilderTest.php
+++ b/tests/Unit/Builders/Matches/EventMatchBuilderTest.php
@@ -52,6 +52,22 @@ it('retrieves matches for past events and eager loads their events', function ()
         ->and($matches->firstOrFail()->relationLoaded('event'))->toBeTrue();
 });
 
+it('retrieves match history with its display relationships eager loaded and ordered', function () {
+    $pastEvent = Event::factory()->past()->create();
+    $wrestler = Wrestler::factory()->create();
+    $match = EventMatch::factory()->forEvent($pastEvent)->create();
+    attachBuilderTestCompetitor($match, $wrestler);
+
+    $history = EventMatch::query()->forHistory()->get();
+
+    expect($history)->toHaveCount(1)
+        ->and($history->firstOrFail()->is($match))->toBeTrue()
+        ->and($history->firstOrFail()->relationLoaded('event'))->toBeTrue()
+        ->and($history->firstOrFail()->relationLoaded('titles'))->toBeTrue()
+        ->and($history->firstOrFail()->relationLoaded('competitors'))->toBeTrue()
+        ->and($history->firstOrFail()->relationLoaded('winningSide'))->toBeTrue();
+});
+
 it('retrieves matches for a competitor and eager loads competitors', function () {
     $event = Event::factory()->past()->create();
     $wrestler = Wrestler::factory()->create();

--- a/tests/Unit/Queries/Titles/TitleChampionshipQueryTest.php
+++ b/tests/Unit/Queries/Titles/TitleChampionshipQueryTest.php
@@ -91,6 +91,17 @@ test('calculates the length of a current championship reign', function () {
     Carbon::setTestNow();
 });
 
+test('calculates current reign length from an explicit as-of date', function () {
+    $championship = TitleChampionship::factory()
+        ->for($this->title)
+        ->forWrestler($this->firstChampion)
+        ->wonOn('2025-01-01')
+        ->current()
+        ->make();
+
+    expect(TitleChampionshipQuery::reignLengthInDays($championship, Carbon::parse('2025-01-11')))->toBe(10);
+});
+
 test('counts reigns and reports vacancy from the current relationship', function () {
     expect(TitleChampionshipQuery::reignCount($this->title))->toBe(3)
         ->and(TitleChampionshipQuery::isVacant($this->title))->toBeFalse();


### PR DESCRIPTION
## Summary
- centralize reusable past-match history constraints and eager loading in EventMatchBuilder
- simplify wrestler, tag-team, and referee previous-match tables
- allow championship reign calculations to use an explicit as-of date
- add focused builder and championship query coverage

## Verification
- focused Pest: 16 tests, 53 assertions
- focused PHPStan (application and Pest configuration): passed
- focused Pint with Blade: passed
- composer test:push: application tests, Rector, and type coverage passed; repository lint remains blocked by existing unrelated Blade formatting findings