### PR TITLE
refactor: consolidate championship history queries

### DIFF
--- a/app/Builders/Titles/TitleChampionshipBuilder.php
+++ b/app/Builders/Titles/TitleChampionshipBuilder.php
@@ -42,6 +42,15 @@ class TitleChampionshipBuilder extends Builder
         return $this->whereMorphedTo('champion', $champion);
     }
 
+    public function forPreviousHistory(): static
+    {
+        return $this
+            ->previous()
+            ->mostRecentlyLostFirst()
+            ->withPreviousChampionshipId()
+            ->with(['title', 'previousChampionship.champion']);
+    }
+
     public function earliestWonFirst(): static
     {
         $this->orderBy('won_at');

--- a/app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/TagTeams/Tables/PreviousTitleChampionships.php
@@ -32,8 +32,6 @@ class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
 
         return TitleChampionship::query()
             ->forChampion($tagTeam)
-            ->previous()
-            ->withPreviousChampionshipId()
-            ->with(['title', 'previousChampionship.champion']);
+            ->forPreviousHistory();
     }
 }

--- a/app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php
+++ b/app/Livewire/Wrestlers/Tables/PreviousTitleChampionships.php
@@ -36,8 +36,6 @@ class PreviousTitleChampionships extends BasePreviousTitleChampionshipsTable
 
         return TitleChampionship::query()
             ->forChampion($wrestler)
-            ->previous()
-            ->withPreviousChampionshipId()
-            ->with(['title', 'previousChampionship.champion']);
+            ->forPreviousHistory();
     }
 }

--- a/app/Models/Titles/TitleChampionship.php
+++ b/app/Models/Titles/TitleChampionship.php
@@ -44,6 +44,7 @@ use Illuminate\Support\Carbon;
  * @method static \Database\Factories\Titles\TitleChampionshipFactory factory($count = null, $state = [])
  * @method static TitleChampionshipBuilder<static>|TitleChampionship current()
  * @method static TitleChampionshipBuilder<static>|TitleChampionship earliestWonFirst()
+ * @method static TitleChampionshipBuilder<static>|TitleChampionship forPreviousHistory()
  * @method static TitleChampionshipBuilder<static>|TitleChampionship forChampion(Wrestler|TagTeam $champion)
  * @method static TitleChampionshipBuilder<static>|TitleChampionship forTitleId(int $titleId)
  * @method static TitleChampionshipBuilder<static>|TitleChampionship mostRecentlyLostFirst()

--- a/tests/Unit/Builders/Titles/TitleChampionshipBuilderTest.php
+++ b/tests/Unit/Builders/Titles/TitleChampionshipBuilderTest.php
@@ -69,3 +69,35 @@ it('filters and orders title championship history', function () {
         $firstChampionship->id,
     ]);
 });
+
+it('builds previous championship history with display relationships', function () {
+    $title = Title::factory()->create();
+    $champion = Wrestler::factory()->create();
+    $firstChampionship = TitleChampionship::factory()
+        ->for($title)
+        ->forWrestler($champion)
+        ->ended()
+        ->create([
+            'won_at' => now()->subYears(2),
+            'lost_at' => now()->subYear()->subDay(),
+        ]);
+    $latestChampionship = TitleChampionship::factory()
+        ->for($title)
+        ->forWrestler($champion)
+        ->ended()
+        ->create([
+            'won_at' => now()->subYear(),
+            'lost_at' => now()->subMonth(),
+        ]);
+
+    $history = TitleChampionship::query()
+        ->forChampion($champion)
+        ->forPreviousHistory()
+        ->get();
+
+    expect($history->modelKeys())->toBe([$latestChampionship->id, $firstChampionship->id])
+        ->and($history->firstOrFail()->getAttribute('previous_championship_id'))->toBe($firstChampionship->id)
+        ->and($history->firstOrFail()->relationLoaded('title'))->toBeTrue()
+        ->and($history->firstOrFail()->relationLoaded('previousChampionship'))->toBeTrue()
+        ->and($history->firstOrFail()->previousChampionship?->champion?->is($champion))->toBeTrue();
+});


### PR DESCRIPTION
## Summary
- add a reusable TitleChampionshipBuilder history query for ended reigns
- consistently order historical reigns by most recent loss
- centralize previous-reign subquery and display eager loading
- simplify wrestler and tag-team championship history tables

## Verification
- focused Pest: 12 tests, 41 assertions
- focused application and Pest PHPStan: passed
- focused Pint with Blade: passed