### PR TITLE
refactor: finalize lifecycle eligibility policies

### DIFF
--- a/app/Lifecycle/IndividualRetirementEligibility.php
+++ b/app/Lifecycle/IndividualRetirementEligibility.php
@@ -11,7 +11,7 @@ use App\Models\Roster\Managers\Manager;
 use App\Models\Roster\Referees\Referee;
 use App\Models\Roster\Wrestlers\Wrestler;
 
-class IndividualRetirementEligibility
+final class IndividualRetirementEligibility
 {
     public function canRetire(Wrestler|Manager|Referee $individual): bool
     {

--- a/app/Lifecycle/TitleLifecycleEligibility.php
+++ b/app/Lifecycle/TitleLifecycleEligibility.php
@@ -13,7 +13,7 @@ use App\Exceptions\Titles\CannotBeRetiredException;
 use App\Exceptions\Titles\CannotBeUnretiredException;
 use App\Models\Titles\Title;
 
-class TitleLifecycleEligibility
+final class TitleLifecycleEligibility
 {
     public function allows(Title $title, TitleLifecycleTransition $transition): bool
     {

--- a/tests/Feature/Architecture/ApplicationArchitectureTest.php
+++ b/tests/Feature/Architecture/ApplicationArchitectureTest.php
@@ -42,3 +42,10 @@ arch('services use the service suffix')
 arch('custom validation rules implement Laravel validation rules')
     ->expect('App\\Rules')
     ->toImplement(ValidationRule::class);
+
+arch('lifecycle eligibility policies are final')
+    ->expect([
+        'App\\Lifecycle\\IndividualRetirementEligibility',
+        'App\\Lifecycle\\TitleLifecycleEligibility',
+    ])
+    ->toBeFinal();


### PR DESCRIPTION
## Summary
- keep individual and title lifecycle eligibility policies closed to inheritance
- add architecture coverage for the previously non-final policies

## Verification
- vendor/bin/pint --blade
- focused Pest: 25 tests, 44 assertions
- git diff --check

The repository-wide pre-push hook remains blocked by the existing unrelated Blade formatting backlog under resources/views.