### PR TITLE
refactor: centralize named builder filters

### DIFF
--- a/app/Builders/Concerns/FiltersByName.php
+++ b/app/Builders/Concerns/FiltersByName.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Builders\Concerns;
+
+trait FiltersByName
+{
+    public function whereName(string $name): static
+    {
+        return $this->where('name', $name);
+    }
+}

--- a/app/Builders/Events/VenueBuilder.php
+++ b/app/Builders/Events/VenueBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Builders\Events;
 
+use App\Builders\Concerns\FiltersByName;
 use App\Models\Events\Venue;
 use Illuminate\Database\Eloquent\Builder;
 
@@ -14,6 +15,8 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class VenueBuilder extends Builder
 {
+    use FiltersByName;
+
     public function alphabetical(): static
     {
         $this->orderBy('name');

--- a/app/Builders/Roster/StableBuilder.php
+++ b/app/Builders/Roster/StableBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Builders\Roster;
 
+use App\Builders\Concerns\FiltersByName;
 use App\Builders\Concerns\ProjectsActivityStatus;
 use App\Models\Roster\Stables\Stable;
 use App\Models\Roster\Stables\StableTagTeam;
@@ -17,6 +18,7 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class StableBuilder extends Builder
 {
+    use FiltersByName;
     use ProjectsActivityStatus;
 
     public function previousForTagTeamId(int $tagTeamId): static

--- a/app/Builders/Roster/TagTeamBuilder.php
+++ b/app/Builders/Roster/TagTeamBuilder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Builders\Roster;
 
 use App\Builders\Concerns\FiltersByEmploymentStatus;
+use App\Builders\Concerns\FiltersByName;
 use App\Builders\Concerns\FiltersByRetirementStatus;
 use App\Models\Roster\TagTeams\TagTeam;
 use Illuminate\Database\Eloquent\Builder;
@@ -17,5 +18,6 @@ use Illuminate\Database\Eloquent\Builder;
 class TagTeamBuilder extends Builder
 {
     use FiltersByEmploymentStatus;
+    use FiltersByName;
     use FiltersByRetirementStatus;
 }

--- a/app/Builders/Titles/TitleBuilder.php
+++ b/app/Builders/Titles/TitleBuilder.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Builders\Titles;
 
+use App\Builders\Concerns\FiltersByName;
 use App\Builders\Concerns\FiltersByRetirementStatus;
 use App\Builders\Concerns\ProjectsActivityStatus;
 use App\Models\Titles\Title;
@@ -16,6 +17,7 @@ use Illuminate\Database\Eloquent\Builder;
  */
 class TitleBuilder extends Builder
 {
+    use FiltersByName;
     use FiltersByRetirementStatus;
     use ProjectsActivityStatus;
 

--- a/app/Lifecycle/StableDeletionEligibility.php
+++ b/app/Lifecycle/StableDeletionEligibility.php
@@ -66,7 +66,7 @@ final class StableDeletionEligibility
         }
 
         $conflictingStable = Stable::query()
-            ->where('name', $stable->name)
+            ->whereName($stable->name)
             ->whereKeyNot($stable->getKey())
             ->first();
 

--- a/app/Lifecycle/StableRetirementEligibility.php
+++ b/app/Lifecycle/StableRetirementEligibility.php
@@ -64,7 +64,7 @@ final class StableRetirementEligibility
         }
 
         $conflictingStable = Stable::query()
-            ->where('name', $stable->name)
+            ->whereName($stable->name)
             ->whereKeyNot($stable->getKey())
             ->whereHas('activityPeriods', fn (Builder $query): Builder => $query->whereNull('ended_at'))
             ->first();

--- a/app/Lifecycle/TagTeamDeletionEligibility.php
+++ b/app/Lifecycle/TagTeamDeletionEligibility.php
@@ -59,7 +59,7 @@ final class TagTeamDeletionEligibility
         }
 
         $conflictingTeam = TagTeam::query()
-            ->where('name', $tagTeam->name)
+            ->whereName($tagTeam->name)
             ->whereKeyNot($tagTeam->getKey())
             ->whereHas('employments', fn (Builder $employmentQuery) => $employmentQuery->whereNull('ended_at'))
             ->first();

--- a/app/Lifecycle/TagTeamRetirementEligibility.php
+++ b/app/Lifecycle/TagTeamRetirementEligibility.php
@@ -52,7 +52,7 @@ final class TagTeamRetirementEligibility
         }
 
         $conflictingTeam = TagTeam::query()
-            ->where('name', $tagTeam->name)
+            ->whereName($tagTeam->name)
             ->whereKeyNot($tagTeam->getKey())
             ->whereHas('employments', fn (Builder $employmentQuery) => $employmentQuery->whereNull('ended_at'))
             ->first();

--- a/app/Lifecycle/TitleDeletionEligibility.php
+++ b/app/Lifecycle/TitleDeletionEligibility.php
@@ -27,7 +27,7 @@ final class TitleDeletionEligibility
         }
 
         $conflictingTitle = Title::query()
-            ->where('name', $title->name)
+            ->whereName($title->name)
             ->whereKeyNot($title->getKey())
             ->first();
 

--- a/app/Lifecycle/VenueDeletionEligibility.php
+++ b/app/Lifecycle/VenueDeletionEligibility.php
@@ -27,7 +27,7 @@ final class VenueDeletionEligibility
         }
 
         $conflictingVenue = Venue::query()
-            ->where('name', $venue->name)
+            ->whereName($venue->name)
             ->whereKeyNot($venue->getKey())
             ->first();
 


### PR DESCRIPTION
## Summary
- add a typed `whereName()` constraint to the existing Eloquent builders
- replace repeated raw name predicates in lifecycle eligibility policies
- preserve model-specific active/employment/activity constraints at their call sites

## Verification
- vendor/bin/pint --blade on all changed PHP files
- focused Pest: 33 tests, 94 assertions
- PHPStan: app/Builders and app/Lifecycle, 0 errors
- git diff --check