### PR TITLE
refactor: centralize historical membership persistence

### DIFF
--- a/app/Services/HistoricalMembershipService.php
+++ b/app/Services/HistoricalMembershipService.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Collection;
+
+class HistoricalMembershipService
+{
+    /**
+     * @template TRelatedModel of Model
+     * @template TDeclaringModel of Model
+     * @template TPivotModel of Pivot
+     *
+     * @param  BelongsToMany<TRelatedModel, TDeclaringModel, TPivotModel>  $relationship
+     * @param  Collection<int, TRelatedModel>|null  $members
+     */
+    public function add(
+        BelongsToMany $relationship,
+        ?Collection $members,
+        Carbon $date,
+    ): void {
+        if ($members === null || $members->isEmpty()) {
+            return;
+        }
+
+        $relationship->attach($members->map(
+            fn (Model $member): int => Arr::integer(['key' => $member->getKey()], 'key'),
+        )->all(), [
+            'joined_at' => $date,
+            'left_at' => null,
+        ]);
+    }
+
+    /**
+     * @template TRelatedModel of Model
+     * @template TDeclaringModel of Model
+     * @template TPivotModel of Pivot
+     *
+     * @param  BelongsToMany<TRelatedModel, TDeclaringModel, TPivotModel>  $relationship
+     * @param  Collection<int, TRelatedModel>|null  $members
+     */
+    public function remove(
+        BelongsToMany $relationship,
+        ?Collection $members,
+        Carbon $date,
+    ): void {
+        if ($members === null || $members->isEmpty()) {
+            return;
+        }
+
+        foreach ($members as $member) {
+            $relationship->newPivotStatementForId($member->getKey())
+                ->whereNull('left_at')
+                ->update(['left_at' => $date]);
+        }
+    }
+
+    /**
+     * @template TRelatedModel of Model
+     * @template TDeclaringModel of Model
+     * @template TPivotModel of Pivot
+     *
+     * @param  BelongsToMany<TRelatedModel, TDeclaringModel, TPivotModel>  $relationship
+     * @param  Collection<int, TRelatedModel>  $currentMembers
+     * @param  Collection<int, TRelatedModel>|null  $desiredMembers
+     */
+    public function synchronize(
+        BelongsToMany $relationship,
+        Collection $currentMembers,
+        ?Collection $desiredMembers,
+        Carbon $date,
+    ): void {
+        if ($desiredMembers === null) {
+            return;
+        }
+
+        $this->remove($relationship, $currentMembers->diff($desiredMembers), $date);
+        $this->add($relationship, $desiredMembers->diff($currentMembers), $date);
+    }
+}

--- a/app/Services/StableMembershipService.php
+++ b/app/Services/StableMembershipService.php
@@ -6,15 +6,12 @@ namespace App\Services;
 
 use App\Data\Stables\StableMembershipData;
 use App\Models\Roster\Stables\Stable;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\Pivot;
-use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
-use Illuminate\Support\Collection;
 
 class StableMembershipService
 {
+    public function __construct(private HistoricalMembershipService $historicalMemberships) {}
+
     public function currentMembers(Stable $stable): StableMembershipData
     {
         return new StableMembershipData(
@@ -25,92 +22,29 @@ class StableMembershipService
 
     public function addMembers(Stable $stable, StableMembershipData $members, Carbon $date): void
     {
-        $this->addMembersToRelationship($stable->wrestlers(), $members->wrestlers, $date);
-        $this->addMembersToRelationship($stable->tagTeams(), $members->tagTeams, $date);
+        $this->historicalMemberships->add($stable->wrestlers(), $members->wrestlers, $date);
+        $this->historicalMemberships->add($stable->tagTeams(), $members->tagTeams, $date);
     }
 
     public function removeMembers(Stable $stable, StableMembershipData $members, Carbon $date): void
     {
-        $this->removeMembersFromRelationship($stable->wrestlers(), $members->wrestlers, $date);
-        $this->removeMembersFromRelationship($stable->tagTeams(), $members->tagTeams, $date);
+        $this->historicalMemberships->remove($stable->wrestlers(), $members->wrestlers, $date);
+        $this->historicalMemberships->remove($stable->tagTeams(), $members->tagTeams, $date);
     }
 
     public function updateMembership(Stable $stable, StableMembershipData $newMembers, Carbon $date): void
     {
-        $this->synchronizeRelationship(
+        $this->historicalMemberships->synchronize(
             $stable->wrestlers(),
             $stable->currentWrestlers,
             $newMembers->wrestlers,
             $date,
         );
-        $this->synchronizeRelationship(
+        $this->historicalMemberships->synchronize(
             $stable->tagTeams(),
             $stable->currentTagTeams,
             $newMembers->tagTeams,
             $date,
         );
-    }
-
-    /**
-     * @template TRelatedModel of Model
-     * @template TPivotModel of Pivot
-     *
-     * @param  BelongsToMany<TRelatedModel, Stable, TPivotModel>  $relationship
-     * @param  Collection<int, TRelatedModel>|null  $members
-     */
-    private function addMembersToRelationship(BelongsToMany $relationship, ?Collection $members, Carbon $date): void
-    {
-        if ($members === null || $members->isEmpty()) {
-            return;
-        }
-
-        $relationship->attach($members->map(
-            fn (Model $member): int => Arr::integer(['key' => $member->getKey()], 'key'),
-        )->all(), [
-            'joined_at' => $date,
-            'left_at' => null,
-        ]);
-    }
-
-    /**
-     * @template TRelatedModel of Model
-     * @template TPivotModel of Pivot
-     *
-     * @param  BelongsToMany<TRelatedModel, Stable, TPivotModel>  $relationship
-     * @param  Collection<int, TRelatedModel>|null  $members
-     */
-    private function removeMembersFromRelationship(BelongsToMany $relationship, ?Collection $members, Carbon $date): void
-    {
-        if ($members === null || $members->isEmpty()) {
-            return;
-        }
-
-        foreach ($members as $member) {
-            $relationship->newPivotStatementForId($member->getKey())
-                ->whereNull('left_at')
-                ->update(['left_at' => $date]);
-        }
-    }
-
-    /**
-     * @template TRelatedModel of Model
-     * @template TPivotModel of Pivot
-     *
-     * @param  BelongsToMany<TRelatedModel, Stable, TPivotModel>  $relationship
-     * @param  Collection<int, TRelatedModel>  $currentMembers
-     * @param  Collection<int, TRelatedModel>|null  $desiredMembers
-     */
-    private function synchronizeRelationship(
-        BelongsToMany $relationship,
-        Collection $currentMembers,
-        ?Collection $desiredMembers,
-        Carbon $date,
-    ): void {
-        if ($desiredMembers === null) {
-            return;
-        }
-
-        $this->removeMembersFromRelationship($relationship, $currentMembers->diff($desiredMembers), $date);
-        $this->addMembersToRelationship($relationship, $desiredMembers->diff($currentMembers), $date);
     }
 }

--- a/app/Services/TagTeamMembershipService.php
+++ b/app/Services/TagTeamMembershipService.php
@@ -6,19 +6,18 @@ namespace App\Services;
 
 use App\Data\TagTeams\TagTeamMembershipData;
 use App\Models\Roster\TagTeams\TagTeam;
-use Illuminate\Database\Eloquent\Collection;
-use Illuminate\Database\Eloquent\Model;
-use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Carbon;
 
 class TagTeamMembershipService
 {
-    public function __construct(private ManagerAssignmentService $managerAssignments) {}
+    public function __construct(
+        private ManagerAssignmentService $managerAssignments,
+        private HistoricalMembershipService $historicalMemberships,
+    ) {}
 
     public function establishMembership(TagTeam $tagTeam, TagTeamMembershipData $members, Carbon $date): void
     {
-        $this->addMembersToRelationship(
+        $this->historicalMemberships->add(
             $tagTeam->wrestlers(),
             $members->wrestlers,
             $date,
@@ -28,65 +27,12 @@ class TagTeamMembershipService
 
     public function updateMembership(TagTeam $tagTeam, TagTeamMembershipData $members, Carbon $date): void
     {
-        $this->synchronizeRelationship(
+        $this->historicalMemberships->synchronize(
             $tagTeam->wrestlers(),
             $tagTeam->currentWrestlers,
             $members->wrestlers,
             $date,
         );
         $this->managerAssignments->synchronize($tagTeam, $members->managers, $date);
-    }
-
-    /**
-     * @template TRelatedModel of Model
-     * @template TPivotModel of Pivot
-     *
-     * @param  BelongsToMany<TRelatedModel, TagTeam, TPivotModel>  $relationship
-     * @param  Collection<int, TRelatedModel>|null  $members
-     */
-    private function addMembersToRelationship(
-        BelongsToMany $relationship,
-        ?Collection $members,
-        Carbon $date,
-    ): void {
-        if ($members === null || $members->isEmpty()) {
-            return;
-        }
-
-        $relationship->attach($members->modelKeys(), [
-            'joined_at' => $date,
-            'left_at' => null,
-        ]);
-    }
-
-    /**
-     * @template TRelatedModel of Model
-     * @template TPivotModel of Pivot
-     *
-     * @param  BelongsToMany<TRelatedModel, TagTeam, TPivotModel>  $relationship
-     * @param  Collection<int, TRelatedModel>  $currentMembers
-     * @param  Collection<int, TRelatedModel>|null  $desiredMembers
-     */
-    private function synchronizeRelationship(
-        BelongsToMany $relationship,
-        Collection $currentMembers,
-        ?Collection $desiredMembers,
-        Carbon $date,
-    ): void {
-        if ($desiredMembers === null) {
-            return;
-        }
-
-        foreach ($currentMembers->diff($desiredMembers) as $member) {
-            $relationship->newPivotStatementForId($member->getKey())
-                ->whereNull('left_at')
-                ->update(['left_at' => $date]);
-        }
-
-        $this->addMembersToRelationship(
-            $relationship,
-            $desiredMembers->diff($currentMembers),
-            $date,
-        );
     }
 }


### PR DESCRIPTION
## Summary
- extract shared joined/left pivot persistence into HistoricalMembershipService
- reuse it for stable and tag-team wrestler/member history
- preserve existing manager assignment semantics and historical records

## Verification
- focused Pest: 8 tests, 42 assertions
- focused application and Pest PHPStan: passed
- focused Pint with Blade: passed
- repository push verification remains affected by unrelated existing Blade formatting findings